### PR TITLE
Fix: restore copiable hex data in the safe app review modal

### DIFF
--- a/src/components/safe-apps/SafeAppsTxModal/ReviewSafeAppsTx.tsx
+++ b/src/components/safe-apps/SafeAppsTxModal/ReviewSafeAppsTx.tsx
@@ -15,6 +15,8 @@ import { ApprovalEditor } from '../../tx/ApprovalEditor'
 import { createMultiSendCallOnlyTx, createTx, dispatchSafeAppsTx } from '@/services/tx/tx-sender'
 import useOnboard from '@/hooks/wallets/useOnboard'
 import useSafeInfo from '@/hooks/useSafeInfo'
+import { Box, Typography } from '@mui/material'
+import { generateDataRowValue } from '@/components/transactions/TxDetails/Summary/TxDataRow'
 
 type ReviewSafeAppsTxProps = {
   safeAppsTx: SafeAppsTxParams
@@ -66,7 +68,18 @@ const ReviewSafeAppsTx = ({
 
         <SendFromBlock />
 
-        {safeTx && <SendToBlock address={safeTx.data.to} title={getInteractionTitle(safeTx.data.value || '', chain)} />}
+        {safeTx && (
+          <>
+            <SendToBlock address={safeTx.data.to} title={getInteractionTitle(safeTx.data.value || '', chain)} />
+
+            <Box pb={2}>
+              <Typography mt={2} color="primary.light">
+                Data (hex encoded)
+              </Typography>
+              {generateDataRowValue(safeTx.data.data, 'rawData')}
+            </Box>
+          </>
+        )}
       </>
     </SignOrExecuteForm>
   )


### PR DESCRIPTION
## What it solves

Fixes a regression introduced in #1899. The hex data was missing in the Safe App tx modal.

## How this PR fixes it
Restores the hex data component.

## How to test it
Make a Transaction Builder tx.

## Screenshots
<img width="644" alt="Screenshot 2023-05-10 at 09 14 24" src="https://github.com/safe-global/safe-wallet-web/assets/381895/a366afd6-3a33-45f5-9c92-98bd07114dc9">
