### PR TITLE
fix: remove error casting

### DIFF
--- a/src/components/safe-apps/AppFrame/useThirdPartyCookies.ts
+++ b/src/components/safe-apps/AppFrame/useThirdPartyCookies.ts
@@ -37,7 +37,7 @@ const useThirdPartyCookies = (): ThirdPartyCookiesType => {
         document.body.removeChild(iframeRef.current as Node)
       }
     } catch (error) {
-      logError(Errors._905, (error as Error).message)
+      logError(Errors._905, error)
     }
   }, [])
 

--- a/src/components/safe-apps/SafeAppLandingPage/index.tsx
+++ b/src/components/safe-apps/SafeAppLandingPage/index.tsx
@@ -42,7 +42,7 @@ const SafeAppLanding = ({ appUrl, chain }: Props) => {
 
     trackEvent(OVERVIEW_EVENTS.OPEN_ONBOARD)
 
-    onboard.connectWallet().catch((e) => logError(Errors._302, (e as Error).message))
+    onboard.connectWallet().catch((e) => logError(Errors._302, e))
   }
 
   const handleDemoClick = () => {

--- a/src/components/settings/DataManagement/useGlobalImportFileParser.ts
+++ b/src/components/settings/DataManagement/useGlobalImportFileParser.ts
@@ -92,7 +92,7 @@ export const useGlobalImportJsonParser = (jsonData: string | undefined): Data =>
     try {
       parsedFile = JSON.parse(jsonData)
     } catch (err) {
-      logError(ErrorCodes._704, (err as Error).message)
+      logError(ErrorCodes._704, err)
 
       data.error = ImportErrors.INVALID_JSON_FORMAT
       return data

--- a/src/components/tx-flow/SafeTxProvider.tsx
+++ b/src/components/tx-flow/SafeTxProvider.tsx
@@ -25,7 +25,7 @@ export const SafeTxContext = createContext<{
   setSafeTxGas: () => {},
 })
 
-// (err) => logError(Errors._103, (err as Error).message)
+// (err) => logError(Errors._103, err)
 
 const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => {
   const [safeTx, setSafeTx] = useState<SafeTransaction>()

--- a/src/components/tx-flow/flows/ExecuteBatch/ReviewBatch.tsx
+++ b/src/components/tx-flow/flows/ExecuteBatch/ReviewBatch.tsx
@@ -25,6 +25,7 @@ import { getMultiSendCallOnlyContract } from '@/services/contracts/safeContracts
 import TxCard from '../../common/TxCard'
 import CheckWallet from '@/components/common/CheckWallet'
 import type { ExecuteBatchFlowProps } from '.'
+import { asError } from '@/services/exceptions/utils'
 
 export const ReviewBatch = ({ params }: { params: ExecuteBatchFlowProps }) => {
   const [isSubmittable, setIsSubmittable] = useState<boolean>(true)
@@ -92,10 +93,11 @@ export const ReviewBatch = ({ params }: { params: ExecuteBatchFlowProps }) => {
 
     try {
       await (willRelay ? onRelay() : onExecute())
-    } catch (err) {
-      logError(Errors._804, (err as Error).message)
+    } catch (_err) {
+      const err = asError(_err)
+      logError(Errors._804, err)
       setIsSubmittable(true)
-      setSubmitError(err as Error)
+      setSubmitError(err)
       return
     }
   }

--- a/src/components/tx-flow/flows/SafeAppsTx/ReviewSafeAppsTx.tsx
+++ b/src/components/tx-flow/flows/SafeAppsTx/ReviewSafeAppsTx.tsx
@@ -19,6 +19,7 @@ import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import ApprovalEditor from '@/components/tx/ApprovalEditor'
 import { getInteractionTitle } from '@/components/safe-apps/utils'
 import ErrorMessage from '@/components/tx/ErrorMessage'
+import { asError } from '@/services/exceptions/utils'
 
 type ReviewSafeAppsTxProps = {
   safeAppsTx: SafeAppsTxParams
@@ -59,7 +60,7 @@ const ReviewSafeAppsTx = ({
     try {
       await dispatchSafeAppsTx(safeTx, requestId, onboard, safe.chainId)
     } catch (error) {
-      setSafeTxError(error as Error)
+      setSafeTxError(asError(error))
     }
   }
 

--- a/src/components/tx-flow/flows/SignMessageOnChain/ReviewSignMessageOnChain.tsx
+++ b/src/components/tx-flow/flows/SignMessageOnChain/ReviewSignMessageOnChain.tsx
@@ -24,6 +24,7 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import useHighlightHiddenTab from '@/hooks/useHighlightHiddenTab'
 import { type SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
+import { asError } from '@/services/exceptions/utils'
 
 export type SignMessageOnChainProps = {
   appId?: number
@@ -97,7 +98,7 @@ const ReviewSignMessageOnChain = ({ message, method, requestId }: SignMessageOnC
     try {
       await dispatchSafeAppsTx(safeTx, requestId, onboard, safe.chainId)
     } catch (error) {
-      setSafeTxError(error as Error)
+      setSafeTxError(asError(error))
     }
   }
 

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -19,6 +19,7 @@ import { TxModalContext } from '@/components/tx-flow'
 import { SuccessScreen } from '@/components/tx-flow/flows/SuccessScreen'
 import useGasLimit from '@/hooks/useGasLimit'
 import AdvancedParams, { useAdvancedParams } from '../AdvancedParams'
+import { asError } from '@/services/exceptions/utils'
 
 const ExecuteForm = ({
   safeTx,
@@ -72,10 +73,11 @@ const ExecuteForm = ({
     try {
       const executedTxId = await executeTx(txOptions, safeTx, txId, origin, willRelay)
       setTxFlow(<SuccessScreen txId={executedTxId} />)
-    } catch (err) {
-      logError(Errors._804, (err as Error).message)
+    } catch (_err) {
+      const err = asError(_err)
+      logError(Errors._804, err)
       setIsSubmittable(true)
-      setSubmitError(err as Error)
+      setSubmitError(err)
       return
     }
 

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -9,6 +9,7 @@ import { useTxActions } from './hooks'
 import type { SignOrExecuteProps } from '.'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { TxModalContext } from '@/components/tx-flow'
+import { asError } from '@/services/exceptions/utils'
 
 const SignForm = ({
   safeTx,
@@ -37,10 +38,11 @@ const SignForm = ({
     try {
       await signTx(safeTx, txId, origin)
       setTxFlow(undefined)
-    } catch (err) {
-      logError(Errors._804, (err as Error).message)
+    } catch (_err) {
+      const err = asError(_err)
+      logError(Errors._804, err)
       setIsSubmittable(true)
-      setSubmitError(err as Error)
+      setSubmitError(err)
       return
     }
 

--- a/src/components/tx/TxSimulation/__tests__/useSimulation.test.ts
+++ b/src/components/tx/TxSimulation/__tests__/useSimulation.test.ts
@@ -46,7 +46,7 @@ describe('useSimulation()', () => {
 
     const mockFetch = jest.spyOn(global, 'fetch')
 
-    mockFetch.mockImplementation(() => Promise.reject({ message: '404 not found' }))
+    mockFetch.mockImplementation(() => Promise.reject(new Error('404 not found')))
 
     jest.spyOn(utils, 'getSimulationPayload').mockImplementation(() =>
       Promise.resolve({

--- a/src/components/tx/TxSimulation/useSimulation.ts
+++ b/src/components/tx/TxSimulation/useSimulation.ts
@@ -5,6 +5,7 @@ import { FETCH_STATUS, type TenderlySimulation } from '@/components/tx/TxSimulat
 import { getSimulationPayload, type SimulationTxParams } from '@/components/tx/TxSimulation/utils'
 import { useAppSelector } from '@/store'
 import { selectTenderly } from '@/store/settingsSlice'
+import { asError } from '@/services/exceptions/utils'
 
 type UseSimulationReturn =
   | {
@@ -53,7 +54,7 @@ export const useSimulation = (): UseSimulationReturn => {
       } catch (error) {
         console.error(error)
 
-        setRequestError((error as Error).message)
+        setRequestError(asError(error).message)
         setSimulationRequestStatus(FETCH_STATUS.ERROR)
       }
     },

--- a/src/components/tx/modals/TokenTransferModal/ReviewSpendingLimitTx.tsx
+++ b/src/components/tx/modals/TokenTransferModal/ReviewSpendingLimitTx.tsx
@@ -21,6 +21,7 @@ import { getTxOptions } from '@/utils/transactions'
 import { MODALS_EVENTS, trackEvent } from '@/services/analytics'
 import useOnboard from '@/hooks/wallets/useOnboard'
 import { WrongChainWarning } from '@/components/tx/WrongChainWarning'
+import { asError } from '@/services/exceptions/utils'
 
 export type SpendingLimitTxParams = {
   safeAddress: string
@@ -86,10 +87,11 @@ const ReviewSpendingLimitTx = ({ params, onSubmit }: TokenTransferModalProps): R
       await dispatchSpendingLimitTxExecution(txParams, txOptions, onboard, safe.chainId, safeAddress)
 
       onSubmit()
-    } catch (err) {
-      logError(Errors._801, (err as Error).message)
+    } catch (_err) {
+      const err = asError(_err)
+      logError(Errors._801, err)
       setIsSubmittable(true)
-      setSubmitError(err as Error)
+      setSubmitError(err)
     }
   }
 

--- a/src/hooks/__tests__/useAsync.test.ts
+++ b/src/hooks/__tests__/useAsync.test.ts
@@ -38,7 +38,7 @@ describe('useAsync hook', () => {
       await Promise.resolve()
     })
 
-    expect(result.current).toEqual([undefined, 'test', false])
+    expect(result.current).toEqual([undefined, new Error('test'), false])
   })
 
   it('should clear the data between reloads', async () => {

--- a/src/hooks/coreSDK/useInitSafeCoreSDK.ts
+++ b/src/hooks/coreSDK/useInitSafeCoreSDK.ts
@@ -36,16 +36,17 @@ export const useInitSafeCoreSDK = () => {
       implementation: safe.implementation.value,
     })
       .then(setSafeSDK)
-      .catch((e) => {
+      .catch((_e) => {
+        const e = asError(_e)
         dispatch(
           showNotification({
             message: 'Please try connecting your wallet again.',
             groupKey: 'core-sdk-init-error',
             variant: 'error',
-            detailedMessage: asError(e).message,
+            detailedMessage: e.message,
           }),
         )
-        trackError(ErrorCodes._105, e)
+        trackError(ErrorCodes._105, e.message)
       })
   }, [
     address,

--- a/src/hooks/coreSDK/useInitSafeCoreSDK.ts
+++ b/src/hooks/coreSDK/useInitSafeCoreSDK.ts
@@ -8,6 +8,7 @@ import { useAppDispatch } from '@/store'
 import { showNotification } from '@/store/notificationsSlice'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { parsePrefixedAddress, sameAddress } from '@/utils/addresses'
+import { asError } from '@/services/exceptions/utils'
 
 export const useInitSafeCoreSDK = () => {
   const { safe, safeLoaded } = useSafeInfo()
@@ -41,10 +42,10 @@ export const useInitSafeCoreSDK = () => {
             message: 'Please try connecting your wallet again.',
             groupKey: 'core-sdk-init-error',
             variant: 'error',
-            detailedMessage: (e as Error).message,
+            detailedMessage: asError(e).message,
           }),
         )
-        trackError(ErrorCodes._105, (e as Error).message)
+        trackError(ErrorCodes._105, e)
       })
   }, [
     address,

--- a/src/hooks/messages/useSyncSafeMessageSigner.ts
+++ b/src/hooks/messages/useSyncSafeMessageSigner.ts
@@ -1,3 +1,4 @@
+import { asError } from '@/services/exceptions/utils'
 import { dispatchPreparedSignature } from '@/services/safe-messages/safeMsgNotifications'
 import { dispatchSafeMsgProposal, dispatchSafeMsgConfirmation } from '@/services/safe-messages/safeMsgSender'
 import { type EIP712TypedData, type SafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
@@ -56,7 +57,7 @@ const useSyncSafeMessageSigner = (
         }
       }
     } catch (e) {
-      setSubmitError(e as Error)
+      setSubmitError(asError(e))
     }
   }, [onboard, requestId, message, safe, decodedMessage, safeAppId, safeMessageHash, onClose])
 

--- a/src/hooks/safe-apps/useSafeAppFromManifest.ts
+++ b/src/hooks/safe-apps/useSafeAppFromManifest.ts
@@ -4,6 +4,7 @@ import { fetchSafeAppFromManifest } from '@/services/safe-apps/manifest'
 import useAsync from '@/hooks/useAsync'
 import { getEmptySafeApp } from '@/components/safe-apps/utils'
 import type { SafeAppDataWithPermissions } from '@/components/safe-apps/types'
+import { asError } from '@/services/exceptions/utils'
 
 type UseSafeAppFromManifestReturnType = {
   safeApp: SafeAppDataWithPermissions
@@ -19,7 +20,7 @@ const useSafeAppFromManifest = (appUrl: string, chainId: string): UseSafeAppFrom
 
   useEffect(() => {
     if (!error) return
-    logError(Errors._903, `${appUrl}, ${(error as Error).message}`)
+    logError(Errors._903, `${appUrl}, ${asError(error).message}`)
   }, [appUrl, error])
 
   return { safeApp: data || emptyApp, isLoading }

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { asError } from '@/services/exceptions/utils'
 
 export type AsyncResult<T> = [result: T | undefined, error: Error | undefined, loading: boolean]
 
@@ -35,7 +36,7 @@ const useAsync = <T>(
         isCurrent && setData(val)
       })
       .catch((err) => {
-        isCurrent && setError(err)
+        isCurrent && setError(asError(err))
       })
       .finally(() => {
         isCurrent && setLoading(false)

--- a/src/hooks/useGasPrice.ts
+++ b/src/hooks/useGasPrice.ts
@@ -9,6 +9,7 @@ import useIntervalCounter from './useIntervalCounter'
 import { useWeb3ReadOnly } from '../hooks/wallets/web3'
 import { Errors, logError } from '@/services/exceptions'
 import { FEATURES, hasFeature } from '@/utils/chains'
+import { asError } from '@/services/exceptions/utils'
 
 // Update gas fees every 20 seconds
 const REFRESH_DELAY = 20e3
@@ -39,8 +40,8 @@ const getGasPrice = async (gasPriceConfigs: GasPrice): Promise<BigNumber | undef
     if (config.type == GAS_PRICE_TYPE.ORACLE) {
       try {
         return await fetchGasOracle(config)
-      } catch (err) {
-        error = err as Error
+      } catch (_err) {
+        error = asError(_err)
         logError(Errors._611, error.message)
         // Continue to the next oracle
         continue

--- a/src/hooks/useMasterCopies.ts
+++ b/src/hooks/useMasterCopies.ts
@@ -36,7 +36,7 @@ export const useMasterCopies = () => {
       const res = await getMasterCopies(chainId)
       return res.map(extractMasterCopyInfo)
     } catch (error) {
-      logError(Errors._619, (error as Error).message)
+      logError(Errors._619, error)
     }
   }
   return useAsync(fetchMasterCopies, [chainId])

--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -58,7 +58,7 @@ export const getConnectedWallet = (wallets: WalletState[]): ConnectedWallet | nu
       icon: primaryWallet.icon,
     }
   } catch (e) {
-    logError(Errors._106, (e as Error).message)
+    logError(Errors._106, e)
     return null
   }
 }
@@ -123,7 +123,7 @@ export const connectWallet = async (
   try {
     wallets = await onboard.connectWallet(options)
   } catch (e) {
-    logError(Errors._302, (e as Error).message)
+    logError(Errors._302, e)
 
     isConnecting = false
     return

--- a/src/services/exceptions/__tests__/index.test.ts
+++ b/src/services/exceptions/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { Errors, logError, trackError, CodedException } from '.'
+import { Errors, logError, trackError, CodedException } from '..'
 import * as constants from '@/config/constants'
 import * as Sentry from '@sentry/react'
 
@@ -37,9 +37,23 @@ describe('CodedException', () => {
     expect(err.content).toBe(Errors._100)
   })
 
-  it('creates an error with an extra message', () => {
+  it('creates an error with an extra message from a string', () => {
     const err = new CodedException(Errors._100, '0x123')
     expect(err.message).toBe('Code 100: Invalid input in the address field (0x123)')
+    expect(err.code).toBe(100)
+    expect(err.content).toBe(Errors._100)
+  })
+
+  it('creates an error with an extra message from an Error instance', () => {
+    const err = new CodedException(Errors._100, new Error('0x123'))
+    expect(err.message).toBe('Code 100: Invalid input in the address field (0x123)')
+    expect(err.code).toBe(100)
+    expect(err.content).toBe(Errors._100)
+  })
+
+  it('creates an error with an extra message from an object', () => {
+    const err = new CodedException(Errors._100, { address: '0x123' })
+    expect(err.message).toBe('Code 100: Invalid input in the address field ({"address":"0x123"})')
     expect(err.code).toBe(100)
     expect(err.content).toBe(Errors._100)
   })

--- a/src/services/exceptions/__tests__/utils.test.ts
+++ b/src/services/exceptions/__tests__/utils.test.ts
@@ -1,0 +1,34 @@
+import { asError } from '@/services/exceptions/utils'
+
+describe('utils', () => {
+  describe('asError', () => {
+    it('should return the same error if thrown is an instance of Error', () => {
+      const thrown = new Error('test error')
+
+      expect(asError(thrown)).toEqual(new Error('test error'))
+    })
+
+    it('should return a new Error instance with the thrown value if thrown is a string', () => {
+      const thrown = 'test error'
+
+      const result = asError(thrown)
+      expect(result).toEqual(new Error('test error'))
+
+      // If stringified:
+      expect(result).not.toEqual(new Error('"test error'))
+    })
+    it('should return a new Error instance with the stringified thrown value if thrown is not an instance of Error', () => {
+      const thrown = { message: 'test error' }
+
+      expect(asError(thrown)).toEqual(new Error('{"message":"test error"}'))
+    })
+
+    it('should return a new Error instance with the string representation of thrown if JSON.stringify throws an error', () => {
+      // Circular dependency
+      const thrown: Record<string, unknown> = {}
+      thrown.a = { b: thrown }
+
+      expect(asError(thrown)).toEqual(new Error('[object Object]'))
+    })
+  })
+})

--- a/src/services/exceptions/index.ts
+++ b/src/services/exceptions/index.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/react'
 import type { CaptureContext } from '@sentry/types'
 import { IS_PRODUCTION } from '@/config/constants'
 import ErrorCodes from './ErrorCodes'
+import { asError } from './utils'
 
 export class CodedException extends Error {
   public readonly code: number
@@ -20,10 +21,10 @@ export class CodedException extends Error {
     return code
   }
 
-  constructor(content: ErrorCodes, extraMessage?: string, context?: CaptureContext) {
+  constructor(content: ErrorCodes, thrown?: unknown, context?: CaptureContext) {
     super()
 
-    const extraInfo = extraMessage ? ` (${extraMessage})` : ''
+    const extraInfo = thrown ? ` (${asError(thrown).message})` : ''
     this.message = `Code ${content}${extraInfo}`
     this.code = this.getCode(content)
     this.content = content
@@ -55,7 +56,7 @@ export class CodedException extends Error {
   }
 }
 
-type ErrorHandler = (content: ErrorCodes, extraMessage?: string, context?: CaptureContext) => CodedException
+type ErrorHandler = (content: ErrorCodes, thrown?: unknown, context?: CaptureContext) => CodedException
 
 export const logError: ErrorHandler = function logError(...args) {
   const error = new CodedException(...args)

--- a/src/services/exceptions/utils.ts
+++ b/src/services/exceptions/utils.ts
@@ -1,0 +1,19 @@
+export const asError = (thrown: unknown): Error => {
+  if (thrown instanceof Error) {
+    return thrown
+  }
+
+  let message: string
+
+  if (typeof thrown === 'string') {
+    message = thrown
+  } else {
+    try {
+      message = JSON.stringify(thrown)
+    } catch {
+      message = String(thrown)
+    }
+  }
+
+  return new Error(message)
+}

--- a/src/services/local-storage/Storage.ts
+++ b/src/services/local-storage/Storage.ts
@@ -1,5 +1,6 @@
 import { LS_NAMESPACE } from '@/config/constants'
 import { Errors, logError } from '@/services/exceptions'
+import { asError } from '../exceptions/utils'
 
 type BrowserStorage = typeof localStorage | typeof sessionStorage
 
@@ -27,7 +28,7 @@ class Storage {
     try {
       saved = this.storage?.getItem(fullKey) ?? null
     } catch (err) {
-      logError(Errors._700, `key ${key} – ${(err as Error).message}`)
+      logError(Errors._700, `key ${key} – ${asError(err).message}`)
     }
 
     if (saved == null) return null
@@ -35,7 +36,7 @@ class Storage {
     try {
       return JSON.parse(saved) as T
     } catch (err) {
-      logError(Errors._700, `key ${key} – ${(err as Error).message}`)
+      logError(Errors._700, `key ${key} – ${asError(err).message}`)
     }
     return null
   }
@@ -49,7 +50,7 @@ class Storage {
         this.storage?.setItem(fullKey, JSON.stringify(item))
       }
     } catch (err) {
-      logError(Errors._701, `key ${key} – ${(err as Error).message}`)
+      logError(Errors._701, `key ${key} – ${asError(err).message}`)
     }
   }
 
@@ -58,7 +59,7 @@ class Storage {
     try {
       this.storage?.removeItem(fullKey)
     } catch (err) {
-      logError(Errors._702, `key ${key} – ${(err as Error).message}`)
+      logError(Errors._702, `key ${key} – ${asError(err).message}`)
     }
   }
 

--- a/src/services/pairing/hooks.ts
+++ b/src/services/pairing/hooks.ts
@@ -59,7 +59,7 @@ export const useInitPairing = () => {
       .then(() => {
         isConnecting = false
       })
-      .catch((e) => logError(Errors._303, (e as Error).message))
+      .catch((e) => logError(Errors._303, e))
   }, [canConnect, chain, isSupported, onboard, connector])
 
   useEffect(() => {

--- a/src/services/safe-apps/AppCommunicator.ts
+++ b/src/services/safe-apps/AppCommunicator.ts
@@ -1,6 +1,7 @@
 import type { MutableRefObject } from 'react'
 import type { SDKMessageEvent, MethodToResponse, ErrorResponse, RequestId } from '@safe-global/safe-apps-sdk'
 import { getSDKVersion, Methods, MessageFormatter } from '@safe-global/safe-apps-sdk'
+import { asError } from '../exceptions/utils'
 
 type MessageHandler = (
   msg: SDKMessageEvent,
@@ -69,7 +70,7 @@ class AppCommunicator {
           this.send(response, msg.data.id)
         }
       } catch (e) {
-        const error = e as Error
+        const error = asError(e)
 
         this.send(error.message, msg.data.id, true)
         this.config?.onError?.(error, msg.data)

--- a/src/services/safe-messages/safeMsgNotifications.ts
+++ b/src/services/safe-messages/safeMsgNotifications.ts
@@ -27,7 +27,7 @@ export const dispatchPreparedSignature = async (
     // fetchedMessage does not have a type because it is explicitly a message
     message = { ...fetchedMessage, type: SafeMessageListItemType.MESSAGE }
   } catch (err) {
-    logError(Errors._613, (err as Error).message)
+    logError(Errors._613, err)
     throw err
   }
 

--- a/src/services/safe-messages/safeMsgSender.ts
+++ b/src/services/safe-messages/safeMsgSender.ts
@@ -7,6 +7,7 @@ import { safeMsgDispatch, SafeMsgEvent } from './safeMsgEvents'
 import { generateSafeMessageHash, tryOffChainMsgSigning } from '@/utils/safe-messages'
 import { normalizeTypedData } from '@/utils/web3'
 import { getAssertedChainSigner } from '@/services/tx/tx-sender/sdk'
+import { asError } from '../exceptions/utils'
 
 export const dispatchSafeMsgProposal = async ({
   onboard,
@@ -38,7 +39,7 @@ export const dispatchSafeMsgProposal = async ({
   } catch (error) {
     safeMsgDispatch(SafeMsgEvent.PROPOSE_FAILED, {
       messageHash,
-      error: error as Error,
+      error: asError(error),
     })
 
     throw error
@@ -70,7 +71,7 @@ export const dispatchSafeMsgConfirmation = async ({
   } catch (error) {
     safeMsgDispatch(SafeMsgEvent.CONFIRM_PROPOSE_FAILED, {
       messageHash,
-      error: error as Error,
+      error: asError(error),
     })
 
     throw error

--- a/src/services/tx/tx-sender/__tests__/ts-sender.test.ts
+++ b/src/services/tx/tx-sender/__tests__/ts-sender.test.ts
@@ -514,7 +514,7 @@ describe('txSender', () => {
       await waitFor(() =>
         expect(txEvents.txDispatch).toHaveBeenCalledWith('FAILED', {
           txId: 'tx_id_123',
-          error: { code: ErrorCode.TRANSACTION_REPLACED, reason: 'cancelled' },
+          error: new Error(JSON.stringify({ code: ErrorCode.TRANSACTION_REPLACED, reason: 'cancelled' })),
         }),
       )
     })

--- a/src/services/tx/tx-sender/dispatch.ts
+++ b/src/services/tx/tx-sender/dispatch.ts
@@ -21,6 +21,7 @@ import {
 } from './sdk'
 import { createWeb3 } from '@/hooks/wallets/web3'
 import { type OnboardAPI } from '@web3-onboard/core'
+import { asError } from '@/services/exceptions/utils'
 
 /**
  * Propose a transaction
@@ -49,9 +50,9 @@ export const dispatchTxProposal = async ({
     proposedTx = await proposeTx(chainId, safeAddress, sender, safeTx, safeTxHash, origin)
   } catch (error) {
     if (txId) {
-      txDispatch(TxEvent.SIGNATURE_PROPOSE_FAILED, { txId, error: error as Error })
+      txDispatch(TxEvent.SIGNATURE_PROPOSE_FAILED, { txId, error: asError(error) })
     } else {
-      txDispatch(TxEvent.PROPOSE_FAILED, { error: error as Error })
+      txDispatch(TxEvent.PROPOSE_FAILED, { error: asError(error) })
     }
     throw error
   }
@@ -80,7 +81,7 @@ export const dispatchTxSigning = async (
   try {
     signedTx = await tryOffChainTxSigning(safeTx, safeVersion, sdk)
   } catch (error) {
-    txDispatch(TxEvent.SIGN_FAILED, { txId, error: error as Error })
+    txDispatch(TxEvent.SIGN_FAILED, { txId, error: asError(error) })
     throw error
   }
 
@@ -108,7 +109,7 @@ export const dispatchOnChainSigning = async (
     await sdkUnchecked.approveTransactionHash(safeTxHash)
     txDispatch(TxEvent.ONCHAIN_SIGNATURE_REQUESTED, eventParams)
   } catch (err) {
-    txDispatch(TxEvent.FAILED, { ...eventParams, error: err as Error })
+    txDispatch(TxEvent.FAILED, { ...eventParams, error: asError(err) })
     throw err
   }
 
@@ -138,7 +139,7 @@ export const dispatchTxExecution = async (
     result = await sdkUnchecked.executeTransaction(safeTx, txOptions)
     txDispatch(TxEvent.EXECUTING, eventParams)
   } catch (error) {
-    txDispatch(TxEvent.FAILED, { ...eventParams, error: error as Error })
+    txDispatch(TxEvent.FAILED, { ...eventParams, error: asError(error) })
     throw error
   }
 
@@ -160,7 +161,7 @@ export const dispatchTxExecution = async (
       if (didReprice(error)) {
         txDispatch(TxEvent.PROCESSED, { ...eventParams, safeAddress })
       } else {
-        txDispatch(TxEvent.FAILED, { ...eventParams, error: error as Error })
+        txDispatch(TxEvent.FAILED, { ...eventParams, error: asError(error) })
       }
     })
 
@@ -189,7 +190,7 @@ export const dispatchBatchExecution = async (
     })
   } catch (err) {
     txs.forEach(({ txId }) => {
-      txDispatch(TxEvent.FAILED, { txId, error: err as Error, groupKey })
+      txDispatch(TxEvent.FAILED, { txId, error: asError(err), groupKey })
     })
     throw err
   }
@@ -230,7 +231,7 @@ export const dispatchBatchExecution = async (
         txs.forEach(({ txId }) => {
           txDispatch(TxEvent.FAILED, {
             txId,
-            error: err as Error,
+            error: asError(err),
             groupKey,
           })
         })
@@ -268,7 +269,7 @@ export const dispatchSpendingLimitTxExecution = async (
     )
     txDispatch(TxEvent.EXECUTING, { groupKey: id })
   } catch (error) {
-    txDispatch(TxEvent.FAILED, { groupKey: id, error: error as Error })
+    txDispatch(TxEvent.FAILED, { groupKey: id, error: asError(error) })
     throw error
   }
 
@@ -287,7 +288,7 @@ export const dispatchSpendingLimitTxExecution = async (
       }
     })
     .catch((error) => {
-      txDispatch(TxEvent.FAILED, { groupKey: id, error: error as Error })
+      txDispatch(TxEvent.FAILED, { groupKey: id, error: asError(error) })
     })
 
   return result?.hash
@@ -339,7 +340,7 @@ export const dispatchTxRelay = async (
     // Monitor relay tx
     waitForRelayedTx(taskId, [txId], safe.address.value)
   } catch (error) {
-    txDispatch(TxEvent.FAILED, { txId, error: error as Error })
+    txDispatch(TxEvent.FAILED, { txId, error: asError(error) })
     throw error
   }
 }
@@ -366,7 +367,7 @@ export const dispatchBatchExecutionRelay = async (
     txs.forEach(({ txId }) => {
       txDispatch(TxEvent.FAILED, {
         txId,
-        error: error as Error,
+        error: asError(error),
         groupKey,
       })
     })

--- a/src/services/tx/tx-sender/recommendedNonce.ts
+++ b/src/services/tx/tx-sender/recommendedNonce.ts
@@ -35,7 +35,7 @@ export const getSafeTxGas = async (
     const estimation = await fetchRecommendedParams(chainId, safeAddress, safeTxData)
     return Number(estimation.safeTxGas)
   } catch (e) {
-    logError(Errors._616, (e as Error).message)
+    logError(Errors._616, e)
   }
 }
 
@@ -45,6 +45,6 @@ export const getRecommendedNonce = async (chainId: string, safeAddress: string):
     const estimation = await fetchRecommendedParams(chainId, safeAddress, blankTxParams)
     return Number(estimation.recommendedNonce)
   } catch (e) {
-    logError(Errors._616, (e as Error).message)
+    logError(Errors._616, e)
   }
 }

--- a/src/services/tx/tx-sender/sdk.ts
+++ b/src/services/tx/tx-sender/sdk.ts
@@ -13,6 +13,7 @@ import { connectWallet, getConnectedWallet } from '@/hooks/wallets/useOnboard'
 import { type OnboardAPI } from '@web3-onboard/core'
 import type { ConnectedWallet } from '@/services/onboard'
 import type { JsonRpcSigner } from '@ethersproject/providers'
+import { asError } from '@/services/exceptions/utils'
 
 export const getAndValidateSafeSDK = (): Safe => {
   const safeSDK = getSafeSDK()
@@ -146,7 +147,7 @@ export const tryOffChainTxSigning = async (
     } catch (error) {
       const isLastSigningMethod = i === signingMethods.length - 1
 
-      if (isWalletRejection(error as Error) || isLastSigningMethod) {
+      if (isWalletRejection(asError(error)) || isLastSigningMethod) {
         throw error
       }
     }

--- a/src/services/tx/txMonitor.ts
+++ b/src/services/tx/txMonitor.ts
@@ -6,6 +6,7 @@ import type { JsonRpcProvider } from '@ethersproject/providers'
 import { POLLING_INTERVAL } from '@/config/constants'
 import { Errors, logError } from '@/services/exceptions'
 import { SafeCreationStatus } from '@/components/new-safe/create/steps/StatusStep/useSafeCreation'
+import { asError } from '../exceptions/utils'
 
 // Provider must be passed as an argument as it is undefined until initialised by `useInitWeb3`
 export const waitForTx = async (provider: JsonRpcProvider, txId: string, txHash: string) => {
@@ -33,7 +34,7 @@ export const waitForTx = async (provider: JsonRpcProvider, txId: string, txHash:
   } catch (error) {
     txDispatch(TxEvent.FAILED, {
       txId,
-      error: error as Error,
+      error: asError(error),
     })
   }
 }
@@ -81,7 +82,7 @@ const getRelayTxStatus = async (taskId: string): Promise<{ task: TransactionStat
       })
     })
   } catch (error) {
-    logError(Errors._632, (error as Error).message)
+    logError(Errors._632, error)
     return
   }
 

--- a/src/utils/ethers-utils.ts
+++ b/src/utils/ethers-utils.ts
@@ -8,7 +8,7 @@ export enum EthersTxReplacedReason {
   replaced = 'replaced',
 }
 
-// TODO: Replace this with ethers v6 types once released
+// TODO: Replace this with ethers v6 types once released and create similar helper to `asError`
 export type EthersError = Error & { code: ErrorCode; reason?: EthersTxReplacedReason; receipt?: TransactionReceipt }
 
 export const didRevert = (receipt: EthersError['receipt']): boolean => {

--- a/src/utils/safe-messages.ts
+++ b/src/utils/safe-messages.ts
@@ -17,6 +17,7 @@ import {
 } from '@safe-global/safe-gateway-typescript-sdk'
 
 import { hasFeature } from './chains'
+import { asError } from '@/services/exceptions/utils'
 
 /*
  * From v1.3.0, EIP-1271 support was moved to the CompatibilityFallbackHandler.
@@ -131,7 +132,7 @@ export const tryOffChainMsgSigning = async (
     } catch (error) {
       const isLastSigningMethod = i === signingMethods.length - 1
 
-      if (isWalletRejection(error as Error) || isLastSigningMethod) {
+      if (isWalletRejection(asError(error)) || isLastSigningMethod) {
         throw error
       }
     }

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -183,7 +183,7 @@ export const getTxOrigin = (app?: SafeAppData): string | undefined => {
   try {
     origin = JSON.stringify({ name: app.name, url: app.url })
   } catch (e) {
-    logError(Errors._808, (e as Error).message)
+    logError(Errors._808, e)
   }
 
   return origin


### PR DESCRIPTION
## What it solves

Removes needs to cast `Error`s

## How this PR fixes it

Caught errors are typed as `unknown` because they can have any value. As such, we were blindly casting them to `Error`.

A new `asError` function is now used to coerce the `unknown` errors into an `Error` instance accordingly.

## How to test it

Observe all unit tests passing.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
