### PR TITLE
fix: improve disable condition and tooltip tile on `TxSummary` buttons

### DIFF
--- a/src/components/transactions/ExecuteTxButton/index.tsx
+++ b/src/components/transactions/ExecuteTxButton/index.tsx
@@ -33,7 +33,7 @@ const ExecuteTxButton = ({
   const isNext = txNonce !== undefined && txNonce === safe.nonce
   const isDisabled = !isNext || isPending || !safeSDK
 
-  const tooltipTitle = getTxButtonTooltip('Execute', { isNext, nonce: safe.nonce, isPending, hasSafeSDK: !!safeSDK })
+  const tooltipTitle = getTxButtonTooltip('Execute', { isNext, nonce: safe.nonce, hasSafeSDK: !!safeSDK })
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()

--- a/src/components/transactions/ExecuteTxButton/index.tsx
+++ b/src/components/transactions/ExecuteTxButton/index.tsx
@@ -14,6 +14,7 @@ import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
 import { ReplaceTxHoverContext } from '../GroupedTxListItems/ReplaceTxHoverProvider'
 import CheckWallet from '@/components/common/CheckWallet'
 import { useSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
+import { getTxButtonTooltip } from '@/components/transactions/utils'
 
 const ExecuteTxButton = ({
   txSummary,
@@ -32,14 +33,7 @@ const ExecuteTxButton = ({
   const isNext = txNonce !== undefined && txNonce === safe.nonce
   const isDisabled = !isNext || isPending || !safeSDK
 
-  const tooltipTitle =
-    isDisabled && !isNext
-      ? `Transaction ${safe.nonce} must be executed first`
-      : isPending
-      ? 'Pending transaction must first succeed'
-      : !safeSDK
-      ? 'Waiting for the SDK to initialize'
-      : 'Execute'
+  const tooltipTitle = getTxButtonTooltip('Execute', { isNext, nonce: safe.nonce, isPending, hasSafeSDK: !!safeSDK })
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()

--- a/src/components/transactions/ExecuteTxButton/index.tsx
+++ b/src/components/transactions/ExecuteTxButton/index.tsx
@@ -13,7 +13,7 @@ import Track from '@/components/common/Track'
 import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
 import { ReplaceTxHoverContext } from '../GroupedTxListItems/ReplaceTxHoverProvider'
 import CheckWallet from '@/components/common/CheckWallet'
-import { getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
+import { useSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 
 const ExecuteTxButton = ({
   txSummary,
@@ -27,7 +27,7 @@ const ExecuteTxButton = ({
   const txNonce = isMultisigExecutionInfo(txSummary.executionInfo) ? txSummary.executionInfo.nonce : undefined
   const isPending = useIsPending(txSummary.id)
   const { setSelectedTxId } = useContext(ReplaceTxHoverContext)
-  const safeSDK = getSafeSDK()
+  const safeSDK = useSafeSDK()
 
   const isNext = txNonce !== undefined && txNonce === safe.nonce
   const isDisabled = !isNext || isPending || !safeSDK

--- a/src/components/transactions/ExecuteTxButton/index.tsx
+++ b/src/components/transactions/ExecuteTxButton/index.tsx
@@ -36,7 +36,7 @@ const ExecuteTxButton = ({
     isDisabled && !isNext
       ? `Transaction ${safe.nonce} must be executed first`
       : isPending
-      ? `There's a pending transaction`
+      ? 'Pending transaction must first succeed'
       : !safeSDK
       ? 'Waiting for the SDK to initialize'
       : 'Execute'

--- a/src/components/transactions/RejectTxButton/index.tsx
+++ b/src/components/transactions/RejectTxButton/index.tsx
@@ -11,7 +11,7 @@ import ErrorIcon from '@/public/images/notifications/error.svg'
 import Track from '@/components/common/Track'
 import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
 import CheckWallet from '@/components/common/CheckWallet'
-import { getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
+import { useSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 
 const NewTxModal = dynamic(() => import('@/components/tx/modals/NewTxModal'))
 
@@ -25,7 +25,7 @@ const RejectTxButton = ({
   const [open, setOpen] = useState<boolean>(false)
   const txNonce = isMultisigExecutionInfo(txSummary.executionInfo) ? txSummary.executionInfo.nonce : undefined
   const isPending = useIsPending(txSummary.id)
-  const safeSDK = getSafeSDK()
+  const safeSDK = useSafeSDK()
   const isDisabled = isPending || !safeSDK
 
   const tooltipTitle =

--- a/src/components/transactions/RejectTxButton/index.tsx
+++ b/src/components/transactions/RejectTxButton/index.tsx
@@ -29,7 +29,7 @@ const RejectTxButton = ({
   const safeSDK = useSafeSDK()
   const isDisabled = isPending || !safeSDK
 
-  const tooltipTitle = getTxButtonTooltip('Replace', { isPending, hasSafeSDK: !!safeSDK })
+  const tooltipTitle = getTxButtonTooltip('Replace', { hasSafeSDK: !!safeSDK })
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()

--- a/src/components/transactions/RejectTxButton/index.tsx
+++ b/src/components/transactions/RejectTxButton/index.tsx
@@ -30,7 +30,7 @@ const RejectTxButton = ({
 
   const tooltipTitle =
     isDisabled && isPending
-      ? `There's a pending transaction`
+      ? 'Pending transaction must first succeed'
       : !safeSDK
       ? 'Waiting for the SDK to initialize'
       : 'Replace'

--- a/src/components/transactions/RejectTxButton/index.tsx
+++ b/src/components/transactions/RejectTxButton/index.tsx
@@ -12,6 +12,7 @@ import Track from '@/components/common/Track'
 import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
 import CheckWallet from '@/components/common/CheckWallet'
 import { useSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
+import { getTxButtonTooltip } from '@/components/transactions/utils'
 
 const NewTxModal = dynamic(() => import('@/components/tx/modals/NewTxModal'))
 
@@ -28,12 +29,7 @@ const RejectTxButton = ({
   const safeSDK = useSafeSDK()
   const isDisabled = isPending || !safeSDK
 
-  const tooltipTitle =
-    isDisabled && isPending
-      ? 'Pending transaction must first succeed'
-      : !safeSDK
-      ? 'Waiting for the SDK to initialize'
-      : 'Replace'
+  const tooltipTitle = getTxButtonTooltip('Replace', { isPending, hasSafeSDK: !!safeSDK })
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()

--- a/src/components/transactions/RejectTxButton/index.tsx
+++ b/src/components/transactions/RejectTxButton/index.tsx
@@ -11,6 +11,7 @@ import ErrorIcon from '@/public/images/notifications/error.svg'
 import Track from '@/components/common/Track'
 import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
 import CheckWallet from '@/components/common/CheckWallet'
+import { getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 
 const NewTxModal = dynamic(() => import('@/components/tx/modals/NewTxModal'))
 
@@ -23,7 +24,16 @@ const RejectTxButton = ({
 }): ReactElement | null => {
   const [open, setOpen] = useState<boolean>(false)
   const txNonce = isMultisigExecutionInfo(txSummary.executionInfo) ? txSummary.executionInfo.nonce : undefined
-  const isDisabled = useIsPending(txSummary.id)
+  const isPending = useIsPending(txSummary.id)
+  const safeSDK = getSafeSDK()
+  const isDisabled = isPending || !safeSDK
+
+  const tooltipTitle =
+    isDisabled && isPending
+      ? `There's a pending transaction`
+      : !safeSDK
+      ? 'Waiting for the SDK to initialize'
+      : 'Replace'
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()
@@ -36,7 +46,7 @@ const RejectTxButton = ({
         {(isOk) => (
           <Track {...TX_LIST_EVENTS.REJECT}>
             {compact ? (
-              <Tooltip title="Replace" arrow placement="top">
+              <Tooltip title={tooltipTitle} arrow placement="top">
                 <span>
                   <IconButton onClick={onClick} color="error" size="small" disabled={!isOk || isDisabled}>
                     <SvgIcon component={ErrorIcon} inheritViewBox fontSize="small" />

--- a/src/components/transactions/SignTxButton/index.tsx
+++ b/src/components/transactions/SignTxButton/index.tsx
@@ -13,6 +13,7 @@ import Track from '@/components/common/Track'
 import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
 import CheckWallet from '@/components/common/CheckWallet'
 import { useSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
+import { getTxButtonTooltip } from '@/components/transactions/utils'
 
 const SignTxButton = ({
   txSummary,
@@ -29,12 +30,7 @@ const SignTxButton = ({
 
   const isDisabled = !isSignable || isPending || !safeSDK
 
-  const tooltipTitle =
-    isDisabled && isPending
-      ? 'Pending transaction must first succeed'
-      : !safeSDK
-      ? 'Waiting for the SDK to initialize'
-      : 'Confirm'
+  const tooltipTitle = getTxButtonTooltip('Confirm', { isPending, hasSafeSDK: !!safeSDK })
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()

--- a/src/components/transactions/SignTxButton/index.tsx
+++ b/src/components/transactions/SignTxButton/index.tsx
@@ -30,7 +30,7 @@ const SignTxButton = ({
 
   const isDisabled = !isSignable || isPending || !safeSDK
 
-  const tooltipTitle = getTxButtonTooltip('Confirm', { isPending, hasSafeSDK: !!safeSDK })
+  const tooltipTitle = getTxButtonTooltip('Confirm', { hasSafeSDK: !!safeSDK })
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()

--- a/src/components/transactions/SignTxButton/index.tsx
+++ b/src/components/transactions/SignTxButton/index.tsx
@@ -12,7 +12,7 @@ import CheckIcon from '@mui/icons-material/Check'
 import Track from '@/components/common/Track'
 import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
 import CheckWallet from '@/components/common/CheckWallet'
-import { getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
+import { useSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 
 const SignTxButton = ({
   txSummary,
@@ -25,7 +25,7 @@ const SignTxButton = ({
   const wallet = useWallet()
   const isSignable = isSignableBy(txSummary, wallet?.address || '')
   const isPending = useIsPending(txSummary.id)
-  const safeSDK = getSafeSDK()
+  const safeSDK = useSafeSDK()
 
   const isDisabled = !isSignable || isPending || !safeSDK
 

--- a/src/components/transactions/SignTxButton/index.tsx
+++ b/src/components/transactions/SignTxButton/index.tsx
@@ -12,6 +12,7 @@ import CheckIcon from '@mui/icons-material/Check'
 import Track from '@/components/common/Track'
 import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
 import CheckWallet from '@/components/common/CheckWallet'
+import { getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 
 const SignTxButton = ({
   txSummary,
@@ -24,13 +25,21 @@ const SignTxButton = ({
   const wallet = useWallet()
   const isSignable = isSignableBy(txSummary, wallet?.address || '')
   const isPending = useIsPending(txSummary.id)
+  const safeSDK = getSafeSDK()
+
+  const isDisabled = !isSignable || isPending || !safeSDK
+
+  const tooltipTitle =
+    isDisabled && isPending
+      ? `There's a pending transaction`
+      : !safeSDK
+      ? 'Waiting for the SDK to initialize'
+      : 'Confirm'
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()
     setOpen(true)
   }
-
-  const isDisabled = !isSignable || isPending
 
   return (
     <>
@@ -38,7 +47,7 @@ const SignTxButton = ({
         {(isOk) => (
           <Track {...TX_LIST_EVENTS.CONFIRM}>
             {compact ? (
-              <Tooltip title="Confirm" arrow placement="top">
+              <Tooltip title={tooltipTitle} arrow placement="top">
                 <span>
                   <IconButton onClick={onClick} color="primary" disabled={!isOk || isDisabled} size="small">
                     <CheckIcon fontSize="small" />

--- a/src/components/transactions/SignTxButton/index.tsx
+++ b/src/components/transactions/SignTxButton/index.tsx
@@ -31,7 +31,7 @@ const SignTxButton = ({
 
   const tooltipTitle =
     isDisabled && isPending
-      ? `There's a pending transaction`
+      ? 'Pending transaction must first succeed'
       : !safeSDK
       ? 'Waiting for the SDK to initialize'
       : 'Confirm'

--- a/src/components/transactions/__tests__/utils.test.ts
+++ b/src/components/transactions/__tests__/utils.test.ts
@@ -25,11 +25,11 @@ describe('transactions utils', () => {
       expect(getTxButtonTooltip(enabledTitle, disabledProps)).toBe('Pending transaction must first succeed')
     })
 
-    it('should return the Safe SDK not initialized message', () => {
+    it('should return the SDK not initialized message', () => {
       const enabledTitle = 'Execute'
       const disabledProps = { ...disabledPropsBase, hasSafeSDK: false }
 
-      expect(getTxButtonTooltip(enabledTitle, disabledProps)).toBe('Waiting for the SDK to initialize')
+      expect(getTxButtonTooltip(enabledTitle, disabledProps)).toBe('Loading')
     })
   })
 })

--- a/src/components/transactions/__tests__/utils.test.ts
+++ b/src/components/transactions/__tests__/utils.test.ts
@@ -2,7 +2,7 @@ import { getTxButtonTooltip } from '../utils'
 
 describe('transactions utils', () => {
   describe('getTooltipTitle', () => {
-    const disabledPropsBase = { isPending: false, hasSafeSDK: true }
+    const disabledPropsBase = { hasSafeSDK: true }
 
     it('should return the enabledTitle if no disabled conditions', () => {
       const enabledTitle = 'Execute'
@@ -16,13 +16,6 @@ describe('transactions utils', () => {
       const disabledProps = { ...disabledPropsBase, isNext: false, nonce }
 
       expect(getTxButtonTooltip(enabledTitle, disabledProps)).toBe('Transaction 2 must be executed first')
-    })
-
-    it('should return the "is tx pending" message', () => {
-      const enabledTitle = 'Execute'
-      const disabledProps = { ...disabledPropsBase, isPending: true }
-
-      expect(getTxButtonTooltip(enabledTitle, disabledProps)).toBe('Pending transaction must first succeed')
     })
 
     it('should return the SDK not initialized message', () => {

--- a/src/components/transactions/__tests__/utils.test.ts
+++ b/src/components/transactions/__tests__/utils.test.ts
@@ -8,7 +8,6 @@ describe('transactions utils', () => {
       const enabledTitle = 'Execute'
 
       expect(getTxButtonTooltip(enabledTitle, disabledPropsBase)).toBe('Execute')
-      expect(true).toBe(true)
     })
 
     it('should return the not isNext message', () => {
@@ -24,7 +23,6 @@ describe('transactions utils', () => {
       const disabledProps = { ...disabledPropsBase, isPending: true }
 
       expect(getTxButtonTooltip(enabledTitle, disabledProps)).toBe('Pending transaction must first succeed')
-      expect(true).toBe(true)
     })
 
     it('should return the Safe SDK not initialized message', () => {
@@ -32,7 +30,6 @@ describe('transactions utils', () => {
       const disabledProps = { ...disabledPropsBase, hasSafeSDK: false }
 
       expect(getTxButtonTooltip(enabledTitle, disabledProps)).toBe('Waiting for the SDK to initialize')
-      expect(true).toBe(true)
     })
   })
 })

--- a/src/components/transactions/__tests__/utils.test.ts
+++ b/src/components/transactions/__tests__/utils.test.ts
@@ -1,0 +1,38 @@
+import { getTxButtonTooltip } from '../utils'
+
+describe('transactions utils', () => {
+  describe('getTooltipTitle', () => {
+    const disabledPropsBase = { isPending: false, hasSafeSDK: true }
+
+    it('should return the enabledTitle if no disabled conditions', () => {
+      const enabledTitle = 'Execute'
+
+      expect(getTxButtonTooltip(enabledTitle, disabledPropsBase)).toBe('Execute')
+      expect(true).toBe(true)
+    })
+
+    it('should return the not isNext message', () => {
+      const enabledTitle = 'Confirm'
+      const nonce = 2
+      const disabledProps = { ...disabledPropsBase, isNext: false, nonce }
+
+      expect(getTxButtonTooltip(enabledTitle, disabledProps)).toBe('Transaction 2 must be executed first')
+    })
+
+    it('should return the "is tx pending" message', () => {
+      const enabledTitle = 'Execute'
+      const disabledProps = { ...disabledPropsBase, isPending: true }
+
+      expect(getTxButtonTooltip(enabledTitle, disabledProps)).toBe('Pending transaction must first succeed')
+      expect(true).toBe(true)
+    })
+
+    it('should return the Safe SDK not initialized message', () => {
+      const enabledTitle = 'Execute'
+      const disabledProps = { ...disabledPropsBase, hasSafeSDK: false }
+
+      expect(getTxButtonTooltip(enabledTitle, disabledProps)).toBe('Waiting for the SDK to initialize')
+      expect(true).toBe(true)
+    })
+  })
+})

--- a/src/components/transactions/utils.ts
+++ b/src/components/transactions/utils.ts
@@ -15,6 +15,6 @@ export const getTxButtonTooltip = (enabledTitle: EnabledTitleType, disabledProps
     : isPending
     ? 'Pending transaction must first succeed'
     : !hasSafeSDK
-    ? 'Waiting for the SDK to initialize'
+    ? 'Loading'
     : enabledTitle
 }

--- a/src/components/transactions/utils.ts
+++ b/src/components/transactions/utils.ts
@@ -1,20 +1,13 @@
 type DisabledPropsType = {
   isNext?: boolean
   nonce?: number
-  isPending: boolean
   hasSafeSDK: boolean
 }
 
 type EnabledTitleType = 'Execute' | 'Replace' | 'Confirm'
 
 export const getTxButtonTooltip = (enabledTitle: EnabledTitleType, disabledProps: DisabledPropsType) => {
-  const { isPending, hasSafeSDK, isNext, nonce } = disabledProps
+  const { hasSafeSDK, isNext, nonce } = disabledProps
 
-  return isNext === false
-    ? `Transaction ${nonce} must be executed first`
-    : isPending
-    ? 'Pending transaction must first succeed'
-    : !hasSafeSDK
-    ? 'Loading'
-    : enabledTitle
+  return isNext === false ? `Transaction ${nonce} must be executed first` : !hasSafeSDK ? 'Loading' : enabledTitle
 }

--- a/src/components/transactions/utils.ts
+++ b/src/components/transactions/utils.ts
@@ -1,0 +1,27 @@
+type DisabledPropsType =
+  | {
+      isNext: false
+      nonce: number
+      isPending: boolean
+      hasSafeSDK: boolean
+    }
+  | {
+      isNext?: boolean
+      nonce?: number
+      isPending: boolean
+      hasSafeSDK: boolean
+    }
+
+type EnabledTitleType = 'Execute' | 'Replace' | 'Confirm'
+
+export const getTxButtonTooltip = (enabledTitle: EnabledTitleType, disabledProps: DisabledPropsType) => {
+  const { isPending, hasSafeSDK, isNext, nonce } = disabledProps
+
+  return isNext === false
+    ? `Transaction ${nonce} must be executed first`
+    : isPending
+    ? 'Pending transaction must first succeed'
+    : !hasSafeSDK
+    ? 'Waiting for the SDK to initialize'
+    : enabledTitle
+}

--- a/src/components/transactions/utils.ts
+++ b/src/components/transactions/utils.ts
@@ -1,16 +1,9 @@
-type DisabledPropsType =
-  | {
-      isNext: false
-      nonce: number
-      isPending: boolean
-      hasSafeSDK: boolean
-    }
-  | {
-      isNext?: boolean
-      nonce?: number
-      isPending: boolean
-      hasSafeSDK: boolean
-    }
+type DisabledPropsType = {
+  isNext?: boolean
+  nonce?: number
+  isPending: boolean
+  hasSafeSDK: boolean
+}
 
 type EnabledTitleType = 'Execute' | 'Replace' | 'Confirm'
 


### PR DESCRIPTION
## What it solves

Resolves #1932

## How this PR fixes it
Includes the `coreSDK` initialization in the condition to disable the `<TxSummary>` buttons (`ExecuteTxButton`, `RejectTxButton` and `SignTxbutton`)
Improve tooltip description as per the disable condition

## How to test it

### Not next tx
1. Go to a Tx queue where a queued tx is fully signed but not the "Next" in the queue
2. Observe the execution icons is disabled and show a tooltip "Transaction {nonce} must be executed first"

### ~Transaction is pending execution~
~1. Go to a Tx queue and have 2 transactions ready to be executed
2. Execute the first one
3. Observe the execution icons in the second one is disabled and show a tooltip "Pending transaction must first succeed"~

### Safe SDK not initialized
1. Go to a Tx queue where there is a tx queued in the "next" nonce
2. Refresh the page
3. Try to hover the Execute/Reject/Sign buttons immediately
4. Observe they are disabled and show a tooltip 'Waiting for the SDK to initialize'

## Screenshots
<img width="432" alt="Screenshot 2023-05-09 at 18 13 36" src="https://github.com/safe-global/safe-wallet-web/assets/32431609/50550232-1593-43ad-aadd-8891811e8a51">


## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
