### PR TITLE
Chore: rm cancel-workflow-action

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -11,11 +11,6 @@ jobs:
     env:
       ARCHIVE_NAME: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
       - uses: actions/checkout@v3
 
       - uses: ./.github/workflows/yarn

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,10 @@ on:
       - dev
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -17,11 +21,6 @@ jobs:
     name: Deploy to dev/staging
 
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
       # Post a PR comment before deploying
       - name: Post a comment while building
         if: github.event.number

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,16 +3,15 @@ name: e2e
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     runs-on: ubuntu-latest
     name: Smoke E2E tests
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
       - uses: actions/checkout@v3
 
       - uses: ./.github/workflows/yarn

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,15 +1,14 @@
 name: 'Lint'
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
       - uses: actions/checkout@v3
 
       - uses: ./.github/workflows/yarn

--- a/.github/workflows/safe-apps-e2e.yml
+++ b/.github/workflows/safe-apps-e2e.yml
@@ -4,16 +4,15 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     runs-on: ubuntu-latest
     name: Safe Apps E2E tests
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
       - uses: actions/checkout@v3
 
       - uses: ./.github/workflows/yarn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,15 +6,14 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
       - uses: actions/checkout@v3
 
       - uses: ./.github/workflows/yarn

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ yarn cmp MyNewComponent
 
 ## Frameworks
 
+This app is built using the following frameworks:
+
 - [Safe Core SDK](https://github.com/safe-global/safe-core-sdk)
 - [Safe Gateway SDK](https://github.com/safe-global/safe-gateway-typescript-sdk)
 - Next.js


### PR DESCRIPTION
## What it solves

Part of #2009

## How this PR fixes it

Replaces `cancel-workflow-action` with a native concurrency setting as per the suggestion in cancel-workflow-action's repo.