### PR TITLE
fix: remove logo height

### DIFF
--- a/src/components/common/Header/styles.module.css
+++ b/src/components/common/Header/styles.module.css
@@ -30,7 +30,6 @@
   width: auto;
   display: block;
   color: var(--color-logo-main);
-  height: 20px;
 }
 
 .logo {


### PR DESCRIPTION
## What it solves

Resolves small logo after rebrand reversion.

## How this PR fixes it

The logo `height` has been removed.

## How to test it

Open the app and observe the correctly sized logo.

## Screenshots

PR:

![image](https://user-images.githubusercontent.com/20442784/236427057-6e070676-b301-450a-b11f-fac730e25877.png)

![image](https://user-images.githubusercontent.com/20442784/236426974-1994e088-0bd8-4f1a-ab4f-3f18a765146e.png)

Prod:

![image](https://user-images.githubusercontent.com/20442784/236427010-ab7ab161-49a3-43e7-95ab-4367434ec461.png)

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
