### PR TITLE
feat: add replacement to transaction status widget

### DIFF
--- a/src/components/tx-flow/common/TxLayout/index.tsx
+++ b/src/components/tx-flow/common/TxLayout/index.tsx
@@ -23,6 +23,7 @@ type TxLayoutProps = {
   txSummary?: TransactionSummary
   onBack?: () => void
   hideNonce?: boolean
+  isReplacement?: boolean
 }
 
 const TxLayout = ({
@@ -34,6 +35,7 @@ const TxLayout = ({
   txSummary,
   onBack,
   hideNonce = false,
+  isReplacement = false,
 }: TxLayoutProps): ReactElement => {
   const [statusVisible, setStatusVisible] = useState<boolean>(true)
 
@@ -110,7 +112,12 @@ const TxLayout = ({
 
                 <Grid item xs={12} md={4} className={classnames(css.widget, { [css.active]: statusVisible })}>
                   {statusVisible && (
-                    <TxStatusWidget step={step} txSummary={txSummary} handleClose={() => setStatusVisible(false)} />
+                    <TxStatusWidget
+                      step={step}
+                      txSummary={txSummary}
+                      handleClose={() => setStatusVisible(false)}
+                      isReplacement={isReplacement}
+                    />
                   )}
 
                   <Box mt={2}>

--- a/src/components/tx-flow/common/TxStatusWidget/index.tsx
+++ b/src/components/tx-flow/common/TxStatusWidget/index.tsx
@@ -20,10 +20,12 @@ const TxStatusWidget = ({
   step,
   txSummary,
   handleClose,
+  isReplacement = false,
 }: {
   step: number
   txSummary?: TransactionSummary
   handleClose: () => void
+  isReplacement?: boolean
 }) => {
   const { safe } = useSafeInfo()
   const { threshold } = safe
@@ -53,7 +55,9 @@ const TxStatusWidget = ({
             <ListItemIcon>
               <CreatedIcon />
             </ListItemIcon>
-            <ListItemText primaryTypographyProps={{ fontWeight: 700 }}>Created</ListItemText>
+            <ListItemText primaryTypographyProps={{ fontWeight: 700 }}>
+              {isReplacement ? 'Create replacement transaction' : 'Create'}
+            </ListItemText>
           </ListItem>
 
           <ListItem className={classnames({ [css.incomplete]: isConfirmedStepIncomplete })}>
@@ -71,6 +75,15 @@ const TxStatusWidget = ({
             </ListItemIcon>
             <ListItemText primaryTypographyProps={{ fontWeight: 700 }}>Execute</ListItemText>
           </ListItem>
+
+          {isReplacement && (
+            <ListItem className={css.incomplete}>
+              <ListItemIcon>
+                <SignedIcon />
+              </ListItemIcon>
+              <ListItemText primaryTypographyProps={{ fontWeight: 700 }}>Transaction is replaced</ListItemText>
+            </ListItem>
+          )}
         </List>
       </div>
     </Paper>

--- a/src/components/tx-flow/flows/ReplaceTx/index.tsx
+++ b/src/components/tx-flow/flows/ReplaceTx/index.tsx
@@ -53,7 +53,7 @@ const ReplaceTxMenu = ({ txNonce }: { txNonce: number }) => {
   )
 
   return (
-    <TxLayout title="Replace transaction" step={0} hideNonce>
+    <TxLayout title="Replace transaction" step={0} hideNonce isReplacement>
       <TxCard>
         <Box my={4} textAlign="center">
           <ReplaceTxIcon />


### PR DESCRIPTION
## What it solves

Resolves missing step for choosing type of replacement transaction

## How this PR fixes it

The `TxStatusWidget` has been adjusted to conditionally name the "Create" step "Create replacement transaction" (for replacements) and add a final "Replacement transaction created" step.

## How to test it

Open the transaction replacement flow and observe the rename/additional step in the widget.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/9ecf81d2-c5bf-45f6-9aab-df956eab8d11)

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/4ed1f892-1df7-4ebe-804e-0bf33ec874b3)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
