### PR TITLE
fix: sign messages with hardware wallets through metamask

### DIFF
--- a/src/utils/safe-messages.ts
+++ b/src/utils/safe-messages.ts
@@ -110,7 +110,14 @@ export const tryOffChainMsgSigning = async (
     try {
       if (signingMethod === 'eth_signTypedData') {
         const typedData = generateSafeMessageTypedData(safe, message)
-        return await signer._signTypedData(typedData.domain as TypedDataDomain, typedData.types, typedData.message)
+        const signature = await signer._signTypedData(
+          typedData.domain as TypedDataDomain,
+          typedData.types,
+          typedData.message,
+        )
+
+        // V needs adjustment when signing with ledger / trezor through metamask
+        return adjustVInSignature(signingMethod, signature)
       }
 
       if (signingMethod === 'eth_sign') {


### PR DESCRIPTION
## What it solves

Resolves #2052 

## How this PR fixes it
We call `adjustVInSignature` for both signing methods.

## How to test it
1. Setup Safe with an owner who signs with ledger / trezor through metamask.
2. Sign a message

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
