### PR TITLE
Refactor: move AdvancedParams to ExecuteForm

### DIFF
--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -14,27 +14,22 @@ import useWalletCanRelay from '@/hooks/useWalletCanRelay'
 import { ExecutionMethod, ExecutionMethodSelector } from '../ExecutionMethodSelector'
 import { hasRemainingRelays } from '@/utils/relaying'
 import type { SignOrExecuteProps } from '.'
-import type { AdvancedParameters } from '../AdvancedParams'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { TxModalContext } from '@/components/tx-flow'
 import { SuccessScreen } from '@/components/tx-flow/flows/SuccessScreen'
+import useGasLimit from '@/hooks/useGasLimit'
+import AdvancedParams, { useAdvancedParams } from '../AdvancedParams'
 
 const ExecuteForm = ({
   safeTx,
-  error,
   txId,
   onSubmit,
   disableSubmit = false,
   origin,
-  advancedParams,
 }: SignOrExecuteProps & {
   safeTx?: SafeTransaction
-  error?: Error
-  advancedParams: AdvancedParameters
 }): ReactElement => {
-  //
-  // Hooks & variables
-  //
+  // Form state
   const [isSubmittable, setIsSubmittable] = useState<boolean>(true)
   const [submitError, setSubmitError] = useState<Error | undefined>()
 
@@ -58,6 +53,10 @@ const ExecuteForm = ({
   // The transaction can/will be relayed
   const canRelay = walletCanRelay && hasRemainingRelays(relays)
   const willRelay = canRelay && executionMethod === ExecutionMethod.RELAY
+
+  // Estimate gas limit
+  const { gasLimit, gasLimitError } = useGasLimit(safeTx)
+  const [advancedParams, setAdvancedParams] = useAdvancedParams(gasLimit)
 
   // Check if transaction will fail
   const { executionValidationError, isValidExecutionLoading } = useIsValidExecution(safeTx, advancedParams.gasLimit)
@@ -85,49 +84,58 @@ const ExecuteForm = ({
 
   const submitDisabled = !safeTx || !isSubmittable || disableSubmit || isValidExecutionLoading || isExecutionLoop
 
-  const displayedError = error || executionValidationError
-
   return (
-    <form onSubmit={handleSubmit}>
-      {canRelay && (
-        <Box mb={2}>
-          <ExecutionMethodSelector
-            executionMethod={executionMethod}
-            setExecutionMethod={setExecutionMethod}
-            relays={relays}
-          />
-        </Box>
-      )}
+    <>
+      <AdvancedParams
+        willExecute
+        params={advancedParams}
+        recommendedGasLimit={gasLimit}
+        onFormSubmit={setAdvancedParams}
+        gasLimitError={gasLimitError}
+        willRelay={willRelay}
+      />
 
-      {/* Error messages */}
-      {isExecutionLoop ? (
-        <ErrorMessage>
-          Cannot execute a transaction from the Safe Account itself, please connect a different account.
-        </ErrorMessage>
-      ) : displayedError ? (
-        <ErrorMessage error={displayedError}>
-          This transaction will most likely fail.{' '}
-          {isNewExecutableTx
-            ? 'To save gas costs, avoid creating the transaction.'
-            : 'To save gas costs, reject this transaction.'}
-        </ErrorMessage>
-      ) : submitError ? (
-        <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
-      ) : (
-        <UnknownContractError />
-      )}
+      <form onSubmit={handleSubmit}>
+        {canRelay && (
+          <Box mb={2}>
+            <ExecutionMethodSelector
+              executionMethod={executionMethod}
+              setExecutionMethod={setExecutionMethod}
+              relays={relays}
+            />
+          </Box>
+        )}
 
-      <DialogActions>
-        {/* Submit button */}
-        <CheckWallet allowNonOwner={true}>
-          {(isOk) => (
-            <Button variant="contained" type="submit" disabled={!isOk || submitDisabled}>
-              Submit
-            </Button>
-          )}
-        </CheckWallet>
-      </DialogActions>
-    </form>
+        {/* Error messages */}
+        {isExecutionLoop ? (
+          <ErrorMessage>
+            Cannot execute a transaction from the Safe Account itself, please connect a different account.
+          </ErrorMessage>
+        ) : executionValidationError || gasLimitError ? (
+          <ErrorMessage error={executionValidationError || gasLimitError}>
+            This transaction will most likely fail.{' '}
+            {isNewExecutableTx
+              ? 'To save gas costs, avoid creating the transaction.'
+              : 'To save gas costs, reject this transaction.'}
+          </ErrorMessage>
+        ) : submitError ? (
+          <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
+        ) : (
+          <UnknownContractError />
+        )}
+
+        <DialogActions>
+          {/* Submit button */}
+          <CheckWallet allowNonOwner={true}>
+            {(isOk) => (
+              <Button variant="contained" type="submit" disabled={!isOk || submitDisabled}>
+                Submit
+              </Button>
+            )}
+          </CheckWallet>
+        </DialogActions>
+      </form>
+    </>
   )
 }
 

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -12,18 +12,14 @@ import { TxModalContext } from '@/components/tx-flow'
 
 const SignForm = ({
   safeTx,
-  error,
   txId,
   onSubmit,
   disableSubmit = false,
   origin,
 }: SignOrExecuteProps & {
   safeTx?: SafeTransaction
-  error?: Error
 }): ReactElement => {
-  //
-  // Hooks & variables
-  //
+  // Form state
   const [isSubmittable, setIsSubmittable] = useState<boolean>(true)
   const [submitError, setSubmitError] = useState<Error | undefined>()
 
@@ -63,13 +59,6 @@ const SignForm = ({
       {isSubmittable && cannotPropose ? (
         <ErrorMessage>
           You are currently not an owner of this Safe Account and won&apos;t be able to submit this transaction.
-        </ErrorMessage>
-      ) : error ? (
-        <ErrorMessage error={error}>
-          This transaction will most likely fail.{' '}
-          {isCreation
-            ? 'To save gas costs, avoid creating the transaction.'
-            : 'To save gas costs, reject this transaction.'}
         </ErrorMessage>
       ) : (
         submitError && (

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -3,13 +3,12 @@ import DecodedTx from '../DecodedTx'
 import ExecuteCheckbox from '../ExecuteCheckbox'
 import { WrongChainWarning } from '../WrongChainWarning'
 import { useImmediatelyExecutable, useValidateNonce } from './hooks'
-import AdvancedParams, { useAdvancedParams } from '../AdvancedParams'
 import { TxSimulation } from '../TxSimulation'
-import useGasLimit from '@/hooks/useGasLimit'
 import ExecuteForm from './ExecuteForm'
 import SignForm from './SignForm'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { Box } from '@mui/material'
+import ErrorMessage from '../ErrorMessage'
 
 export type SignOrExecuteProps = {
   txId?: string
@@ -33,48 +32,27 @@ const SignOrExecuteForm = (props: SignOrExecuteProps): ReactElement => {
   const canExecute = isCorrectNonce && (props.isExecutable || isNewExecutableTx)
   const willExecute = (props.onlyExecute || shouldExecute) && canExecute
 
-  // Estimate gas limit
-  const { gasLimit, gasLimitError } = useGasLimit(willExecute ? safeTx : undefined)
-  const [advancedParams, setAdvancedParams] = useAdvancedParams(gasLimit)
-
-  // Error
-  const error = safeTxError || gasLimitError
-
   return (
     <>
       {props.children}
 
-      <TxSimulation
-        canExecute
-        gasLimit={advancedParams.gasLimit?.toNumber()}
-        transactions={safeTx}
-        disabled={!!gasLimitError}
-      />
-
       <DecodedTx tx={safeTx} txId={props.txId} />
+
+      <TxSimulation canExecute={canExecute} disabled={false} transactions={safeTx} />
 
       {canExecute && !props.onlyExecute && <ExecuteCheckbox onChange={setShouldExecute} />}
 
       {/* Warning message and switch button */}
       <WrongChainWarning />
 
-      {willExecute && (
-        <AdvancedParams
-          params={advancedParams}
-          recommendedGasLimit={gasLimit}
-          willExecute={willExecute}
-          onFormSubmit={setAdvancedParams}
-          gasLimitError={gasLimitError}
-          willRelay={false /* FIXME */}
-        />
+      {safeTxError && (
+        <ErrorMessage error={safeTxError}>
+          This transaction will most likely fail. To save gas costs, avoid confirming the transaction.
+        </ErrorMessage>
       )}
 
       <Box mt={4}>
-        {willExecute ? (
-          <ExecuteForm {...props} safeTx={safeTx} error={error} advancedParams={advancedParams} />
-        ) : (
-          <SignForm {...props} safeTx={safeTx} error={error} />
-        )}
+        {willExecute ? <ExecuteForm {...props} safeTx={safeTx} /> : <SignForm {...props} safeTx={safeTx} />}
       </Box>
     </>
   )


### PR DESCRIPTION
AdvancedParams are only used for execution, so they are now in the ExecuteForm.