### PR TITLE
fix: fallback to `eth_sign`

### DIFF
--- a/src/services/safe-messages/safeMsgSender.ts
+++ b/src/services/safe-messages/safeMsgSender.ts
@@ -1,11 +1,10 @@
 import { proposeSafeMessage, confirmSafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
 import type { SafeInfo, SafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
 import { isObjectEIP712TypedData } from '@safe-global/safe-apps-sdk'
-import type { TypedDataDomain } from 'ethers'
 import type { OnboardAPI } from '@web3-onboard/core'
 
 import { safeMsgDispatch, SafeMsgEvent } from './safeMsgEvents'
-import { generateSafeMessageHash, generateSafeMessageTypedData } from '@/utils/safe-messages'
+import { generateSafeMessageHash, tryOffChainMsgSigning } from '@/utils/safe-messages'
 import { normalizeTypedData } from '@/utils/web3'
 import { getAssertedChainSigner } from '@/services/tx/tx-sender/sdk'
 
@@ -21,12 +20,10 @@ export const dispatchSafeMsgProposal = async ({
   safeAppId?: number
 }): Promise<void> => {
   const messageHash = generateSafeMessageHash(safe, message)
-  let signature = undefined
-  try {
-    const typedData = generateSafeMessageTypedData(safe, message)
 
+  try {
     const signer = await getAssertedChainSigner(onboard, safe.chainId)
-    signature = await signer._signTypedData(typedData.domain as TypedDataDomain, typedData.types, typedData.message)
+    const signature = await tryOffChainMsgSigning(signer, safe, message)
 
     let normalizedMessage = message
     if (isObjectEIP712TypedData(message)) {
@@ -64,14 +61,8 @@ export const dispatchSafeMsgConfirmation = async ({
   const messageHash = generateSafeMessageHash(safe, message)
 
   try {
-    const typedData = generateSafeMessageTypedData(safe, message)
-
     const signer = await getAssertedChainSigner(onboard, safe.chainId)
-    const signature = await signer._signTypedData(
-      typedData.domain as TypedDataDomain,
-      typedData.types,
-      typedData.message,
-    )
+    const signature = await tryOffChainMsgSigning(signer, safe, message)
 
     await confirmSafeMessage(safe.chainId, messageHash, {
       signature,

--- a/src/services/tx/tx-sender/__tests__/sdk.test.ts
+++ b/src/services/tx/tx-sender/__tests__/sdk.test.ts
@@ -1,20 +1,20 @@
-import { _getSupportedSigningMethods } from '@/services/tx/tx-sender/sdk'
+import { getSupportedSigningMethods } from '@/services/tx/tx-sender/sdk'
 
 describe('getSupportedSigningMethods', () => {
   it('should return `eth_signTypedData` for older Safes', () => {
-    const result = _getSupportedSigningMethods('1.0.0')
+    const result = getSupportedSigningMethods('1.0.0')
 
     expect(result).toEqual(['eth_signTypedData'])
   })
 
   it("should return `eth_signTypedData` for unsupported contracts (backend returns `SafeInfo['version']` as `null`)", () => {
-    const result = _getSupportedSigningMethods(null)
+    const result = getSupportedSigningMethods(null)
 
     expect(result).toEqual(['eth_signTypedData'])
   })
 
   it('should generally return `eth_signTypedData` and `eth_sign` for newer Safes', () => {
-    const result = _getSupportedSigningMethods('1.3.0')
+    const result = getSupportedSigningMethods('1.3.0')
 
     expect(result).toEqual(['eth_signTypedData', 'eth_sign'])
   })

--- a/src/services/tx/tx-sender/dispatch.ts
+++ b/src/services/tx/tx-sender/dispatch.ts
@@ -17,7 +17,7 @@ import {
   getSafeSDKWithSigner,
   getUncheckedSafeSDK,
   assertWalletChain,
-  tryOffChainSigning,
+  tryOffChainTxSigning,
 } from './sdk'
 import { createWeb3 } from '@/hooks/wallets/web3'
 import { type OnboardAPI } from '@web3-onboard/core'
@@ -78,7 +78,7 @@ export const dispatchTxSigning = async (
 
   let signedTx: SafeTransaction | undefined
   try {
-    signedTx = await tryOffChainSigning(safeTx, safeVersion, sdk)
+    signedTx = await tryOffChainTxSigning(safeTx, safeVersion, sdk)
   } catch (error) {
     txDispatch(TxEvent.SIGN_FAILED, { txId, error: error as Error })
     throw error

--- a/src/services/tx/tx-sender/sdk.ts
+++ b/src/services/tx/tx-sender/sdk.ts
@@ -123,7 +123,7 @@ export const getSafeSDKWithSigner = async (onboard: OnboardAPI, chainId: SafeInf
 
 type SigningMethods = Parameters<Safe['signTransaction']>[1]
 
-export const _getSupportedSigningMethods = (safeVersion: SafeInfo['version']): SigningMethods[] => {
+export const getSupportedSigningMethods = (safeVersion: SafeInfo['version']): SigningMethods[] => {
   const ETH_SIGN_TYPED_DATA: SigningMethods = 'eth_signTypedData'
   const ETH_SIGN: SigningMethods = 'eth_sign'
 
@@ -134,12 +134,12 @@ export const _getSupportedSigningMethods = (safeVersion: SafeInfo['version']): S
   return [ETH_SIGN_TYPED_DATA, ETH_SIGN]
 }
 
-export const tryOffChainSigning = async (
+export const tryOffChainTxSigning = async (
   safeTx: SafeTransaction,
   safeVersion: SafeInfo['version'],
   sdk: Safe,
 ): Promise<SafeTransaction> => {
-  const signingMethods = _getSupportedSigningMethods(safeVersion)
+  const signingMethods = getSupportedSigningMethods(safeVersion)
 
   for await (const [i, signingMethod] of signingMethods.entries()) {
     try {

--- a/src/utils/safe-messages.ts
+++ b/src/utils/safe-messages.ts
@@ -1,9 +1,13 @@
 import { hashMessage } from 'ethers/lib/utils'
 import { gte } from 'semver'
+import { adjustVInSignature } from '@safe-global/safe-core-sdk/dist/src/utils/signatures'
 import type { SafeInfo, SafeMessage, EIP712TypedData } from '@safe-global/safe-gateway-typescript-sdk'
+import type { providers, TypedDataDomain } from 'ethers'
 
 import { hashTypedData } from '@/utils/web3'
 import { isValidAddress } from './validation'
+import { isWalletRejection } from '@/utils/wallets'
+import { getSupportedSigningMethods } from '@/services/tx/tx-sender/sdk'
 
 /*
  * From v1.3.0, EIP-1271 support was moved to the CompatibilityFallbackHandler.
@@ -66,4 +70,39 @@ export const supportsEIP1271 = ({ version, fallbackHandler }: SafeInfo): boolean
   }
 
   return gte(version, EIP1271_SUPPORTED_SAFE_VERSION)
+}
+
+export const tryOffChainMsgSigning = async (
+  signer: providers.JsonRpcSigner,
+  safe: SafeInfo,
+  message: SafeMessage['message'],
+): Promise<string> => {
+  const signingMethods = getSupportedSigningMethods(safe.version)
+
+  for await (const [i, signingMethod] of signingMethods.entries()) {
+    try {
+      if (signingMethod === 'eth_signTypedData') {
+        const typedData = generateSafeMessageTypedData(safe, message)
+        return await signer._signTypedData(typedData.domain as TypedDataDomain, typedData.types, typedData.message)
+      }
+
+      if (signingMethod === 'eth_sign') {
+        const signerAddress = await signer.getAddress()
+
+        const messageHash = generateSafeMessageHash(safe, message)
+        const signature = await signer.signMessage(messageHash)
+
+        return adjustVInSignature(signingMethod, signature, messageHash, signerAddress)
+      }
+    } catch (error) {
+      const isLastSigningMethod = i === signingMethods.length - 1
+
+      if (isWalletRejection(error as Error) || isLastSigningMethod) {
+        throw error
+      }
+    }
+  }
+
+  // Won't be reached, but TS otherwise complains
+  throw new Error('No supported signing methods')
 }

--- a/src/utils/safe-messages.ts
+++ b/src/utils/safe-messages.ts
@@ -1,6 +1,7 @@
 import { hashMessage } from 'ethers/lib/utils'
 import { gte } from 'semver'
 import { adjustVInSignature } from '@safe-global/safe-core-sdk/dist/src/utils/signatures'
+import { ethers } from 'ethers'
 import type { SafeInfo, SafeMessage, EIP712TypedData } from '@safe-global/safe-gateway-typescript-sdk'
 import type { providers, TypedDataDomain } from 'ethers'
 
@@ -90,7 +91,7 @@ export const tryOffChainMsgSigning = async (
         const signerAddress = await signer.getAddress()
 
         const messageHash = generateSafeMessageHash(safe, message)
-        const signature = await signer.signMessage(messageHash)
+        const signature = await signer.signMessage(ethers.utils.arrayify(messageHash))
 
         return adjustVInSignature(signingMethod, signature, messageHash, signerAddress)
       }


### PR DESCRIPTION
## What it solves

Resolves https://github.com/5afe/safe-support/issues/191

## How this PR fixes it

If `eth_signTypedData` is not supported by the current wallet (e.g. Ledger), `eth_sign` is used instead to sign off-chain messages (if supported by the Safe version).

## How to test it

Try to sign an EIP-712 message off-chain with a Ledger and observe a successful message creation.

## Screenshots

![off-chain-ledger](https://user-images.githubusercontent.com/20442784/236871841-2df3bbd4-d355-499f-b84b-519c5cd6da92.gif)

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
