### PR TITLE
Fix: useAsync should clear data if no promise

### DIFF
--- a/src/hooks/loadables/useLoadBalances.ts
+++ b/src/hooks/loadables/useLoadBalances.ts
@@ -14,15 +14,17 @@ export const useLoadBalances = (): AsyncResult<SafeBalanceResponse> => {
   const currency = useAppSelector(selectCurrency)
   const settings = useAppSelector(selectSettings)
   const chain = useCurrentChain()
+
   const isTrustedTokenList = useMemo(() => {
-    const hasTrustedList = chain !== undefined && hasFeature(chain, FEATURES.DEFAULT_TOKENLIST)
+    if (chain === undefined) return
+    const hasTrustedList = hasFeature(chain, FEATURES.DEFAULT_TOKENLIST)
     return hasTrustedList && (!settings.tokenList || settings.tokenList === TOKEN_LISTS.TRUSTED)
   }, [chain, settings.tokenList])
 
   // Re-fetch assets when the entire SafeInfo updates
   const [data, error, loading] = useAsync<SafeBalanceResponse | undefined>(
-    async () => {
-      if (!safe) return
+    () => {
+      if (!safe || isTrustedTokenList === undefined) return
       return getBalances(safe.chainId, safe.address.value, currency, {
         trusted: isTrustedTokenList,
       })

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -15,18 +15,19 @@ const useAsync = <T>(
   const callback = useCallback(asyncCall, dependencies)
 
   useEffect(() => {
-    clearData && setData(undefined)
     setError(undefined)
 
     const promise = callback()
 
     // Not a promise, exit early
     if (!promise) {
+      setData(undefined)
       setLoading(false)
       return
     }
 
     let isCurrent = true
+    clearData && setData(undefined)
     setLoading(true)
 
     promise


### PR DESCRIPTION
## What it solves

#1974 

The `useAsync` hook with a third param set to false currently caches data even if the callback does an early exit.
It should only cache data between reloads, not when the callback returns (doesn't matter a promise or not).
If the callback returns no promise, it should be treated as if it returns a promise that resolves to undefined, just w/o the async part.

## How to test it
`useAsync` with `false` as a third param is used in places where we poll info but don't want to clear the data between polls:
* Single tx page (because we poll the tx details when the queue/history tags update)
* Expanded tx details in the tx list (for the same reason)
* Approval editor (polls balances)
* Gas price
* Pending txs queue
* Regular queue
* Messages queue
* History
* Assets