### PR TITLE
fix: move default value to placeholder

### DIFF
--- a/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
@@ -170,6 +170,7 @@ const CreateTokenTransfer = ({
                 }}
                 className={css.amount}
                 required
+                placeholder="0"
                 {...register(TokenTransferFields.amount, {
                   required: true,
                   validate: (val) => {

--- a/src/components/tx-flow/flows/TokenTransfer/index.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/index.tsx
@@ -31,7 +31,7 @@ type TokenTransferFlowProps = Partial<TokenTransferParams> & {
 const defaultParams: TokenTransferParams = {
   recipient: '',
   tokenAddress: ZERO_ADDRESS,
-  amount: '0',
+  amount: '',
   type: TokenTransferType.multiSig,
 }
 


### PR DESCRIPTION
## What it solves

Having to remove `0` from the amount field.

## How this PR fixes it

The default value has been moved to the placeholder.

## How to test it

Create a transaction and observe the new placeholder instead of having to remove the default value before entering the desired one.

## Screenshots

![amount placeholder](https://github.com/safe-global/safe-wallet-web/assets/20442784/f3270d9a-4c78-426e-aa6a-e6e559e5839d)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
