### PR TITLE
Fix: don't clear pending queue when polling

### DIFF
--- a/src/hooks/usePendingTxs.ts
+++ b/src/hooks/usePendingTxs.ts
@@ -31,10 +31,14 @@ export const usePendingTxsQueue = (): {
   const { chainId } = safe
   const pendingIds = usePendingTxIds()
 
-  const [untrustedQueue, error, loading] = useAsync<TransactionListPage>(() => {
-    if (!pendingIds.length) return
-    return getTransactionQueue(chainId, safeAddress, undefined, false)
-  }, [chainId, safeAddress, pendingIds])
+  const [untrustedQueue, error, loading] = useAsync<TransactionListPage>(
+    () => {
+      if (!pendingIds.length) return
+      return getTransactionQueue(chainId, safeAddress, undefined, false)
+    },
+    [chainId, safeAddress, pendingIds],
+    false,
+  )
 
   const pendingTxPage = useMemo(() => {
     if (!untrustedQueue || !pendingIds.length) return


### PR DESCRIPTION
## What it solves

Resolves #1956

## How this PR fixes it
Adds a useAsync flag to not clear the previous poll result.

## How to test it
* Make a 1/1 execution
* Go to the queue and wait for 15 seconds
* The pending tx should not blink
* Switch to another Safe
* The queue should be immediately replaced with the new Safe's queue