### PR TITLE
Chore: fix tx builder unit tests

### DIFF
--- a/src/tests/pages/apps-share.test.tsx
+++ b/src/tests/pages/apps-share.test.tsx
@@ -8,6 +8,7 @@ import crypto from 'crypto'
 import type { EIP1193Provider } from '@web3-onboard/core'
 
 const FETCH_TIMEOUT = 5000
+const TX_BUILDER = 'https://apps-portal.safe.global/tx-builder'
 
 describe('Share Safe App Page', () => {
   beforeEach(() => {
@@ -19,7 +20,7 @@ describe('Share Safe App Page', () => {
     render(<ShareSafeApp />, {
       routerProps: {
         query: {
-          appUrl: 'https://apps.gnosis-safe.io/tx-builder/',
+          appUrl: TX_BUILDER,
           chain: 'eth',
         },
       },
@@ -38,7 +39,7 @@ describe('Share Safe App Page', () => {
         expect(
           screen.getByText('Compose custom contract interactions and batch them into a single transaction'),
         ).toBeInTheDocument()
-        expect(screen.getByText('https://apps.gnosis-safe.io/tx-builder')).toBeInTheDocument()
+        expect(screen.getByText(TX_BUILDER)).toBeInTheDocument()
       },
       { timeout: FETCH_TIMEOUT },
     )
@@ -48,7 +49,7 @@ describe('Share Safe App Page', () => {
     render(<ShareSafeApp />, {
       routerProps: {
         query: {
-          appUrl: 'https://apps.gnosis-safe.io/tx-builder/',
+          appUrl: TX_BUILDER,
           chain: 'eth',
         },
       },
@@ -73,7 +74,7 @@ describe('Share Safe App Page', () => {
     render(<ShareSafeApp />, {
       routerProps: {
         query: {
-          appUrl: 'https://apps.gnosis-safe.io/tx-builder/',
+          appUrl: TX_BUILDER,
           chain: 'eth',
         },
       },
@@ -145,7 +146,7 @@ describe('Share Safe App Page', () => {
     render(<ShareSafeApp />, {
       routerProps: {
         query: {
-          appUrl: 'https://apps.gnosis-safe.io/tx-builder/',
+          appUrl: TX_BUILDER,
           chain: 'eth',
         },
       },


### PR DESCRIPTION
Unit tests were failing because of the updated Tx Builder URL. Looks like we aren't mocking the Safe App list request properly.