### PR TITLE
feat: spending limit selector

### DIFF
--- a/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
@@ -177,12 +177,6 @@ const CreateTokenTransfer = ({
             </Box>
           )}
 
-          {!disableSpendingLimit && !!spendingLimitAmount && (
-            <FormControl fullWidth sx={{ mt: 2 }}>
-              <SpendingLimitRow availableAmount={spendingLimitAmount} selectedToken={selectedToken?.tokenInfo} />
-            </FormControl>
-          )}
-
           <FormControl fullWidth sx={{ mt: 2 }}>
             <NumberField
               label={errors.amount?.message || 'Amount'}
@@ -210,6 +204,12 @@ const CreateTokenTransfer = ({
               })}
             />
           </FormControl>
+
+          {!disableSpendingLimit && !!spendingLimitAmount && (
+            <FormControl fullWidth sx={{ mt: 2 }}>
+              <SpendingLimitRow availableAmount={spendingLimitAmount} selectedToken={selectedToken?.tokenInfo} />
+            </FormControl>
+          )}
         </DialogContent>
 
         <DialogActions>

--- a/src/components/tx/SpendingLimitRow/index.tsx
+++ b/src/components/tx/SpendingLimitRow/index.tsx
@@ -1,10 +1,13 @@
-import { FormControl, FormControlLabel, Radio, RadioGroup, Typography } from '@mui/material'
+import { FormControl, FormControlLabel, InputLabel, Radio, RadioGroup } from '@mui/material'
 import { Controller, useFormContext } from 'react-hook-form'
 import type { BigNumber } from '@ethersproject/bignumber'
+import classNames from 'classnames'
 import { safeFormatUnits } from '@/utils/formatters'
 import type { TokenInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { SendAssetsField, SendTxType } from '@/components/tx/modals/TokenTransferModal/SendAssetsForm'
 import useIsOnlySpendingLimitBeneficiary from '@/hooks/useIsOnlySpendingLimitBeneficiary'
+
+import css from './styles.module.css'
 
 const SpendingLimitRow = ({
   availableAmount,
@@ -19,45 +22,55 @@ const SpendingLimitRow = ({
   const formattedAmount = safeFormatUnits(availableAmount, selectedToken?.decimals)
 
   return (
-    <>
-      <Typography>Send as</Typography>
-      <FormControl>
-        <Controller
-          rules={{ required: true }}
-          control={control}
-          name={SendAssetsField.type}
-          render={({ field: { onChange, ...field } }) => (
-            <RadioGroup
-              onChange={(e) => {
-                onChange(e)
+    <FormControl>
+      <InputLabel shrink required sx={{ backgroundColor: 'background.paper', px: '6px', mx: '-6px' }}>
+        Send as
+      </InputLabel>
+      <Controller
+        rules={{ required: true }}
+        control={control}
+        name={SendAssetsField.type}
+        render={({ field: { onChange, ...field } }) => (
+          <RadioGroup
+            row
+            onChange={(e) => {
+              onChange(e)
 
-                // Validate only after the field is changed
-                setTimeout(() => {
-                  trigger(SendAssetsField.amount)
-                }, 10)
-              }}
-              {...field}
-              defaultValue={SendTxType.multiSig}
-            >
-              {!isOnlySpendLimitBeneficiary && (
-                <FormControlLabel
-                  value={SendTxType.multiSig}
-                  label="Multisig transaction"
-                  control={<Radio />}
-                  componentsProps={{ typography: { variant: 'body2' } }}
-                />
-              )}
+              // Validate only after the field is changed
+              setTimeout(() => {
+                trigger(SendAssetsField.amount)
+              }, 10)
+            }}
+            {...field}
+            defaultValue={SendTxType.multiSig}
+            className={css.group}
+          >
+            {!isOnlySpendLimitBeneficiary && (
               <FormControlLabel
-                value={SendTxType.spendingLimit}
-                label={`Spending limit transaction (${formattedAmount} ${selectedToken?.symbol})`}
+                value={SendTxType.multiSig}
+                // TODO: Add tooltip when we have the text
+                label="Multisig transaction"
                 control={<Radio />}
                 componentsProps={{ typography: { variant: 'body2' } }}
+                className={css.label}
               />
-            </RadioGroup>
-          )}
-        />
-      </FormControl>
-    </>
+            )}
+            <FormControlLabel
+              value={SendTxType.spendingLimit}
+              // TODO: Add tooltip when we have the text
+              label={
+                <>
+                  Spending limit <b>{`(${formattedAmount} ${selectedToken?.symbol})`}</b>
+                </>
+              }
+              control={<Radio />}
+              componentsProps={{ typography: { variant: 'body2' } }}
+              className={classNames(css.label, { [css.spendingLimit]: !isOnlySpendLimitBeneficiary })}
+            />
+          </RadioGroup>
+        )}
+      />
+    </FormControl>
   )
 }
 

--- a/src/components/tx/SpendingLimitRow/styles.module.css
+++ b/src/components/tx/SpendingLimitRow/styles.module.css
@@ -1,0 +1,15 @@
+.group {
+  border: 1px solid var(--color-border-main);
+  border-radius: 4px;
+  display: grid;
+  grid-template-columns: 50% 50%;
+}
+
+.label {
+  margin: 0;
+  padding: 12px 3px;
+}
+
+.spendingLimit {
+  border-left: 1px solid var(--color-border-main);
+}


### PR DESCRIPTION
## What it solves

Resolves #2100

## How this PR fixes it

This updates the spending limit selector to match that of the [new designs](https://www.figma.com/file/ptTs6lDBeUuLNySroJ5PiF/Web-Master-File?type=design&node-id=5230-264187&t=B0OQUDy2kbDKsMnU-0).

## How to test it

Create a transaction and observe the new styled spending limit selector.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/5fd24be6-ca84-49b3-a771-51accfd687d5)

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/f175fdb9-4fd0-4f1c-be6e-d15638552859)

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/1bde3380-52d8-4efb-ba1b-7654e2736558)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
