### PR TITLE
Chore: pass dockerhub project id from github secrets

### DIFF
--- a/.github/workflows/deploy-dockerhub.yml
+++ b/.github/workflows/deploy-dockerhub.yml
@@ -25,14 +25,14 @@ jobs:
       if: github.ref == 'refs/heads/main'
       run: bash scripts/github/deploy_docker.sh staging
       env:
-        DOCKERHUB_PROJECT: web-core
+        DOCKERHUB_PROJECT: ${{ secrets.DOCKER_PROJECT }}
     - name: Deploy Dockerhub dev
       if: github.ref == 'refs/heads/dev'
       run: bash scripts/github/deploy_docker.sh dev
       env:
-        DOCKERHUB_PROJECT: web-core
+        DOCKERHUB_PROJECT: ${{ secrets.DOCKER_PROJECT }}
     - name: Deploy Dockerhub tag
       if: startsWith(github.ref, 'refs/tags/')
       run: bash scripts/github/deploy_docker.sh ${GITHUB_REF##*/}
       env:
-        DOCKERHUB_PROJECT: web-core
+        DOCKERHUB_PROJECT: ${{ secrets.DOCKER_PROJECT }}


### PR DESCRIPTION
The Dockerhub project was renamed to safe-wallet-web to match the new name of this repo, so the deploy action must be updated. To make it more flexible, let's make it a GitHub secret along with the Dockerhub username/password.

<img width="790" alt="Screenshot 2023-05-11 at 11 14 14" src="https://github.com/safe-global/safe-wallet-web/assets/381895/a79022e7-3849-4ad0-bd50-e1ad251e7594">
