### PR TITLE
feat: Make it easier to paste eth addresses

### DIFF
--- a/src/components/common/AddressInput/index.test.tsx
+++ b/src/components/common/AddressInput/index.test.tsx
@@ -83,6 +83,15 @@ describe('AddressInput tests', () => {
     const { input, utils } = setup('')
 
     act(() => {
+      fireEvent.change(input, { target: { value: `eth:${TEST_ADDRESS_A}` } })
+      jest.advanceTimersByTime(1000)
+    })
+
+    await waitFor(() =>
+      expect(utils.getByLabelText(`"eth" doesn't match the current chain`, { exact: false })).toBeDefined(),
+    )
+
+    act(() => {
       fireEvent.change(input, { target: { value: 'gor:0x123' } })
       jest.advanceTimersByTime(1000)
     })

--- a/src/components/common/AddressInput/index.test.tsx
+++ b/src/components/common/AddressInput/index.test.tsx
@@ -83,15 +83,6 @@ describe('AddressInput tests', () => {
     const { input, utils } = setup('')
 
     act(() => {
-      fireEvent.change(input, { target: { value: `eth:${TEST_ADDRESS_A}` } })
-      jest.advanceTimersByTime(1000)
-    })
-
-    await waitFor(() =>
-      expect(utils.getByLabelText(`"eth" doesn't match the current chain`, { exact: false })).toBeDefined(),
-    )
-
-    act(() => {
       fireEvent.change(input, { target: { value: 'gor:0x123' } })
       jest.advanceTimersByTime(1000)
     })
@@ -242,5 +233,22 @@ describe('AddressInput tests', () => {
     })
 
     expect(methods.getValues().recipient).toBe(TEST_ADDRESS_A)
+  })
+
+  it('should clean up the input value if it contains a valid address', async () => {
+    ;(useCurrentChain as jest.Mock).mockImplementation(() => ({
+      shortName: 'gor',
+      chainId: '5',
+      chainName: 'Goerli',
+      features: [],
+    }))
+
+    const { input } = setup(``)
+
+    act(() => {
+      fireEvent.change(input, { target: { value: `Here's my address: ${TEST_ADDRESS_A}` } })
+    })
+
+    await waitFor(() => expect(input.value).toBe(TEST_ADDRESS_A))
   })
 })

--- a/src/components/common/AddressInput/index.tsx
+++ b/src/components/common/AddressInput/index.tsx
@@ -7,7 +7,7 @@ import { useCurrentChain } from '@/hooks/useChains'
 import useNameResolver from './useNameResolver'
 import ScanQRButton from '../ScanQRModal/ScanQRButton'
 import { FEATURES, hasFeature } from '@/utils/chains'
-import { parsePrefixedAddress } from '@/utils/addresses'
+import { cleanInputValue, parsePrefixedAddress } from '@/utils/addresses'
 import useDebounce from '@/hooks/useDebounce'
 
 export type AddressInputProps = TextFieldProps & { name: string; validate?: Validate<string>; deps?: string | string[] }
@@ -90,9 +90,11 @@ const AddressInput = ({ name, validate, required = true, deps, ...props }: Addre
             required,
 
             setValueAs: (value: string): string => {
-              rawValueRef.current = value
+              // Clean the input value
+              const cleanValue = cleanInputValue(value, currentShortName)
+              rawValueRef.current = cleanValue
               // This also checksums the address
-              return parsePrefixedAddress(value).address
+              return parsePrefixedAddress(cleanValue).address
             },
 
             validate: async () => {

--- a/src/components/common/AddressInput/index.tsx
+++ b/src/components/common/AddressInput/index.tsx
@@ -91,7 +91,7 @@ const AddressInput = ({ name, validate, required = true, deps, ...props }: Addre
 
             setValueAs: (value: string): string => {
               // Clean the input value
-              const cleanValue = cleanInputValue(value, currentShortName)
+              const cleanValue = cleanInputValue(value)
               rawValueRef.current = cleanValue
               // This also checksums the address
               return parsePrefixedAddress(cleanValue).address

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -54,11 +54,10 @@ export const formatPrefixedAddress = (address: string, prefix?: string): string 
 }
 
 export const cleanInputValue = (value: string): string => {
-  const regex = new RegExp('(?:([a-z0-9]+):)?(0x[a-f0-9]{40})\\b', 'i')
-
+  const regex = /(?:([a-z0-9]+):)?(0x[a-f0-9]{40})\b/i
   const match = value.match(regex)
   // if match, return the address with optional prefix
-  if (match?.length) return match[0]
+  if (match) return match[0]
 
   // if no match, return the original value
   return value

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -54,17 +54,12 @@ export const formatPrefixedAddress = (address: string, prefix?: string): string 
 }
 
 export const cleanInputValue = (value: string): string => {
-  const regex = /(0x[a-fA-F0-9]{40})\b/
-  const regexWithPrefix = /([a-zA-Z0-9]+):(0x[a-fA-F0-9]{40})\b/
+  const regex = new RegExp('(?:([a-z0-9]+):)?(0x[a-f0-9]{40})\\b', 'i')
 
-  // if value matches the regex with prefix, return the match with prefix
-  if (regexWithPrefix.test(value)) {
-    return value.match(regexWithPrefix)?.[0] || value
-  }
-  // if value matches the regex without prefix, return the match
-  if (regex.test(value)) {
-    return `${value.match(regex)?.[0]}`
-  }
+  const match = value.match(regex)
+  // if match, return the address with optional prefix
+  if (match?.length) return match[0]
+
   // if no match, return the original value
   return value
 }

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -53,9 +53,9 @@ export const formatPrefixedAddress = (address: string, prefix?: string): string 
   return prefix ? `${prefix}:${address}` : address
 }
 
-export const cleanInputValue = (value: string, prefix: string): string => {
+export const cleanInputValue = (value: string): string => {
   const regex = /(0x[a-fA-F0-9]{40})\b/
-  const regexWithPrefix = new RegExp(`${prefix}:(0x[a-fA-F0-9]{40})\\b`)
+  const regexWithPrefix = /([a-zA-Z0-9]+):(0x[a-fA-F0-9]{40})\b/
 
   // if value matches the regex with prefix, return the match with prefix
   if (regexWithPrefix.test(value)) {

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -52,3 +52,19 @@ export const parsePrefixedAddress = (value: string): PrefixedAddress => {
 export const formatPrefixedAddress = (address: string, prefix?: string): string => {
   return prefix ? `${prefix}:${address}` : address
 }
+
+export const cleanInputValue = (value: string, prefix: string): string => {
+  const regex = /(0x[a-fA-F0-9]{40})\b/
+  const regexWithPrefix = new RegExp(`${prefix}:(0x[a-fA-F0-9]{40})\\b`)
+
+  // if value matches the regex with prefix, return the match with prefix
+  if (regexWithPrefix.test(value)) {
+    return value.match(regexWithPrefix)?.[0] || value
+  }
+  // if value matches the regex without prefix, return the match
+  if (regex.test(value)) {
+    return `${value.match(regex)?.[0]}`
+  }
+  // if no match, return the original value
+  return value
+}


### PR DESCRIPTION
## What it solves

Resolves #1631 

## How this PR fixes it

- Adds a cleanup function `cleanInputValue` which finds a valid address in the input and removes the rest

## How to test it

1. Open the Safe
2. Click on the `New transaction` button on the sidebar
3. Click on the `Send tokens` button
4. Paste a string including a valid Ethereum address
(Eg. - `Here's my address: 0x0000000000000000000000000000000000000000`)
5. It should resolve this string to just the address.

## Screenshots

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
