### PR TITLE
feat: Add settings to change default transaction execution behaviour

### DIFF
--- a/src/components/balances/AssetsTable/index.test.tsx
+++ b/src/components/balances/AssetsTable/index.test.tsx
@@ -108,6 +108,7 @@ describe('AssetsTable', () => {
           signing: {
             onChainSigning: false,
           },
+          transactionExecution: true,
         },
       },
     })
@@ -213,6 +214,7 @@ describe('AssetsTable', () => {
           signing: {
             onChainSigning: false,
           },
+          transactionExecution: true,
         },
       },
     })
@@ -314,6 +316,7 @@ describe('AssetsTable', () => {
           signing: {
             onChainSigning: false,
           },
+          transactionExecution: true,
         },
       },
     })
@@ -412,6 +415,7 @@ describe('AssetsTable', () => {
           signing: {
             onChainSigning: false,
           },
+          transactionExecution: true,
         },
       },
     })

--- a/src/components/balances/HiddenTokenButton/index.test.tsx
+++ b/src/components/balances/HiddenTokenButton/index.test.tsx
@@ -86,6 +86,7 @@ describe('HiddenTokenToggle', () => {
           signing: {
             onChainSigning: false,
           },
+          transactionExecution: true,
         },
       },
     })

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -22,6 +22,8 @@ import { useRelaysBySafe } from '@/hooks/useRemainingRelays'
 import useWalletCanRelay from '@/hooks/useWalletCanRelay'
 import { ExecutionMethod, ExecutionMethodSelector } from '../ExecutionMethodSelector'
 import { hasRemainingRelays } from '@/utils/relaying'
+import { useAppSelector } from '@/store'
+import { selectSettings } from '@/store/settingsSlice'
 
 type SignOrExecuteProps = {
   safeTx?: SafeTransaction
@@ -48,10 +50,12 @@ const SignOrExecuteForm = ({
   origin,
   ...props
 }: SignOrExecuteProps): ReactElement => {
+  const settings = useAppSelector(selectSettings)
+
   //
   // Hooks & variables
   //
-  const [shouldExecute, setShouldExecute] = useState<boolean>(true)
+  const [shouldExecute, setShouldExecute] = useState<boolean>(settings.transactionExecution)
   const [isSubmittable, setIsSubmittable] = useState<boolean>(true)
   const [tx, setTx] = useState<SafeTransaction | undefined>(safeTx)
   const [submitError, setSubmitError] = useState<Error | undefined>()

--- a/src/pages/settings/appearance.tsx
+++ b/src/pages/settings/appearance.tsx
@@ -1,14 +1,21 @@
-import { Checkbox, FormControlLabel, FormGroup, Grid, Paper, Typography, Switch } from '@mui/material'
+import { Checkbox, FormControlLabel, FormGroup, Grid, Paper, Typography, Switch, Tooltip, SvgIcon } from '@mui/material'
 import type { ChangeEvent } from 'react'
 import type { NextPage } from 'next'
 import Head from 'next/head'
 
 import { useAppDispatch, useAppSelector } from '@/store'
-import { selectSettings, setCopyShortName, setDarkMode, setShowShortName } from '@/store/settingsSlice'
+import {
+  selectSettings,
+  setCopyShortName,
+  setDarkMode,
+  setShowShortName,
+  setTransactionExecution,
+} from '@/store/settingsSlice'
 import SettingsHeader from '@/components/settings/SettingsHeader'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 import { useDarkMode } from '@/hooks/useDarkMode'
 import ExternalLink from '@/components/common/ExternalLink'
+import InfoIcon from '@/public/images/notifications/info.svg'
 
 const Appearance: NextPage = () => {
   const dispatch = useAppDispatch()
@@ -16,11 +23,12 @@ const Appearance: NextPage = () => {
   const isDarkMode = useDarkMode()
 
   const handleToggle = (
-    action: typeof setCopyShortName | typeof setDarkMode | typeof setShowShortName,
+    action: typeof setCopyShortName | typeof setDarkMode | typeof setShowShortName | typeof setTransactionExecution,
     event:
       | typeof SETTINGS_EVENTS.APPEARANCE.PREPEND_PREFIXES
       | typeof SETTINGS_EVENTS.APPEARANCE.COPY_PREFIXES
-      | typeof SETTINGS_EVENTS.APPEARANCE.DARK_MODE,
+      | typeof SETTINGS_EVENTS.APPEARANCE.DARK_MODE
+      | typeof SETTINGS_EVENTS.APPEARANCE.TRANSACTION_EXECUTION,
   ) => {
     return (_: ChangeEvent<HTMLInputElement>, checked: boolean) => {
       dispatch(action(checked))
@@ -31,6 +39,26 @@ const Appearance: NextPage = () => {
       })
     }
   }
+
+  const infoIcon = (
+    <Tooltip
+      title={
+        settings.transactionExecution
+          ? 'The transaction will be by default executed when fully signed.'
+          : 'If you want to sign the transaction by default and manually execute it later, uncheck this box.'
+      }
+    >
+      <span>
+        <SvgIcon
+          component={InfoIcon}
+          inheritViewBox
+          fontSize="small"
+          color="border"
+          sx={{ verticalAlign: 'middle', marginLeft: 0.5 }}
+        />
+      </span>
+    </Tooltip>
+  )
 
   return (
     <>
@@ -73,6 +101,31 @@ const Appearance: NextPage = () => {
                     />
                   }
                   label="Copy addresses with chain prefix"
+                />
+              </FormGroup>
+            </Grid>
+          </Grid>
+
+          <Grid container alignItems="center" marginTop={2} spacing={3}>
+            <Grid item lg={4} xs={12}>
+              <Typography variant="h4" fontWeight="bold" mb={1}>
+                Transaction execution
+              </Typography>
+            </Grid>
+            <Grid item xs>
+              <Typography mb={2}>
+                {/* Change the default setting for last signer */}
+                Choose execution behavior when the transaction is fully signed.
+              </Typography>
+              <FormGroup>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={settings.transactionExecution}
+                      onChange={handleToggle(setTransactionExecution, SETTINGS_EVENTS.APPEARANCE.TRANSACTION_EXECUTION)}
+                    />
+                  }
+                  label={<>Last signer executes transaction {infoIcon}</>}
                 />
               </FormGroup>
             </Grid>

--- a/src/services/analytics/events/settings.ts
+++ b/src/services/analytics/events/settings.ts
@@ -48,6 +48,10 @@ export const SETTINGS_EVENTS = {
       action: 'Dark mode',
       category: SETTINGS_CATEGORY,
     },
+    TRANSACTION_EXECUTION: {
+      action: 'Transaction execution',
+      category: SETTINGS_CATEGORY,
+    },
   },
   MODULES: {
     REMOVE_MODULE: {

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -41,6 +41,8 @@ export type SettingsState = {
   signing: {
     onChainSigning: boolean
   }
+
+  transactionExecution: boolean
 }
 
 export const initialState: SettingsState = {
@@ -66,6 +68,7 @@ export const initialState: SettingsState = {
   signing: {
     onChainSigning: false,
   },
+  transactionExecution: true,
 }
 
 export const settingsSlice = createSlice({
@@ -74,6 +77,9 @@ export const settingsSlice = createSlice({
   reducers: {
     setCurrency: (state, { payload }: PayloadAction<SettingsState['currency']>) => {
       state.currency = payload
+    },
+    setTransactionExecution: (state, { payload }: PayloadAction<SettingsState['transactionExecution']>) => {
+      state.transactionExecution = payload
     },
     setShowShortName: (state, { payload }: PayloadAction<SettingsState['shortName']['show']>) => {
       state.shortName.show = payload
@@ -127,6 +133,7 @@ export const {
   setRpc,
   setTenderly,
   setOnChainSigning,
+  setTransactionExecution,
 } = settingsSlice.actions
 
 export const selectSettings = (state: RootState): SettingsState => state[settingsSlice.name]


### PR DESCRIPTION
## What it solves

This pull request introduces a new feature that allows users to disable transaction execution by default. With this enhancement, users gain the flexibility to adopt alternative workflows or employ relayers to forward pre-signed transactions. By providing this option, the PR expands the functionality and customization capabilities of the system, catering to diverse user preferences and needs.

## How this PR fixes it

This PR adds a `transactionExecution` flag in the settings, enabling users to easily enable or disable transaction execution based on their preferences.

## How to test it

Steps to test:

1. Go to Settings
2. Go to Appearance
3. Uncheck "Last signer executes transaction"
4. Create a new Transaction & `Execute transaction` checkbox should be un-checked if you are the last signer.

## Screenshots

<img width="1509" alt="image" src="https://github.com/safe-global/safe-wallet-web/assets/5251472/b0341d30-03a4-4adc-9602-4004d6e7d789">
<img width="1194" alt="image" src="https://github.com/safe-global/safe-wallet-web/assets/5251472/a64b9c4f-670e-4568-9ec2-61fa1d17e549">
<img width="444" alt="image" src="https://github.com/safe-global/safe-wallet-web/assets/5251472/2b790569-ef54-4c10-8b7a-0463a1483e6f">
<img width="651" alt="image" src="https://github.com/safe-global/safe-wallet-web/assets/5251472/e90ff45c-36d1-4551-ae41-2617a228655f">


## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
