### PR TITLE
fix: keep expand/collapse buttons from rotating

### DIFF
--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from 'react'
 import type { Dispatch, ReactElement, SetStateAction } from 'react'
 import type { AccordionProps } from '@mui/material/Accordion/Accordion'
 import SingleTxDecoded from '@/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded'
-import { AccordionSummary, Box, Button, Divider } from '@mui/material'
+import { AccordionSummary, Box, Button, Divider, Stack } from '@mui/material'
 import css from './styles.module.css'
 
 type MultisendProps = {
@@ -13,8 +13,6 @@ type MultisendProps = {
   showDelegateCallWarning?: boolean
   compact?: boolean
 }
-
-const MIN_SCROLL_TXS = 4
 
 const MultisendActionsHeader = ({
   setOpen,
@@ -28,21 +26,16 @@ const MultisendActionsHeader = ({
   }
 
   return (
-    <AccordionSummary
-      className={css.summary}
-      expandIcon={
-        <>
-          <Button onClick={onClickAll(true)} variant="text">
-            Expand all
-          </Button>
-          <Divider className={css.divider} />
-          <Button onClick={onClickAll(false)} variant="text">
-            Collapse all
-          </Button>
-        </>
-      }
-    >
+    <AccordionSummary className={css.summary}>
       All actions
+      <Stack direction="row" divider={<Divider className={css.divider} />}>
+        <Button onClick={onClickAll(true)} variant="text">
+          Expand all
+        </Button>
+        <Button onClick={onClickAll(false)} variant="text">
+          Collapse all
+        </Button>
+      </Stack>
     </AccordionSummary>
   )
 }

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from 'react'
 import type { Dispatch, ReactElement, SetStateAction } from 'react'
 import type { AccordionProps } from '@mui/material/Accordion/Accordion'
 import SingleTxDecoded from '@/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded'
-import { AccordionSummary, Box, Button, Divider, Stack } from '@mui/material'
+import { Box, Button, Divider, Stack } from '@mui/material'
 import css from './styles.module.css'
 
 type MultisendProps = {
@@ -26,7 +26,7 @@ const MultisendActionsHeader = ({
   }
 
   return (
-    <AccordionSummary className={css.summary}>
+    <div className={css.summary}>
       All actions
       <Stack direction="row" divider={<Divider className={css.divider} />}>
         <Button onClick={onClickAll(true)} variant="text">
@@ -36,7 +36,7 @@ const MultisendActionsHeader = ({
           Collapse all
         </Button>
       </Stack>
-    </AccordionSummary>
+    </div>
   )
 }
 

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -26,7 +26,7 @@ const MultisendActionsHeader = ({
   }
 
   return (
-    <div className={css.summary}>
+    <div className={css.actionsHeader}>
       All actions
       <Stack direction="row" divider={<Divider className={css.divider} />}>
         <Button onClick={onClickAll(true)} variant="text">

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
@@ -1,18 +1,16 @@
 .summary {
   border-bottom: 1px solid var(--color-border-light);
   cursor: auto !important;
+  padding-left: 16px;
   padding-right: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .summary button {
   padding-left: 18px;
   padding-right: 18px;
-}
-
-.summary :global .MuiAccordionSummary-content {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
 }
 
 .divider {

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
@@ -1,4 +1,4 @@
-.summary {
+.actionsHeader {
   border-bottom: 1px solid var(--color-border-light);
   cursor: auto !important;
   padding-left: 16px;
@@ -8,7 +8,7 @@
   align-items: center;
 }
 
-.summary button {
+.actionsHeader button {
   padding-left: 18px;
   padding-right: 18px;
 }

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
@@ -9,8 +9,14 @@
   padding-right: 18px;
 }
 
+.summary :global .MuiAccordionSummary-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
 .divider {
   margin-top: 14px;
   margin-bottom: 14px;
-  border-color: var(--color-border-light);
+  border: 1px solid var(--color-border-light);
 }


### PR DESCRIPTION
## What it solves

Resolves #2002

## How this PR fixes it
Replace the `AccordionSummary` by a styled `<div>` element.

## How to test it
1. Queue any multiSend tx
2. Open the tx queue
3. Click on the "rocket" or "check" icon to sign / execute directly from the list
4. Click on Expand all

## Screenshots
https://github.com/safe-global/safe-wallet-web/assets/32431609/9f43a994-3bcd-4e90-8d55-1df68c8f8c9b

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
