### PR TITLE
fix: remove margin from data import pane

### DIFF
--- a/src/components/settings/DataManagement/index.tsx
+++ b/src/components/settings/DataManagement/index.tsx
@@ -117,7 +117,7 @@ const DataManagement = () => {
       </Paper>
 
       <Paper sx={{ p: 4 }}>
-        <Grid container spacing={3} mt={2}>
+        <Grid container spacing={3}>
           <Grid item sm={4} xs={12}>
             <Typography variant="h4" fontWeight={700}>
               Data import


### PR DESCRIPTION
## What it solves

Resolves excessibe padding in "Data import" settings pane.

## How this PR fixes it

The `margin-top` of the pane has been removed.

## How to test it

Open the "Data" settings and observe a similar style between the import/export panes.

## Screenshots

Before:

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/48556595-0292-40ea-94eb-ddb7a2a8afd3)

After:

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/5368f5f6-1aba-44eb-a912-3c6f18ae62b5)

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
