### PR TITLE
fix: hide `safeTxGas` when `0`

### DIFF
--- a/src/components/transactions/TxDetails/Summary/index.tsx
+++ b/src/components/transactions/TxDetails/Summary/index.tsx
@@ -76,9 +76,11 @@ export const PartialSummary = ({ safeTx }: { safeTx: SafeTransaction }) => {
   const txData = safeTx.data
   return (
     <>
-      <TxDataRow title="safeTxGas:">
-        <SafeTxGasForm />
-      </TxDataRow>
+      {!!txData.safeTxGas && (
+        <TxDataRow title="safeTxGas:">
+          <SafeTxGasForm />
+        </TxDataRow>
+      )}
       <TxDataRow title="Raw data:">{generateDataRowValue(txData.data, 'rawData')}</TxDataRow>
     </>
   )

--- a/src/components/transactions/TxDetails/Summary/index.tsx
+++ b/src/components/transactions/TxDetails/Summary/index.tsx
@@ -9,6 +9,8 @@ import { dateString } from '@/utils/formatters'
 import css from './styles.module.css'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import SafeTxGasForm from '../SafeTxGasForm'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import { isLegacyVersion } from '@/hooks/coreSDK/safeCoreSDK'
 
 interface Props {
   txDetails: TransactionDetails
@@ -73,10 +75,11 @@ const Summary = ({ txDetails, defaultExpanded = false }: Props): ReactElement =>
 export default Summary
 
 export const PartialSummary = ({ safeTx }: { safeTx: SafeTransaction }) => {
+  const { safe } = useSafeInfo()
   const txData = safeTx.data
   return (
     <>
-      {!!txData.safeTxGas && (
+      {safe.version && isLegacyVersion(safe.version) && (
         <TxDataRow title="safeTxGas:">
           <SafeTxGasForm />
         </TxDataRow>


### PR DESCRIPTION
## What it solves

Resolves showing `safeTxGas` on Safe versions that don't need it.

## How this PR fixes it

If the Safe version is "legacy" (<1.3.0), the `safeTxGas` field is shown. This is preferable to checking whether the value is `0` as the user may set it to `0` on legacy versions, removing the field without the options of altering it again after seeing a failing simulation.

## How to test it

- Create a transaction on a Safe <1.3.0 and observe the `safeTxGas` field present.
- Create a transaction on a Safe >=1.3.0 and observe the `safeTxGas` field _not_ present.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
