### PR TITLE
test: E2E remove NFT tooltip assertion

### DIFF
--- a/cypress/e2e/smoke/balances.cy.js
+++ b/cypress/e2e/smoke/balances.cy.js
@@ -152,7 +152,8 @@ describe('Assets > Coins', () => {
     })
   })
 
-  describe('fiat currency can be changed', () => {
+  // The staging endpoint https://safe-client.staging.5afe.dev/v1/balances/supported-fiat-codes is returning error
+  describe.skip('fiat currency can be changed', () => {
     it('should have USD as default currency', () => {
       // First row Fiat balance should not contain EUR
       cy.get(balanceSingleRow).first().find('td').eq(FIAT_AMOUNT_COLUMN).should('not.contain', 'EUR')

--- a/cypress/e2e/smoke/balances.cy.js
+++ b/cypress/e2e/smoke/balances.cy.js
@@ -152,8 +152,7 @@ describe('Assets > Coins', () => {
     })
   })
 
-  // The staging endpoint https://safe-client.staging.5afe.dev/v1/balances/supported-fiat-codes is returning error
-  describe.skip('fiat currency can be changed', () => {
+  describe('fiat currency can be changed', () => {
     it('should have USD as default currency', () => {
       // First row Fiat balance should not contain EUR
       cy.get(balanceSingleRow).first().find('td').eq(FIAT_AMOUNT_COLUMN).should('not.contain', 'EUR')

--- a/cypress/e2e/smoke/nfts.cy.js
+++ b/cypress/e2e/smoke/nfts.cy.js
@@ -12,9 +12,6 @@ describe('Assets > NFTs', () => {
   describe('should have NFTs', () => {
     it('should have NFTs in the table', () => {
       cy.get('tbody tr').should('have.length', 5)
-      cy.contains('Please note that the links to OpenSea')
-      cy.contains('button', 'Got it!').click()
-      cy.contains('Please note that the links to OpenSea').should('not.exist')
     })
 
     it('should have info in the NFT row', () => {


### PR DESCRIPTION
## What it solves
Removes a leftover E2E test after removing the NFT links tooltip

## How this PR fixes it
- Removes a the tooltip test
- ~Comments out a fiat currency selector test relying on a failing CGW endpoint.~
