### PR TITLE
Fix: keystone modal scroll

### DIFF
--- a/src/styles/onboard.css
+++ b/src/styles/onboard.css
@@ -104,6 +104,9 @@
 #kv_sdk_container + .ReactModalPortal > div {
   z-index: 1301 !important;
 }
+#kv_sdk_container + .ReactModalPortal .ReactModal__Content {
+  padding: 0 !important;
+}
 
 /* Ledger modal */
 .ledger-ck-modal > div#ModalWrapper {


### PR DESCRIPTION
## What it solves

Resolves #1358

## How this PR fixes it
Adds a line of CSS to remove extra padding.

## Screenshots

<img width="870" alt="Screenshot 2023-06-26 at 14 41 05" src="https://github.com/safe-global/safe-wallet-web/assets/381895/977e4b2d-99b9-4c14-848b-cde86cfdd834">

<img width="653" alt="Screenshot 2023-06-26 at 14 41 12" src="https://github.com/safe-global/safe-wallet-web/assets/381895/66605248-7916-49ab-9ccd-19f4c61e1faf">
