### PR TITLE
Chore: fix e2e tests

### DIFF
--- a/cypress/e2e/smoke/balances.cy.js
+++ b/cypress/e2e/smoke/balances.cy.js
@@ -3,7 +3,7 @@ const balanceSingleRow = '[aria-labelledby="tableTitle"] > tbody tr'
 
 const TEST_SAFE = 'gor:0x97d314157727D517A706B5D08507A1f9B44AaaE9'
 const PAGINATION_TEST_SAFE = 'gor:0x850493a15914aAC05a821A3FAb973b4598889A7b'
-const ASSETS_LENGTH = 7
+const ASSETS_LENGTH = 8
 const ASSET_NAME_COLUMN = 0
 const TOKEN_AMOUNT_COLUMN = 1
 const FIAT_AMOUNT_COLUMN = 2
@@ -20,21 +20,15 @@ describe('Assets > Coins', () => {
     cy.contains('Görli Ether')
 
     cy.contains('button', 'Got it').click()
+
+    cy.get(balanceSingleRow).should('have.length.lessThan', ASSETS_LENGTH)
+    cy.contains('div', 'Default tokens').click()
+    cy.wait(100)
+    cy.contains('div', 'All tokens').click()
+    cy.get(balanceSingleRow).should('have.length', ASSETS_LENGTH)
   })
 
   describe('should have different tokens', () => {
-    it(`should have ${ASSETS_LENGTH} entries in the table`, () => {
-      // "Spam" tokens filtered
-      cy.get(balanceSingleRow).should('have.length', 3)
-
-      // Enable all tokens
-      cy.contains('div', 'Default tokens').click()
-      cy.wait(100)
-      cy.contains('div', 'All tokens').click()
-
-      cy.get(balanceSingleRow).should('have.length', ASSETS_LENGTH)
-    })
-
     it('should have Dai', () => {
       // Row should have an image with alt text "Dai"
       cy.contains('Dai')
@@ -215,7 +209,7 @@ describe('Assets > Coins', () => {
     it('should allow changing rows per page and navigate to next and previous page', () => {
       // Table should have 25 rows inittially
       cy.contains('Rows per page:').next().contains('25')
-      cy.contains('1–25 of 27')
+      cy.contains('1–25 of')
       cy.get(balanceSingleRow).should('have.length', 25)
 
       // Change to 10 rows per page
@@ -225,22 +219,22 @@ describe('Assets > Coins', () => {
 
       // Table should have 10 rows
       cy.contains('Rows per page:').next().contains('10')
-      cy.contains('1–10 of 27')
+      cy.contains('1–10 of')
       cy.get(balanceSingleRow).should('have.length', 10)
 
       // Click on the next page button
       cy.get('button[aria-label="Go to next page"]').click({ force: true })
       cy.get('button[aria-label="Go to next page"]').click({ force: true })
 
-      // Table should have 7 rows
-      cy.contains('21–27 of 27')
-      cy.get(balanceSingleRow).should('have.length', 7)
+      // Table should have N rows
+      cy.contains('21–28 of')
+      cy.get(balanceSingleRow).should('have.length', ASSETS_LENGTH)
 
       // Click on the previous page button
       cy.get('button[aria-label="Go to previous page"]').click({ force: true })
 
       // Table should have 10 rows
-      cy.contains('11–20 of 27')
+      cy.contains('11–20 of')
       cy.get(balanceSingleRow).should('have.length', 10)
     })
   })

--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -197,12 +197,8 @@ export const useInitOnboard = () => {
       onboard.state.actions.setWalletModules(supportedWallets)
     }
 
-    enableWallets()
-  }, [chain, onboard])
-
-  // Connect to the last connected wallet
-  useEffect(() => {
-    if (onboard && onboard.state.get().wallets.length === 0) {
+    // Connect to the last connected wallet
+    enableWallets().then(() => {
       const label = lastWalletStorage.get()
       if (!label) return
 
@@ -212,8 +208,8 @@ export const useInitOnboard = () => {
             autoSelect: { label, disableModals: true },
           })
       })
-    }
-  }, [onboard])
+    })
+  }, [chain, onboard])
 }
 
 export default useStore


### PR DESCRIPTION
The Balances test broke because of a spam token that was airdropped on goerli. And because the backend on Goerli suddenly started filtering out all the tokens other than ETH as spam.

All the tests that depended on a wallet connect didn't work because Onboard initially has a different set of wallets enabled, and the E2E wallet appears only after the reconnection to the last wallet has already run.