### PR TITLE
Release 1.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "homepage": "https://github.com/safe-global/web-core",
   "license": "GPL-3.0",
   "type": "module",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "scripts": {
     "dev": "next dev",
     "start": "next dev",

--- a/src/components/address-book/ExportDialog/index.tsx
+++ b/src/components/address-book/ExportDialog/index.tsx
@@ -11,6 +11,7 @@ import { type AddressBookState, selectAllAddressBooks } from '@/store/addressBoo
 import { useAppSelector } from '@/store'
 import { trackEvent, ADDRESS_BOOK_EVENTS } from '@/services/analytics'
 import ExternalLink from '@/components/common/ExternalLink'
+import { HelpCenterArticle } from '@/config/constants'
 
 const COL_1 = 'address'
 const COL_2 = 'name'
@@ -66,7 +67,7 @@ const ExportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
 
         <Typography mt={1}>
           <ExternalLink
-            href="https://help.safe.global/en/articles/5299068-address-book-export-and-import"
+            href={HelpCenterArticle.ADDRESS_BOOK_DATA}
             title="Learn about the address book import and export"
           >
             Learn about the address book import and export

--- a/src/components/address-book/ImportDialog/index.tsx
+++ b/src/components/address-book/ImportDialog/index.tsx
@@ -17,6 +17,7 @@ import ErrorMessage from '@/components/tx/ErrorMessage'
 import { Errors, logError } from '@/services/exceptions'
 import FileUpload, { FileTypes, type FileInfo } from '@/components/common/FileUpload'
 import ExternalLink from '@/components/common/ExternalLink'
+import { HelpCenterArticle } from '@/config/constants'
 
 type AddressBookCSVRow = ['address', 'name', 'chainId']
 
@@ -154,7 +155,7 @@ const ImportDialog = ({ handleClose }: { handleClose: () => void }): ReactElemen
           Only CSV files exported from a {'Safe'} can be imported.
           <br />
           <ExternalLink
-            href="https://help.safe.global/en/articles/5299068-address-book-export-and-import"
+            href={HelpCenterArticle.ADDRESS_BOOK_DATA}
             title="Learn about the address book import and export"
           >
             Learn about the address book import and export

--- a/src/components/balances/TokenListSelect/index.tsx
+++ b/src/components/balances/TokenListSelect/index.tsx
@@ -9,6 +9,7 @@ import ExternalLink from '@/components/common/ExternalLink'
 import { OnboardingTooltip } from '@/components/common/OnboardingTooltip'
 import Track from '@/components/common/Track'
 import { ASSETS_EVENTS, trackEvent } from '@/services/analytics'
+import { HelpCenterArticle } from '@/config/constants'
 
 const LS_TOKENLIST_ONBOARDING = 'tokenlist_onboarding'
 
@@ -64,10 +65,7 @@ const TokenListSelect = () => {
                   arrow
                   title={
                     <Typography>
-                      Learn more about{' '}
-                      <ExternalLink href="https://help.safe.global/en/articles/6951406-default-token-list-local-hiding-of-spam-tokens">
-                        default tokens
-                      </ExternalLink>
+                      Learn more about <ExternalLink href={HelpCenterArticle.SPAM_TOKENS}>default tokens</ExternalLink>
                     </Typography>
                   }
                 >

--- a/src/components/common/ErrorBoundary/index.tsx
+++ b/src/components/common/ErrorBoundary/index.tsx
@@ -1,7 +1,7 @@
 import { Typography, Link } from '@mui/material'
 import type { FallbackRender } from '@sentry/react'
 
-import { IS_PRODUCTION } from '@/config/constants'
+import { HELP_CENTER_URL, IS_PRODUCTION } from '@/config/constants'
 import { AppRoutes } from '@/config/routes'
 import WarningIcon from '@/public/images/notifications/warning.svg'
 
@@ -24,7 +24,7 @@ const ErrorBoundary: FallbackRender = ({ error, componentStack }) => {
         {IS_PRODUCTION ? (
           <Typography color="text.primary">
             In case the problem persists, please reach out to us via our{' '}
-            <ExternalLink href="https://help.safe.global">Help Center</ExternalLink>
+            <ExternalLink href={HELP_CENTER_URL}>Help Center</ExternalLink>
           </Typography>
         ) : (
           <>

--- a/src/components/common/PairingDetails/PairingDescription.tsx
+++ b/src/components/common/PairingDetails/PairingDescription.tsx
@@ -3,8 +3,7 @@ import type { ReactElement } from 'react'
 
 import AppStoreButton from '@/components/common/AppStoreButton'
 import ExternalLink from '../ExternalLink'
-
-const HELP_ARTICLE = 'https://help.safe.global/en/articles/5584901-desktop-pairing'
+import { HelpCenterArticle } from '@/config/constants'
 
 const PairingDescription = (): ReactElement => {
   return (
@@ -12,7 +11,7 @@ const PairingDescription = (): ReactElement => {
       <Typography variant="caption" align="center">
         Scan this code in the {'Safe'} mobile app to sign transactions with your mobile device.
         <br />
-        <ExternalLink href={HELP_ARTICLE} title="Learn more about mobile pairing.">
+        <ExternalLink href={HelpCenterArticle.MOBILE_SAFE} title="Learn more about mobile pairing.">
           Learn more about this feature.
         </ExternalLink>
       </Typography>

--- a/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
+++ b/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
@@ -8,7 +8,7 @@ import AccordionDetails from '@mui/material/AccordionDetails'
 import css from './styles.module.css'
 import { useBrowserPermissions } from '@/hooks/safe-apps/permissions'
 import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
-import { SafeAppsTag, SAFE_APPS_SUPPORT_CHAT_URL } from '@/config/constants'
+import { DISCORD_URL, SafeAppsTag } from '@/config/constants'
 import { useDarkMode } from '@/hooks/useDarkMode'
 import { OpenInNew } from '@mui/icons-material'
 import NetworkError from '@/public/images/common/network-error.svg'
@@ -36,7 +36,7 @@ const WidgetLoadErrorFallback = () => (
         <SvgIcon component={NetworkError} inheritViewBox className={css.loadErroricon} />
         <Typography variant="body1" color="text.primary">
           You can try to reload the page and in case the problem persists, please reach out to us via{' '}
-          <Link target="_blank" href={SAFE_APPS_SUPPORT_CHAT_URL} fontSize="medium">
+          <Link target="_blank" href={DISCORD_URL} fontSize="medium">
             Discord
             <OpenInNew fontSize="small" color="primary" className={css.loadErroricon} />
           </Link>

--- a/src/components/dashboard/Relaying/index.tsx
+++ b/src/components/dashboard/Relaying/index.tsx
@@ -8,10 +8,9 @@ import GasStationIcon from '@/public/images/common/gas-station.svg'
 import ExternalLink from '@/components/common/ExternalLink'
 import classnames from 'classnames'
 import css from './styles.module.css'
+import { HelpCenterArticle } from '@/config/constants'
 import { useCurrentChain } from '@/hooks/useChains'
 import { SPONSOR_LOGOS } from '@/components/tx/SponsoredBy'
-
-const RELAYING_HELP_ARTICLE = 'https://help.safe.global/en/articles/7224713-what-is-gas-fee-sponsoring'
 
 const Relaying = () => {
   const chain = useCurrentChain()
@@ -44,7 +43,7 @@ const Relaying = () => {
               Benefit from a gasless experience powered by Gelato and Safe. Experience gasless UX for the next month!
             </Typography>
             <Track {...OVERVIEW_EVENTS.RELAYING_HELP_ARTICLE}>
-              <ExternalLink href={RELAYING_HELP_ARTICLE}>Read more</ExternalLink>
+              <ExternalLink href={HelpCenterArticle.RELAYING}>Read more</ExternalLink>
             </Track>
           </Box>
           <Divider />

--- a/src/components/new-safe/create/index.tsx
+++ b/src/components/new-safe/create/index.tsx
@@ -19,6 +19,7 @@ import type { CreateSafeInfoItem } from '@/components/new-safe/create/CreateSafe
 import CreateSafeInfos from '@/components/new-safe/create/CreateSafeInfos'
 import { type ReactElement, useMemo, useState } from 'react'
 import ExternalLink from '@/components/common/ExternalLink'
+import { HelpCenterArticle } from '@/config/constants'
 
 export type NewSafeFormData = {
   name: string
@@ -65,10 +66,7 @@ const staticHints: Record<
           <>
             Not sure how many owners and confirmations you need for your Safe?
             <br />
-            <ExternalLink
-              href="https://help.safe.global/en/articles/4772567-what-safe-setup-should-i-use"
-              fontWeight="bold"
-            >
+            <ExternalLink href={HelpCenterArticle.SAFE_SETUP} fontWeight="bold">
               Learn more about setting up your Safe.
             </ExternalLink>
           </>

--- a/src/components/safe-apps/AppFrame/ThirdPartyCookiesWarning.tsx
+++ b/src/components/safe-apps/AppFrame/ThirdPartyCookiesWarning.tsx
@@ -1,13 +1,11 @@
 import React from 'react'
 import { Alert, AlertTitle } from '@mui/material'
 import ExternalLink from '@/components/common/ExternalLink'
+import { HelpCenterArticle } from '@/config/constants'
 
 type ThirdPartyCookiesWarningProps = {
   onClose: () => void
 }
-
-const HELP_LINK =
-  'https://help.safe.global/en/articles/5955031-why-do-i-need-to-enable-third-party-cookies-for-safe-apps'
 
 export const ThirdPartyCookiesWarning = ({ onClose }: ThirdPartyCookiesWarningProps): React.ReactElement => {
   return (
@@ -24,7 +22,7 @@ export const ThirdPartyCookiesWarning = ({ onClose }: ThirdPartyCookiesWarningPr
       <AlertTitle>
         Third party cookies are disabled. Safe Apps may therefore not work properly. You can find out more information
         about this{' '}
-        <ExternalLink href={HELP_LINK} fontSize="inherit">
+        <ExternalLink href={HelpCenterArticle.COOKIES} fontSize="inherit">
           here
         </ExternalLink>
       </AlertTitle>

--- a/src/components/safe-apps/SafeAppsErrorBoundary/SafeAppsLoadError.tsx
+++ b/src/components/safe-apps/SafeAppsErrorBoundary/SafeAppsLoadError.tsx
@@ -1,7 +1,7 @@
 import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
 import SvgIcon from '@mui/material/SvgIcon'
-import { SAFE_APPS_SUPPORT_CHAT_URL } from '@/config/constants'
+import { DISCORD_URL } from '@/config/constants'
 import NetworkError from '@/public/images/apps/network-error.svg'
 
 import css from './styles.module.css'
@@ -21,7 +21,7 @@ const SafeAppsLoadError = ({ onBackToApps }: SafeAppsLoadErrorProps): React.Reac
 
         <div>
           <Typography component="span">In case the problem persists, please reach out to us via </Typography>
-          <ExternalLink href={SAFE_APPS_SUPPORT_CHAT_URL} fontSize="medium">
+          <ExternalLink href={DISCORD_URL} fontSize="medium">
             Discord
           </ExternalLink>
         </div>

--- a/src/components/safe-apps/SafeAppsTxModal/ReviewSafeAppsTx.tsx
+++ b/src/components/safe-apps/SafeAppsTxModal/ReviewSafeAppsTx.tsx
@@ -15,6 +15,8 @@ import { ApprovalEditor } from '../../tx/ApprovalEditor'
 import { createMultiSendCallOnlyTx, createTx, dispatchSafeAppsTx } from '@/services/tx/tx-sender'
 import useOnboard from '@/hooks/wallets/useOnboard'
 import useSafeInfo from '@/hooks/useSafeInfo'
+import { Box, Typography } from '@mui/material'
+import { generateDataRowValue } from '@/components/transactions/TxDetails/Summary/TxDataRow'
 
 type ReviewSafeAppsTxProps = {
   safeAppsTx: SafeAppsTxParams
@@ -66,7 +68,18 @@ const ReviewSafeAppsTx = ({
 
         <SendFromBlock />
 
-        {safeTx && <SendToBlock address={safeTx.data.to} title={getInteractionTitle(safeTx.data.value || '', chain)} />}
+        {safeTx && (
+          <>
+            <SendToBlock address={safeTx.data.to} title={getInteractionTitle(safeTx.data.value || '', chain)} />
+
+            <Box pb={2}>
+              <Typography mt={2} color="primary.light">
+                Data (hex encoded)
+              </Typography>
+              {generateDataRowValue(safeTx.data.data, 'rawData')}
+            </Box>
+          </>
+        )}
       </>
     </SignOrExecuteForm>
   )

--- a/src/components/safe-messages/PaginatedMsgs/index.tsx
+++ b/src/components/safe-messages/PaginatedMsgs/index.tsx
@@ -11,7 +11,7 @@ import InfiniteScroll from '@/components/common/InfiniteScroll'
 import PagePlaceholder from '@/components/common/PagePlaceholder'
 import MsgList from '@/components/safe-messages/MsgList'
 import SkeletonTxList from '@/components/common/PaginatedTxns/SkeletonTxList'
-import { SIGNED_MESSAFES_HELP_LINK } from '@/components/transactions/SignedMessagesHelpLink'
+import { HelpCenterArticle } from '@/config/constants'
 
 const NoMessages = (): ReactElement => {
   return (
@@ -24,7 +24,7 @@ const NoMessages = (): ReactElement => {
         </Typography>
       }
     >
-      <Link rel="noopener noreferrer" target="_blank" href={SIGNED_MESSAFES_HELP_LINK} fontWeight={700}>
+      <Link rel="noopener noreferrer" target="_blank" href={HelpCenterArticle.SIGNED_MESSAGES} fontWeight={700}>
         Learn more about off-chain messages{' '}
         <SvgIcon component={LinkIcon} inheritViewBox fontSize="small" sx={{ verticalAlign: 'middle', ml: 0.5 }} />
       </Link>

--- a/src/components/settings/FallbackHandler/index.tsx
+++ b/src/components/settings/FallbackHandler/index.tsx
@@ -8,15 +8,13 @@ import EthHashInfo from '@/components/common/EthHashInfo'
 import AlertIcon from '@/public/images/common/alert.svg'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { getFallbackHandlerDeployment } from '@safe-global/safe-deployments'
-import { LATEST_SAFE_VERSION } from '@/config/constants'
+import { HelpCenterArticle, LATEST_SAFE_VERSION } from '@/config/constants'
 import ExternalLink from '@/components/common/ExternalLink'
 import { useTxBuilderApp } from '@/hooks/safe-apps/useTxBuilderApp'
 
 import css from '../SafeModules/styles.module.css'
 
 const FALLBACK_HANDLER_VERSION = '>=1.1.1'
-const FALLBACK_HANDLER_ARTICLE =
-  'https://help.gnosis-safe.io/en/articles/4738352-what-is-a-fallback-handler-and-how-does-it-relate-to-the-gnosis-safe'
 
 export const FallbackHandler = (): ReactElement | null => {
   const { safe } = useSafeInfo()
@@ -94,7 +92,8 @@ export const FallbackHandler = (): ReactElement | null => {
           <Box>
             <Typography>
               The fallback handler adds fallback logic for funtionality that may not be present in the Safe contract.
-              Learn more about the fallback handler <ExternalLink href={FALLBACK_HANDLER_ARTICLE}>here</ExternalLink>
+              Learn more about the fallback handler{' '}
+              <ExternalLink href={HelpCenterArticle.FALLBACK_HANDLER}>here</ExternalLink>
             </Typography>
             {safe.fallbackHandler ? (
               <Box className={css.container}>

--- a/src/components/settings/TransactionGuards/index.tsx
+++ b/src/components/settings/TransactionGuards/index.tsx
@@ -7,6 +7,7 @@ import css from './styles.module.css'
 import ExternalLink from '@/components/common/ExternalLink'
 import { SAFE_FEATURES } from '@safe-global/safe-core-sdk-utils'
 import { hasSafeFeature } from '@/utils/safe-versions'
+import { HelpCenterArticle } from '@/config/constants'
 
 const NoTransactionGuard = () => {
   return (
@@ -49,10 +50,7 @@ const TransactionGuards = () => {
               Transaction guards impose additional constraints that are checked prior to executing a Safe transaction.
               Transaction guards are potentially risky, so make sure to only use transaction guards from trusted
               sources. Learn more about transaction guards{' '}
-              <ExternalLink href="https://help.safe.global/en/articles/5324092-what-is-a-transaction-guard">
-                here
-              </ExternalLink>
-              .
+              <ExternalLink href={HelpCenterArticle.TRANSACTION_GUARD}>here</ExternalLink>.
             </Typography>
             {safe.guard ? (
               <GuardDisplay guardAddress={safe.guard.value} chainId={safe.chainId} />

--- a/src/components/sidebar/SidebarFooter/index.tsx
+++ b/src/components/sidebar/SidebarFooter/index.tsx
@@ -15,12 +15,10 @@ import BeamerIcon from '@/public/images/sidebar/whats-new.svg'
 import HelpCenterIcon from '@/public/images/sidebar/help-center.svg'
 import { ListItem } from '@mui/material'
 import DebugToggle from '../DebugToggle'
-import { IS_PRODUCTION } from '@/config/constants'
+import { HELP_CENTER_URL, IS_PRODUCTION } from '@/config/constants'
 import Track from '@/components/common/Track'
 import { OVERVIEW_EVENTS } from '@/services/analytics/events/overview'
 import { useCurrentChain } from '@/hooks/useChains'
-
-const WHATS_NEW_PATH = 'https://help.safe.global/en/'
 
 const SidebarFooter = (): ReactElement => {
   const dispatch = useAppDispatch()
@@ -63,7 +61,7 @@ const SidebarFooter = (): ReactElement => {
 
       <Track {...OVERVIEW_EVENTS.HELP_CENTER}>
         <ListItem disablePadding>
-          <a target="_blank" rel="noopener noreferrer" href={WHATS_NEW_PATH} style={{ width: '100%' }}>
+          <a target="_blank" rel="noopener noreferrer" href={HELP_CENTER_URL} style={{ width: '100%' }}>
             <SidebarListItemButton>
               <SidebarListItemIcon color="primary">
                 <HelpCenterIcon />

--- a/src/components/terms/index.tsx
+++ b/src/components/terms/index.tsx
@@ -2,6 +2,7 @@ import { Typography } from '@mui/material'
 import Link from 'next/link'
 import MUILink from '@mui/material/Link'
 import { AppRoutes } from '@/config/routes'
+import { DISCORD_URL, HELP_CENTER_URL, TWITTER_URL } from '@/config/constants'
 
 const SafeTerms = () => {
   return (
@@ -531,25 +532,25 @@ const SafeTerms = () => {
       <ol start={1}>
         <li>
           Intercom:{' '}
-          <Link href="https://help.safe.global" passHref>
+          <Link href={HELP_CENTER_URL} passHref>
             <MUILink target="_blank" rel="noreferrer">
-              https://help.safe.global
+              {HELP_CENTER_URL}
             </MUILink>
           </Link>
         </li>
         <li>
           Discord:{' '}
-          <Link href="https://chat.safe.global/" passHref>
+          <Link href={DISCORD_URL} passHref>
             <MUILink target="_blank" rel="noreferrer">
-              https://chat.safe.global
+              {DISCORD_URL}
             </MUILink>
           </Link>
         </li>
         <li>
           Twitter:{' '}
-          <Link href="https://twitter.com/safe" passHref>
+          <Link href={TWITTER_URL} passHref>
             <MUILink target="_blank" rel="noreferrer">
-              https://twitter.com/safe
+              {TWITTER_URL}
             </MUILink>
           </Link>
         </li>

--- a/src/components/transactions/GroupedTxListItems/index.tsx
+++ b/src/components/transactions/GroupedTxListItems/index.tsx
@@ -7,6 +7,7 @@ import ExpandableTransactionItem from '@/components/transactions/TxListItem/Expa
 import css from './styles.module.css'
 import { ReplaceTxHoverContext, ReplaceTxHoverProvider } from './ReplaceTxHoverProvider'
 import ExternalLink from '@/components/common/ExternalLink'
+import { HelpCenterArticle } from '@/config/constants'
 
 const Disclaimer = ({ nonce }: { nonce?: number }) => (
   <Box className={css.disclaimerContainer}>
@@ -16,7 +17,7 @@ const Disclaimer = ({ nonce }: { nonce?: number }) => (
     </Typography>
 
     <ExternalLink
-      href="https://help.safe.global/en/articles/4730252-why-are-transactions-with-the-same-nonce-conflicting-with-each-other"
+      href={HelpCenterArticle.CONFLICTING_TRANSACTIONS}
       title="Why are transactions with the same nonce conflicting with each other?"
       className={css.link}
     >

--- a/src/components/transactions/SignedMessagesHelpLink/index.tsx
+++ b/src/components/transactions/SignedMessagesHelpLink/index.tsx
@@ -3,8 +3,7 @@ import InfoIcon from '@/public/images/notifications/info.svg'
 import ExternalLink from '@/components/common/ExternalLink'
 import { useAppSelector } from '@/store'
 import { selectSafeMessages } from '@/store/safeMessagesSlice'
-
-export const SIGNED_MESSAFES_HELP_LINK = 'https://help.safe.global/en/articles/7021891-what-are-signed-messages'
+import { HelpCenterArticle } from '@/config/constants'
 
 const SignedMessagesHelpLink = () => {
   const safeMessages = useAppSelector(selectSafeMessages)
@@ -17,7 +16,7 @@ const SignedMessagesHelpLink = () => {
   return (
     <Box display="flex" alignItems="center" gap={1}>
       <SvgIcon component={InfoIcon} inheritViewBox color="border" fontSize="small" />
-      <ExternalLink noIcon href={SIGNED_MESSAFES_HELP_LINK}>
+      <ExternalLink noIcon href={HelpCenterArticle.SIGNED_MESSAGES}>
         <Typography variant="body2" fontWeight={700}>
           What are signed messages?
         </Typography>

--- a/src/components/transactions/TxDetails/TxData/DecodedData/MethodDetails/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/MethodDetails/index.tsx
@@ -1,21 +1,20 @@
 import type { ReactElement } from 'react'
 import { generateDataRowValue, TxDataRow } from '@/components/transactions/TxDetails/Summary/TxDataRow'
-import { camelCaseToSpaces } from '@/utils/formatters'
 import { isAddress, isArrayParameter, isByte } from '@/utils/transaction-guards'
 import type { DataDecoded } from '@safe-global/safe-gateway-typescript-sdk'
 import { Box, Typography } from '@mui/material'
 import { Value } from '@/components/transactions/TxDetails/TxData/DecodedData/ValueArray'
+import { camelCaseToWords } from '@/utils/formatters'
 
 type MethodDetailsProps = {
   data: DataDecoded
 }
 
 export const MethodDetails = ({ data }: MethodDetailsProps): ReactElement => {
-  const methodName = camelCaseToSpaces(data.method)
   return (
     <Box>
-      <Typography variant="overline" sx={({ palette }) => ({ color: `${palette.border.main}` })}>
-        <b>{methodName}</b>
+      <Typography variant="overline" color="text.secondary">
+        <b>{camelCaseToWords(data.method)}</b>
       </Typography>
 
       {data.parameters?.map((param, index) => {
@@ -25,7 +24,7 @@ export const MethodDetails = ({ data }: MethodDetailsProps): ReactElement => {
         return (
           <TxDataRow key={`${data.method}_param-${index}`} title={`${param.name}(${param.type}):`}>
             {isArrayValueParam ? (
-              <Value method={methodName} type={param.type} value={param.value as string} />
+              <Value method={data.method} type={param.type} value={param.value as string} />
             ) : (
               generateDataRowValue(param.value as string, inlineType, true)
             )}

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -10,9 +10,8 @@ import css from './styles.module.css'
 
 type MultisendProps = {
   txData?: TransactionData
-  variant?: AccordionProps['variant']
   showDelegateCallWarning?: boolean
-  noHeader?: boolean
+  compact?: boolean
 }
 
 const MIN_SCROLL_TXS = 4
@@ -50,9 +49,8 @@ const MultisendActionsHeader = ({
 
 export const Multisend = ({
   txData,
-  variant = 'elevation',
   showDelegateCallWarning = true,
-  noHeader = false,
+  compact = false,
 }: MultisendProps): ReactElement | null => {
   const [openMap, setOpenMap] = useState<Record<number, boolean>>()
   const isOpenMapUndefined = openMap == null
@@ -87,39 +85,37 @@ export const Multisend = ({
 
   return (
     <>
-      {!noHeader && <MultisendActionsHeader setOpen={setOpenMap} amount={multiSendTransactions.length} />}
+      <MultisendActionsHeader setOpen={setOpenMap} amount={multiSendTransactions.length} />
 
-      <div className={noHeader && multiSendTransactions.length >= MIN_SCROLL_TXS ? css.scrollWrapper : undefined}>
-        <Box display="flex" flexDirection="column" gap={noHeader ? 1 : undefined}>
-          {multiSendTransactions.map(({ dataDecoded, data, value, to, operation }, index) => {
-            const onChange: AccordionProps['onChange'] = (_, expanded) => {
-              setOpenMap((prev) => ({
-                ...prev,
-                [index]: expanded,
-              }))
-            }
+      <Box display="flex" flexDirection="column" gap={compact ? 1 : undefined}>
+        {multiSendTransactions.map(({ dataDecoded, data, value, to, operation }, index) => {
+          const onChange: AccordionProps['onChange'] = (_, expanded) => {
+            setOpenMap((prev) => ({
+              ...prev,
+              [index]: expanded,
+            }))
+          }
 
-            return (
-              <SingleTxDecoded
-                key={`${data ?? to}-${index}`}
-                tx={{
-                  dataDecoded,
-                  data,
-                  value,
-                  to,
-                  operation,
-                }}
-                txData={txData}
-                showDelegateCallWarning={showDelegateCallWarning}
-                actionTitle={`Action ${index + 1}`}
-                variant={variant}
-                expanded={openMap?.[index] ?? false}
-                onChange={onChange}
-              />
-            )
-          })}
-        </Box>
-      </div>
+          return (
+            <SingleTxDecoded
+              key={`${data ?? to}-${index}`}
+              tx={{
+                dataDecoded,
+                data,
+                value,
+                to,
+                operation,
+              }}
+              txData={txData}
+              showDelegateCallWarning={showDelegateCallWarning}
+              actionTitle={`Action ${index + 1}`}
+              variant="elevation"
+              expanded={openMap?.[index] ?? false}
+              onChange={onChange}
+            />
+          )
+        })}
+      </Box>
     </>
   )
 }

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
@@ -1,21 +1,3 @@
-.scrollWrapper {
-  max-height: 168px;
-  overflow: auto;
-  padding-bottom: 2em;
-}
-
-.scrollWrapper:after {
-  content: '';
-  position: absolute;
-  z-index: 1;
-  bottom: 0;
-  left: 0;
-  pointer-events: none;
-  background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 90%);
-  width: 100%;
-  height: 4em;
-}
-
 .summary {
   border-bottom: 1px solid var(--color-border-light);
   cursor: auto !important;

--- a/src/components/transactions/TxDetails/TxData/Rejection/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/Rejection/index.tsx
@@ -3,6 +3,7 @@ import { NOT_AVAILABLE } from '@/components/transactions/TxDetails'
 import type { MultisigExecutionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 import { Box, Typography } from '@mui/material'
 import React from 'react'
+import { HelpCenterArticle } from '@/config/constants'
 
 interface Props {
   nonce?: MultisigExecutionDetails['nonce']
@@ -24,10 +25,7 @@ const RejectionTxInfo = ({ nonce, isTxExecuted }: Props) => {
       <Typography mr={2}>{message}</Typography>
       {!isTxExecuted && (
         <Box mt={2} sx={{ width: 'fit-content' }}>
-          <ExternalLink
-            href="https://help.safe.global/en/articles/4738501-why-do-i-need-to-pay-for-cancelling-a-transaction"
-            title={title}
-          >
+          <ExternalLink href={HelpCenterArticle.CANCELLING_TRANSACTIONS} title={title}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
               <Typography sx={{ textDecoration: 'underline' }}>{title}</Typography>
             </Box>

--- a/src/components/transactions/Warning/index.tsx
+++ b/src/components/transactions/Warning/index.tsx
@@ -5,6 +5,7 @@ import type { AlertColor } from '@mui/material'
 import InfoOutlinedIcon from '@/public/images/notifications/info.svg'
 import css from './styles.module.css'
 import ExternalLink from '@/components/common/ExternalLink'
+import { HelpCenterArticle } from '@/config/constants'
 
 const Warning = ({
   title,
@@ -29,9 +30,6 @@ const Warning = ({
   )
 }
 
-const UNEXPECTED_DELEGATE_ARTICLE =
-  'https://help.safe.global/en/articles/6302452-why-do-i-see-an-unexpected-delegate-call-warning-in-my-transaction'
-
 export const DelegateCallWarning = ({ showWarning }: { showWarning: boolean }): ReactElement => {
   const severity = showWarning ? 'warning' : 'success'
   return (
@@ -42,7 +40,7 @@ export const DelegateCallWarning = ({ showWarning }: { showWarning: boolean }): 
           {showWarning && (
             <>
               <br />
-              <ExternalLink href={UNEXPECTED_DELEGATE_ARTICLE}>Learn more</ExternalLink>
+              <ExternalLink href={HelpCenterArticle.UNEXPECTED_DELEGATE_CALL}>Learn more</ExternalLink>
             </>
           )}
         </>

--- a/src/components/tx/AdvancedParams/AdvancedParamsForm.tsx
+++ b/src/components/tx/AdvancedParams/AdvancedParamsForm.tsx
@@ -10,8 +10,7 @@ import { AdvancedField, type AdvancedParameters } from './types.d'
 import GasLimitInput from './GasLimitInput'
 import ExternalLink from '@/components/common/ExternalLink'
 import NumberField from '@/components/common/NumberField'
-
-const HELP_LINK = 'https://help.safe.global/en/articles/4738445-advanced-transaction-parameters'
+import { HelpCenterArticle } from '@/config/constants'
 
 type AdvancedParamsFormProps = {
   params: AdvancedParameters
@@ -183,7 +182,9 @@ const AdvancedParamsForm = ({ params, ...props }: AdvancedParamsFormProps) => {
 
             {/* Help link */}
             <Typography mt={2}>
-              <ExternalLink href={HELP_LINK}>How can I configure these parameters manually?</ExternalLink>
+              <ExternalLink href={HelpCenterArticle.ADVANCED_PARAMS}>
+                How can I configure these parameters manually?
+              </ExternalLink>
             </Typography>
           </DialogContent>
 

--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -58,13 +58,22 @@ const DecodedTx = ({ tx, txId }: DecodedTxProps): ReactElement | null => {
         </ErrorBoundary>
       )}
 
-      <Accordion
-        elevation={0}
-        onChange={onChangeExpand}
-        sx={!tx ? { pointerEvents: 'none' } : undefined}
-        defaultExpanded={isMultisend}
-        key={isMultisend.toString()}
-      >
+      {isMultisend && (
+        <Box my={2}>
+          <Multisend
+            txData={{
+              dataDecoded: decodedData,
+              to: { value: tx?.data.to || '' },
+              value: tx?.data.value,
+              operation: tx?.data.operation === OperationType.DelegateCall ? Operation.DELEGATE : Operation.CALL,
+              trustedDelegateCallTarget: false,
+            }}
+            compact
+          />
+        </Box>
+      )}
+
+      <Accordion elevation={0} onChange={onChangeExpand} sx={!tx ? { pointerEvents: 'none' } : undefined}>
         <AccordionSummary>Transaction details</AccordionSummary>
 
         <AccordionDetails>
@@ -84,22 +93,6 @@ const DecodedTx = ({ tx, txId }: DecodedTxProps): ReactElement | null => {
             <ErrorMessage error={decodedDataError}>Failed decoding transaction data</ErrorMessage>
           ) : (
             decodedDataLoading && <Skeleton />
-          )}
-
-          {isMultisend && (
-            <Box mt={2}>
-              <Multisend
-                txData={{
-                  dataDecoded: decodedData,
-                  to: { value: tx?.data.to || '' },
-                  value: tx?.data.value,
-                  operation: tx?.data.operation === OperationType.DelegateCall ? Operation.DELEGATE : Operation.CALL,
-                  trustedDelegateCallTarget: false,
-                }}
-                variant="outlined"
-                noHeader
-              />
-            </Box>
           )}
         </AccordionDetails>
       </Accordion>

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -35,7 +35,6 @@ export const SAFE_TOKEN_ADDRESSES: { [chainId: string]: string } = {
 // Safe Apps
 export const SAFE_APPS_INFURA_TOKEN = process.env.NEXT_PUBLIC_SAFE_APPS_INFURA_TOKEN || INFURA_TOKEN
 export const SAFE_APPS_THIRD_PARTY_COOKIES_CHECK_URL = 'https://third-party-cookies-check.gnosis-safe.com'
-export const SAFE_APPS_SUPPORT_CHAT_URL = 'https://chat.safe.global'
 export const SAFE_APPS_DEMO_SAFE_MAINNET = 'eth:0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7'
 export const SAFE_APPS_SDK_DOCS_URL = 'https://docs.safe.global/learn/safe-tools/sdks/safe-apps'
 
@@ -57,8 +56,6 @@ export enum SafeAppsTag {
   DASHBOARD_FEATURED = 'dashboard-widgets',
   SAFE_GOVERNANCE_APP = 'safe-governance-app',
   WALLET_CONNECT = 'wallet-connect',
-  // TODO: Remove safe-claiming-app when we remove the old claiming app
-  SAFE_CLAIMING_APP = 'safe-claiming-app',
 }
 
 // Safe Gelato relay service
@@ -66,3 +63,25 @@ export const SAFE_RELAY_SERVICE_URL_PRODUCTION =
   process.env.NEXT_PUBLIC_SAFE_RELAY_SERVICE_URL_PRODUCTION || 'https://safe-client-nest.safe.global/v1/relay'
 export const SAFE_RELAY_SERVICE_URL_STAGING =
   process.env.NEXT_PUBLIC_SAFE_RELAY_SERVICE_URL_STAGING || 'https://safe-client-nest.staging.5afe.dev/v1/relay'
+
+// Help Center
+export const HELP_CENTER_URL = 'https://help.safe.global'
+export const HelpCenterArticle = {
+  ADDRESS_BOOK_DATA: `${HELP_CENTER_URL}/en/articles/40811-address-book-export-and-import`,
+  ADVANCED_PARAMS: `${HELP_CENTER_URL}/en/articles/40837-advanced-transaction-parameters`,
+  CANCELLING_TRANSACTIONS: `${HELP_CENTER_URL}/en/articles/40836-why-do-i-need-to-pay-for-cancelling-a-transaction`,
+  COOKIES: `${HELP_CENTER_URL}/en/articles/40797-why-do-i-need-to-enable-third-party-cookies-for-safe-apps`,
+  CONFLICTING_TRANSACTIONS: `${HELP_CENTER_URL}/en/articles/40839-why-are-transactions-with-the-same-nonce-conflicting-with-each-other`,
+  FALLBACK_HANDLER: `${HELP_CENTER_URL}/en/articles/40838-what-is-a-fallback-handler-and-how-does-it-relate-to-safe`,
+  MOBILE_SAFE: `${HELP_CENTER_URL}/en/articles/40801-connect-to-web-with-mobile-safe`,
+  RELAYING: `${HELP_CENTER_URL}/en/articles/59203-what-is-gas-fee-sponsoring`,
+  SAFE_SETUP: `${HELP_CENTER_URL}/en/articles/40835-what-safe-setup-should-i-use`,
+  SIGNED_MESSAGES: `${HELP_CENTER_URL}/en/articles/40783-what-are-signed-messages`,
+  SPAM_TOKENS: `${HELP_CENTER_URL}/en/articles/40784-default-token-list-local-hiding-of-spam-tokens`,
+  TRANSACTION_GUARD: `${HELP_CENTER_URL}/en/articles/40809-what-is-a-transaction-guard`,
+  UNEXPECTED_DELEGATE_CALL: `${HELP_CENTER_URL}/en/articles/40794-why-do-i-see-an-unexpected-delegate-call-warning-in-my-transaction`,
+} as const
+
+// Social
+export const DISCORD_URL = 'https://chat.safe.global'
+export const TWITTER_URL = 'https://twitter.com/safe'

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -108,7 +108,7 @@ const WebCoreApp = ({
           <InitApp />
 
           <PageLayout pathname={router.pathname}>
-            <Component {...pageProps} />
+            <Component {...pageProps} key={router.query.safe?.toString()} />
           </PageLayout>
 
           <CookieBanner />

--- a/src/pages/balances/nfts.tsx
+++ b/src/pages/balances/nfts.tsx
@@ -7,6 +7,7 @@ import NftCollections from '@/components/nfts/NftCollections'
 import SafeAppCard from '@/components/safe-apps/SafeAppCard'
 import { SafeAppsTag } from '@/config/constants'
 import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 // `React.memo` requires a `displayName`
 const NftApps = memo(function NftApps(): ReactElement | null {
@@ -40,6 +41,8 @@ const NftApps = memo(function NftApps(): ReactElement | null {
 })
 
 const NFTs: NextPage = () => {
+  const { safe, safeAddress } = useSafeInfo()
+
   return (
     <>
       <Head>
@@ -53,7 +56,7 @@ const NFTs: NextPage = () => {
           <NftApps />
 
           <Grid item xs>
-            <NftCollections />
+            <NftCollections key={safe.chainId + safeAddress} />
           </Grid>
         </Grid>
       </main>

--- a/src/pages/balances/nfts.tsx
+++ b/src/pages/balances/nfts.tsx
@@ -7,7 +7,6 @@ import NftCollections from '@/components/nfts/NftCollections'
 import SafeAppCard from '@/components/safe-apps/SafeAppCard'
 import { SafeAppsTag } from '@/config/constants'
 import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
-import useSafeInfo from '@/hooks/useSafeInfo'
 
 // `React.memo` requires a `displayName`
 const NftApps = memo(function NftApps(): ReactElement | null {
@@ -41,8 +40,6 @@ const NftApps = memo(function NftApps(): ReactElement | null {
 })
 
 const NFTs: NextPage = () => {
-  const { safe, safeAddress } = useSafeInfo()
-
   return (
     <>
       <Head>
@@ -56,7 +53,7 @@ const NFTs: NextPage = () => {
           <NftApps />
 
           <Grid item xs>
-            <NftCollections key={safe.chainId + safeAddress} />
+            <NftCollections />
           </Grid>
         </Grid>
       </main>

--- a/src/pages/new-safe/load.tsx
+++ b/src/pages/new-safe/load.tsx
@@ -15,7 +15,7 @@ const Load: NextPage = () => {
       </Head>
 
       {safeAddress ? (
-        <LoadSafe key={safeAddress} initialData={{ ...loadSafeDefaultData, address: safeAddress }} />
+        <LoadSafe initialData={{ ...loadSafeDefaultData, address: safeAddress }} />
       ) : (
         <LoadSafe initialData={loadSafeDefaultData} />
       )}

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -75,11 +75,8 @@ export const dateString = (date: number) => {
   return new Intl.DateTimeFormat(undefined, formatterOptions).format(new Date(date))
 }
 
-export const camelCaseToSpaces = (str: string): string => {
-  return str
-    .replace(/([A-Z][a-z0-9]+)/g, ' $1 ')
-    .replace(/\s{2}/g, ' ')
-    .trim()
+export const camelCaseToWords = (camelCase: string): string => {
+  return camelCase.replace(/[a-z](?=[A-Z])/g, (str) => str + ' ')
 }
 
 export const ellipsis = (str: string, length: number): string => {


### PR DESCRIPTION
## Summary
* Update and centralize Help Center links (#1882)
* Fix multisend details in transaction modals (#1960)
* Fix NFT page data reload on account switch (#1963)
* Fix: restore copiable hex data in the safe app review modal (#1970)
* fix: rerender on Safe address change (#1968)