### PR TITLE
Fix: a tiny fix for balance changes CSS

### DIFF
--- a/src/components/tx/security/redefine/RedefineBalanceChange/styles.module.css
+++ b/src/components/tx/security/redefine/RedefineBalanceChange/styles.module.css
@@ -3,6 +3,7 @@
   max-height: 300px;
   overflow-y: auto;
   align-items: center;
+  gap: 1px;
 }
 
 .balanceChange {
@@ -14,6 +15,10 @@
 
 .balanceChange:last-child {
   margin-bottom: 0;
+}
+
+.balanceChange svg {
+  flex-shrink: 0;
 }
 
 .nftId {


### PR DESCRIPTION
Adds a one-pixel gap between balance changes so that they aren't butt-to-butt.
<img width="572" alt="Screenshot 2023-06-22 at 09 07 57" src="https://github.com/safe-global/safe-wallet-web/assets/381895/4bac07b8-f139-4fad-b7ad-20423a12daf0">
