### PR TITLE
[TX flow] styles: fix send token styles

### DIFF
--- a/src/components/tx-flow/common/TxCard/index.tsx
+++ b/src/components/tx-flow/common/TxCard/index.tsx
@@ -4,9 +4,9 @@ import css from '../styles.module.css'
 
 const sx = { my: 2, border: 0 }
 
-const TxCard = ({ children, className }: { children: ReactNode; className?: string }) => {
+const TxCard = ({ children }: { children: ReactNode }) => {
   return (
-    <Card sx={sx} className={className}>
+    <Card sx={sx}>
       <CardContent className={css.cardContent}>{children}</CardContent>
     </Card>
   )

--- a/src/components/tx-flow/common/TxLayout/index.tsx
+++ b/src/components/tx-flow/common/TxLayout/index.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType, ReactElement, ReactNode } from 'react'
-import { Box, Container, Grid, Typography, Button, Paper, SvgIcon, Divider } from '@mui/material'
+import { Box, Container, Grid, Typography, Button, Paper, SvgIcon } from '@mui/material'
 import type { TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import { ProgressBar } from '@/components/common/ProgressBar'
 import SafeTxProvider from '../../SafeTxProvider'
@@ -61,8 +61,6 @@ const TxLayout = ({
 
                   {!hideNonce && <TxNonce />}
                 </Box>
-
-                <Divider sx={{ position: 'relative', zIndex: '1' }} />
               </Paper>
 
               <div className={css.step}>

--- a/src/components/tx-flow/common/TxLayout/styles.module.css
+++ b/src/components/tx-flow/common/TxLayout/styles.module.css
@@ -1,5 +1,4 @@
 .header {
-  margin-bottom: -22px;
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }
@@ -27,10 +26,6 @@
   border-top-right-radius: 0;
   border-top-left-radius: 0;
   margin-top: 0;
-}
-
-.step :global(.MuiCardContent-root:last-child) {
-  padding-bottom: var(--space-2);
 }
 
 /* Submit button */

--- a/src/components/tx-flow/common/styles.module.css
+++ b/src/components/tx-flow/common/styles.module.css
@@ -1,7 +1,3 @@
-.stepFirstCard {
-  padding-top: var(--space-3);
-}
-
 .cardContent {
   display: flex;
   flex-direction: column;
@@ -10,5 +6,5 @@
 }
 
 .nestedDivider {
-  margin: 0 calc(-1 * var(--space-2));
+  margin: 0 calc(-1 * var(--space-3));
 }

--- a/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
@@ -128,7 +128,7 @@ const CreateTokenTransfer = ({
   const isAddressValid = !!recipient && !errors[TokenTransferFields.recipient]
 
   return (
-    <TxCard className={commonCss.stepFirstCard}>
+    <TxCard>
       <FormProvider {...formMethods}>
         <form onSubmit={handleSubmit(onSubmit)} className={css.form}>
           <FormControl fullWidth>

--- a/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
@@ -131,7 +131,7 @@ const CreateTokenTransfer = ({
     <TxCard>
       <FormProvider {...formMethods}>
         <form onSubmit={handleSubmit(onSubmit)} className={css.form}>
-          <FormControl fullWidth>
+          <FormControl fullWidth sx={{ mt: 1 }}>
             {addressBook[recipient] ? (
               <Box
                 onClick={() => {

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -40,7 +40,7 @@ const SignOrExecuteForm = (props: SignOrExecuteProps): ReactElement => {
 
   return (
     <>
-      <TxCard className={commonCss.stepFirstCard}>
+      <TxCard>
         {props.children}
 
         <DecodedTx tx={safeTx} txId={props.txId} />


### PR DESCRIPTION
## What it solves
Harmonizes the styles in the Send Token flow that were unnecessary present after merging the last PRs into the epic branch.

## How to test it
Check https://epic_tx_flow--walletweb.review-wallet-web.5afe.dev/ vs this PR deployment for the Send Tokens create and review steps

## Screenshots
<img width="699" alt="Screenshot 2023-06-20 at 22 40 57" src="https://github.com/safe-global/safe-wallet-web/assets/32431609/708bcb0e-666d-4097-a84a-3aad4855e8d9">
<img width="684" alt="Screenshot 2023-06-20 at 22 41 10" src="https://github.com/safe-global/safe-wallet-web/assets/32431609/9a9d9577-c8d6-4840-a8d3-b07c57f43a6b">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
