### PR TITLE
[TX flow] feat: confirm/execute title component

### DIFF
--- a/src/components/tx-flow/common/TxCard/index.tsx
+++ b/src/components/tx-flow/common/TxCard/index.tsx
@@ -1,12 +1,13 @@
 import type { ReactNode } from 'react'
 import { Card, CardContent } from '@mui/material'
+import css from '../styles.module.css'
 
 const sx = { my: 1 }
 
 const TxCard = ({ children }: { children: ReactNode }) => {
   return (
     <Card sx={sx}>
-      <CardContent>{children}</CardContent>
+      <CardContent className={css.cardContent}>{children}</CardContent>
     </Card>
   )
 }

--- a/src/components/tx-flow/common/styles.module.css
+++ b/src/components/tx-flow/common/styles.module.css
@@ -1,0 +1,5 @@
+.cardContent {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}

--- a/src/components/tx/SignOrExecuteForm/ConfirmationTitle.tsx
+++ b/src/components/tx/SignOrExecuteForm/ConfirmationTitle.tsx
@@ -1,0 +1,35 @@
+import { Stack, SvgIcon, Typography } from '@mui/material'
+import EditIcon from '@/public/images/common/edit.svg'
+import classnames from 'classnames'
+import css from './styles.module.css'
+
+export enum ConfirmationTitleTypes {
+  sign = 'confirm',
+  execute = 'execute',
+}
+
+const ConfirmationTitle = ({ isCreation, variant }: { isCreation?: boolean; variant: ConfirmationTitleTypes }) => {
+  return (
+    <div className={css.wrapper}>
+      <div
+        className={classnames(css.icon, {
+          [css.sign]: variant === ConfirmationTitleTypes.sign,
+          [css.execute]: variant === ConfirmationTitleTypes.execute,
+        })}
+      >
+        <SvgIcon component={EditIcon} inheritViewBox fontSize="small" color="primary" />
+      </div>
+      <Stack direction="column">
+        <Typography variant="h5" sx={{ textTransform: 'capitalize' }}>
+          {variant}
+        </Typography>
+        <Typography variant="body2">
+          You&apos;re about to {isCreation ? 'create and ' : ''}
+          {variant} this transaction.
+        </Typography>
+      </Stack>
+    </div>
+  )
+}
+
+export default ConfirmationTitle

--- a/src/components/tx/SignOrExecuteForm/ConfirmationTitle.tsx
+++ b/src/components/tx/SignOrExecuteForm/ConfirmationTitle.tsx
@@ -1,6 +1,5 @@
 import { Stack, SvgIcon, Typography } from '@mui/material'
 import EditIcon from '@/public/images/common/edit.svg'
-import classnames from 'classnames'
 import css from './styles.module.css'
 
 export enum ConfirmationTitleTypes {
@@ -11,12 +10,7 @@ export enum ConfirmationTitleTypes {
 const ConfirmationTitle = ({ isCreation, variant }: { isCreation?: boolean; variant: ConfirmationTitleTypes }) => {
   return (
     <div className={css.wrapper}>
-      <div
-        className={classnames(css.icon, {
-          [css.sign]: variant === ConfirmationTitleTypes.sign,
-          [css.execute]: variant === ConfirmationTitleTypes.execute,
-        })}
-      >
+      <div className={`${css.icon} ${variant === ConfirmationTitleTypes.sign ? css.sign : css.execute}`}>
         <SvgIcon component={EditIcon} inheritViewBox fontSize="small" color="primary" />
       </div>
       <Stack direction="column">

--- a/src/components/tx/SignOrExecuteForm/ConfirmationTitle.tsx
+++ b/src/components/tx/SignOrExecuteForm/ConfirmationTitle.tsx
@@ -1,4 +1,4 @@
-import { Stack, SvgIcon, Typography } from '@mui/material'
+import { SvgIcon, Typography } from '@mui/material'
 import EditIcon from '@/public/images/common/edit.svg'
 import css from './styles.module.css'
 
@@ -11,9 +11,9 @@ const ConfirmationTitle = ({ isCreation, variant }: { isCreation?: boolean; vari
   return (
     <div className={css.wrapper}>
       <div className={`${css.icon} ${variant === ConfirmationTitleTypes.sign ? css.sign : css.execute}`}>
-        <SvgIcon component={EditIcon} inheritViewBox fontSize="small" color="primary" />
+        <SvgIcon component={EditIcon} inheritViewBox fontSize="small" />
       </div>
-      <Stack direction="column">
+      <div>
         <Typography variant="h5" sx={{ textTransform: 'capitalize' }}>
           {variant}
         </Typography>
@@ -21,7 +21,7 @@ const ConfirmationTitle = ({ isCreation, variant }: { isCreation?: boolean; vari
           You&apos;re about to {isCreation ? 'create and ' : ''}
           {variant} this transaction.
         </Typography>
-      </Stack>
+      </div>
     </div>
   )
 }

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement, type SyntheticEvent, useContext, useState } from 'react'
-import { Box, Button, CardActions, Typography } from '@mui/material'
+import { Box, Button, CardActions } from '@mui/material'
 
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import { logError, Errors } from '@/services/exceptions'
@@ -19,6 +19,7 @@ import { TxModalContext } from '@/components/tx-flow'
 import { SuccessScreen } from '@/components/tx-flow/flows/SuccessScreen'
 import useGasLimit from '@/hooks/useGasLimit'
 import AdvancedParams, { useAdvancedParams } from '../AdvancedParams'
+import ConfirmationTitle, { ConfirmationTitleTypes } from '@/components/tx/SignOrExecuteForm/ConfirmationTitle'
 
 const ExecuteForm = ({
   safeTx,
@@ -86,9 +87,7 @@ const ExecuteForm = ({
 
   return (
     <>
-      <Typography variant="h5" mb={2}>
-        Execution
-      </Typography>
+      <ConfirmationTitle variant={ConfirmationTitleTypes.execute} />
 
       <AdvancedParams
         willExecute

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -19,7 +19,6 @@ import { TxModalContext } from '@/components/tx-flow'
 import { SuccessScreen } from '@/components/tx-flow/flows/SuccessScreen'
 import useGasLimit from '@/hooks/useGasLimit'
 import AdvancedParams, { useAdvancedParams } from '../AdvancedParams'
-import ConfirmationTitle, { ConfirmationTitleTypes } from '@/components/tx/SignOrExecuteForm/ConfirmationTitle'
 
 const ExecuteForm = ({
   safeTx,
@@ -87,8 +86,6 @@ const ExecuteForm = ({
 
   return (
     <>
-      <ConfirmationTitle variant={ConfirmationTitleTypes.execute} />
-
       <AdvancedParams
         willExecute
         params={advancedParams}

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -9,7 +9,6 @@ import { useTxActions } from './hooks'
 import type { SignOrExecuteProps } from '.'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { TxModalContext } from '@/components/tx-flow'
-import ConfirmationTitle, { ConfirmationTitleTypes } from '@/components/tx/SignOrExecuteForm/ConfirmationTitle'
 
 const SignForm = ({
   safeTx,
@@ -28,9 +27,6 @@ const SignForm = ({
   const isOwner = useIsSafeOwner()
   const { signTx } = useTxActions()
   const { setTxFlow } = useContext(TxModalContext)
-
-  // Check that the transaction is executable
-  const isCreation = !txId
 
   // On modal submit
   const handleSubmit = async (e: SyntheticEvent) => {
@@ -66,8 +62,6 @@ const SignForm = ({
           <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
         )
       )}
-
-      <ConfirmationTitle variant={ConfirmationTitleTypes.sign} isCreation={isCreation} />
 
       <CardActions>
         {/* Submit button */}

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement, type SyntheticEvent, useContext, useState } from 'react'
-import { Button, CardActions, Typography } from '@mui/material'
+import { Button, CardActions } from '@mui/material'
 
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import { logError, Errors } from '@/services/exceptions'
@@ -9,6 +9,7 @@ import { useTxActions } from './hooks'
 import type { SignOrExecuteProps } from '.'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { TxModalContext } from '@/components/tx-flow'
+import ConfirmationTitle, { ConfirmationTitleTypes } from '@/components/tx/SignOrExecuteForm/ConfirmationTitle'
 
 const SignForm = ({
   safeTx,
@@ -55,10 +56,6 @@ const SignForm = ({
 
   return (
     <form onSubmit={handleSubmit}>
-      <Typography variant="h5" mb={2}>
-        Confirmation
-      </Typography>
-
       {/* Error messages */}
       {isSubmittable && cannotPropose ? (
         <ErrorMessage>
@@ -70,10 +67,7 @@ const SignForm = ({
         )
       )}
 
-      <Typography variant="body2" color="border.main" textAlign="center" mt={3}>
-        You&apos;re about to {isCreation ? 'create and ' : ''}
-        sign a transaction and will need to confirm it with your currently connected wallet.
-      </Typography>
+      <ConfirmationTitle variant={ConfirmationTitleTypes.sign} isCreation={isCreation} />
 
       <CardActions>
         {/* Submit button */}

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -10,6 +10,8 @@ import ErrorMessage from '../ErrorMessage'
 import TxChecks from './TxChecks'
 import TxCard from '@/components/tx-flow/common/TxCard'
 import ConfirmationTitle, { ConfirmationTitleTypes } from '@/components/tx/SignOrExecuteForm/ConfirmationTitle'
+import { useAppSelector } from '@/store'
+import { selectSettings } from '@/store/settingsSlice'
 
 export type SignOrExecuteProps = {
   txId?: string
@@ -23,7 +25,8 @@ export type SignOrExecuteProps = {
 }
 
 const SignOrExecuteForm = (props: SignOrExecuteProps): ReactElement => {
-  const [shouldExecute, setShouldExecute] = useState<boolean>(true)
+  const { transactionExecution } = useAppSelector(selectSettings)
+  const [shouldExecute, setShouldExecute] = useState<boolean>(transactionExecution)
   const isCreation = !props.txId
   const isNewExecutableTx = useImmediatelyExecutable() && isCreation
   const { safeTx, safeTxError } = useContext(SafeTxContext)
@@ -47,7 +50,7 @@ const SignOrExecuteForm = (props: SignOrExecuteProps): ReactElement => {
 
       <TxCard>
         <ConfirmationTitle
-          variant={shouldExecute ? ConfirmationTitleTypes.execute : ConfirmationTitleTypes.sign}
+          variant={willExecute ? ConfirmationTitleTypes.execute : ConfirmationTitleTypes.sign}
           isCreation={isCreation}
         />
 

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -9,6 +9,7 @@ import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import ErrorMessage from '../ErrorMessage'
 import TxChecks from './TxChecks'
 import TxCard from '@/components/tx-flow/common/TxCard'
+import ConfirmationTitle, { ConfirmationTitleTypes } from '@/components/tx/SignOrExecuteForm/ConfirmationTitle'
 
 export type SignOrExecuteProps = {
   txId?: string
@@ -45,6 +46,11 @@ const SignOrExecuteForm = (props: SignOrExecuteProps): ReactElement => {
       </TxCard>
 
       <TxCard>
+        <ConfirmationTitle
+          variant={shouldExecute ? ConfirmationTitleTypes.execute : ConfirmationTitleTypes.sign}
+          isCreation={isCreation}
+        />
+
         {canExecute && !props.onlyExecute && <ExecuteCheckbox onChange={setShouldExecute} />}
 
         {/* Warning message and switch button */}

--- a/src/components/tx/SignOrExecuteForm/styles.module.css
+++ b/src/components/tx/SignOrExecuteForm/styles.module.css
@@ -1,0 +1,33 @@
+.wrapper {
+  padding: 8px 0px 8px;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 6px;
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+}
+
+.sign {
+  background-color: var(--color-info-background);
+}
+
+.sign svg {
+  color: var(--color-info-dark);
+}
+
+.execute {
+  background-color: var(--color-secondary-background);
+}
+
+.execute svg {
+  color: var(--color-secondary-dark);
+}

--- a/src/components/tx/SignOrExecuteForm/styles.module.css
+++ b/src/components/tx/SignOrExecuteForm/styles.module.css
@@ -3,7 +3,6 @@
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  margin-bottom: var(--space-2);
 }
 
 .icon {


### PR DESCRIPTION
## What it solves
Implements a component for the Confirm/Execute titles

## How to test it
1. Get to the review state of different transaction flows and observe the component changing states depending if you're going to execute / sign / create&execute the transaction

## Screenshots
<img width="619" alt="Screenshot 2023-06-19 at 11 05 36" src="https://github.com/safe-global/safe-wallet-web/assets/32431609/3ddd69ae-0dd8-4334-8628-31bd85d58ebd">

<img width="622" alt="Screenshot 2023-06-16 at 17 42 59" src="https://github.com/safe-global/safe-wallet-web/assets/32431609/6c6033ad-b47a-40cb-99c4-2dfe1ef77339">
<img width="749" alt="Screenshot 2023-06-16 at 17 42 51" src="https://github.com/safe-global/safe-wallet-web/assets/32431609/fd4268a3-8b47-41af-82b0-1651b0a6de50">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
