### PR TITLE
feat: add confirmation badge to flow

### DIFF
--- a/src/components/tx-flow/common/TxStatusWidget/index.tsx
+++ b/src/components/tx-flow/common/TxStatusWidget/index.tsx
@@ -34,7 +34,7 @@ const TxStatusWidget = ({
   const { confirmationsSubmitted = 0 } = isMultisigExecutionInfo(executionInfo) ? executionInfo : {}
 
   const isConfirmedStepIncomplete = step < 1 && !confirmationsSubmitted
-  const canSign = txSummary ? isSignableBy(txSummary, wallet?.address || '') : false
+  const canSign = txSummary ? isSignableBy(txSummary, wallet?.address || '') : true
 
   return (
     <Paper>

--- a/src/components/tx-flow/common/TxStatusWidget/index.tsx
+++ b/src/components/tx-flow/common/TxStatusWidget/index.tsx
@@ -8,6 +8,7 @@ import classnames from 'classnames'
 import css from './styles.module.css'
 import CloseIcon from '@mui/icons-material/Close'
 import useWallet from '@/hooks/wallets/useWallet'
+import { useDarkMode } from '@/hooks/useDarkMode'
 
 const confirmedMessage = (threshold: number, confirmations: number) => {
   return (
@@ -26,6 +27,7 @@ const TxStatusWidget = ({
   txSummary?: TransactionSummary
   handleClose: () => void
 }) => {
+  const isDarkMode = useDarkMode()
   const wallet = useWallet()
   const { safe } = useSafeInfo()
   const { threshold } = safe
@@ -66,7 +68,15 @@ const TxStatusWidget = ({
             <ListItemText primaryTypographyProps={{ fontWeight: 700 }}>
               {confirmedMessage(threshold, confirmationsSubmitted)}
               {canSign && (
-                <Typography variant="body2" component="span" className={css.badge}>
+                <Typography
+                  variant="body2"
+                  component="span"
+                  className={css.badge}
+                  sx={({ palette }) => ({
+                    bgcolor: isDarkMode ? `${palette.primary.main}` : `${palette.secondary.main}`,
+                    color: isDarkMode ? `${palette.text.secondary}` : `${palette.text.primary}`,
+                  })}
+                >
                   +1
                 </Typography>
               )}

--- a/src/components/tx-flow/common/TxStatusWidget/index.tsx
+++ b/src/components/tx-flow/common/TxStatusWidget/index.tsx
@@ -3,10 +3,11 @@ import CreatedIcon from '@/public/images/messages/created.svg'
 import SignedIcon from '@/public/images/messages/signed.svg'
 import { type TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import { isMultisigExecutionInfo } from '@/utils/transaction-guards'
+import { isMultisigExecutionInfo, isSignableBy } from '@/utils/transaction-guards'
 import classnames from 'classnames'
 import css from './styles.module.css'
 import CloseIcon from '@mui/icons-material/Close'
+import useWallet from '@/hooks/wallets/useWallet'
 
 const confirmedMessage = (threshold: number, confirmations: number) => {
   return (
@@ -25,6 +26,7 @@ const TxStatusWidget = ({
   txSummary?: TransactionSummary
   handleClose: () => void
 }) => {
+  const wallet = useWallet()
   const { safe } = useSafeInfo()
   const { threshold } = safe
 
@@ -32,6 +34,7 @@ const TxStatusWidget = ({
   const { confirmationsSubmitted = 0 } = isMultisigExecutionInfo(executionInfo) ? executionInfo : {}
 
   const isConfirmedStepIncomplete = step < 1 && !confirmationsSubmitted
+  const canSign = txSummary ? isSignableBy(txSummary, wallet?.address || '') : false
 
   return (
     <Paper>
@@ -62,6 +65,11 @@ const TxStatusWidget = ({
             </ListItemIcon>
             <ListItemText primaryTypographyProps={{ fontWeight: 700 }}>
               {confirmedMessage(threshold, confirmationsSubmitted)}
+              {canSign && (
+                <Typography variant="body2" component="span" className={css.badge}>
+                  +1
+                </Typography>
+              )}
             </ListItemText>
           </ListItem>
 

--- a/src/components/tx-flow/common/TxStatusWidget/styles.module.css
+++ b/src/components/tx-flow/common/TxStatusWidget/styles.module.css
@@ -61,14 +61,12 @@
 .badge {
   margin-left: var(--space-1);
   padding-right: 2px;
-  background-color: var(--color-secondary-main);
   border-radius: 50%;
   width: var(--space-3);
   height: var(--space-3);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: var(--color-text-primary);
 }
 
 @media (max-width: 899.95px) {

--- a/src/components/tx-flow/common/TxStatusWidget/styles.module.css
+++ b/src/components/tx-flow/common/TxStatusWidget/styles.module.css
@@ -58,6 +58,19 @@
   height: 32px;
 }
 
+.badge {
+  margin-left: var(--space-1);
+  padding-right: 2px;
+  background-color: var(--color-secondary-main);
+  border-radius: 50%;
+  width: var(--space-3);
+  height: var(--space-3);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-primary);
+}
+
 @media (max-width: 899.95px) {
   .header {
     padding: 0;


### PR DESCRIPTION
## What it solves

Resolves missing badge

## How this PR fixes it

A "+1" confirmation badge has been added to the "Confirmed (x of y)" step of the `TxStatusWidget` according to [the designs](https://www.figma.com/file/ptTs6lDBeUuLNySroJ5PiF/Web-Master-File?type=design&node-id=7215-190523&mode=design&t=BILFwrztl702t1KI-0).

## How to test it

- Create a transaction and observe the badge.
- Confirm a transaction and observe the badge.
- Execute a transaction that you have already confirmed and observe no badge.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/39f17cdc-ad1e-4a30-8605-60df302c2d4f)

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/17155c92-fc25-4fc1-bb56-ef29ea626a40)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
