### PR TITLE
fix: redirect non-existing "Messages" tab

### DIFF
--- a/src/pages/transactions/messages.tsx
+++ b/src/pages/transactions/messages.tsx
@@ -1,11 +1,28 @@
+import { useEffect } from 'react'
 import Head from 'next/head'
+import { FEATURES } from '@safe-global/safe-gateway-typescript-sdk'
+import { useRouter } from 'next/router'
 import type { NextPage } from 'next'
 
 import PaginatedMsgs from '@/components/safe-messages/PaginatedMsgs'
 import TxHeader from '@/components/transactions/TxHeader'
 import SignedMessagesHelpLink from '@/components/transactions/SignedMessagesHelpLink'
+import { AppRoutes } from '@/config/routes'
+import { useCurrentChain } from '@/hooks/useChains'
+import { hasFeature } from '@/utils/chains'
 
 const Messages: NextPage = () => {
+  const chain = useCurrentChain()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!chain || hasFeature(chain, FEATURES.EIP1271)) {
+      return
+    }
+
+    router.replace({ ...router, pathname: AppRoutes.transactions.history })
+  }, [router, chain])
+
   return (
     <>
       <Head>


### PR DESCRIPTION
## What it solves

Resolves #1972

## How this PR fixes it

When navigating _from_ the "Messages" tab of a Safe that supports/has Messages (e.g. Goerli Safes on staging) _to_ a Safe that doesn't (e.g. other network on staging), the Safe now redirect to the "History" tab.

## How to test it

1. Open the "Messages" tab of a Safe on Goerli (on staging).
2. Switch to a Safe on mainnet.
3. Observe the redirection.

## Screenshots

![messages-redirection](https://github.com/safe-global/safe-wallet-web/assets/20442784/03ef9f4d-8b4d-456b-8d15-e6e64a016bd4)

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
