### PR TITLE
fix: onboard warning colours

### DIFF
--- a/src/styles/onboard.css
+++ b/src/styles/onboard.css
@@ -40,11 +40,11 @@
   --onboard-danger-600: var(--color-error-main);
   --onboard-danger-700: var(--color-error-dark);
 
-  --onboard-warning-100: var(--color-error-background);
-  --onboard-warning-400: var(--color-error-light);
-  --onboard-warning-500: var(--color-error-light);
-  --onboard-warning-600: var(--color-error-main);
-  --onboard-warning-700: var(--color-error-dark);
+  --onboard-warning-100: var(--color-warning-background);
+  --onboard-warning-400: var(--color-warning-light);
+  --onboard-warning-500: var(--color-warning-light);
+  --onboard-warning-600: var(--color-warning-main);
+  --onboard-warning-700: var(--color-warning-dark);
 
   /* Connect modal */
   --onboard-modal-z-index: 1301;


### PR DESCRIPTION
## What it solves

Resolves unclear warning perceived as an error

## How this PR fixes it

The warning palette of onboard has been aligned with those from the Safe.

Note: previously the rejection message was red but with the palette adjustment, it is now yellow.

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/5a99f0d0-201a-4104-902e-5768d87f2dad)

## How to test it

Open the wallet connection modal and observe the "Why don't I see my wallet?" information in a yellow wrapper.

No error messages should have chaged, e.g. not able to connect to hardware wallet:

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/e98df11c-6da8-4161-8c78-a3cc4ad4927d)

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/9df2b65f-000f-48d2-af91-db6219ee7cc3)

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
