### PR TITLE
Chore: "Accept selection" in e2e tests

### DIFF
--- a/cypress/e2e/smoke/address_book.cy.js
+++ b/cypress/e2e/smoke/address_book.cy.js
@@ -19,7 +19,7 @@ const GNO_CSV_ENTRY = {
 
 describe('Address book', () => {
   before(() => {
-    cy.visit(`/${GOERLI_TEST_SAFE}/address-book`, { failOnStatusCode: false })
+    cy.visit(`/address-book?safe=${GOERLI_TEST_SAFE}`)
     cy.contains('Accept selection').click()
     // Waits for the Address Book table to be in the page
     cy.contains('p', 'Address book').should('be.visible')
@@ -84,7 +84,7 @@ describe('Address book', () => {
       cy.contains('Gnosis Chain').click()
 
       // Navigate to the Address Book page
-      cy.visit(`/${GNO_TEST_SAFE}/address-book`, { failOnStatusCode: false })
+      cy.visit(`/address-book?safe=${GNO_TEST_SAFE}`)
 
       // Waits for the Address Book table to be in the page
       cy.contains('p', 'Address book').should('be.visible')

--- a/cypress/e2e/smoke/balances.cy.js
+++ b/cypress/e2e/smoke/balances.cy.js
@@ -203,6 +203,9 @@ describe('Assets > Coins', () => {
       cy.visit(`/balances?safe=${PAGINATION_TEST_SAFE}`)
       cy.contains('button', 'Accept selection').click()
 
+      // Find button with the text OK (terms banner), and if it exists, click it
+      cy.get('button').contains('Ok').click({ force: true })
+
       // Table is loaded
       cy.contains('Görli Ether')
       cy.contains('button', 'Got it').click()

--- a/cypress/e2e/smoke/balances.cy.js
+++ b/cypress/e2e/smoke/balances.cy.js
@@ -14,8 +14,8 @@ describe('Assets > Coins', () => {
 
   before(() => {
     // Open the Safe used for testing
-    cy.visit(`/balances?safe=${TEST_SAFE}`, { failOnStatusCode: false })
-    cy.contains('button', 'Accept all').click()
+    cy.visit(`/balances?safe=${TEST_SAFE}`)
+    cy.contains('button', 'Accept selection').click()
     // Table is loaded
     cy.contains('Görli Ether')
 
@@ -200,10 +200,8 @@ describe('Assets > Coins', () => {
   describe('pagination should work', () => {
     before(() => {
       // Open the Safe used for testing pagination
-      cy.visit(`/balances?safe=${PAGINATION_TEST_SAFE}`, { failOnStatusCode: false })
+      cy.visit(`/balances?safe=${PAGINATION_TEST_SAFE}`)
       cy.contains('button', 'Accept selection').click()
-
-      cy.wait(1000)
 
       // Table is loaded
       cy.contains('Görli Ether')

--- a/cypress/e2e/smoke/balances.cy.js
+++ b/cypress/e2e/smoke/balances.cy.js
@@ -201,7 +201,7 @@ describe('Assets > Coins', () => {
     before(() => {
       // Open the Safe used for testing pagination
       cy.visit(`/balances?safe=${PAGINATION_TEST_SAFE}`, { failOnStatusCode: false })
-      cy.contains('button', 'Accept all').click()
+      cy.contains('button', 'Accept selection').click()
 
       cy.wait(1000)
 

--- a/cypress/e2e/smoke/beamer.cy.js
+++ b/cypress/e2e/smoke/beamer.cy.js
@@ -3,7 +3,7 @@ const TEST_SAFE = 'gor:0x97d314157727D517A706B5D08507A1f9B44AaaE9'
 describe('Beamer', () => {
   it('should require accept "Updates" cookies to display Beamer', () => {
     // Disable PWA, otherwise it will throw a security error
-    cy.visit(`/${TEST_SAFE}/address-book`, { failOnStatusCode: false })
+    cy.visit(`/address-book?safe=${TEST_SAFE}`)
 
     // Way to select the cookies banner without an id
     cy.contains('Accept selection').click()

--- a/cypress/e2e/smoke/create_safe_simple.cy.js
+++ b/cypress/e2e/smoke/create_safe_simple.cy.js
@@ -8,7 +8,7 @@ describe('Create Safe form', () => {
     cy.visit('/welcome')
 
     // Close cookie banner
-    cy.contains('button', 'Accept all').click()
+    cy.contains('button', 'Accept selection').click()
 
     // Ensure wallet is connected to correct chain via header
     cy.contains('E2E Wallet @ Görli')

--- a/cypress/e2e/smoke/create_tx.cy.js
+++ b/cypress/e2e/smoke/create_tx.cy.js
@@ -10,7 +10,7 @@ describe('Queue a transaction on 1/N', () => {
   before(() => {
     cy.connectE2EWallet()
 
-    cy.visit(`/${SAFE}/home`, { failOnStatusCode: false })
+    cy.visit(`/home?safe=${SAFE}`)
 
     cy.contains('Accept selection').click()
   })

--- a/cypress/e2e/smoke/dashboard.cy.js
+++ b/cypress/e2e/smoke/dashboard.cy.js
@@ -3,7 +3,7 @@ const SAFE = encodeURIComponent('gor:0xCD4FddB8FfA90012DFE11eD4bf258861204FeEAE'
 describe('Dashboard', () => {
   before(() => {
     // Go to the test Safe home page
-    cy.visit(`/home?safe=${SAFE}`, { failOnStatusCode: false })
+    cy.visit(`/home?safe=${SAFE}`)
     cy.contains('button', 'Accept selection').click()
 
     // Wait for dashboard to initialize

--- a/cypress/e2e/smoke/nfts.cy.js
+++ b/cypress/e2e/smoke/nfts.cy.js
@@ -4,7 +4,7 @@ describe('Assets > NFTs', () => {
   before(() => {
     cy.connectE2EWallet()
 
-    cy.visit(`/${TEST_SAFE}/balances/nfts`, { failOnStatusCode: false })
+    cy.visit(`/balances/nfts?safe=${TEST_SAFE}`)
     cy.contains('button', 'Accept selection').click()
     cy.contains('E2E Wallet @ Görli')
   })

--- a/cypress/e2e/smoke/pending_actions.cy.js
+++ b/cypress/e2e/smoke/pending_actions.cy.js
@@ -4,13 +4,8 @@ describe('Pending actions', () => {
   before(() => {
     cy.connectE2EWallet()
 
-    cy.visit('/welcome')
-
-    // Close cookie banner
-    cy.contains('button', 'Accept all').click()
-
-    // Ensure wallet is connected to correct chain via header
-    cy.wait(5000)
+    cy.visit(`/welcome`, { failOnStatusCode: false })
+    cy.contains('button', 'Accept selection').click()
     cy.contains('E2E Wallet @ Görli')
   })
 

--- a/cypress/e2e/smoke/pending_actions.cy.js
+++ b/cypress/e2e/smoke/pending_actions.cy.js
@@ -4,7 +4,7 @@ describe('Pending actions', () => {
   before(() => {
     cy.connectE2EWallet()
 
-    cy.visit(`/welcome`, { failOnStatusCode: false })
+    cy.visit(`/welcome`)
     cy.contains('button', 'Accept selection').click()
     cy.contains('E2E Wallet @ Görli')
   })

--- a/cypress/e2e/smoke/tx_history.cy.js
+++ b/cypress/e2e/smoke/tx_history.cy.js
@@ -7,7 +7,7 @@ const CONTRACT_INTERACTION = 'Contract interaction'
 describe('Transaction history', () => {
   before(() => {
     // Go to the test Safe transaction history
-    cy.visit(`/${SAFE}/transactions/history`, { failOnStatusCode: false })
+    cy.visit(`/transactions/history?safe=${SAFE}`)
     cy.contains('button', 'Accept selection').click()
   })
 


### PR DESCRIPTION
This pending actions test is constantly failing, and I think it's because it clicks on `Accept all`, whereas most other tests click on `Accept selection`. Beamer is then enabled, and it loads very slowly which might block other things on the page.