### PR TITLE
feat: execute/sign `RadioGroup`

### DIFF
--- a/src/components/tx/ExecuteCheckbox/index.tsx
+++ b/src/components/tx/ExecuteCheckbox/index.tsx
@@ -1,53 +1,45 @@
 import type { ChangeEvent, ReactElement } from 'react'
-import { Checkbox, FormControlLabel, SvgIcon, Tooltip } from '@mui/material'
-import InfoIcon from '@/public/images/notifications/info.svg'
+import { FormControlLabel, RadioGroup, Radio } from '@mui/material'
 import { trackEvent, MODALS_EVENTS } from '@/services/analytics'
 import { useAppDispatch, useAppSelector } from '@/store'
 import { selectSettings, setTransactionExecution } from '@/store/settingsSlice'
 
-const ExecuteCheckbox = ({
-  onChange,
-  disabled = false,
-}: {
-  onChange: (checked: boolean) => void
-  disabled?: boolean
-}): ReactElement => {
+import css from './styles.module.css'
+
+const ExecuteCheckbox = ({ onChange }: { onChange: (checked: boolean) => void }): ReactElement => {
   const settings = useAppSelector(selectSettings)
-  const defaultChecked = settings.transactionExecution
   const dispatch = useAppDispatch()
 
-  const handleChange = (_: ChangeEvent<HTMLInputElement>, checked: boolean) => {
+  const handleChange = (_: ChangeEvent<HTMLInputElement>, value: string) => {
+    const checked = value === 'true'
     trackEvent({ ...MODALS_EVENTS.EXECUTE_TX, label: checked })
     dispatch(setTransactionExecution(checked))
     onChange(checked)
   }
 
-  const infoIcon = (
-    <Tooltip
-      title={
-        disabled
-          ? 'This transaction is fully signed and will be executed.'
-          : 'If you want to sign the transaction now but manually execute it later, uncheck this box.'
-      }
-    >
-      <span>
-        <SvgIcon
-          component={InfoIcon}
-          inheritViewBox
-          fontSize="small"
-          color="border"
-          sx={{ verticalAlign: 'middle', marginLeft: 0.5 }}
-        />
-      </span>
-    </Tooltip>
-  )
-
   return (
-    <FormControlLabel
-      control={<Checkbox defaultChecked={defaultChecked} onChange={handleChange} disabled={disabled} />}
-      label={<>Execute transaction {infoIcon}</>}
-      sx={{ mb: 1 }}
-    />
+    <RadioGroup row value={String(settings.transactionExecution)} onChange={handleChange} className={css.group}>
+      <FormControlLabel
+        value="true"
+        label={
+          <>
+            Yes, <b>execute</b>
+          </>
+        }
+        control={<Radio />}
+        className={css.radio}
+      />
+      <FormControlLabel
+        value="false"
+        label={
+          <>
+            No, only <b>sign</b>
+          </>
+        }
+        control={<Radio />}
+        className={css.radio}
+      />
+    </RadioGroup>
   )
 }
 

--- a/src/components/tx/ExecuteCheckbox/styles.module.css
+++ b/src/components/tx/ExecuteCheckbox/styles.module.css
@@ -1,0 +1,12 @@
+.group {
+  display: grid;
+  grid-template-columns: auto auto;
+  gap: var(--space-2);
+}
+
+.radio {
+  margin: 0;
+  border: 1px solid var(--color-border-main);
+  border-radius: 4px;
+  padding: 9px 3px;
+}


### PR DESCRIPTION
## What it solves

Partially resolves #2026

## How this PR fixes it

This redesigns the execution checkbox in accordance with [the design](https://www.figma.com/file/ptTs6lDBeUuLNySroJ5PiF/Web-Master-File?type=design&node-id=5188-172291&t=mADPGUm7uT4huNpO-0).

Note: the placement of the component is incorrect but will be moved as we progress with this issue.

## How to test it

Create a transaction and observe the option to switch between execution/signing, working as intended.

## Screenshots

![execute sign radiogroup](https://github.com/safe-global/safe-wallet-web/assets/20442784/ed8fe26e-0373-4c79-83c3-beb6d1879a96)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
