### PR TITLE
[e2e] - fix dashboard - change token counter

### DIFF
--- a/cypress/e2e/smoke/dashboard.cy.js
+++ b/cypress/e2e/smoke/dashboard.cy.js
@@ -23,7 +23,7 @@ describe('Dashboard', () => {
       cy.contains('2/3')
       cy.get(`a[href="/balances?safe=${SAFE}"]`).contains('View assets')
       // Text next to Tokens contains a number greater than 0
-      cy.contains('p', 'Tokens').next().contains('3')
+      cy.contains('p', 'Tokens').next().contains('4')
       cy.contains('p', 'NFTs').next().contains('0')
     })
   })


### PR DESCRIPTION
## What it solves

The safe has received a spam token, increasing the token counter in the dashboard. For now I just updated the number so the test passes since there isn't much we can do about spam tokens
