### PR TITLE
fix: Allow non-owners with spending limit to execute transaction

### DIFF
--- a/src/components/common/CheckWallet/index.tsx
+++ b/src/components/common/CheckWallet/index.tsx
@@ -27,7 +27,7 @@ const CheckWallet = ({ children, allowSpendingLimit, allowNonOwner }: CheckWalle
     ? Message.WalletNotConnected
     : !isSafeOwner && !isSpendingLimit && !allowNonOwner
     ? Message.NotSafeOwner
-    : isSpendingLimit && !allowSpendingLimit
+    : isSpendingLimit && !allowSpendingLimit && !allowNonOwner
     ? Message.OnlySpendingLimitBeneficiary
     : ''
 


### PR DESCRIPTION
## What it solves
Allows non-owners with spending limit to execute transaction

Resolves #2073

## How to test it
- Create safe 2of2
- add owners Owner1Addr and Owner2Addr
- add spending limit of 1 ETH for NonOwnerAddr
- Create send 2 ETH transaction
- sign with Owner1Addr and Owner2Addr but do not execute
- Attempt to execute transaction with NonOwnerAddr


## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
