### PR TITLE
fix: remove "Powered by" from balance changes

### DIFF
--- a/src/components/tx/security/redefine/RedefineBalanceChange.tsx
+++ b/src/components/tx/security/redefine/RedefineBalanceChange.tsx
@@ -7,19 +7,15 @@ import { type RedefineModuleResponse } from '@/services/security/modules/Redefin
 import { sameAddress } from '@/utils/addresses'
 import { FEATURES } from '@/utils/chains'
 import { formatVisualAmount } from '@/utils/formatters'
-import { Box, Chip, CircularProgress, Grid, SvgIcon, Typography } from '@mui/material'
+import { Box, Chip, CircularProgress, Grid, Typography } from '@mui/material'
 import { TokenType } from '@safe-global/safe-gateway-typescript-sdk'
 import { ErrorBoundary } from '@sentry/react'
 import { useContext } from 'react'
 import { TxSecurityContext } from '../shared/TxSecurityContext'
-import RedefineLogo from '@/public/images/transactions/redefine.svg'
-import RedefineLogoDark from '@/public/images/transactions/redefine-dark-mode.svg'
 import ArrowOutwardIcon from '@/public/images/transactions/outgoing.svg'
 import ArrowDownwardIcon from '@/public/images/transactions/incoming.svg'
 
 import css from './styles.module.css'
-import sharedCss from '@/components/tx/security/shared/styles.module.css'
-import { useDarkMode } from '@/hooks/useDarkMode'
 
 const FungibleBalanceChange = ({
   change,
@@ -143,7 +139,6 @@ const BalanceChanges = () => {
 
 export const RedefineBalanceChanges = () => {
   const isFeatureEnabled = useHasFeature(FEATURES.RISK_MITIGATION)
-  const isDarkMode = useDarkMode()
 
   if (!isFeatureEnabled) {
     return null
@@ -154,14 +149,6 @@ export const RedefineBalanceChanges = () => {
       <Box className={css.head}>
         <Typography variant="subtitle2" fontWeight={700}>
           Balance change
-        </Typography>
-        <Typography variant="caption" className={sharedCss.poweredBy}>
-          Powered by{' '}
-          <SvgIcon
-            inheritViewBox
-            sx={{ height: '40px', width: '52px' }}
-            component={isDarkMode ? RedefineLogoDark : RedefineLogo}
-          />
         </Typography>
       </Box>
       <ErrorBoundary fallback={<div>Error showing balance changes</div>}>


### PR DESCRIPTION
## What it solves

Resolves duplicate "Powered by" labels.

## How this PR fixes it

The "Powered by" label of the balance change section of the transaction flow has been removed.

## How to test it

Create a transaction sending assets and observe the balance change without "Powered by".

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/5c5500a3-919b-4430-b067-b429e88bc2bf)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
