### PR TITLE
fix: improve array decoding

### DIFF
--- a/src/components/transactions/TxDetails/TxData/DecodedData/ValueArray/ValueArray.test.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/ValueArray/ValueArray.test.tsx
@@ -1,0 +1,13 @@
+import { Value } from '.'
+import { render } from '@/tests/test-utils'
+
+describe('ValueArray', () => {
+  it('should render Snapshot Proposal', () => {
+    const result = render(<Value type="string[]" value='[\n  "Yes",\n  "No"\n]' method="Proposal" />)
+
+    expect(result.queryByText('[', { exact: false })).toBeInTheDocument()
+    expect(result.queryByText('Yes', { exact: false })).toBeInTheDocument()
+    expect(result.queryByText('No', { exact: false })).toBeInTheDocument()
+    expect(result.queryByText(']', { exact: false })).toBeInTheDocument()
+  })
+})

--- a/src/components/transactions/TxDetails/TxData/DecodedData/ValueArray/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/ValueArray/index.tsx
@@ -63,7 +63,7 @@ export const Value = ({ type, value, ...props }: ValueArrayProps): ReactElement 
     )
   }
 
-  return <GenericValue type={type} value={parsedValue} {...props} />
+  return <GenericValue value={parsedValue} {...props} />
 }
 
 const getTextValue = (value: string, key?: string) => {
@@ -89,7 +89,7 @@ const getArrayValue = (parentId: string, value: string[], separator?: boolean) =
   </Typography>
 )
 
-const GenericValue = ({ method, value }: ValueArrayProps): React.ReactElement => {
+const GenericValue = ({ method, value }: Omit<ValueArrayProps, 'type'>): React.ReactElement => {
   if (Array.isArray(value)) {
     return getArrayValue(method, value)
   }

--- a/src/components/transactions/TxDetails/TxData/DecodedData/ValueArray/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/ValueArray/index.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import type { ReactElement } from 'react'
 import { Typography } from '@mui/material'
 import { isAddress, isArrayParameter } from '@/utils/transaction-guards'
@@ -12,13 +13,30 @@ type ValueArrayProps = {
   key?: string
 }
 
-export const Value = ({ type, ...props }: ValueArrayProps): ReactElement => {
-  if (isArrayParameter(type) && isAddress(type)) {
+// Sometime DApps return stringified arrays, e.g. "["hello","world"]"
+const parseValue = (value: ValueArrayProps['value']) => {
+  if (Array.isArray(value)) {
+    return value
+  }
+
+  try {
+    return JSON.parse(value)
+  } catch {
+    return value
+  }
+}
+
+export const Value = ({ type, value, ...props }: ValueArrayProps): ReactElement => {
+  const parsedValue = useMemo(() => {
+    return parseValue(value)
+  }, [value])
+
+  if (isArrayParameter(type) && isAddress(type) && Array.isArray(parsedValue)) {
     return (
       <Typography component="div" variant="body2">
         [
         <div className={css.nestedWrapper}>
-          {(props.value as string[]).map((address, index) => {
+          {parsedValue.map((address, index) => {
             const key = `${props.key || props.method}-${index}`
             if (Array.isArray(address)) {
               const newProps = {
@@ -45,34 +63,36 @@ export const Value = ({ type, ...props }: ValueArrayProps): ReactElement => {
     )
   }
 
-  return <GenericValue type={type} {...props} />
+  return <GenericValue type={type} value={parsedValue} {...props} />
 }
 
-const GenericValue = ({ method, type, value }: ValueArrayProps): React.ReactElement => {
-  const getTextValue = (value: string, key?: string) => <HexEncodedData limit={60} hexData={value} key={key} />
+const getTextValue = (value: string, key?: string) => {
+  return <HexEncodedData limit={60} hexData={value} key={key} />
+}
 
-  const getArrayValue = (parentId: string, value: string[] | string, separator?: boolean) => (
-    <Typography component="div" variant="body2">
-      [
-      <div className={css.nestedWrapper}>
-        {(value as string[]).map((currentValue, index, values) => {
-          const key = `${parentId}-value-${index}`
-          const hasSeparator = index < values.length - 1
+const getArrayValue = (parentId: string, value: string[], separator?: boolean) => (
+  <Typography component="div" variant="body2">
+    [
+    <div className={css.nestedWrapper}>
+      {value.map((currentValue, index, values) => {
+        const key = `${parentId}-value-${index}`
+        const hasSeparator = index < values.length - 1
 
-          return Array.isArray(currentValue) ? (
-            <div key={key}>{getArrayValue(key, currentValue, hasSeparator)}</div>
-          ) : (
-            getTextValue(currentValue, key)
-          )
-        })}
-      </div>
-      ]{separator ? ',' : null}
-    </Typography>
-  )
+        return Array.isArray(currentValue) ? (
+          <div key={key}>{getArrayValue(key, currentValue, hasSeparator)}</div>
+        ) : (
+          getTextValue(currentValue, key)
+        )
+      })}
+    </div>
+    ]{separator ? ',' : null}
+  </Typography>
+)
 
-  if (isArrayParameter(type) || Array.isArray(value)) {
+const GenericValue = ({ method, value }: ValueArrayProps): React.ReactElement => {
+  if (Array.isArray(value)) {
     return getArrayValue(method, value)
   }
 
-  return getTextValue(value as string)
+  return getTextValue(value)
 }


### PR DESCRIPTION
## What it solves

Resolves #1920

## How this PR fixes it

The `ValueArray` component now uses `isArray` as a type guard to prevent stringified arrays, labelled as array, e.g. "string[]" from being mapped.

## How to test it

1. Connect a Safe via WalletConnect to Snapshot.
2. Create a proposal with multiple choices.
3. Observe the `choices` rendered correctly in an array (above each other).

Signing other typed data should also not crash the interface.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/1ed49f55-2821-447c-a1ab-6ee88e1078dd)