### PR TITLE
Eip 1271 backward compatibility

### DIFF
--- a/src/components/balances/AssetsTable/index.test.tsx
+++ b/src/components/balances/AssetsTable/index.test.tsx
@@ -106,7 +106,7 @@ describe('AssetsTable', () => {
             rpc: {},
           },
           signing: {
-            useOnChainSigning: false,
+            onChainSigning: false,
           },
         },
       },
@@ -211,7 +211,7 @@ describe('AssetsTable', () => {
             rpc: {},
           },
           signing: {
-            useOnChainSigning: false,
+            onChainSigning: false,
           },
         },
       },
@@ -312,7 +312,7 @@ describe('AssetsTable', () => {
             rpc: {},
           },
           signing: {
-            useOnChainSigning: false,
+            onChainSigning: false,
           },
         },
       },
@@ -410,7 +410,7 @@ describe('AssetsTable', () => {
             rpc: {},
           },
           signing: {
-            useOnChainSigning: false,
+            onChainSigning: false,
           },
         },
       },

--- a/src/components/balances/AssetsTable/index.test.tsx
+++ b/src/components/balances/AssetsTable/index.test.tsx
@@ -105,6 +105,9 @@ describe('AssetsTable', () => {
             },
             rpc: {},
           },
+          signing: {
+            useOnChainSigning: false,
+          },
         },
       },
     })
@@ -207,6 +210,9 @@ describe('AssetsTable', () => {
             },
             rpc: {},
           },
+          signing: {
+            useOnChainSigning: false,
+          },
         },
       },
     })
@@ -305,6 +311,9 @@ describe('AssetsTable', () => {
             },
             rpc: {},
           },
+          signing: {
+            useOnChainSigning: false,
+          },
         },
       },
     })
@@ -399,6 +408,9 @@ describe('AssetsTable', () => {
               accessToken: '',
             },
             rpc: {},
+          },
+          signing: {
+            useOnChainSigning: false,
           },
         },
       },

--- a/src/components/balances/HiddenTokenButton/index.test.tsx
+++ b/src/components/balances/HiddenTokenButton/index.test.tsx
@@ -83,6 +83,9 @@ describe('HiddenTokenToggle', () => {
             },
             rpc: {},
           },
+          signing: {
+            useOnChainSigning: false,
+          },
         },
       },
     })

--- a/src/components/balances/HiddenTokenButton/index.test.tsx
+++ b/src/components/balances/HiddenTokenButton/index.test.tsx
@@ -84,7 +84,7 @@ describe('HiddenTokenToggle', () => {
             rpc: {},
           },
           signing: {
-            useOnChainSigning: false,
+            onChainSigning: false,
           },
         },
       },

--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -65,7 +65,7 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement 
   const [signMessageModalState, openSignMessageModal, closeSignMessageModal] = useSignMessageModal()
   const { safe, safeLoaded, safeAddress } = useSafeInfo()
   const tokenlist = useAppSelector(selectTokenList)
-  const useOnChainSigning = useAppSelector(selectOnChainSigning)
+  const onChainSigning = useAppSelector(selectOnChainSigning)
 
   const addressBook = useAddressBook()
   const chain = useCurrentChain()
@@ -96,7 +96,7 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement 
       sdkVersion: string,
     ) => {
       const isOffChainSigningSupported = isOffchainEIP1271Supported(safe, chain, sdkVersion)
-      const signOffChain = isOffChainSigningSupported && !useOnChainSigning
+      const signOffChain = isOffChainSigningSupported && !onChainSigning
       openSignMessageModal(message, requestId, method, signOffChain && !!settings.offChainSigning)
     },
     onGetPermissions: getPermissions,

--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -45,7 +45,7 @@ import css from './styles.module.css'
 import SafeAppIframe from './SafeAppIframe'
 import useGetSafeInfo from './useGetSafeInfo'
 import { hasFeature, FEATURES } from '@/utils/chains'
-import { selectTokenList, selectUseOnChainSigning, TOKEN_LISTS } from '@/store/settingsSlice'
+import { selectTokenList, selectOnChainSigning, TOKEN_LISTS } from '@/store/settingsSlice'
 
 const UNKNOWN_APP_NAME = 'Unknown Safe App'
 
@@ -65,7 +65,7 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement 
   const [signMessageModalState, openSignMessageModal, closeSignMessageModal] = useSignMessageModal()
   const { safe, safeLoaded, safeAddress } = useSafeInfo()
   const tokenlist = useAppSelector(selectTokenList)
-  const useOnChainSigning = useAppSelector(selectUseOnChainSigning)
+  const useOnChainSigning = useAppSelector(selectOnChainSigning)
 
   const addressBook = useAddressBook()
   const chain = useCurrentChain()

--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -45,7 +45,7 @@ import css from './styles.module.css'
 import SafeAppIframe from './SafeAppIframe'
 import useGetSafeInfo from './useGetSafeInfo'
 import { hasFeature, FEATURES } from '@/utils/chains'
-import { selectTokenList, TOKEN_LISTS } from '@/store/settingsSlice'
+import { selectTokenList, selectUseOnChainSigning, TOKEN_LISTS } from '@/store/settingsSlice'
 
 const UNKNOWN_APP_NAME = 'Unknown Safe App'
 
@@ -65,6 +65,7 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement 
   const [signMessageModalState, openSignMessageModal, closeSignMessageModal] = useSignMessageModal()
   const { safe, safeLoaded, safeAddress } = useSafeInfo()
   const tokenlist = useAppSelector(selectTokenList)
+  const useOnChainSigning = useAppSelector(selectUseOnChainSigning)
 
   const addressBook = useAddressBook()
   const chain = useCurrentChain()
@@ -95,7 +96,8 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement 
       sdkVersion: string,
     ) => {
       const isOffChainSigningSupported = isOffchainEIP1271Supported(safe, chain, sdkVersion)
-      openSignMessageModal(message, requestId, method, isOffChainSigningSupported && !!settings.offChainSigning)
+      const signOffChain = isOffChainSigningSupported && !useOnChainSigning
+      openSignMessageModal(message, requestId, method, signOffChain && !!settings.offChainSigning)
     },
     onGetPermissions: getPermissions,
     onSetPermissions: setPermissionsRequest,

--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -57,7 +57,7 @@ type AppFrameProps = {
 const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement => {
   const chainId = useChainId()
   const [txModalState, openTxModal, closeTxModal] = useTxModal()
-  // HACK: We enforce offChainSigning for all apps
+  // We use offChainSigning by default
   const [settings, setSettings] = useState<SafeSettings>({
     offChainSigning: true,
   })

--- a/src/components/safe-apps/AppFrame/useAppCommunicator.ts
+++ b/src/components/safe-apps/AppFrame/useAppCommunicator.ts
@@ -53,6 +53,7 @@ export type UseAppCommunicatorHandlers = {
     message: string | EIP712TypedData,
     requestId: string,
     method: Methods.signMessage | Methods.signTypedMessage,
+    sdkVersion: string,
   ) => void
   onGetTxBySafeTxHash: (transactionId: string) => Promise<TransactionDetails>
   onGetEnvironmentInfo: () => EnvironmentInfo
@@ -174,8 +175,8 @@ const useAppCommunicator = (
 
     communicator?.on(Methods.signMessage, (msg) => {
       const { message } = msg.data.params as SignMessageParams
-
-      handlers.onSignMessage(message, msg.data.id, Methods.signMessage)
+      const sdkVersion = msg.data.env.sdkVersion
+      handlers.onSignMessage(message, msg.data.id, Methods.signMessage, sdkVersion)
     })
 
     communicator?.on(Methods.getOffChainSignature, (msg) => {
@@ -184,8 +185,8 @@ const useAppCommunicator = (
 
     communicator?.on(Methods.signTypedMessage, (msg) => {
       const { typedData } = msg.data.params as SignTypedMessageParams
-
-      handlers.onSignMessage(typedData, msg.data.id, Methods.signTypedMessage)
+      const sdkVersion = msg.data.env.sdkVersion
+      handlers.onSignMessage(typedData, msg.data.id, Methods.signTypedMessage, sdkVersion)
     })
 
     communicator?.on(Methods.getChainInfo, handlers.onGetChainInfo)

--- a/src/components/settings/SafeAppsSigningMethod/index.test.tsx
+++ b/src/components/settings/SafeAppsSigningMethod/index.test.tsx
@@ -1,0 +1,27 @@
+import { act, fireEvent, render } from '@/tests/test-utils'
+import { SafeAppsSigningMethod } from '.'
+
+describe('SafeAppsSigningMethod', () => {
+  it('Toggle on-chain signing', async () => {
+    const result = render(<SafeAppsSigningMethod />, {
+      initialReduxState: {
+        settings: {
+          signing: {
+            useOnChainSigning: false,
+          },
+        } as any,
+      },
+    })
+
+    const checkbox = result.getByRole('checkbox')
+    expect(checkbox).not.toBeChecked()
+
+    act(() => fireEvent.click(checkbox))
+
+    expect(checkbox).toBeChecked()
+
+    act(() => fireEvent.click(checkbox))
+
+    expect(checkbox).not.toBeChecked()
+  })
+})

--- a/src/components/settings/SafeAppsSigningMethod/index.tsx
+++ b/src/components/settings/SafeAppsSigningMethod/index.tsx
@@ -5,13 +5,13 @@ import { selectUseOnChainSigning, setUseOnChainSigning } from '@/store/settingsS
 import { FormControlLabel, Checkbox, Paper, Typography, FormGroup, Grid } from '@mui/material'
 
 export const SafeAppsSigningMethod = () => {
-  const useOnChainSigning = useAppSelector(selectUseOnChainSigning)
+  const onChainSigning = useAppSelector(selectUseOnChainSigning)
 
   const dispatch = useAppDispatch()
 
   const onChange = () => {
     trackEvent(SETTINGS_EVENTS.SAFE_APPS.CHANGE_SIGNING_METHOD)
-    dispatch(setUseOnChainSigning(!useOnChainSigning))
+    dispatch(setUseOnChainSigning(!onChainSigning))
   }
 
   return (
@@ -25,9 +25,8 @@ export const SafeAppsSigningMethod = () => {
 
         <Grid item xs>
           <Typography mb={2}>
-            This setting determines how your Safe Account will sign message requests from Safe Apps. By default it is
-            preferred to use gasless off-chain signatures. In case some Dapps only support on-chain signatures the
-            default behavior can be changed with this setting. Learn more about message signing{' '}
+            This setting determines how the {'Safe{Wallet}'} will sign message requests from Safe Apps. Gasless,
+            off-chain signing is used by default. Learn more about message signing{' '}
             <ExternalLink href="https://help.safe.global/en/articles/7021891-what-are-signed-messages">
               here
             </ExternalLink>
@@ -41,7 +40,7 @@ export const SafeAppsSigningMethod = () => {
                   color: palette.text.disabled,
                 },
               })}
-              control={<Checkbox checked={useOnChainSigning} onChange={onChange} name="use-on-chain-signing" />}
+              control={<Checkbox checked={onChainSigning} onChange={onChange} name="use-on-chain-signing" />}
               label="Always use on-chain signatures"
             />
           </FormGroup>

--- a/src/components/settings/SafeAppsSigningMethod/index.tsx
+++ b/src/components/settings/SafeAppsSigningMethod/index.tsx
@@ -1,0 +1,52 @@
+import ExternalLink from '@/components/common/ExternalLink'
+import { SETTINGS_EVENTS, trackEvent } from '@/services/analytics'
+import { useAppDispatch, useAppSelector } from '@/store'
+import { selectUseOnChainSigning, setUseOnChainSigning } from '@/store/settingsSlice'
+import { FormControlLabel, Checkbox, Paper, Typography, FormGroup, Grid } from '@mui/material'
+
+export const SafeAppsSigningMethod = () => {
+  const useOnChainSigning = useAppSelector(selectUseOnChainSigning)
+
+  const dispatch = useAppDispatch()
+
+  const onChange = () => {
+    trackEvent(SETTINGS_EVENTS.SAFE_APPS.CHANGE_SIGNING_METHOD)
+    dispatch(setUseOnChainSigning(!useOnChainSigning))
+  }
+
+  return (
+    <Paper sx={{ padding: 4 }}>
+      <Grid container spacing={3}>
+        <Grid item lg={4} xs={12}>
+          <Typography variant="h4" fontWeight="bold" mb={1}>
+            Signing method
+          </Typography>
+        </Grid>
+
+        <Grid item xs>
+          <Typography mb={2}>
+            This setting determines how your Safe Account will sign message requests from Safe Apps. By default it is
+            preferred to use gasless off-chain signatures. In case some Dapps only support on-chain signatures the
+            default behavior can be changed with this setting. Learn more about message signing{' '}
+            <ExternalLink href="https://help.safe.global/en/articles/7021891-what-are-signed-messages">
+              here
+            </ExternalLink>
+            .
+          </Typography>
+          <FormGroup>
+            <FormControlLabel
+              sx={({ palette }) => ({
+                flex: 1,
+                '.MuiIconButton-root:not(.Mui-checked)': {
+                  color: palette.text.disabled,
+                },
+              })}
+              control={<Checkbox checked={useOnChainSigning} onChange={onChange} name="use-on-chain-signing" />}
+              label="Always use on-chain signatures"
+            />
+          </FormGroup>
+        </Grid>
+      </Grid>
+    </Paper>
+  )
+}

--- a/src/components/settings/SafeAppsSigningMethod/index.tsx
+++ b/src/components/settings/SafeAppsSigningMethod/index.tsx
@@ -1,21 +1,21 @@
 import ExternalLink from '@/components/common/ExternalLink'
 import { SETTINGS_EVENTS, trackEvent } from '@/services/analytics'
 import { useAppDispatch, useAppSelector } from '@/store'
-import { selectUseOnChainSigning, setUseOnChainSigning } from '@/store/settingsSlice'
+import { selectOnChainSigning, setOnChainSigning } from '@/store/settingsSlice'
 import { FormControlLabel, Checkbox, Paper, Typography, FormGroup, Grid } from '@mui/material'
 
 export const SafeAppsSigningMethod = () => {
-  const onChainSigning = useAppSelector(selectUseOnChainSigning)
+  const onChainSigning = useAppSelector(selectOnChainSigning)
 
   const dispatch = useAppDispatch()
 
   const onChange = () => {
     trackEvent(SETTINGS_EVENTS.SAFE_APPS.CHANGE_SIGNING_METHOD)
-    dispatch(setUseOnChainSigning(!onChainSigning))
+    dispatch(setOnChainSigning(!onChainSigning))
   }
 
   return (
-    <Paper sx={{ padding: 4 }}>
+    <Paper sx={{ padding: 4, mt: 2 }}>
       <Grid container spacing={3}>
         <Grid item lg={4} xs={12}>
           <Typography variant="h4" fontWeight="bold" mb={1}>

--- a/src/components/sidebar/SidebarNavigation/config.tsx
+++ b/src/components/sidebar/SidebarNavigation/config.tsx
@@ -93,7 +93,7 @@ export const settingsNavItems = [
     href: AppRoutes.settings.spendingLimits,
   },
   {
-    label: 'Safe Apps permissions',
+    label: 'Safe Apps',
     href: AppRoutes.settings.safeApps.index,
   },
   {

--- a/src/pages/settings/safe-apps/index.tsx
+++ b/src/pages/settings/safe-apps/index.tsx
@@ -3,18 +3,20 @@ import Head from 'next/head'
 
 import SafeAppsPermissions from '@/components/settings/SafeAppsPermissions'
 import SettingsHeader from '@/components/settings/SettingsHeader'
+import { SafeAppsSigningMethod } from '@/components/settings/SafeAppsSigningMethod'
 
 const SafeAppsPermissionsPage: NextPage = () => {
   return (
     <>
       <Head>
-        <title>{'Safe{Wallet} – Settings – Safe Apps permissions'}</title>
+        <title>{'Safe{Wallet} – Settings – Safe Apps'}</title>
       </Head>
 
       <SettingsHeader />
 
       <main>
         <SafeAppsPermissions />
+        <SafeAppsSigningMethod />
       </main>
     </>
   )

--- a/src/services/analytics/events/settings.ts
+++ b/src/services/analytics/events/settings.ts
@@ -106,4 +106,10 @@ export const SETTINGS_EVENTS = {
       category: SETTINGS_CATEGORY,
     },
   },
+  SAFE_APPS: {
+    CHANGE_SIGNING_METHOD: {
+      action: 'Safe apps signing method changed',
+      category: SETTINGS_CATEGORY,
+    },
+  },
 }

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -97,7 +97,7 @@ export const settingsSlice = createSlice({
     setEnv: (state, { payload }: PayloadAction<EnvState>) => {
       state.env = payload
     },
-    setUseOnChainSigning: (state, { payload }: PayloadAction<boolean>) => {
+    setOnChainSigning: (state, { payload }: PayloadAction<boolean>) => {
       state.signing.onChainSigning = payload
     },
     setSettings: (_, { payload }: PayloadAction<SettingsState>) => {
@@ -117,7 +117,7 @@ export const {
   setHiddenTokensForChain,
   setTokenList,
   setEnv,
-  setUseOnChainSigning,
+  setOnChainSigning,
 } = settingsSlice.actions
 
 export const selectSettings = (state: RootState): SettingsState => state[settingsSlice.name]
@@ -140,4 +140,4 @@ export const selectTenderly = createSelector(selectSettings, (settings) => setti
 
 export const isEnvInitialState = createSelector(selectSettings, (settings) => isEqual(settings.env, initialState.env))
 
-export const selectUseOnChainSigning = createSelector(selectSettings, (settings) => settings.signing.onChainSigning)
+export const selectOnChainSigning = createSelector(selectSettings, (settings) => settings.signing.onChainSigning)

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -38,6 +38,9 @@ export type SettingsState = {
     darkMode?: boolean
   }
   env: EnvState
+  signing: {
+    useOnChainSigning: boolean
+  }
 }
 
 const initialState: SettingsState = {
@@ -59,6 +62,9 @@ const initialState: SettingsState = {
       url: '',
       accessToken: '',
     },
+  },
+  signing: {
+    useOnChainSigning: false,
   },
 }
 
@@ -91,6 +97,9 @@ export const settingsSlice = createSlice({
     setEnv: (state, { payload }: PayloadAction<EnvState>) => {
       state.env = payload
     },
+    setUseOnChainSigning: (state, { payload }: PayloadAction<boolean>) => {
+      state.signing.useOnChainSigning = payload
+    },
     setSettings: (_, { payload }: PayloadAction<SettingsState>) => {
       // We must return as we are overwriting the entire state
       // Preserve default nested settings if importing without
@@ -108,6 +117,7 @@ export const {
   setHiddenTokensForChain,
   setTokenList,
   setEnv,
+  setUseOnChainSigning,
 } = settingsSlice.actions
 
 export const selectSettings = (state: RootState): SettingsState => state[settingsSlice.name]
@@ -129,3 +139,5 @@ export const selectRpc = createSelector(selectSettings, (settings) => settings.e
 export const selectTenderly = createSelector(selectSettings, (settings) => settings.env.tenderly)
 
 export const isEnvInitialState = createSelector(selectSettings, (settings) => isEqual(settings.env, initialState.env))
+
+export const selectUseOnChainSigning = createSelector(selectSettings, (settings) => settings.signing.useOnChainSigning)

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -39,7 +39,7 @@ export type SettingsState = {
   }
   env: EnvState
   signing: {
-    useOnChainSigning: boolean
+    onChainSigning: boolean
   }
 }
 
@@ -64,7 +64,7 @@ const initialState: SettingsState = {
     },
   },
   signing: {
-    useOnChainSigning: false,
+    onChainSigning: false,
   },
 }
 
@@ -98,7 +98,7 @@ export const settingsSlice = createSlice({
       state.env = payload
     },
     setUseOnChainSigning: (state, { payload }: PayloadAction<boolean>) => {
-      state.signing.useOnChainSigning = payload
+      state.signing.onChainSigning = payload
     },
     setSettings: (_, { payload }: PayloadAction<SettingsState>) => {
       // We must return as we are overwriting the entire state
@@ -140,4 +140,4 @@ export const selectTenderly = createSelector(selectSettings, (settings) => setti
 
 export const isEnvInitialState = createSelector(selectSettings, (settings) => isEqual(settings.env, initialState.env))
 
-export const selectUseOnChainSigning = createSelector(selectSettings, (settings) => settings.signing.useOnChainSigning)
+export const selectUseOnChainSigning = createSelector(selectSettings, (settings) => settings.signing.onChainSigning)

--- a/src/utils/__tests__/safe-messages.test.ts
+++ b/src/utils/__tests__/safe-messages.test.ts
@@ -1,8 +1,9 @@
 import { ethers } from 'ethers'
 import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 
-import { generateSafeMessageTypedData, supportsEIP1271 } from '../safe-messages'
+import { generateSafeMessageTypedData, isOffchainEIP1271Supported } from '../safe-messages'
 import { hexZeroPad } from 'ethers/lib/utils'
+import { FEATURES } from '../chains'
 
 const MOCK_ADDRESS = ethers.utils.hexZeroPad('0x123', 20)
 
@@ -244,49 +245,95 @@ describe('safe-messages', () => {
   describe('supportsEIP1271', () => {
     it('false for 1.3.0 Safes without fallback handler', () => {
       expect(
-        supportsEIP1271({
-          chainId: '5',
-          version: '1.3.0',
-          fallbackHandler: null,
-        } as any),
+        isOffchainEIP1271Supported(
+          {
+            chainId: '5',
+            version: '1.3.0',
+            fallbackHandler: null,
+          } as any,
+          {
+            features: [FEATURES.EIP1271],
+          } as any,
+          '7.11.0',
+        ),
       ).toBeFalsy()
     })
 
     it('false for 1.3.0 Safes with invalid fallback handler', () => {
       expect(
-        supportsEIP1271({
-          chainId: '5',
-          version: '0.0.1',
-          fallbackHandler: { value: 'this is not an address' },
-        } as any),
+        isOffchainEIP1271Supported(
+          {
+            chainId: '5',
+            version: '0.0.1',
+            fallbackHandler: { value: 'this is not an address' },
+          } as any,
+          {
+            features: [FEATURES.EIP1271],
+          } as any,
+          '7.11.0',
+        ),
       ).toBeFalsy()
     })
 
     it('true for 1.3.0 Safes with fallback handler', () => {
       expect(
-        supportsEIP1271({
-          chainId: '5',
-          version: '1.3.0',
-          fallbackHandler: { value: hexZeroPad('0x2222', 20) },
-        } as any),
+        isOffchainEIP1271Supported(
+          {
+            chainId: '5',
+            version: '1.3.0',
+            fallbackHandler: { value: hexZeroPad('0x2222', 20) },
+          } as any,
+          {
+            features: [FEATURES.EIP1271],
+          } as any,
+          '7.11.0',
+        ),
       ).toBeTruthy()
     })
 
     it('true for 1.1.0 Safes', () => {
       expect(
-        supportsEIP1271({
-          chainId: '5',
-          version: '1.0.0',
-        } as any),
+        isOffchainEIP1271Supported(
+          {
+            chainId: '5',
+            version: '1.0.0',
+          } as any,
+          {
+            features: [FEATURES.EIP1271],
+          } as any,
+          '7.11.0',
+        ),
       ).toBeTruthy()
     })
 
     it('false for 0.0.1 Safes', () => {
       expect(
-        supportsEIP1271({
-          chainId: '5',
-          version: '0.0.1',
-        } as any),
+        isOffchainEIP1271Supported(
+          {
+            chainId: '5',
+            version: '0.0.1',
+          } as any,
+          {
+            features: [FEATURES.EIP1271],
+          } as any,
+          '7.11.0',
+        ),
+      ).toBeFalsy()
+    })
+
+    it('false for unsupported safeAppsSdk version', () => {
+      expect(
+        isOffchainEIP1271Supported(
+          {
+            chainId: '5',
+            version: '1.3.0',
+            fallbackHandler: { value: hexZeroPad('0x2222', 20) },
+          } as any,
+          {
+            features: [FEATURES.EIP1271],
+          } as any,
+          '7.10.0',
+        ),
       ).toBeFalsy()
     })
   })


### PR DESCRIPTION
## What it solves

Resolves #1943 

## How this PR fixes it
- [x] Uses on-chain signing for safe-apps-sdk version `<7.11.0`
- [x] Adds a Setting to always sign on-chain for backward compatibility

New analytics event:
- Change "Use on-chain signatures" setting

## How to test it
- Add the new Wallet Connect [PR deployment](https://pr657--safereactapps.review-react-hr.5afe.dev/wallet-connect/) as custom app
- Open a dapp that requires signatures (e.g. opensea login)
- Witness that by default it uses off-chain signing
- Change the setting to on-chain signing
- Witness that it now uses on-chain signing

## Screenshots
![Screenshot 2023-05-05 at 11 19 56](https://user-images.githubusercontent.com/2670790/236421240-1d995c67-d624-445a-bd36-2aa32c6db17d.png)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻