### PR TITLE
fix: don't check WC v1 session for v2 reconnection

### DIFF
--- a/src/hooks/wallets/wallets.ts
+++ b/src/hooks/wallets/wallets.ts
@@ -17,13 +17,12 @@ import { CGW_NAMES, WALLET_KEYS } from './consts'
 // We need to modify the module name as onboard dedupes modules with the same label and the WC v1 and v2 modules have the same
 // @see https://github.com/blocknative/web3-onboard/blob/d399e0b76daf7b363d6a74b100b2c96ccb14536c/packages/core/src/store/actions.ts#L419
 // TODO: When removing this, also remove the associated CSS in `onboard.css`
+export const WALLET_CONNECT_V1_MODULE_NAME = 'WalletConnect v1'
 const walletConnectV1 = (): WalletInit => {
   return (helpers) => {
-    const MODULE_LABEL = 'WalletConnect v1'
-
     const walletConnectModule = walletConnect({ version: 1, bridge: WC_BRIDGE })(helpers) as WalletModule
 
-    walletConnectModule.label = MODULE_LABEL
+    walletConnectModule.label = WALLET_CONNECT_V1_MODULE_NAME
 
     return walletConnectModule
   }

--- a/src/utils/wallets.ts
+++ b/src/utils/wallets.ts
@@ -7,6 +7,7 @@ import { ErrorCode } from '@ethersproject/logger'
 import { type ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import { getWeb3ReadOnly, isSmartContract } from '@/hooks/wallets/web3'
 import { WALLET_KEYS } from '@/hooks/wallets/consts'
+import { WALLET_CONNECT_V1_MODULE_NAME } from '@/hooks/wallets/wallets'
 
 const isWCRejection = (err: Error): boolean => {
   return /rejected/.test(err?.message)
@@ -22,7 +23,7 @@ export const isWalletRejection = (err: EthersError | Error): boolean => {
 
 export const WalletNames = {
   METAMASK: ProviderLabel.MetaMask,
-  WALLET_CONNECT: 'WalletConnect',
+  WALLET_CONNECT: WALLET_CONNECT_V1_MODULE_NAME,
   SAFE_MOBILE_PAIRING: PAIRING_MODULE_LABEL,
 }
 


### PR DESCRIPTION
## What it solves

Resolves WC v1 session caching interfering with v2.

## How this PR fixes it

The local session of WC v1 is no longer checked when trying to auto-connect to v2.

## How to test it

Create a session with WC v1 and refresh the Safe. Observe that WC v2 does not try to auto-connect.

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
