### PR TITLE
fix: Do not rerender approval editor in confirmation modal

### DIFF
--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -1,4 +1,4 @@
-import type { SyntheticEvent, ReactElement } from 'react'
+import { type SyntheticEvent, type ReactElement, useMemo } from 'react'
 import { Accordion, AccordionDetails, AccordionSummary, Box, Skeleton, Typography } from '@mui/material'
 import { OperationType, type SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import {
@@ -44,6 +44,13 @@ const DecodedTx = ({ tx, txId }: DecodedTxProps): ReactElement | null => {
     return getTransactionDetails(chainId, txId)
   }, [])
 
+  const approvalEditorTx = useMemo(() => {
+    if (!decodedData || !txDetails?.txData) {
+      return undefined
+    }
+    return { ...decodedData, to: txDetails?.txData?.to.value }
+  }, [decodedData, txDetails?.txData])
+
   const onChangeExpand = (_: SyntheticEvent, expanded: boolean) => {
     trackEvent({ ...MODALS_EVENTS.TX_DETAILS, label: expanded ? 'Open' : 'Close' })
   }
@@ -52,9 +59,9 @@ const DecodedTx = ({ tx, txId }: DecodedTxProps): ReactElement | null => {
 
   return (
     <Box mb={2}>
-      {decodedData && txDetails?.txData && (
+      {approvalEditorTx && (
         <ErrorBoundary fallback={<div>Error parsing data</div>}>
-          <ApprovalEditor txs={{ ...decodedData, to: txDetails.txData.to.value }} />
+          <ApprovalEditor txs={approvalEditorTx} />
         </ErrorBoundary>
       )}
 


### PR DESCRIPTION
## What it solves
Avoids rerenders of approval editor, when the queue gets polled

Resolves #2003 

## How this PR fixes it
Memoize prop for approval editor

## How to test it
1.    Queue a transaction containing approval(s)
2.    Wait ~10-15s
3.    Witness the approval editor rerendering


## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
