### PR TITLE
Fix: acronyms in camelCaseToSpaces

### DIFF
--- a/src/utils/__tests__/formatters.test.ts
+++ b/src/utils/__tests__/formatters.test.ts
@@ -33,7 +33,7 @@ describe('formatters', () => {
       expect(formatters.camelCaseToSpaces('safeTransferFrom')).toEqual('safe Transfer From')
     })
 
-    it('should convert "depositERC20token" to "transfer ERC20 Token"', () => {
+    it('should convert "depositERC20token" to "deposit ERC20 Token"', () => {
       expect(formatters.camelCaseToSpaces('depositERC20Token')).toEqual('deposit ERC20 Token')
     })
   })

--- a/src/utils/__tests__/formatters.test.ts
+++ b/src/utils/__tests__/formatters.test.ts
@@ -27,6 +27,17 @@ describe('formatters', () => {
       ).toBe('1000000000000000000000000000000000000000000000000000000000000000001.1')
     })
   })
+
+  describe('camelCaseToSpaces', () => {
+    it('should convert "safeTransferFrom" to "safe Transfer From"', () => {
+      expect(formatters.camelCaseToSpaces('safeTransferFrom')).toEqual('safe Transfer From')
+    })
+
+    it('should convert "depositERC20token" to "transfer ERC20 Token"', () => {
+      expect(formatters.camelCaseToSpaces('depositERC20Token')).toEqual('deposit ERC20 Token')
+    })
+  })
+
   describe('safeFormatUnits', () => {
     it('formats to gwei by default', () => {
       const result1 = formatters.safeFormatUnits('1')

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -76,7 +76,7 @@ export const dateString = (date: number) => {
 }
 
 export const camelCaseToSpaces = (str: string): string => {
-  return str.replace(/^|[a-z0-9](?=[A-Z])/g, (str) => str + ' ').trim()
+  return str.replace(/[a-z0-9](?=[A-Z])/g, (str) => str + ' ')
 }
 
 export const ellipsis = (str: string, length: number): string => {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -76,10 +76,7 @@ export const dateString = (date: number) => {
 }
 
 export const camelCaseToSpaces = (str: string): string => {
-  return str
-    .replace(/([A-Z][a-z0-9]+)/g, ' $1 ')
-    .replace(/\s{2}/g, ' ')
-    .trim()
+  return str.replace(/^|[a-z0-9](?=[A-Z])/g, (str) => str + ' ').trim()
 }
 
 export const ellipsis = (str: string, length: number): string => {


### PR DESCRIPTION
## What it solves
`camelCaseToSpaces` was working incorrectly when there were multiple capital letters in a row.

## How to test
Make or find a transaction that has an acronym in the method name. E.g. depostERC20Token or something similar.
The decoded method should look like `DEPOSIT ERC20 TOKEN`.
<img width="586" alt="Screenshot 2023-05-09 at 15 14 26" src="https://github.com/safe-global/safe-wallet-web/assets/381895/0798c021-88fe-410a-a3da-b46dce9cd4f8">
