### PR TITLE
Fix: support injected wallet icons

### DIFF
--- a/src/components/common/WalletIcon/index.tsx
+++ b/src/components/common/WalletIcon/index.tsx
@@ -1,53 +1,4 @@
 import { Skeleton } from '@mui/material'
-import metamaskIcon from '@web3-onboard/injected-wallets/dist/icons/metamask'
-import coinbaseIcon from '@web3-onboard/coinbase/dist/icon'
-import keystoneIcon from '@web3-onboard/keystone/dist/icon'
-import walletConnectIcon from '@web3-onboard/walletconnect/dist/icon'
-import trezorIcon from '@web3-onboard/trezor/dist/icon'
-import ledgerIcon from '@web3-onboard/ledger/dist/icon'
-import tallyhoIcon from '@web3-onboard/tallyho/dist/icon'
-
-import { WALLET_KEYS } from '@/hooks/wallets/wallets'
-import pairingIcon from '@/services/pairing/icon'
-import { PAIRING_MODULE_LABEL } from '@/services/pairing/module'
-import { E2E_WALLET_NAME } from '@/tests/e2e-wallet'
-
-enum ADDITIONAL_KEYS {
-  METAMASK = 'METAMASK',
-}
-
-export type ALL_WALLET_KEYS = typeof WALLET_KEYS & typeof ADDITIONAL_KEYS
-
-type Props = {
-  [k in keyof ALL_WALLET_KEYS]: string
-}
-
-const WALLET_ICONS: Props = {
-  [ADDITIONAL_KEYS.METAMASK]: metamaskIcon,
-  [WALLET_KEYS.COINBASE]: coinbaseIcon,
-  [WALLET_KEYS.INJECTED]: metamaskIcon,
-  [WALLET_KEYS.KEYSTONE]: keystoneIcon,
-  [WALLET_KEYS.WALLETCONNECT]: walletConnectIcon,
-  [WALLET_KEYS.TREZOR]: trezorIcon,
-  [WALLET_KEYS.LEDGER]: ledgerIcon,
-  [WALLET_KEYS.PAIRING]: pairingIcon,
-  [WALLET_KEYS.TALLYHO]: tallyhoIcon,
-}
-
-// Labels may differ from ALL_WALLET_KEYS
-const WALLET_LABELS: { [label: string]: WALLET_KEYS } = {
-  [PAIRING_MODULE_LABEL]: WALLET_KEYS.PAIRING,
-}
-
-const getWalletIcon = (provider: string) => {
-  if (provider === E2E_WALLET_NAME) {
-    return metamaskIcon
-  }
-
-  const label = WALLET_LABELS?.[provider] || provider.toUpperCase()
-
-  return WALLET_ICONS[label]
-}
 
 const WalletIcon = ({
   provider,
@@ -60,13 +11,11 @@ const WalletIcon = ({
   height?: number
   icon?: string
 }) => {
-  const svg = getWalletIcon(provider) || icon
-
-  return svg ? (
+  return icon ? (
     <img
       width={width}
       height={height}
-      src={`data:image/svg+xml;utf8,${encodeURIComponent(svg)}`}
+      src={`data:image/svg+xml;utf8,${encodeURIComponent(icon)}`}
       alt={`${provider} logo`}
     />
   ) : (

--- a/src/components/common/WalletIcon/index.tsx
+++ b/src/components/common/WalletIcon/index.tsx
@@ -49,14 +49,24 @@ const getWalletIcon = (provider: string) => {
   return WALLET_ICONS[label]
 }
 
-const WalletIcon = ({ provider, width = 30, height = 30 }: { provider: string; width?: number; height?: number }) => {
-  const icon = getWalletIcon(provider)
+const WalletIcon = ({
+  provider,
+  width = 30,
+  height = 30,
+  icon,
+}: {
+  provider: string
+  width?: number
+  height?: number
+  icon?: string
+}) => {
+  const svg = getWalletIcon(provider) || icon
 
-  return icon ? (
+  return svg ? (
     <img
       width={width}
       height={height}
-      src={`data:image/svg+xml;utf8,${encodeURIComponent(icon)}`}
+      src={`data:image/svg+xml;utf8,${encodeURIComponent(svg)}`}
       alt={`${provider} logo`}
     />
   ) : (

--- a/src/components/common/WalletInfo/index.tsx
+++ b/src/components/common/WalletInfo/index.tsx
@@ -20,7 +20,7 @@ const WalletInfo = ({ wallet }: { wallet: ConnectedWallet }): ReactElement => {
     <Box className={css.container}>
       <Box className={css.imageContainer}>
         <Suspense>
-          <WalletIcon provider={wallet.label} />
+          <WalletIcon provider={wallet.label} icon={wallet.icon} />
         </Suspense>
       </Box>
       <Box>

--- a/src/components/sidebar/PendingActions/index.tsx
+++ b/src/components/sidebar/PendingActions/index.tsx
@@ -52,7 +52,7 @@ const PendingActionButtons = ({
                   borderBottomRightRadius: ({ shape }) => shape.borderRadius,
                 }}
               >
-                <WalletIcon provider={wallet.label} />
+                <WalletIcon provider={wallet.label} icon={wallet.icon} />
                 <Typography variant="body2">{totalToSign}</Typography>
               </ButtonBase>
             </Tooltip>

--- a/src/components/tx/ExecutionMethodSelector/index.tsx
+++ b/src/components/tx/ExecutionMethodSelector/index.tsx
@@ -61,7 +61,8 @@ export const ExecutionMethodSelector = ({
               value={ExecutionMethod.WALLET}
               label={
                 <Typography className={css.radioLabel}>
-                  <WalletIcon provider={wallet?.label || ''} width={20} height={20} /> Connected wallet
+                  <WalletIcon provider={wallet?.label || ''} width={20} height={20} icon={wallet?.icon} /> Connected
+                  wallet
                 </Typography>
               }
               control={<Radio />}

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -10,6 +10,7 @@ declare global {
       _metamask: {
         isUnlocked: () => Promise<boolean>
       }
+      isConnected?: () => boolean
     }
     beamer_config?: BeamerConfig
     Beamer?: BeamerMethods

--- a/src/hooks/wallets/useOnboard.test.ts
+++ b/src/hooks/wallets/useOnboard.test.ts
@@ -12,7 +12,7 @@ describe('getConnectedWallet', () => {
     const wallets = [
       {
         label: 'Wallet 1',
-        icon: '',
+        icon: 'wallet1.svg',
         provider: null as unknown as EIP1193Provider,
         chains: [{ id: '0x4' }],
         accounts: [
@@ -25,7 +25,7 @@ describe('getConnectedWallet', () => {
       },
       {
         label: 'Wallet 2',
-        icon: '',
+        icon: 'wallet2.svg',
         provider: null as unknown as EIP1193Provider,
         chains: [{ id: '0x100' }],
         accounts: [
@@ -40,6 +40,7 @@ describe('getConnectedWallet', () => {
 
     expect(getConnectedWallet(wallets)).toEqual({
       label: 'Wallet 1',
+      icon: 'wallet1.svg',
       address: '0x1234567890123456789012345678901234567890',
       provider: wallets[0].provider,
       chainId: '4',
@@ -50,7 +51,7 @@ describe('getConnectedWallet', () => {
     const wallets = [
       {
         label: 'Wallet 1',
-        icon: '',
+        icon: 'wallet1.svg',
         provider: null as unknown as EIP1193Provider,
         chains: [{ id: '0x4' }],
         accounts: [

--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -19,6 +19,7 @@ export type ConnectedWallet = {
   address: string
   ens?: string
   provider: EIP1193Provider
+  icon?: string
 }
 
 const lastWalletStorage = localItem<string>('lastWallet')
@@ -54,6 +55,7 @@ export const getConnectedWallet = (wallets: WalletState[]): ConnectedWallet | nu
       ens: account.ens?.name,
       chainId: Number(primaryWallet.chains[0].id).toString(10),
       provider: primaryWallet.provider,
+      icon: primaryWallet.icon,
     }
   } catch (e) {
     logError(Errors._106, (e as Error).message)

--- a/src/utils/wallets.ts
+++ b/src/utils/wallets.ts
@@ -27,6 +27,10 @@ export const WalletNames = {
 export const isWalletUnlocked = async (walletName: string): Promise<boolean> => {
   if (typeof window === 'undefined') return false
 
+  if (window.ethereum?.isConnected?.()) {
+    return true
+  }
+
   // Only MetaMask exposes a method to check if the wallet is unlocked
   if (walletName === WalletNames.METAMASK) {
     return window.ethereum?._metamask?.isUnlocked?.() || false


### PR DESCRIPTION
## What it solves
Injected wallets can have a custom icon, which we were ignoring. I've added it as a prop, so it's now displayed.

Before:
<img width="290" alt="Screenshot 2023-05-05 at 14 09 34" src="https://user-images.githubusercontent.com/381895/236453944-ee5435bf-a3b6-47b1-a170-62bc0156f927.png">

After:
<img width="261" alt="Screenshot 2023-05-05 at 14 06 01" src="https://user-images.githubusercontent.com/381895/236453802-54677433-7701-4dd9-9aae-f8cd19b54cef.png">

## How to test

* Connect with a custom wallet like Rabby or Zerion
* Check the wallet info in the header
* Check the Pending Actions in the Safe List
* Check the icon in the Relaying vs Wallet select
