### PR TITLE
[TX flow] Design adjustments

### DIFF
--- a/src/components/tx-flow/common/TxLayout/styles.module.css
+++ b/src/components/tx-flow/common/TxLayout/styles.module.css
@@ -64,6 +64,10 @@
   font-size: 14px;
 }
 
+.step :global(.MuiAccordionSummary-expandIconWrapper) {
+  margin-left: var(--space-2);
+}
+
 .statusButton {
   position: absolute;
   top: 0;

--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -83,7 +83,7 @@ const TxNonce = () => {
     setNonce(recommendedNonce)
   }, [recommendedNonce, setNonce])
 
-  if (nonce === undefined) return <Skeleton variant="rounded" width={40} height={26} />
+  if (nonce === undefined) return <Skeleton variant="rounded" width={40} height={38} />
 
   return (
     <Box display="flex" alignItems="center" gap={1}>

--- a/src/components/tx-flow/common/styles.module.css
+++ b/src/components/tx-flow/common/styles.module.css
@@ -1,7 +1,7 @@
 .cardContent {
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: var(--space-2);
   padding: var(--space-3);
 }
 

--- a/src/components/tx-flow/flows/NewTx/index.tsx
+++ b/src/components/tx-flow/flows/NewTx/index.tsx
@@ -7,6 +7,7 @@ import { TxModalContext } from '../../'
 import TokenTransferFlow from '../TokenTransfer'
 import { AppRoutes } from '@/config/routes'
 import css from './styles.module.css'
+import Link from 'next/link'
 
 const BUTTONS_HEIGHT = '91px'
 
@@ -16,7 +17,10 @@ const NewTxMenu = () => {
   const txBuilder = useTxBuilderApp()
 
   const onNftsClick = useCallback(() => {
-    router.push(AppRoutes.balances.nfts, { query: { safe: router.query.safe } })
+    router.push({
+      pathname: AppRoutes.balances.nfts,
+      query: { safe: router.query.safe },
+    })
   }, [router])
 
   const onTokensClick = useCallback(() => {
@@ -34,14 +38,18 @@ const NewTxMenu = () => {
       <SendNFTsButton onClick={onNftsClick} sx={{ height: BUTTONS_HEIGHT }} />
 
       {txBuilder && txBuilder.app && (
-        <TxButton
-          startIcon={<img src={txBuilder.app.iconUrl} height={20} width="auto" alt={txBuilder.app.name} />}
-          variant="outlined"
-          onClick={() => console.log('open contract interaction flow')}
-          sx={{ height: BUTTONS_HEIGHT }}
-        >
-          Contract interaction
-        </TxButton>
+        <Link href={txBuilder.link} passHref>
+          <a style={{ width: '100%' }}>
+            <TxButton
+              startIcon={<img src={txBuilder.app.iconUrl} height={20} width="auto" alt={txBuilder.app.name} />}
+              variant="outlined"
+              onClick={() => console.log('open contract interaction flow')}
+              sx={{ height: BUTTONS_HEIGHT }}
+            >
+              Contract interaction
+            </TxButton>
+          </a>
+        </Link>
       )}
     </Box>
   )

--- a/src/components/tx-flow/flows/TokenTransfer/SendAmountBlock.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/SendAmountBlock.tsx
@@ -34,7 +34,7 @@ const SendAmountBlock = ({
   children?: ReactNode
 }) => {
   return (
-    <Grid container gap={1}>
+    <Grid container gap={1} alignItems="center">
       <Grid item xs={2}>
         Send
       </Grid>

--- a/src/components/tx-flow/flows/TokenTransfer/SendToBlock.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/SendToBlock.tsx
@@ -3,7 +3,7 @@ import EthHashInfo from '@/components/common/EthHashInfo'
 
 const SendToBlock = ({ address }: { address: string; title?: string }) => {
   return (
-    <Grid container gap={1}>
+    <Grid container gap={1} alignItems="center">
       <Grid item xs={2}>
         To
       </Grid>

--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -31,6 +31,7 @@ import Multisend from '@/components/transactions/TxDetails/TxData/DecodedData/Mu
 import InfoIcon from '@/public/images/notifications/info.svg'
 import ExternalLink from '@/components/common/ExternalLink'
 import { HelpCenterArticle } from '@/config/constants'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 
 type DecodedTxProps = {
   tx?: SafeTransaction
@@ -93,7 +94,7 @@ const DecodedTx = ({ tx, txId }: DecodedTxProps): ReactElement | null => {
       )}
 
       <Accordion elevation={0} onChange={onChangeExpand} sx={!tx ? { pointerEvents: 'none' } : undefined}>
-        <AccordionSummary>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
           <span style={{ flex: 1 }}>Transaction details</span>
 
           {decodedData ? decodedData.method : tx?.data.operation === OperationType.DelegateCall ? 'Delegate call' : ''}

--- a/src/components/tx/ExecuteCheckbox/styles.module.css
+++ b/src/components/tx/ExecuteCheckbox/styles.module.css
@@ -6,7 +6,7 @@
 
 .radio {
   margin: 0;
-  border: 1px solid var(--color-border-main);
-  border-radius: 4px;
+  border: 1px solid var(--color-border-light);
+  border-radius: 6px;
   padding: 9px 3px;
 }

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement, type SyntheticEvent, useContext, useState } from 'react'
-import { Button, CardActions } from '@mui/material'
+import { Button, CardActions, Divider } from '@mui/material'
 import classNames from 'classnames'
 
 import ErrorMessage from '@/components/tx/ErrorMessage'
@@ -23,6 +23,7 @@ import AdvancedParams, { useAdvancedParams } from '../AdvancedParams'
 import { asError } from '@/services/exceptions/utils'
 
 import css from './styles.module.css'
+import commonCss from '@/components/tx-flow/common/styles.module.css'
 
 const ExecuteForm = ({
   safeTx,
@@ -130,6 +131,8 @@ const ExecuteForm = ({
         ) : (
           <UnknownContractError />
         )}
+
+        <Divider className={commonCss.nestedDivider} sx={{ pt: 3 }} />
 
         <CardActions>
           {/* Submit button */}

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement, type SyntheticEvent, useContext, useState } from 'react'
-import { Button, CardActions } from '@mui/material'
+import { Button, CardActions, Divider } from '@mui/material'
 
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import { logError, Errors } from '@/services/exceptions'
@@ -10,6 +10,7 @@ import type { SignOrExecuteProps } from '.'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { TxModalContext } from '@/components/tx-flow'
 import { asError } from '@/services/exceptions/utils'
+import commonCss from '@/components/tx-flow/common/styles.module.css'
 
 const SignForm = ({
   safeTx,
@@ -64,6 +65,8 @@ const SignForm = ({
           <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
         )
       )}
+
+      <Divider className={commonCss.nestedDivider} sx={{ pt: 3 }} />
 
       <CardActions>
         {/* Submit button */}

--- a/src/components/tx/SignOrExecuteForm/TxChecks.tsx
+++ b/src/components/tx/SignOrExecuteForm/TxChecks.tsx
@@ -2,6 +2,7 @@ import { type ReactElement, useContext } from 'react'
 import { TxSimulation } from '../TxSimulation'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { Typography } from '@mui/material'
+import { RedefineScanResult } from '@/components/tx/security/redefine/RedefineScanResult/RedefineScanResult'
 
 const TxChecks = (): ReactElement => {
   const { safeTx } = useContext(SafeTxContext)
@@ -11,6 +12,8 @@ const TxChecks = (): ReactElement => {
       <Typography variant="h5">Transaction checks</Typography>
 
       <TxSimulation canExecute disabled={false} transactions={safeTx} />
+
+      <RedefineScanResult />
     </>
   )
 }

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -12,10 +12,7 @@ import TxCard from '@/components/tx-flow/common/TxCard'
 import ConfirmationTitle, { ConfirmationTitleTypes } from '@/components/tx/SignOrExecuteForm/ConfirmationTitle'
 import { useAppSelector } from '@/store'
 import { selectSettings } from '@/store/settingsSlice'
-import { Divider } from '@mui/material'
-import commonCss from '@/components/tx-flow/common/styles.module.css'
 import { TransactionSecurityProvider } from '../security/TransactionSecurityContext'
-import { RedefineScanResult } from '@/components/tx/security/redefine/RedefineScanResult/RedefineScanResult'
 
 export type SignOrExecuteProps = {
   txId?: string
@@ -59,23 +56,17 @@ const SignOrExecuteForm = (props: SignOrExecuteProps): ReactElement => {
             isCreation={isCreation}
           />
 
-          {canExecute && !props.onlyExecute && <ExecuteCheckbox onChange={setShouldExecute} />}
-
-          <RedefineScanResult />
-
-          {/* Warning message and switch button */}
-          <WrongChainWarning />
-
           {safeTxError && (
             <ErrorMessage error={safeTxError}>
               This transaction will most likely fail. To save gas costs, avoid confirming the transaction.
             </ErrorMessage>
           )}
 
-          <div>
-            <Divider className={commonCss.nestedDivider} />
-            {willExecute ? <ExecuteForm {...props} safeTx={safeTx} /> : <SignForm {...props} safeTx={safeTx} />}
-          </div>
+          {canExecute && !props.onlyExecute && <ExecuteCheckbox onChange={setShouldExecute} />}
+
+          <WrongChainWarning />
+
+          {willExecute ? <ExecuteForm {...props} safeTx={safeTx} /> : <SignForm {...props} safeTx={safeTx} />}
         </TxCard>
       </>
     </TransactionSecurityProvider>

--- a/src/components/tx/SignOrExecuteForm/styles.module.css
+++ b/src/components/tx/SignOrExecuteForm/styles.module.css
@@ -1,8 +1,8 @@
 .wrapper {
-  padding: 8px 0px 8px;
   display: flex;
   align-items: center;
   gap: var(--space-2);
+  margin-bottom: var(--space-1);
 }
 
 .icon {

--- a/src/components/tx/TxSimulation/index.tsx
+++ b/src/components/tx/TxSimulation/index.tsx
@@ -54,7 +54,7 @@ const TxSimulationBlock = ({ transactions, canExecute, disabled, gasLimit }: TxS
   const isSimulationLoading = simulationRequestStatus === FETCH_STATUS.LOADING
 
   return (
-    <Accordion expanded={isSimulationFinished} elevation={0} sx={{ mt: '16px !important' }}>
+    <Accordion expanded={isSimulationFinished} elevation={0}>
       {!isSimulationFinished ? (
         <AccordionSummary className={css.simulateAccordion}>
           <Typography>Transaction validity</Typography>

--- a/src/components/tx/TxSimulation/styles.module.css
+++ b/src/components/tx/TxSimulation/styles.module.css
@@ -14,5 +14,4 @@
 .skeletonWrapper {
   border-radius: 8px;
   overflow: hidden;
-  margin-top: var(--space-2);
 }

--- a/src/components/tx/security/shared/SecurityWarnings/styles.module.css
+++ b/src/components/tx/security/shared/SecurityWarnings/styles.module.css
@@ -55,6 +55,5 @@
   border-radius: 6px;
   border: 1px solid var(--color-border-light);
   padding: 0;
-  margin-top: var(--space-2);
   background-color: var(--color-background-main);
 }


### PR DESCRIPTION
## What it solves

Part of #2067 

## How this PR fixes it

- Adjusts the layout for reviewing send token txs according to the design
- Moves Redefine block up to tx checks
- Adds the contract interaction link in new tx menu
- Fixes the NFT Transfer link in new tx menu

## How to test it

1. Try sending nfts and contract interaction via the new tx menu
2. Observe the send tokens review screen

## Screenshots
<img width="476" alt="Screenshot 2023-06-23 at 16 04 10" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/f89b7c79-7aee-4d90-9476-7e8503dbef60">
<img width="697" alt="Screenshot 2023-06-23 at 16 04 23" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/a9cd88cc-0c08-45c1-9bad-19afe6d9281f">



## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
