### PR TITLE
Fix: do not memoize IntersectionObserver

### DIFF
--- a/src/hooks/useOnceVisible.ts
+++ b/src/hooks/useOnceVisible.ts
@@ -1,42 +1,27 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { MutableRefObject } from 'react'
 
 // A hook to detect when an element is visible in the viewport for the first time
 const useOnceVisible = (element: MutableRefObject<HTMLElement | null>): boolean => {
   const [onceVisible, setOnceVisible] = useState<boolean>(false)
 
-  // Create and memoize an instance of IntersectionObserver
-  const observer = useMemo(() => {
-    return new IntersectionObserver((entries) => {
+  useEffect(() => {
+    if (!element.current) return
+
+    const observer = new IntersectionObserver((entries) => {
       const intersectingEntry = entries.find((entry) => entry.isIntersecting)
       if (intersectingEntry) {
         setOnceVisible(true)
         observer.unobserve(intersectingEntry.target)
       }
     })
-  }, [])
 
-  // Disconnect the observer on unmount
-  useEffect(() => {
+    observer.observe(element.current)
+
     return () => {
       observer.disconnect()
     }
-  }, [observer])
-
-  // Observe the target element
-  useEffect(() => {
-    const target = element.current
-
-    if (target) {
-      observer.observe(target)
-    }
-
-    return () => {
-      if (target) {
-        observer.unobserve(target)
-      }
-    }
-  }, [observer, element])
+  }, [element])
 
   return onceVisible
 }


### PR DESCRIPTION
## What it solves

Resolves #1974

## How this PR fixes it

I can't tell 100% why it was doing that, but somehow the memoized observer was triggering another tx list page load, even though the entire InfiniteScroll component was unmounted.

Anyway, this fixes it.

## How to test it
See the steps in #1974 