### PR TITLE
Fix: don't refresh main component on first page load

### DIFF
--- a/src/hooks/loadables/useLoadBalances.ts
+++ b/src/hooks/loadables/useLoadBalances.ts
@@ -14,15 +14,17 @@ export const useLoadBalances = (): AsyncResult<SafeBalanceResponse> => {
   const currency = useAppSelector(selectCurrency)
   const settings = useAppSelector(selectSettings)
   const chain = useCurrentChain()
+
   const isTrustedTokenList = useMemo(() => {
-    const hasTrustedList = chain !== undefined && hasFeature(chain, FEATURES.DEFAULT_TOKENLIST)
+    if (chain === undefined) return
+    const hasTrustedList = hasFeature(chain, FEATURES.DEFAULT_TOKENLIST)
     return hasTrustedList && (!settings.tokenList || settings.tokenList === TOKEN_LISTS.TRUSTED)
   }, [chain, settings.tokenList])
 
   // Re-fetch assets when the entire SafeInfo updates
   const [data, error, loading] = useAsync<SafeBalanceResponse | undefined>(
-    async () => {
-      if (!safe) return
+    () => {
+      if (!safe || isTrustedTokenList === undefined) return
       return getBalances(safe.chainId, safe.address.value, currency, {
         trusted: isTrustedTokenList,
       })

--- a/src/hooks/loadables/useLoadBalances.ts
+++ b/src/hooks/loadables/useLoadBalances.ts
@@ -7,9 +7,8 @@ import { selectCurrency, selectSettings, TOKEN_LISTS } from '@/store/settingsSli
 import { useCurrentChain } from '../useChains'
 import { FEATURES, hasFeature } from '@/utils/chains'
 import { POLLING_INTERVAL } from '@/config/constants'
-import useSafeAddress from '../useSafeAddress'
 import useIntervalCounter from '../useIntervalCounter'
-import useChainId from '../useChainId'
+import useSafeInfo from '../useSafeInfo'
 
 const useTokenListSetting = (): boolean | undefined => {
   const chain = useCurrentChain()
@@ -26,9 +25,9 @@ const useTokenListSetting = (): boolean | undefined => {
 export const useLoadBalances = (): AsyncResult<SafeBalanceResponse> => {
   const [pollCount, resetPolling] = useIntervalCounter(POLLING_INTERVAL)
   const currency = useAppSelector(selectCurrency)
-  const chainId = useChainId()
-  const safeAddress = useSafeAddress()
   const isTrustedTokenList = useTokenListSetting()
+  const { safe, safeAddress } = useSafeInfo()
+  const chainId = safe.chainId
 
   // Re-fetch assets when the entire SafeInfo updates
   const [data, error, loading] = useAsync<SafeBalanceResponse>(

--- a/src/hooks/loadables/useLoadTxHistory.ts
+++ b/src/hooks/loadables/useLoadTxHistory.ts
@@ -9,8 +9,8 @@ export const useLoadTxHistory = (): AsyncResult<TransactionListPage> => {
   const { chainId, txHistoryTag } = safe
 
   // Re-fetch when chainId/address, or txHistoryTag change
-  const [data, error, loading] = useAsync<TransactionListPage | undefined>(
-    async () => {
+  const [data, error, loading] = useAsync<TransactionListPage>(
+    () => {
       if (!safeLoaded) return
       return getTransactionHistory(chainId, safeAddress)
     },

--- a/src/hooks/loadables/useLoadTxQueue.ts
+++ b/src/hooks/loadables/useLoadTxQueue.ts
@@ -13,8 +13,8 @@ export const useLoadTxQueue = (): AsyncResult<TransactionListPage> => {
   const reloadTag = txQueuedTag + txHistoryTag + proposedId
 
   // Re-fetch when chainId/address, or txQueueTag change
-  const [data, error, loading] = useAsync<TransactionListPage | undefined>(
-    async () => {
+  const [data, error, loading] = useAsync<TransactionListPage>(
+    () => {
       if (!safeLoaded) return
       return getTransactionQueue(chainId, safeAddress)
     },

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -15,18 +15,19 @@ const useAsync = <T>(
   const callback = useCallback(asyncCall, dependencies)
 
   useEffect(() => {
-    clearData && setData(undefined)
     setError(undefined)
 
     const promise = callback()
 
     // Not a promise, exit early
     if (!promise) {
+      setData(undefined)
       setLoading(false)
       return
     }
 
     let isCurrent = true
+    clearData && setData(undefined)
     setLoading(true)
 
     promise

--- a/src/hooks/useChangedValue.ts
+++ b/src/hooks/useChangedValue.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+
+// Return the value only when if it was previously set to a non-falsy value
+const useChangedValue = <T>(value: T): T | undefined => {
+  const [_, setPrevValue] = useState<T>(value)
+  const [newValue, setNewValue] = useState<T>()
+
+  useEffect(() => {
+    setPrevValue((prev) => {
+      if (prev) {
+        setNewValue(value)
+      }
+      return value
+    })
+  }, [value])
+
+  return newValue
+}
+
+export default useChangedValue

--- a/src/hooks/useChangedValue.ts
+++ b/src/hooks/useChangedValue.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-// Return the value only when if it was previously set to a non-falsy value
+// Return the value only if it has been previously set to a non-falsy value
 const useChangedValue = <T>(value: T): T | undefined => {
   const [_, setPrevValue] = useState<T>(value)
   const [newValue, setNewValue] = useState<T>()

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -34,12 +34,12 @@ import ErrorBoundary from '@/components/common/ErrorBoundary'
 import createEmotionCache from '@/utils/createEmotionCache'
 import MetaTags from '@/components/common/MetaTags'
 import useAdjustUrl from '@/hooks/useAdjustUrl'
+import useSafeMessageNotifications from '@/hooks/useSafeMessageNotifications'
+import useSafeMessagePendingStatuses from '@/hooks/useSafeMessagePendingStatuses'
+import useChangedValue from '@/hooks/useChangedValue'
 
 // Importing it dynamically to prevent hydration errors because we read the local storage
 const TermsBanner = dynamic(() => import('@/components/common/TermsBanner'), { ssr: false })
-
-import useSafeMessageNotifications from '@/hooks/useSafeMessageNotifications'
-import useSafeMessagePendingStatuses from '@/hooks/useSafeMessagePendingStatuses'
 
 const GATEWAY_URL = IS_PRODUCTION || cgwDebugStorage.get() ? GATEWAY_URL_PRODUCTION : GATEWAY_URL_STAGING
 
@@ -94,10 +94,12 @@ const WebCoreApp = ({
   router,
   emotionCache = clientSideEmotionCache,
 }: WebCoreAppProps): ReactElement => {
+  const safeKey = useChangedValue(router.query.safe?.toString())
+
   return (
     <StoreHydrator>
       <Head>
-        <title key="default-title">{'Safe{Wallet}'}</title>
+        <title key="default-title">{'Safe'}</title>
         <MetaTags prefetchUrl={GATEWAY_URL} />
       </Head>
 
@@ -108,7 +110,7 @@ const WebCoreApp = ({
           <InitApp />
 
           <PageLayout pathname={router.pathname}>
-            <Component {...pageProps} key={router.query.safe?.toString()} />
+            <Component {...pageProps} key={safeKey} />
           </PageLayout>
 
           <CookieBanner />

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -99,7 +99,7 @@ const WebCoreApp = ({
   return (
     <StoreHydrator>
       <Head>
-        <title key="default-title">{'Safe'}</title>
+        <title key="default-title">{'Safe{Wallet}'}</title>
         <MetaTags prefetchUrl={GATEWAY_URL} />
       </Head>
 


### PR DESCRIPTION
## What it solves

Resolves #1980

This was a regression from #1968.

## How this PR fixes it

The `router.query` is initially empty. This is to avoid hydration issues with the static build which doesn't have any query params by definition.

On safe-specific routes, `router.query.safe` then gets populated with the value from the URL, thus going from undefined to a string. This causes the main page component to re-render due to the `key` prop.

I've added a hook that only changes the key if the previous value was set.