### PR TITLE
fix: show messages tab if chain supports EIP-1271

### DIFF
--- a/src/components/transactions/TxNavigation/index.tsx
+++ b/src/components/transactions/TxNavigation/index.tsx
@@ -2,18 +2,14 @@ import NavTabs from '@/components/common/NavTabs'
 import { transactionNavItems } from '@/components/sidebar/SidebarNavigation/config'
 import { AppRoutes } from '@/config/routes'
 import { useCurrentChain } from '@/hooks/useChains'
-import useSafeMessages from '@/hooks/messages/useSafeMessages'
 import { hasFeature, FEATURES } from '@/utils/chains'
 
 const TxNavigation = () => {
   const chain = useCurrentChain()
-  const { page } = useSafeMessages()
 
   const isEIP1271 = chain && hasFeature(chain, FEATURES.EIP1271)
-  const hasMessages = page && page.results.length > 0
-  const showMessages = isEIP1271 && hasMessages
 
-  const navItems = showMessages
+  const navItems = isEIP1271
     ? transactionNavItems
     : transactionNavItems.filter((item) => item.href !== AppRoutes.transactions.messages)
 


### PR DESCRIPTION
## What it solves

Resolves #2101

## How this PR fixes it

The messages tab is now _always_ shown if a chain supports EIP-1271, no longer taking into account if signed messages exist.

## How to test it

1. Open a Safe on a chain that supports EIP-1271 with no signed messages and observe the tab present.
2. Switch to a Safe on a chain that _doesn't_ support EIP-1271 and observe no tab present.

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
