### PR TITLE
feat: Remember the state of Execute transaction checkbox in settings

### DIFF
--- a/src/components/balances/AssetsTable/index.test.tsx
+++ b/src/components/balances/AssetsTable/index.test.tsx
@@ -108,6 +108,7 @@ describe('AssetsTable', () => {
           signing: {
             onChainSigning: false,
           },
+          transactionExecution: true,
         },
       },
     })
@@ -213,6 +214,7 @@ describe('AssetsTable', () => {
           signing: {
             onChainSigning: false,
           },
+          transactionExecution: true,
         },
       },
     })
@@ -314,6 +316,7 @@ describe('AssetsTable', () => {
           signing: {
             onChainSigning: false,
           },
+          transactionExecution: true,
         },
       },
     })
@@ -412,6 +415,7 @@ describe('AssetsTable', () => {
           signing: {
             onChainSigning: false,
           },
+          transactionExecution: true,
         },
       },
     })

--- a/src/components/balances/HiddenTokenButton/index.test.tsx
+++ b/src/components/balances/HiddenTokenButton/index.test.tsx
@@ -86,6 +86,7 @@ describe('HiddenTokenToggle', () => {
           signing: {
             onChainSigning: false,
           },
+          transactionExecution: true,
         },
       },
     })

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -22,6 +22,8 @@ import { useRelaysBySafe } from '@/hooks/useRemainingRelays'
 import useWalletCanRelay from '@/hooks/useWalletCanRelay'
 import { ExecutionMethod, ExecutionMethodSelector } from '../ExecutionMethodSelector'
 import { hasRemainingRelays } from '@/utils/relaying'
+import { useAppDispatch, useAppSelector } from '@/store'
+import { selectSettings, setTransactionExecution } from '@/store/settingsSlice'
 
 type SignOrExecuteProps = {
   safeTx?: SafeTransaction
@@ -48,10 +50,12 @@ const SignOrExecuteForm = ({
   origin,
   ...props
 }: SignOrExecuteProps): ReactElement => {
+  const settings = useAppSelector(selectSettings)
+
   //
   // Hooks & variables
   //
-  const [shouldExecute, setShouldExecute] = useState<boolean>(true)
+  const [shouldExecute, setShouldExecute] = useState<boolean>(settings.transactionExecution)
   const [isSubmittable, setIsSubmittable] = useState<boolean>(true)
   const [tx, setTx] = useState<SafeTransaction | undefined>(safeTx)
   const [submitError, setSubmitError] = useState<Error | undefined>()
@@ -61,6 +65,7 @@ const SignOrExecuteForm = ({
   const currentChain = useCurrentChain()
   const { signTx, executeTx } = useTxActions()
   const [relays] = useRelaysBySafe()
+  const dispatch = useAppDispatch()
 
   // Check that the transaction is executable
   const isCreation = !txId
@@ -149,6 +154,11 @@ const SignOrExecuteForm = ({
     setAdvancedParams(data)
   }
 
+  const hangleExecuteCheckboxChange = (checked: boolean) => {
+    setShouldExecute(checked)
+    dispatch(setTransactionExecution(checked))
+  }
+
   const cannotPropose = !isOwner && !onlyExecute // Can't sign or create a tx if not an owner
   const submitDisabled =
     !isSubmittable ||
@@ -168,7 +178,9 @@ const SignOrExecuteForm = ({
 
         <DecodedTx tx={tx} txId={txId} />
 
-        {canExecute && <ExecuteCheckbox checked={shouldExecute} onChange={setShouldExecute} disabled={onlyExecute} />}
+        {canExecute && (
+          <ExecuteCheckbox checked={shouldExecute} onChange={hangleExecuteCheckboxChange} disabled={onlyExecute} />
+        )}
 
         <AdvancedParams
           params={advancedParams}

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -41,6 +41,7 @@ export type SettingsState = {
   signing: {
     onChainSigning: boolean
   }
+  transactionExecution: boolean
 }
 
 export const initialState: SettingsState = {
@@ -66,6 +67,7 @@ export const initialState: SettingsState = {
   signing: {
     onChainSigning: false,
   },
+  transactionExecution: true,
 }
 
 export const settingsSlice = createSlice({
@@ -83,6 +85,9 @@ export const settingsSlice = createSlice({
     },
     setQrShortName: (state, { payload }: PayloadAction<SettingsState['shortName']['qr']>) => {
       state.shortName.qr = payload
+    },
+    setTransactionExecution: (state, { payload }: PayloadAction<SettingsState['transactionExecution']>) => {
+      state.transactionExecution = payload
     },
     setDarkMode: (state, { payload }: PayloadAction<SettingsState['theme']['darkMode']>) => {
       state.theme.darkMode = payload
@@ -127,6 +132,7 @@ export const {
   setRpc,
   setTenderly,
   setOnChainSigning,
+  setTransactionExecution,
 } = settingsSlice.actions
 
 export const selectSettings = (state: RootState): SettingsState => state[settingsSlice.name]


### PR DESCRIPTION
## What it solves

This pull request addresses the need to save the last checkbox state of the "Execute Transaction" checkbox in the settings. With this enhancement, the system will remember the user's preference regarding immediate transaction execution. If a user chooses not to execute the transaction immediately, this setting will be preserved, eliminating the need to uncheck the box repeatedly. However, users can still recheck the box, and the checked state will also be remembered.

## How this PR fixes it

This PR adds a `transactionExecution` flag in the settings, enabling users to enable or disable transaction execution based on their preferences easily.

## How to test it

Steps to test:

1. Create a new Transaction
2. Uncheck the `Execute transaction` checkbox (Assuming the transaction is ready for execution)
3. Refresh the page and create another transaction, the last state of the `Execute transaction` checkbox should be remembered.

## Screenshots

NA

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
