### PR TITLE
Fix: show added safes with or w/o a wallet

### DIFF
--- a/src/components/sidebar/SafeList/index.tsx
+++ b/src/components/sidebar/SafeList/index.tsx
@@ -159,7 +159,6 @@ const SafeList = ({ closeDrawer }: { closeDrawer?: () => void }): ReactElement =
       )}
 
       {!hasNoSafes &&
-        hasWallet &&
         configs.map((chain) => {
           const ownedSafesOnChain = ownedSafes[chain.chainId] ?? []
           const addedSafesOnChain = addedSafes[chain.chainId] ?? {}


### PR DESCRIPTION
## What it solves

Fixes a regression from #1937 

SafeList should always show added safes regardless of the connected wallet.