### PR TITLE
Tests: fix balances - rm Ok button

### DIFF
--- a/cypress/e2e/smoke/balances.cy.js
+++ b/cypress/e2e/smoke/balances.cy.js
@@ -203,9 +203,6 @@ describe('Assets > Coins', () => {
       cy.visit(`/balances?safe=${PAGINATION_TEST_SAFE}`)
       cy.contains('button', 'Accept selection').click()
 
-      // Find button with the text OK (terms banner), and if it exists, click it
-      cy.get('button').contains('Ok').click({ force: true })
-
       // Table is loaded
       cy.contains('Görli Ether')
       cy.contains('button', 'Got it').click()


### PR DESCRIPTION
## What it solves

The Terms banner was removed in #2041, but the OK button in the balances test remained.