### PR TITLE
fix: update claiming app data URL

### DIFF
--- a/src/hooks/useSafeTokenAllocation.ts
+++ b/src/hooks/useSafeTokenAllocation.ts
@@ -8,7 +8,7 @@ import useAsync from './useAsync'
 import useSafeInfo from './useSafeInfo'
 import { getWeb3ReadOnly } from './wallets/web3'
 
-export const VESTING_URL = 'https://safe-claiming-app-data.gnosis-safe.io/allocations/'
+export const VESTING_URL = 'https://safe-claiming-app-data.safe.global/allocations/'
 
 type VestingData = {
   tag: 'user' | 'ecosystem' | 'investor'


### PR DESCRIPTION
## What it solves

Updates claiming data URL

## How this PR fixes it

`safe-claiming-app-data.gnosis-safe.io` has been exchanged with `safe-claiming-app-data.safe.global` as per [request](https://5afe.slack.com/archives/C04MQSC3R7Y/p1687260130435589).

## How to test it

Open a Safe with a token allocation and observe it still correctly displaying.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
