### PR TITLE
chore: Fix modularized imports

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -22,19 +22,19 @@ const nextConfig = {
     images: {
       unoptimized: true,
     },
-  },
-  modularizeImports: {
-    '@mui/material': {
-      transform: '@mui/material/{{member}}',
-    },
-    '@mui/icons-material/?(((\\w*)?/?)*)': {
-      transform: '@mui/icons-material/{{ matches.[1] }}/{{member}}',
-    },
-    lodash: {
-      transform: 'lodash/{{member}}',
-    },
-    'date-fns': {
-      transform: 'date-fns/{{member}}',
+    modularizeImports: {
+      '@mui/material': {
+        transform: '@mui/material/{{member}}',
+      },
+      '@mui/icons-material/?(((\\w*)?/?)*)': {
+        transform: '@mui/icons-material/{{ matches.[1] }}/{{member}}',
+      },
+      lodash: {
+        transform: 'lodash/{{member}}',
+      },
+      'date-fns': {
+        transform: 'date-fns/{{member}}',
+      },
     },
   },
   async rewrites() {


### PR DESCRIPTION
## What it solves

Moves the `modularizeImports` config back to `experimental` in the next config. This was changed as part of https://github.com/safe-global/safe-wallet-web/pull/2049 to remove the warnings but `modularizeImports` seem to be an `experimental` feature of next and stopped working altogether after.

The change resulted in more than twice the number of modules being loaded on local dev (17k+ instead of ~6k).

## How to test it

1. Run the local dev environment
2. Observe significantly fewer modules being loaded
