### PR TITLE
Chore: disable jest warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prettier": "prettier -w \"{src,cypress,mocks,scripts}/**/*.{ts,tsx,css,js}\"",
     "fix": "yarn lint:fix && ts-prune && yarn prettier",
     "test": "cross-env TZ=CET DEBUG_PRINT_LIMIT=30000 jest",
-    "test:ci": "yarn test --ci --coverage --json --watchAll=false --testLocationInResults --outputFile=jest.results.json",
+    "test:ci": "yarn test --ci --silent --coverage --json --watchAll=false --testLocationInResults --outputFile=jest.results.json",
     "test:coverage": "yarn test --coverage --watchAll=false",
     "cmp": "./scripts/cmp.sh",
     "routes": "node scripts/generate-routes.js > src/config/routes.ts && prettier -w src/config/routes.ts && cat src/config/routes.ts",


### PR DESCRIPTION
The "not wrapped in act" warnings make it really difficult to read the logs when tests fail.