### PR TITLE
Fix: reset tx list pages when Safe is changed

### DIFF
--- a/src/components/common/PaginatedTxns/index.tsx
+++ b/src/components/common/PaginatedTxns/index.tsx
@@ -12,6 +12,7 @@ import { type TxFilter, useTxFilter } from '@/utils/tx-history-filter'
 import { isTransactionListItem } from '@/utils/transaction-guards'
 import NoTransactionsIcon from '@/public/images/transactions/no-transactions.svg'
 import { useHasPendingTxs } from '@/hooks/usePendingTxs'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 const NoQueuedTxns = () => {
   return <PagePlaceholder img={<NoTransactionsIcon />} text="Queued transactions will appear here" />
@@ -68,11 +69,12 @@ const TxPage = ({
 const PaginatedTxns = ({ useTxns }: { useTxns: typeof useTxHistory | typeof useTxQueue }): ReactElement => {
   const [pages, setPages] = useState<string[]>([''])
   const [filter] = useTxFilter()
+  const { safeAddress, safe } = useSafeInfo()
 
-  // Reset the pages when the filter changes
+  // Reset the pages when the Safe Account or filter changes
   useEffect(() => {
     setPages([''])
-  }, [filter, useTxns])
+  }, [filter, safe.chainId, safeAddress, useTxns])
 
   // Trigger the next page load
   const onNextPage = (pageUrl: string) => {

--- a/src/components/safe-messages/PaginatedMsgs/index.tsx
+++ b/src/components/safe-messages/PaginatedMsgs/index.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@mui/material'
 import { Typography, Link, SvgIcon } from '@mui/material'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { ReactElement } from 'react'
 
 import ErrorMessage from '@/components/tx/ErrorMessage'
@@ -12,6 +12,7 @@ import PagePlaceholder from '@/components/common/PagePlaceholder'
 import MsgList from '@/components/safe-messages/MsgList'
 import SkeletonTxList from '@/components/common/PaginatedTxns/SkeletonTxList'
 import { HelpCenterArticle } from '@/config/constants'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 const NoMessages = (): ReactElement => {
   return (
@@ -62,11 +63,17 @@ const MsgPage = ({
 
 const PaginatedMsgs = (): ReactElement => {
   const [pages, setPages] = useState<string[]>([''])
+  const { safeAddress, safe } = useSafeInfo()
 
   // Trigger the next page load
   const onNextPage = (pageUrl: string) => {
     setPages((prev) => prev.concat(pageUrl))
   }
+
+  // Reset the pages when the Safe Account changes
+  useEffect(() => {
+    setPages([''])
+  }, [safe.chainId, safeAddress])
 
   return (
     <Box mb={4} position="relative">


### PR DESCRIPTION
## What it solves

Resolves #1974

## How this PR fixes it
"Manually" resets the state of the loaded page URLs in PaginatedTxns.

I'm worried that this might be not the only such place where we might be having stale state after #1756.

## How to test it
* Make your browser zoom really small (press Ctrl+- a few times)
* Open a Safe with lots of hsitorical txs, go to Transactions
* Observe that it loaded two initial pages of history
* Switch to another Safe