### PR TITLE
fix: re-render `<NftCollections>` component when loading other Safe

### DIFF
--- a/src/pages/balances/nfts.tsx
+++ b/src/pages/balances/nfts.tsx
@@ -7,6 +7,7 @@ import NftCollections from '@/components/nfts/NftCollections'
 import SafeAppCard from '@/components/safe-apps/SafeAppCard'
 import { SafeAppsTag } from '@/config/constants'
 import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 // `React.memo` requires a `displayName`
 const NftApps = memo(function NftApps(): ReactElement | null {
@@ -40,6 +41,8 @@ const NftApps = memo(function NftApps(): ReactElement | null {
 })
 
 const NFTs: NextPage = () => {
+  const { safe, safeAddress } = useSafeInfo()
+
   return (
     <>
       <Head>
@@ -53,7 +56,7 @@ const NFTs: NextPage = () => {
           <NftApps />
 
           <Grid item xs>
-            <NftCollections />
+            <NftCollections key={safe.chainId + safeAddress} />
           </Grid>
         </Grid>
       </main>


### PR DESCRIPTION
## What it solves

Resolves #1959

## How this PR fixes it
Reload `<NftCollections>` component when changing `safeAddress` or `chainId`

## How to test it
1. Go to the NFTs page of a Safe containing NFTs
2. Change to another loaded Safe in the Sidebar
3. The table should display only the current Safe NFTs

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
