### PR TITLE
feat: unexpected delegate call security module

### DIFF
--- a/src/components/tx/TxSecurityWarnings/index.tsx
+++ b/src/components/tx/TxSecurityWarnings/index.tsx
@@ -5,10 +5,12 @@ import { BalanceChanges } from '../BalanceChange'
 import { useRedefine } from './useRedefine'
 import { useRecipientModule } from './useRecipientModule'
 import { shortenAddress } from '@/utils/formatters'
+import { useDelegateCallModule } from './useDelegateCallModule'
 
 export const TxSecurityWarnings = ({ safeTx }: { safeTx: SafeTransaction | undefined }) => {
   const [redefineScanResult, , redefineLoading] = useRedefine(safeTx)
   const [recipientScanResult, , recipientLoading] = useRecipientModule(safeTx)
+  const [delegateCallScanResult, , delegateCallLoading] = useDelegateCallModule(safeTx)
 
   return (
     <>
@@ -38,6 +40,19 @@ export const TxSecurityWarnings = ({ safeTx }: { safeTx: SafeTransaction | undef
               />
             ))}
             <SecurityWarning severity={recipientScanResult.severity} />
+          </>
+        )
+      )}
+      {delegateCallLoading ? (
+        <CircularProgress />
+      ) : (
+        delegateCallScanResult?.payload && (
+          <>
+            <SecurityHint
+              severity={delegateCallScanResult.severity}
+              text={delegateCallScanResult.payload.description.short}
+            />
+            <SecurityWarning severity={delegateCallScanResult.severity} />
           </>
         )
       )}

--- a/src/components/tx/TxSecurityWarnings/useDelegateCallModule.ts
+++ b/src/components/tx/TxSecurityWarnings/useDelegateCallModule.ts
@@ -1,0 +1,25 @@
+import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
+
+import useAsync from '@/hooks/useAsync'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import { DelegateCallModule } from '@/services/security/modules/DelegateCallModule'
+import type { DelegateCallModuleResponse } from '@/services/security/modules/DelegateCallModule'
+import type { SecurityResponse } from '@/services/security/modules/types'
+
+const DelegateCallModuleInstance = new DelegateCallModule()
+
+export const useDelegateCallModule = (safeTransaction: SafeTransaction | undefined) => {
+  const { safe, safeLoaded } = useSafeInfo()
+
+  return useAsync<SecurityResponse<DelegateCallModuleResponse>>(() => {
+    if (!safeTransaction || !safeLoaded) {
+      return
+    }
+
+    return DelegateCallModuleInstance.scanTransaction({
+      safeTransaction,
+      safeVersion: safe.version,
+      chainId: safe.chainId,
+    })
+  }, [safeTransaction, safeLoaded, safe.version, safe.chainId])
+}

--- a/src/services/security/modules/DelegateCallModule/index.test.ts
+++ b/src/services/security/modules/DelegateCallModule/index.test.ts
@@ -1,0 +1,87 @@
+import { OperationType } from '@safe-global/safe-core-sdk-types'
+import { getMultiSendCallOnlyDeployment } from '@safe-global/safe-deployments'
+import { hexZeroPad } from 'ethers/lib/utils'
+
+import { DelegateCallModule } from '.'
+import { createMockSafeTransaction, getMockMultiSendCalldata } from '@/tests/transactions'
+
+describe('DelegateCallModule', () => {
+  const DelegateCallModuleInstance = new DelegateCallModule()
+
+  it('should not warn about Call operation transactions', async () => {
+    const recipient = hexZeroPad('0x1', 20)
+
+    const safeTransaction = createMockSafeTransaction({
+      to: recipient,
+      data: '0x',
+      operation: OperationType.Call,
+    })
+
+    const result = await DelegateCallModuleInstance.scanTransaction({
+      safeTransaction,
+      chainId: '5',
+      safeVersion: '1.3.0',
+    })
+
+    expect(result).toEqual({
+      severity: 0,
+    })
+  })
+
+  it('should not warn about MultiSendCallOnly DelegateCall operation transactions', async () => {
+    const CHAIN_ID = '5'
+    const SAFE_VERSION = '1.3.0'
+
+    const multiSend = getMultiSendCallOnlyDeployment({
+      network: CHAIN_ID,
+      version: SAFE_VERSION,
+    })!.defaultAddress
+
+    const recipient1 = hexZeroPad('0x2', 20)
+    const recipient2 = hexZeroPad('0x3', 20)
+
+    const data = getMockMultiSendCalldata([recipient1, recipient2])
+
+    const safeTransaction = createMockSafeTransaction({
+      to: multiSend,
+      data,
+      operation: OperationType.DelegateCall,
+    })
+
+    const result = await DelegateCallModuleInstance.scanTransaction({
+      safeTransaction,
+      chainId: CHAIN_ID,
+      safeVersion: SAFE_VERSION,
+    })
+
+    expect(result).toEqual({
+      severity: 0,
+    })
+  })
+
+  it('should warn about non-MultiSendCallOnly DelegateCall operation transactions', async () => {
+    const recipient = hexZeroPad('0x1', 20)
+
+    const safeTransaction = createMockSafeTransaction({
+      to: recipient,
+      data: '0x',
+      operation: OperationType.DelegateCall,
+    })
+
+    const result = await DelegateCallModuleInstance.scanTransaction({
+      safeTransaction,
+      chainId: '5',
+      safeVersion: '1.3.0',
+    })
+
+    expect(result).toEqual({
+      severity: 3,
+      payload: {
+        description: {
+          long: 'This transaction is a DelegateCall. It calls a smart contract that will be able to modify your Safe Account.',
+          short: 'Unexpected DelegateCall',
+        },
+      },
+    })
+  })
+})

--- a/src/services/security/modules/DelegateCallModule/index.ts
+++ b/src/services/security/modules/DelegateCallModule/index.ts
@@ -1,0 +1,53 @@
+import { OperationType } from '@safe-global/safe-core-sdk-types'
+import { getMultiSendCallOnlyDeployment } from '@safe-global/safe-deployments'
+import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
+
+import { SecuritySeverity } from '../types'
+import type { SecurityModule, SecurityResponse } from '../types'
+
+type DelegateCallModuleRequest = {
+  chainId: string
+  safeVersion: SafeInfo['version']
+  safeTransaction: SafeTransaction
+}
+
+export type DelegateCallModuleResponse = {
+  description: {
+    short: string
+    long: string
+  }
+}
+
+export class DelegateCallModule implements SecurityModule<DelegateCallModuleRequest, DelegateCallModuleResponse> {
+  private isUnexpectedDelegateCall(request: DelegateCallModuleRequest): boolean {
+    const { chainId, safeTransaction, safeVersion } = request
+
+    if (safeTransaction.data.operation !== OperationType.DelegateCall) {
+      return false
+    }
+
+    // We need not check for nested delegate calls as we only use MultiSendCallOnly in the UI
+    const multiSendDeployment = getMultiSendCallOnlyDeployment({ network: chainId, version: safeVersion ?? undefined })
+
+    return multiSendDeployment?.defaultAddress !== safeTransaction.data.to
+  }
+
+  async scanTransaction(request: DelegateCallModuleRequest): Promise<SecurityResponse<DelegateCallModuleResponse>> {
+    if (!this.isUnexpectedDelegateCall(request)) {
+      return {
+        severity: SecuritySeverity.NONE,
+      }
+    }
+
+    return {
+      severity: SecuritySeverity.HIGH,
+      payload: {
+        description: {
+          short: 'Unexpected DelegateCall',
+          long: 'This transaction is a DelegateCall. It calls a smart contract that will be able to modify your Safe Account.',
+        },
+      },
+    }
+  }
+}


### PR DESCRIPTION
## What it solves

Resolves #2016

## How this PR fixes it

This adds the `DelegateCallModule`, as well as associated hook and demo implementation in the transaction modal.

The implementation checks and warns whether the given transaction is a non-MultiSend `DelegateCall`.

## How to test it

Create a `DelegateCall` transaction and observe the warning.

## Screenshots

Please note that this is a demo implementation.

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/837e86d3-f21a-4fb1-8971-aaf9a6133d49)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
