### PR TITLE
feat: add tooltip to advanced details

### DIFF
--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -1,5 +1,14 @@
 import { type SyntheticEvent, type ReactElement, useMemo } from 'react'
-import { Accordion, AccordionDetails, AccordionSummary, Box, Skeleton, Typography } from '@mui/material'
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Skeleton,
+  SvgIcon,
+  Tooltip,
+  Typography,
+} from '@mui/material'
 import { OperationType, type SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import {
   type DecodedDataResponse,
@@ -19,6 +28,9 @@ import ApprovalEditor from '@/components/tx/ApprovalEditor'
 import { ErrorBoundary } from '@sentry/react'
 import { getNativeTransferData } from '@/services/tx/tokenTransferParams'
 import Multisend from '@/components/transactions/TxDetails/TxData/DecodedData/Multisend'
+import InfoIcon from '@/public/images/notifications/info.svg'
+import ExternalLink from '@/components/common/ExternalLink'
+import { HelpCenterArticle } from '@/config/constants'
 
 type DecodedTxProps = {
   tx?: SafeTransaction
@@ -97,8 +109,34 @@ const DecodedTx = ({ tx, txId }: DecodedTxProps): ReactElement | null => {
           )}
 
           <Box mt={2}>
-            <Typography variant="overline" fontWeight="bold" color="border.main">
+            <Typography variant="overline" fontWeight="bold" color="border.main" display="flex" alignItems="center">
               Advanced details
+              <Tooltip
+                title={
+                  <>
+                    If you are unsure, don&apos;t edit these values.
+                    <ExternalLink href={HelpCenterArticle.ADVANCED_PARAMS} title="Learn more about advanced details">
+                      Learn more about advanced details
+                    </ExternalLink>
+                    .
+                  </>
+                }
+                arrow
+                placement="top"
+              >
+                <span>
+                  <SvgIcon
+                    component={InfoIcon}
+                    inheritViewBox
+                    color="border"
+                    fontSize="small"
+                    sx={{
+                      verticalAlign: 'middle',
+                      ml: 0.5,
+                    }}
+                  />
+                </span>
+              </Tooltip>
             </Typography>
 
             {txDetails ? <Summary txDetails={txDetails} defaultExpanded /> : tx && <PartialSummary safeTx={tx} />}

--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -114,7 +114,7 @@ const DecodedTx = ({ tx, txId }: DecodedTxProps): ReactElement | null => {
               <Tooltip
                 title={
                   <>
-                    If you are unsure, don&apos;t edit these values.
+                    We recommend not changing the default values unless necessary.{' '}
                     <ExternalLink href={HelpCenterArticle.ADVANCED_PARAMS} title="Learn more about advanced details">
                       Learn more about advanced details
                     </ExternalLink>


### PR DESCRIPTION
## What it solves

Resolves unclear advanced details.

## How this PR fixes it

This adds a tooltip next to the advanced details in the transaction flow.

## How to test it

Create a transaction and open the details. Observe the new tooltip.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/f6a4b766-be7c-4db6-a5a1-14c0b7e340ce)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
