### PR TITLE
fix: merge custom env vars per chain

### DIFF
--- a/src/components/settings/EnvironmentVariables/EnvHintButton/index.tsx
+++ b/src/components/settings/EnvironmentVariables/EnvHintButton/index.tsx
@@ -6,10 +6,12 @@ import { useAppSelector } from '@/store'
 import { isEnvInitialState } from '@/store/settingsSlice'
 import css from './styles.module.css'
 import AlertIcon from '@/public/images/common/alert.svg'
+import useChainId from '@/hooks/useChainId'
 
 const EnvHintButton = () => {
   const router = useRouter()
-  const isInitialState = useAppSelector(isEnvInitialState)
+  const chainId = useChainId()
+  const isInitialState = useAppSelector((state) => isEnvInitialState(state, chainId))
 
   if (isInitialState) {
     return null

--- a/src/components/settings/EnvironmentVariables/index.tsx
+++ b/src/components/settings/EnvironmentVariables/index.tsx
@@ -3,7 +3,7 @@ import { Paper, Grid, Typography, TextField, Button, Tooltip, IconButton, SvgIco
 import InputAdornment from '@mui/material/InputAdornment'
 import RotateLeftIcon from '@mui/icons-material/RotateLeft'
 import { useAppDispatch, useAppSelector } from '@/store'
-import { selectSettings, setEnv } from '@/store/settingsSlice'
+import { selectSettings, setRpc, setTenderly } from '@/store/settingsSlice'
 import { TENDERLY_SIMULATE_ENDPOINT_URL } from '@/config/constants'
 import useChainId from '@/hooks/useChainId'
 import { useCurrentChain } from '@/hooks/useChains'
@@ -46,15 +46,21 @@ const EnvironmentVariables = () => {
 
   const onSubmit = handleSubmit((data) => {
     trackEvent({ ...SETTINGS_EVENTS.ENV_VARIABLES.SAVE })
+
     dispatch(
-      setEnv({
-        rpc: data[EnvVariablesField.rpc] ? { [chainId]: data[EnvVariablesField.rpc] } : {},
-        tenderly: {
-          url: data[EnvVariablesField.tenderlyURL],
-          accessToken: data[EnvVariablesField.tenderlyToken],
-        },
+      setRpc({
+        chainId,
+        rpc: data[EnvVariablesField.rpc],
       }),
     )
+
+    dispatch(
+      setTenderly({
+        url: data[EnvVariablesField.tenderlyURL],
+        accessToken: data[EnvVariablesField.tenderlyToken],
+      }),
+    )
+
     location.reload()
   })
 

--- a/src/store/__tests__/settingsSlice.test.ts
+++ b/src/store/__tests__/settingsSlice.test.ts
@@ -1,5 +1,7 @@
 import { hexZeroPad } from 'ethers/lib/utils'
-import { setHiddenTokensForChain, settingsSlice } from '../settingsSlice'
+import { setHiddenTokensForChain, settingsSlice, isEnvInitialState, initialState } from '../settingsSlice'
+import type { SettingsState } from '../settingsSlice'
+import type { RootState } from '..'
 
 describe('settingsSlice', () => {
   it('handle hiddenTokens', () => {
@@ -21,6 +23,125 @@ describe('settingsSlice', () => {
     expect(state.hiddenTokens).toEqual({
       ['1']: [token1, token2],
       ['5']: [token3],
+    })
+  })
+
+  describe('setRpc', () => {
+    it('should set the RPC for the specified chain', () => {
+      const state = settingsSlice.reducer(
+        initialState,
+        settingsSlice.actions.setRpc({ chainId: '1', rpc: 'https://example.com' }),
+      )
+
+      expect(state.env.rpc).toEqual({
+        ['1']: 'https://example.com',
+      })
+    })
+
+    it('should delete the RPC for the specified chain', () => {
+      const initialState = {
+        env: {
+          rpc: {
+            ['1']: 'https://example.com',
+            ['5']: 'https://other-example.com',
+          },
+        },
+      } as unknown as SettingsState
+
+      const state = settingsSlice.reducer(initialState, settingsSlice.actions.setRpc({ chainId: '1', rpc: '' }))
+
+      expect(state.env.rpc).toEqual({
+        ['5']: 'https://other-example.com',
+      })
+    })
+  })
+
+  describe('setTenderly', () => {
+    it('should set the Tenderly URL and access token', () => {
+      const state = settingsSlice.reducer(
+        undefined,
+        settingsSlice.actions.setTenderly({ url: 'https://example.com', accessToken: 'test123' }),
+      )
+
+      expect(state.env.tenderly).toEqual({
+        url: 'https://example.com',
+        accessToken: 'test123',
+      })
+    })
+
+    it('should delete the Tenderly URL and access token', () => {
+      const initialState = {
+        env: {
+          tenderly: {
+            url: '',
+            accessToken: '',
+          },
+        },
+      } as unknown as SettingsState
+
+      const state = settingsSlice.reducer(initialState, settingsSlice.actions.setTenderly({ url: '', accessToken: '' }))
+
+      expect(state.env.tenderly).toEqual({
+        url: '',
+        accessToken: '',
+      })
+    })
+  })
+
+  describe('isEnvInitialState', () => {
+    it('should return true if the env is the initial state', () => {
+      const state = {
+        settings: {
+          env: {
+            rpc: {},
+            tenderly: { url: '', accessToken: '' },
+          },
+        },
+      } as unknown as RootState
+
+      expect(isEnvInitialState(state, '5')).toEqual(true)
+    })
+
+    it('should return true if the env does not have a custom RPC set on the current chain', () => {
+      const state = {
+        settings: {
+          env: {
+            rpc: { ['1']: 'https://example.com' },
+            tenderly: { url: '', accessToken: '' },
+          },
+        },
+      } as unknown as RootState
+
+      expect(isEnvInitialState(state, '5')).toEqual(true)
+    })
+
+    it('should return false if the env is has a custom RPC set on the current chain', () => {
+      const state = {
+        settings: {
+          env: {
+            rpc: { ['5']: 'https://other-example.com' },
+            tenderly: { url: '', accessToken: '' },
+          },
+        },
+      } as unknown as RootState
+
+      expect(isEnvInitialState(state, '5')).toEqual(false)
+    })
+
+    it('should return false if the env is has a custom Tenderly set', () => {
+      const state = {
+        settings: {
+          env: {
+            rpc: {},
+            tenderly: {
+              url: 'https://example.com',
+              accessToken: 'test123',
+            },
+          },
+        },
+      } as unknown as RootState
+
+      expect(isEnvInitialState(state, '5')).toEqual(false)
     })
   })
 })

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -40,7 +40,7 @@ export type SettingsState = {
   env: EnvState
 }
 
-const initialState: SettingsState = {
+export const initialState: SettingsState = {
   currency: 'usd',
 
   tokenList: TOKEN_LISTS.TRUSTED,
@@ -88,8 +88,16 @@ export const settingsSlice = createSlice({
     setTokenList: (state, { payload }: PayloadAction<SettingsState['tokenList']>) => {
       state.tokenList = payload
     },
-    setEnv: (state, { payload }: PayloadAction<EnvState>) => {
-      state.env = payload
+    setRpc: (state, { payload }: PayloadAction<{ chainId: string; rpc: string }>) => {
+      const { chainId, rpc } = payload
+      if (rpc) {
+        state.env.rpc[chainId] = rpc
+      } else {
+        delete state.env.rpc[chainId]
+      }
+    },
+    setTenderly: (state, { payload }: PayloadAction<EnvState['tenderly']>) => {
+      state.env.tenderly = merge({}, state.env.tenderly, payload)
     },
     setSettings: (_, { payload }: PayloadAction<SettingsState>) => {
       // We must return as we are overwriting the entire state
@@ -107,7 +115,8 @@ export const {
   setDarkMode,
   setHiddenTokensForChain,
   setTokenList,
-  setEnv,
+  setRpc,
+  setTenderly,
 } = settingsSlice.actions
 
 export const selectSettings = (state: RootState): SettingsState => state[settingsSlice.name]
@@ -128,4 +137,6 @@ export const selectRpc = createSelector(selectSettings, (settings) => settings.e
 
 export const selectTenderly = createSelector(selectSettings, (settings) => settings.env.tenderly)
 
-export const isEnvInitialState = createSelector(selectSettings, (settings) => isEqual(settings.env, initialState.env))
+export const isEnvInitialState = createSelector([selectSettings, (_, chainId) => chainId], (settings, chainId) => {
+  return isEqual(settings.env.tenderly, initialState.env.tenderly) && !settings.env.rpc[chainId]
+})


### PR DESCRIPTION
## What it solves

Resolves #1978

## How this PR fixes it

Setting custom env. vars. no longer fully overwrite the `EnvState`. RPC/Tenderly settings now have their own actions:
- `setRpc` only sets the current chain
- `setTenderly` only sets the Tenderly settings

The sidebar hint is now only shown when there is either a custom RPC for the current chain or custom Tenderly settings.

## How to test it

### RPCs
1. Set a custom RPC on Goerli and observe the warning in the sidebar.
2. Switch to another network and observe no warning.

### Tenderly
1. Set custom Tenderlys ettings and observe the warning in the sidebar.
2. Switch to another network and observe the warning.

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
