### PR TITLE
fix: remove creation modal query param on close

### DIFF
--- a/src/components/dashboard/CreationDialog/index.tsx
+++ b/src/components/dashboard/CreationDialog/index.tsx
@@ -1,5 +1,6 @@
 import React, { type ElementType } from 'react'
 import { Box, Button, Dialog, DialogContent, Grid, SvgIcon, Typography } from '@mui/material'
+import { useRouter } from 'next/router'
 
 import HomeIcon from '@/public/images/sidebar/home.svg'
 import TransactionIcon from '@/public/images/sidebar/transactions.svg'
@@ -9,6 +10,7 @@ import BeamerIcon from '@/public/images/sidebar/whats-new.svg'
 import HelpCenterIcon from '@/public/images/sidebar/help-center.svg'
 import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
 import { useCurrentChain } from '@/hooks/useChains'
+import { CREATION_MODAL_QUERY_PARM } from '@/components/new-safe/create/logic'
 
 const HintItem = ({ Icon, title, description }: { Icon: ElementType; title: string; description: string }) => {
   return (
@@ -26,9 +28,17 @@ const HintItem = ({ Icon, title, description }: { Icon: ElementType; title: stri
 }
 
 const CreationDialog = () => {
+  const router = useRouter()
   const [open, setOpen] = React.useState(true)
   const [remoteSafeApps = []] = useRemoteSafeApps()
   const chain = useCurrentChain()
+
+  const onClose = () => {
+    const { [CREATION_MODAL_QUERY_PARM]: _, ...query } = router.query
+    router.replace({ pathname: router.pathname, query })
+
+    setOpen(false)
+  }
 
   return (
     <Dialog open={open}>
@@ -64,7 +74,7 @@ const CreationDialog = () => {
           />
         </Grid>
         <Box display="flex" justifyContent="center">
-          <Button onClick={() => setOpen(false)} variant="contained" size="stretched">
+          <Button onClick={onClose} variant="contained" size="stretched">
             Got it
           </Button>
         </Box>

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -10,11 +10,12 @@ import { useRouter } from 'next/router'
 import Relaying from '@/components/dashboard/Relaying'
 import { FEATURES } from '@/utils/chains'
 import { useHasFeature } from '@/hooks/useChains'
+import { CREATION_MODAL_QUERY_PARM } from '../new-safe/create/logic'
 
 const Dashboard = (): ReactElement => {
   const router = useRouter()
   const supportsRelaying = useHasFeature(FEATURES.RELAYING)
-  const { showCreationModal = '' } = router.query
+  const { [CREATION_MODAL_QUERY_PARM]: showCreationModal = '' } = router.query
 
   return (
     <>

--- a/src/components/new-safe/create/logic/index.ts
+++ b/src/components/new-safe/create/logic/index.ts
@@ -235,6 +235,8 @@ export const checkSafeCreationTx = async (
   }
 }
 
+export const CREATION_MODAL_QUERY_PARM = 'showCreationModal'
+
 export const getRedirect = (
   chainPrefix: string,
   safeAddress: string,
@@ -248,7 +250,7 @@ export const getRedirect = (
 
   // Go to the dashboard if no specific redirect is provided
   if (!redirectUrl) {
-    return { pathname: AppRoutes.home, query: { safe: address, showCreationModal: true } }
+    return { pathname: AppRoutes.home, query: { safe: address, [CREATION_MODAL_QUERY_PARM]: true } }
   }
 
   // Otherwise, redirect to the provided URL (e.g. from a Safe App)


### PR DESCRIPTION
## What it solves

Resolves #2088

## How this PR fixes it

The `showCreationModal` query param is now removed when closing the creation modal when closing.

## How to test it

After creating a Safe and opening it, close the creation modal and observe that the param is removed from the URL.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
