### PR TITLE
[TX flow] Display Token balance

### DIFF
--- a/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
@@ -205,7 +205,9 @@ const CreateTokenTransfer = ({
                       <TokenIcon logoUri={item.tokenInfo.logoUri} tokenSymbol={item.tokenInfo.symbol} />
 
                       <Grid item xs>
-                        <Typography variant="body2">{item.tokenInfo.name}</Typography>
+                        <Typography variant="body2" lineHeight="18px">
+                          {item.tokenInfo.name}
+                        </Typography>
 
                         <Typography variant="caption" component="p">
                           {formatVisualAmount(item.balance, item.tokenInfo.decimals)} {item.tokenInfo.symbol}

--- a/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
@@ -19,6 +19,7 @@ import {
   CardActions,
   Divider,
   FormControl,
+  Grid,
   InputLabel,
   MenuItem,
   SvgIcon,
@@ -34,7 +35,7 @@ import NumberField from '@/components/common/NumberField'
 import { validateDecimalLength, validateLimitedAmount } from '@/utils/validation'
 import { type TokenTransferParams, TokenTransferFields, TokenTransferType } from '.'
 import TxCard from '../../common/TxCard'
-import { safeFormatUnits } from '@/utils/formatters'
+import { formatVisualAmount, safeFormatUnits } from '@/utils/formatters'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
 import css from './styles.module.css'
 
@@ -200,12 +201,17 @@ const CreateTokenTransfer = ({
               >
                 {balancesItems.map((item) => (
                   <MenuItem key={item.tokenInfo.address} value={item.tokenInfo.address}>
-                    <div className={css.item}>
+                    <Grid container alignItems="center" gap={1}>
                       <TokenIcon logoUri={item.tokenInfo.logoUri} tokenSymbol={item.tokenInfo.symbol} />
-                      <Typography>
-                        <b>{item.tokenInfo.symbol}</b>
-                      </Typography>
-                    </div>
+
+                      <Grid item xs>
+                        <Typography variant="body2">{item.tokenInfo.name}</Typography>
+
+                        <Typography variant="caption" component="p">
+                          {formatVisualAmount(item.balance, item.tokenInfo.decimals)} {item.tokenInfo.symbol}
+                        </Typography>
+                      </Grid>
+                    </Grid>
                   </MenuItem>
                 ))}
               </TextField>

--- a/src/components/tx-flow/flows/TokenTransfer/styles.module.css
+++ b/src/components/tx-flow/flows/TokenTransfer/styles.module.css
@@ -50,7 +50,7 @@
   display: flex;
   background-color: var(--color-background-main);
   border-radius: 6px;
-  padding: 10px var(--space-5) 10px var(--space-2) !important;
+  padding: var(--space-1) var(--space-5) var(--space-1) var(--space-2) !important;
 }
 
 .select :global(.MuiSelect-icon) {

--- a/src/components/tx-flow/flows/TokenTransfer/styles.module.css
+++ b/src/components/tx-flow/flows/TokenTransfer/styles.module.css
@@ -24,11 +24,12 @@
 }
 
 .amount {
+  min-width: 130px;
   flex-grow: 1;
 }
 
 .amount :global(.MuiInput-input) {
-  padding-left: var(--space-3);
+  padding-left: var(--space-2);
 }
 
 .max {
@@ -38,6 +39,10 @@
   margin-right: var(--space-1);
   min-height: 50px;
   padding: var(--space-2);
+}
+
+.select {
+  flex-shrink: 0;
 }
 
 .select :global(.MuiSelect-select) {
@@ -50,14 +55,6 @@
 
 .select :global(.MuiSelect-icon) {
   margin-right: var(--space-2);
-}
-
-.item {
-  display: inline-flex;
-  gap: 6px;
-  align-items: center;
-  padding-top: 2px;
-  padding-bottom: 2px;
 }
 
 .token {


### PR DESCRIPTION
## How this PR fixes it

- Displays the token balance in the amount input field
- Slightly decreases the spacing of the amount input as discussed [here](https://www.figma.com/file/ptTs6lDBeUuLNySroJ5PiF?node-id=5230:264187#476048952)

## How to test it

1. Open the Safe
2. Create a new transaction
3. Observe the token balance is visible

## Screenshots
<img width="700" alt="Screenshot 2023-06-22 at 15 32 36" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/5e6b9c92-7e74-415b-b55a-1c1c85f64690">
<img width="758" alt="Screenshot 2023-06-22 at 15 32 43" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/b865037a-1191-4ff6-8fa3-6afdcafbaa4f">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
