### PR TITLE
Feat: tx details - full multisend view

### DIFF
--- a/src/components/transactions/TxDetails/TxData/DecodedData/MethodDetails/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/MethodDetails/index.tsx
@@ -1,21 +1,20 @@
 import type { ReactElement } from 'react'
 import { generateDataRowValue, TxDataRow } from '@/components/transactions/TxDetails/Summary/TxDataRow'
-import { camelCaseToSpaces } from '@/utils/formatters'
 import { isAddress, isArrayParameter, isByte } from '@/utils/transaction-guards'
 import type { DataDecoded } from '@safe-global/safe-gateway-typescript-sdk'
 import { Box, Typography } from '@mui/material'
 import { Value } from '@/components/transactions/TxDetails/TxData/DecodedData/ValueArray'
+import { camelCaseToWords } from '@/utils/formatters'
 
 type MethodDetailsProps = {
   data: DataDecoded
 }
 
 export const MethodDetails = ({ data }: MethodDetailsProps): ReactElement => {
-  const methodName = camelCaseToSpaces(data.method)
   return (
     <Box>
-      <Typography variant="overline" sx={({ palette }) => ({ color: `${palette.border.main}` })}>
-        <b>{methodName}</b>
+      <Typography variant="overline" color="text.secondary">
+        <b>{camelCaseToWords(data.method)}</b>
       </Typography>
 
       {data.parameters?.map((param, index) => {
@@ -25,7 +24,7 @@ export const MethodDetails = ({ data }: MethodDetailsProps): ReactElement => {
         return (
           <TxDataRow key={`${data.method}_param-${index}`} title={`${param.name}(${param.type}):`}>
             {isArrayValueParam ? (
-              <Value method={methodName} type={param.type} value={param.value as string} />
+              <Value method={data.method} type={param.type} value={param.value as string} />
             ) : (
               generateDataRowValue(param.value as string, inlineType, true)
             )}

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -10,9 +10,8 @@ import css from './styles.module.css'
 
 type MultisendProps = {
   txData?: TransactionData
-  variant?: AccordionProps['variant']
   showDelegateCallWarning?: boolean
-  noHeader?: boolean
+  compact?: boolean
 }
 
 const MIN_SCROLL_TXS = 4
@@ -50,9 +49,8 @@ const MultisendActionsHeader = ({
 
 export const Multisend = ({
   txData,
-  variant = 'elevation',
   showDelegateCallWarning = true,
-  noHeader = false,
+  compact = false,
 }: MultisendProps): ReactElement | null => {
   const [openMap, setOpenMap] = useState<Record<number, boolean>>()
   const isOpenMapUndefined = openMap == null
@@ -87,39 +85,37 @@ export const Multisend = ({
 
   return (
     <>
-      {!noHeader && <MultisendActionsHeader setOpen={setOpenMap} amount={multiSendTransactions.length} />}
+      <MultisendActionsHeader setOpen={setOpenMap} amount={multiSendTransactions.length} />
 
-      <div className={noHeader && multiSendTransactions.length >= MIN_SCROLL_TXS ? css.scrollWrapper : undefined}>
-        <Box display="flex" flexDirection="column" gap={noHeader ? 1 : undefined}>
-          {multiSendTransactions.map(({ dataDecoded, data, value, to, operation }, index) => {
-            const onChange: AccordionProps['onChange'] = (_, expanded) => {
-              setOpenMap((prev) => ({
-                ...prev,
-                [index]: expanded,
-              }))
-            }
+      <Box display="flex" flexDirection="column" gap={compact ? 1 : undefined}>
+        {multiSendTransactions.map(({ dataDecoded, data, value, to, operation }, index) => {
+          const onChange: AccordionProps['onChange'] = (_, expanded) => {
+            setOpenMap((prev) => ({
+              ...prev,
+              [index]: expanded,
+            }))
+          }
 
-            return (
-              <SingleTxDecoded
-                key={`${data ?? to}-${index}`}
-                tx={{
-                  dataDecoded,
-                  data,
-                  value,
-                  to,
-                  operation,
-                }}
-                txData={txData}
-                showDelegateCallWarning={showDelegateCallWarning}
-                actionTitle={`Action ${index + 1}`}
-                variant={variant}
-                expanded={openMap?.[index] ?? false}
-                onChange={onChange}
-              />
-            )
-          })}
-        </Box>
-      </div>
+          return (
+            <SingleTxDecoded
+              key={`${data ?? to}-${index}`}
+              tx={{
+                dataDecoded,
+                data,
+                value,
+                to,
+                operation,
+              }}
+              txData={txData}
+              showDelegateCallWarning={showDelegateCallWarning}
+              actionTitle={`Action ${index + 1}`}
+              variant="elevation"
+              expanded={openMap?.[index] ?? false}
+              onChange={onChange}
+            />
+          )
+        })}
+      </Box>
     </>
   )
 }

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
@@ -1,21 +1,3 @@
-.scrollWrapper {
-  max-height: 168px;
-  overflow: auto;
-  padding-bottom: 2em;
-}
-
-.scrollWrapper:after {
-  content: '';
-  position: absolute;
-  z-index: 1;
-  bottom: 0;
-  left: 0;
-  pointer-events: none;
-  background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 90%);
-  width: 100%;
-  height: 4em;
-}
-
 .summary {
   border-bottom: 1px solid var(--color-border-light);
   cursor: auto !important;

--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -58,13 +58,22 @@ const DecodedTx = ({ tx, txId }: DecodedTxProps): ReactElement | null => {
         </ErrorBoundary>
       )}
 
-      <Accordion
-        elevation={0}
-        onChange={onChangeExpand}
-        sx={!tx ? { pointerEvents: 'none' } : undefined}
-        defaultExpanded={isMultisend}
-        key={isMultisend.toString()}
-      >
+      {isMultisend && (
+        <Box my={2}>
+          <Multisend
+            txData={{
+              dataDecoded: decodedData,
+              to: { value: tx?.data.to || '' },
+              value: tx?.data.value,
+              operation: tx?.data.operation === OperationType.DelegateCall ? Operation.DELEGATE : Operation.CALL,
+              trustedDelegateCallTarget: false,
+            }}
+            compact
+          />
+        </Box>
+      )}
+
+      <Accordion elevation={0} onChange={onChangeExpand} sx={!tx ? { pointerEvents: 'none' } : undefined}>
         <AccordionSummary>Transaction details</AccordionSummary>
 
         <AccordionDetails>
@@ -84,22 +93,6 @@ const DecodedTx = ({ tx, txId }: DecodedTxProps): ReactElement | null => {
             <ErrorMessage error={decodedDataError}>Failed decoding transaction data</ErrorMessage>
           ) : (
             decodedDataLoading && <Skeleton />
-          )}
-
-          {isMultisend && (
-            <Box mt={2}>
-              <Multisend
-                txData={{
-                  dataDecoded: decodedData,
-                  to: { value: tx?.data.to || '' },
-                  value: tx?.data.value,
-                  operation: tx?.data.operation === OperationType.DelegateCall ? Operation.DELEGATE : Operation.CALL,
-                  trustedDelegateCallTarget: false,
-                }}
-                variant="outlined"
-                noHeader
-              />
-            </Box>
           )}
         </AccordionDetails>
       </Accordion>

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -75,11 +75,8 @@ export const dateString = (date: number) => {
   return new Intl.DateTimeFormat(undefined, formatterOptions).format(new Date(date))
 }
 
-export const camelCaseToSpaces = (str: string): string => {
-  return str
-    .replace(/([A-Z][a-z0-9]+)/g, ' $1 ')
-    .replace(/\s{2}/g, ' ')
-    .trim()
+export const camelCaseToWords = (camelCase: string): string => {
+  return camelCase.replace(/[a-z](?=[A-Z])/g, (str) => str + ' ')
 }
 
 export const ellipsis = (str: string, length: number): string => {


### PR DESCRIPTION
## What it solves

We got user feedback that the multisend inside the Transaction details was hard to view, as opposed to the tx details in the history/queue.

## How this PR fixes it
I've made it look like the details in the history.
* moved it out of the accordion
* removed inner scroll
* showed the expand/collapse all buttons

This basically reverts the design to how it was in v1.8.1 (see #1899).

## Screenshots
<img width="632" alt="Screenshot 2023-05-09 at 09 20 54" src="https://user-images.githubusercontent.com/381895/237023543-c4cc90f6-b098-4fb3-acb0-167a6e3c7fbb.png">