### PR TITLE
refactor: save entire data structure on submission

### DIFF
--- a/src/components/tx-flow/common/TxLayout.tsx
+++ b/src/components/tx-flow/common/TxLayout.tsx
@@ -29,17 +29,13 @@ const TxLayout = ({ title, children, step = 0, txSummary }: TxLayoutProps) => {
 
           <Grid item container xs={12} gap={3}>
             <Grid item xs={7} component={Paper}>
-              {<ProgressBar value={progress} />}
+              <ProgressBar value={progress} />
 
               <Box display="flex" justifyContent="flex-end" py={2} px={3}>
                 <TxNonce />
               </Box>
 
-              {steps.map((children, index) => (
-                <div key={index} style={{ display: index === step ? '' : 'none' }}>
-                  {children}
-                </div>
-              ))}
+              <div>{steps[step]}</div>
             </Grid>
 
             <Grid item xs={4}>

--- a/src/components/tx-flow/common/TxLayout.tsx
+++ b/src/components/tx-flow/common/TxLayout.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { Box, Container, Grid, Paper, Typography } from '@mui/material'
+import { Box, Container, Grid, Paper, Typography, Button } from '@mui/material'
 import type { TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import { ProgressBar } from '@/components/common/ProgressBar'
 import SafeTxProvider from '../SafeTxProvider'
@@ -11,9 +11,10 @@ type TxLayoutProps = {
   children: ReactNode
   step?: number
   txSummary?: TransactionSummary
+  onBack?: () => void
 }
 
-const TxLayout = ({ title, children, step = 0, txSummary }: TxLayoutProps) => {
+const TxLayout = ({ title, children, step = 0, txSummary, onBack }: TxLayoutProps) => {
   const steps = Array.isArray(children) ? children : [children]
   const progress = Math.round(((step + 1) / steps.length) * 100)
 
@@ -35,7 +36,14 @@ const TxLayout = ({ title, children, step = 0, txSummary }: TxLayoutProps) => {
                 <TxNonce />
               </Box>
 
-              <div>{steps[step]}</div>
+              <div>
+                {steps[step]}
+                {onBack && step > 0 && (
+                  <Button variant="contained" onClick={onBack}>
+                    Back
+                  </Button>
+                )}
+              </div>
             </Grid>
 
             <Grid item xs={4}>

--- a/src/components/tx-flow/flows/NftTransfer/ReviewNftBatch.tsx
+++ b/src/components/tx-flow/flows/NftTransfer/ReviewNftBatch.tsx
@@ -12,7 +12,6 @@ import { SafeTxContext } from '../../SafeTxProvider'
 type ReviewNftBatchProps = {
   params: SubmittedNftTransferParams
   onSubmit: () => void
-  onBack: () => void
   txNonce?: number
 }
 

--- a/src/components/tx-flow/flows/NftTransfer/index.tsx
+++ b/src/components/tx-flow/flows/NftTransfer/index.tsx
@@ -26,13 +26,13 @@ const NftTransferFlow = ({ txNonce, ...params }: NftTransferFlowProps) => {
   ])
 
   const steps = [
-    <SendNftBatch key={0} params={data[0]} onSubmit={(formData) => nextStep<1>(formData)} />,
+    <SendNftBatch key={0} params={data[0]} onSubmit={(formData) => nextStep([formData, formData])} />,
 
-    data[1] && <ReviewNftBatch key={1} params={data[1]} txNonce={txNonce} onSubmit={() => null} onBack={prevStep} />,
+    data[1] && <ReviewNftBatch key={1} params={data[1]} txNonce={txNonce} onSubmit={() => null} />,
   ]
 
   return (
-    <TxLayout title="Send tokens" step={step}>
+    <TxLayout title="Send tokens" step={step} onBack={prevStep}>
       {steps}
     </TxLayout>
   )

--- a/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
@@ -33,8 +33,8 @@ import SpendingLimitRow from '@/components/tx/SpendingLimitRow'
 import NumberField from '@/components/common/NumberField'
 import InputValueHelper from '@/components/common/InputValueHelper'
 import { validateDecimalLength, validateLimitedAmount } from '@/utils/validation'
-import { AutocompleteItem, SendTxType } from '@/components/tx/modals/TokenTransferModal/SendAssetsForm'
-import { type TokenTransferParams, TokenTransferFields } from '.'
+import { AutocompleteItem } from '@/components/tx/modals/TokenTransferModal/SendAssetsForm'
+import { type TokenTransferParams, TokenTransferFields, TokenTransferType } from '.'
 
 const CreateTokenTransfer = ({
   params,
@@ -59,9 +59,9 @@ const CreateTokenTransfer = ({
     defaultValues: {
       ...params,
       [TokenTransferFields.type]: disableSpendingLimit
-        ? SendTxType.multiSig
+        ? TokenTransferType.multiSig
         : isOnlySpendingLimitBeneficiary
-        ? SendTxType.spendingLimit
+        ? TokenTransferType.spendingLimit
         : params.type,
     },
     mode: 'onChange',
@@ -93,7 +93,7 @@ const CreateTokenTransfer = ({
 
   const type = watch(TokenTransferFields.type)
   const spendingLimit = useSpendingLimit(selectedToken?.tokenInfo)
-  const isSpendingLimitType = type === SendTxType.spendingLimit
+  const isSpendingLimitType = type === TokenTransferType.spendingLimit
   const spendingLimitAmount = spendingLimit ? BigNumber.from(spendingLimit.amount).sub(spendingLimit.spent) : undefined
   const totalAmount = BigNumber.from(selectedToken?.balance || 0)
   const maxAmount = isSpendingLimitType

--- a/src/components/tx-flow/flows/TokenTransfer/ReviewTokenTransfer.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/ReviewTokenTransfer.tsx
@@ -4,7 +4,7 @@ import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import { TokenTransferReview } from '@/components/tx/modals/TokenTransferModal/ReviewTokenTx'
 import SendFromBlock from '@/components/tx/SendFromBlock'
 import SendToBlock from '@/components/tx/SendToBlock'
-import { DialogContent } from '@mui/material'
+import { Button, DialogContent } from '@mui/material'
 import { createTokenTransferParams } from '@/services/tx/tokenTransferParams'
 import { createTx } from '@/services/tx/tx-sender'
 import type { TokenTransferParams } from '.'
@@ -13,6 +13,7 @@ import { SafeTxContext } from '../../SafeTxProvider'
 const ReviewTokenTransfer = ({
   params,
   onSubmit,
+  onBack,
   txNonce,
 }: {
   params: TokenTransferParams
@@ -48,6 +49,10 @@ const ReviewTokenTransfer = ({
       <SendFromBlock />
 
       <SendToBlock address={params.recipient || ''} />
+
+      <Button variant="contained" onClick={onBack}>
+        Back
+      </Button>
 
       <SignOrExecuteForm onSubmit={onSubmit} />
     </DialogContent>

--- a/src/components/tx-flow/flows/TokenTransfer/ReviewTokenTransfer.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/ReviewTokenTransfer.tsx
@@ -4,7 +4,7 @@ import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import { TokenTransferReview } from '@/components/tx/modals/TokenTransferModal/ReviewTokenTx'
 import SendFromBlock from '@/components/tx/SendFromBlock'
 import SendToBlock from '@/components/tx/SendToBlock'
-import { Button, DialogContent } from '@mui/material'
+import { DialogContent } from '@mui/material'
 import { createTokenTransferParams } from '@/services/tx/tokenTransferParams'
 import { createTx } from '@/services/tx/tx-sender'
 import type { TokenTransferParams } from '.'
@@ -13,12 +13,10 @@ import { SafeTxContext } from '../../SafeTxProvider'
 const ReviewTokenTransfer = ({
   params,
   onSubmit,
-  onBack,
   txNonce,
 }: {
   params: TokenTransferParams
   onSubmit: () => void
-  onBack: () => void
   txNonce?: number
 }) => {
   const { setSafeTx, setSafeTxError, setNonce } = useContext(SafeTxContext)
@@ -49,10 +47,6 @@ const ReviewTokenTransfer = ({
       <SendFromBlock />
 
       <SendToBlock address={params.recipient || ''} />
-
-      <Button variant="contained" onClick={onBack}>
-        Back
-      </Button>
 
       <SignOrExecuteForm onSubmit={onSubmit} />
     </DialogContent>

--- a/src/components/tx-flow/flows/TokenTransfer/index.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/index.tsx
@@ -1,3 +1,4 @@
+import merge from 'lodash/merge'
 import TxLayout from '@/components/tx-flow/common/TxLayout'
 import useTxStepper from '../../useTxStepper'
 import CreateTokenTransfer from './CreateTokenTransfer'
@@ -8,24 +9,42 @@ export enum SendTxType {
   spendingLimit = 'spendingLimit',
 }
 
-export type TokenTransferParams = {
-  recipient?: string
-  tokenAddress?: string
-  amount?: string
-  type?: SendTxType
+export enum TokenTransferFields {
+  recipient = 'recipient',
+  tokenAddress = 'tokenAddress',
+  amount = 'amount',
+  type = 'type',
 }
 
-type TokenTransferFlowProps = TokenTransferParams & {
+export type TokenTransferParams = {
+  [TokenTransferFields.recipient]: string
+  [TokenTransferFields.tokenAddress]: string
+  [TokenTransferFields.amount]: string
+  [TokenTransferFields.type]: SendTxType
+}
+
+type TokenTransferFlowProps = Partial<TokenTransferParams> & {
   txNonce?: number
 }
 
+const defaultData: TokenTransferParams = {
+  recipient: '',
+  tokenAddress: '',
+  amount: '',
+  type: SendTxType.multiSig,
+}
+
 const TokenTransferFlow = ({ txNonce, ...params }: TokenTransferFlowProps) => {
-  const { data, step, nextStep, prevStep } = useTxStepper<[TokenTransferParams, TokenTransferParams]>([params, params])
+  const initialData = merge({}, defaultData, params)
+  const { data, step, nextStep, prevStep } = useTxStepper<[TokenTransferParams, TokenTransferParams]>([
+    initialData,
+    initialData,
+  ])
 
   const steps = [
-    <CreateTokenTransfer key={0} params={data[0]} txNonce={txNonce} onSubmit={(formData) => nextStep<1>(formData)} />,
+    <CreateTokenTransfer key={0} params={data[0]} txNonce={txNonce} onSubmit={nextStep} />,
 
-    <ReviewTokenTransfer key={1} txNonce={txNonce} params={data[1]} onSubmit={() => null} onBack={prevStep} />,
+    <ReviewTokenTransfer key={1} params={data[1]} txNonce={txNonce} onSubmit={() => null} onBack={prevStep} />,
   ]
 
   return (

--- a/src/components/tx-flow/useTxStepper.tsx
+++ b/src/components/tx-flow/useTxStepper.tsx
@@ -1,20 +1,25 @@
-import { useCallback, useState } from 'react'
+import { useState } from 'react'
+import merge from 'lodash/merge'
 
-const useTxStepper = <T extends Array<any>>(initialData: T) => {
+const useTxStepper = <T extends Array<unknown>>(initialData: T) => {
   const [step, setStep] = useState(0)
   const [data, setData] = useState<T>(initialData)
 
-  const nextStep = useCallback(<S extends keyof T>(stepData: T[S]) => {
+  const nextStep = <S extends number>(stepData: T[S]) => {
     setStep((prevStep) => {
-      const newStep = prevStep + 1
-      setData((prevData) => ({ ...prevData, [newStep]: stepData }))
-      return newStep
+      const nextStep = prevStep + 1
+      setData((prevData) => {
+        prevData[prevStep] = stepData
+        prevData[nextStep] = merge({}, prevData[nextStep], stepData)
+        return prevData
+      })
+      return prevStep + 1
     })
-  }, [])
+  }
 
-  const prevStep = useCallback(() => {
+  const prevStep = () => {
     setStep((prevStep) => prevStep - 1)
-  }, [])
+  }
 
   return { step, data, nextStep, prevStep }
 }

--- a/src/components/tx-flow/useTxStepper.tsx
+++ b/src/components/tx-flow/useTxStepper.tsx
@@ -1,25 +1,17 @@
-import { useState } from 'react'
-import merge from 'lodash/merge'
+import { useCallback, useState } from 'react'
 
 const useTxStepper = <T extends Array<unknown>>(initialData: T) => {
   const [step, setStep] = useState(0)
   const [data, setData] = useState<T>(initialData)
 
-  const nextStep = <S extends number>(stepData: T[S]) => {
-    setStep((prevStep) => {
-      const nextStep = prevStep + 1
-      setData((prevData) => {
-        prevData[prevStep] = stepData
-        prevData[nextStep] = merge({}, prevData[nextStep], stepData)
-        return prevData
-      })
-      return prevStep + 1
-    })
-  }
+  const nextStep = useCallback((entireData: T) => {
+    setData(entireData)
+    setStep((prevStep) => prevStep + 1)
+  }, [])
 
-  const prevStep = () => {
+  const prevStep = useCallback(() => {
     setStep((prevStep) => prevStep - 1)
-  }
+  }, [])
 
   return { step, data, nextStep, prevStep }
 }

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, type SyntheticEvent, useState } from 'react'
+import { type ReactElement, type SyntheticEvent, useContext, useState } from 'react'
 import { Button, Typography } from '@mui/material'
 
 import ErrorMessage from '@/components/tx/ErrorMessage'
@@ -8,6 +8,7 @@ import CheckWallet from '@/components/common/CheckWallet'
 import { useTxActions } from './hooks'
 import type { SignOrExecuteProps } from '.'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import { TxModalContext } from '@/components/tx-flow'
 
 const SignForm = ({
   safeTx,
@@ -29,6 +30,7 @@ const SignForm = ({
   // Hooks
   const isOwner = useIsSafeOwner()
   const { signTx } = useTxActions()
+  const { setTxFlow } = useContext(TxModalContext)
 
   // Check that the transaction is executable
   const isCreation = !txId
@@ -41,6 +43,7 @@ const SignForm = ({
 
     try {
       await signTx(safeTx, txId, origin)
+      setTxFlow(undefined)
     } catch (err) {
       logError(Errors._804, (err as Error).message)
       setIsSubmittable(true)


### PR DESCRIPTION
## What it solves

This updates the `nextStep` function to require the entire data structure to be set on submission.

## Other small changes

- Only renders current step
- Adds back button (yet to be styled)
- Closes modal when signing

## How to test it

Open the transaction creation flow and click next, observing the data present in the second step. Clicking back should also retain the values on the first step.

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
