### PR TITLE
feat: show alert before closing transaction flow

### DIFF
--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -130,7 +130,6 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement 
       if (signOffChain) {
         setTxFlow(
           <SignMessageFlow
-            onClose={() => setTxFlow(undefined)}
             logoUri={safeAppFromManifest?.iconUrl || ''}
             name={safeAppFromManifest?.name || ''}
             message={message}

--- a/src/components/safe-messages/SignMsgButton/index.tsx
+++ b/src/components/safe-messages/SignMsgButton/index.tsx
@@ -20,7 +20,7 @@ const SignMsgButton = ({ msg, compact = false }: { msg: SafeMessage; compact?: b
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()
-    setTxFlow(<SignMessageFlow onClose={() => setTxFlow(undefined)} {...msg} />)
+    setTxFlow(<SignMessageFlow {...msg} />)
   }
 
   const isDisabled = !isSignable || isPending

--- a/src/components/tx-flow/common/TxFlowExitWarning/index.tsx
+++ b/src/components/tx-flow/common/TxFlowExitWarning/index.tsx
@@ -1,0 +1,46 @@
+import { DialogContent, DialogContentText, DialogActions, Button, SvgIcon } from '@mui/material'
+import type { ReactElement } from 'react'
+
+import ModalDialog from '@/components/common/ModalDialog'
+import AlertIcon from '@/public/images/notifications/alert.svg'
+
+export const TxFlowExitWarning = ({
+  open,
+  onCancel,
+  onClose,
+}: {
+  open: boolean
+  onCancel: () => void
+  onClose: () => void
+}): ReactElement => {
+  return (
+    <ModalDialog
+      open={open}
+      onClose={onCancel}
+      dialogTitle={
+        <>
+          <SvgIcon
+            component={AlertIcon}
+            inheritViewBox
+            fontSize="inherit"
+            color="error"
+            sx={{ verticalAlign: 'middle', mr: '12px' }}
+          />{' '}
+          Are you sure?
+        </>
+      }
+    >
+      <DialogContent sx={{ p: 'var(--space-3) !important' }}>
+        <DialogContentText color="primary">
+          If you leave this page, the current progress will be lost.
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions sx={{ padding: 'var(--space-2) var(--space-3) !important' }}>
+        <Button onClick={onCancel}>Back to editing</Button>
+        <Button variant="contained" onClick={onClose}>
+          Leave
+        </Button>
+      </DialogActions>
+    </ModalDialog>
+  )
+}

--- a/src/components/tx-flow/common/TxFlowExitWarning/index.tsx
+++ b/src/components/tx-flow/common/TxFlowExitWarning/index.tsx
@@ -34,7 +34,7 @@ export const TxFlowExitWarning = ({
     >
       <DialogContent sx={{ p: 'var(--space-3) !important' }}>
         <DialogContentText color={isDarkMode ? undefined : 'primary'}>
-          If you leave this page, the current progress will be lost.
+          Leaving this page will result in the loss of all progress.
         </DialogContentText>
       </DialogContent>
       <DialogActions sx={{ padding: 'var(--space-2) var(--space-3) !important' }}>

--- a/src/components/tx-flow/common/TxFlowExitWarning/index.tsx
+++ b/src/components/tx-flow/common/TxFlowExitWarning/index.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react'
 
 import ModalDialog from '@/components/common/ModalDialog'
 import AlertIcon from '@/public/images/notifications/alert.svg'
+import { useDarkMode } from '@/hooks/useDarkMode'
 
 export const TxFlowExitWarning = ({
   open,
@@ -13,6 +14,7 @@ export const TxFlowExitWarning = ({
   onCancel: () => void
   onClose: () => void
 }): ReactElement => {
+  const isDarkMode = useDarkMode()
   return (
     <ModalDialog
       open={open}
@@ -31,7 +33,7 @@ export const TxFlowExitWarning = ({
       }
     >
       <DialogContent sx={{ p: 'var(--space-3) !important' }}>
-        <DialogContentText color="primary">
+        <DialogContentText color={isDarkMode ? undefined : 'primary'}>
           If you leave this page, the current progress will be lost.
         </DialogContentText>
       </DialogContent>

--- a/src/components/tx-flow/common/TxFlowExitWarning/index.tsx
+++ b/src/components/tx-flow/common/TxFlowExitWarning/index.tsx
@@ -34,7 +34,7 @@ export const TxFlowExitWarning = ({
     >
       <DialogContent sx={{ p: 'var(--space-3) !important' }}>
         <DialogContentText color={isDarkMode ? undefined : 'primary'}>
-          Leaving this page will result in the loss of all progress.
+          Closing this window will discard your current progress.
         </DialogContentText>
       </DialogContent>
       <DialogActions sx={{ padding: 'var(--space-2) var(--space-3) !important' }}>

--- a/src/components/tx-flow/flows/SignMessage/SignMessage.test.tsx
+++ b/src/components/tx-flow/flows/SignMessage/SignMessage.test.tsx
@@ -99,7 +99,6 @@ describe('SignMessage', () => {
           logoUri="www.fake.com/test.png"
           name="Test App"
           message={hexlify(toUtf8Bytes(EXAMPLE_MESSAGE))}
-          onClose={jest.fn}
         />,
       )
 
@@ -108,13 +107,7 @@ describe('SignMessage', () => {
 
     it('displays the SafeMessage message', () => {
       const { getByText } = render(
-        <SignMessage
-          logoUri="www.fake.com/test.png"
-          name="Test App"
-          message={EXAMPLE_MESSAGE}
-          requestId="123"
-          onClose={jest.fn}
-        />,
+        <SignMessage logoUri="www.fake.com/test.png" name="Test App" message={EXAMPLE_MESSAGE} requestId="123" />,
       )
 
       expect(getByText('0xaa05af77f274774b8bdc7b61d98bc40da523dc2821fdea555f4d6aa413199bcc')).toBeInTheDocument()
@@ -122,13 +115,7 @@ describe('SignMessage', () => {
 
     it('generates the SafeMessage hash if not provided', () => {
       const { getByText } = render(
-        <SignMessage
-          logoUri="www.fake.com/test.png"
-          name="Test App"
-          message={EXAMPLE_MESSAGE}
-          requestId="123"
-          onClose={jest.fn}
-        />,
+        <SignMessage logoUri="www.fake.com/test.png" name="Test App" message={EXAMPLE_MESSAGE} requestId="123" />,
       )
 
       expect(getByText('0x73d0948ac608c5d00a6dd26dd396cce79b459307ea365f5a5bd5d3119c2d9708')).toBeInTheDocument()
@@ -176,13 +163,7 @@ describe('SignMessage', () => {
 
     it('renders the message', () => {
       const { getByText } = render(
-        <SignMessage
-          requestId="123"
-          logoUri="www.fake.com/test.png"
-          name="Test App"
-          message={EXAMPLE_MESSAGE}
-          onClose={jest.fn}
-        />,
+        <SignMessage requestId="123" logoUri="www.fake.com/test.png" name="Test App" message={EXAMPLE_MESSAGE} />,
       )
 
       Object.keys(EXAMPLE_MESSAGE.message).forEach((key) => {
@@ -194,13 +175,7 @@ describe('SignMessage', () => {
 
     it('displays the SafeMessage message', () => {
       const { getByText } = render(
-        <SignMessage
-          logoUri="www.fake.com/test.png"
-          name="Test App"
-          message={EXAMPLE_MESSAGE}
-          requestId="123"
-          onClose={jest.fn}
-        />,
+        <SignMessage logoUri="www.fake.com/test.png" name="Test App" message={EXAMPLE_MESSAGE} requestId="123" />,
       )
 
       expect(getByText('0xd5ffe9f6faa9cc9294673fb161b1c7b3e0c98241e90a38fc6c451941f577fb19')).toBeInTheDocument()
@@ -208,13 +183,7 @@ describe('SignMessage', () => {
 
     it('generates the SafeMessage hash if not provided', () => {
       const { getByText } = render(
-        <SignMessage
-          logoUri="www.fake.com/test.png"
-          name="Test App"
-          message={EXAMPLE_MESSAGE}
-          requestId="123"
-          onClose={jest.fn}
-        />,
+        <SignMessage logoUri="www.fake.com/test.png" name="Test App" message={EXAMPLE_MESSAGE} requestId="123" />,
       )
 
       expect(getByText('0x10c926c4f417e445de3fddc7ad8c864f81b9c81881b88eba646015de10d21613')).toBeInTheDocument()
@@ -233,7 +202,6 @@ describe('SignMessage', () => {
         name="Test App"
         message="Hello world!"
         requestId="123"
-        onClose={jest.fn}
         safeAppId={25}
       />,
     )
@@ -300,13 +268,7 @@ describe('SignMessage', () => {
     jest.spyOn(useSafeMessages, 'useSafeMessage').mockReturnValue(msg)
 
     const { getByText } = render(
-      <SignMessage
-        logoUri="www.fake.com/test.png"
-        name="Test App"
-        message={messageText}
-        requestId="123"
-        onClose={jest.fn}
-      />,
+      <SignMessage logoUri="www.fake.com/test.png" name="Test App" message={messageText} requestId="123" />,
     )
 
     await act(async () => {
@@ -348,7 +310,6 @@ describe('SignMessage', () => {
         name="Test App"
         message="Hello world!"
         requestId="123"
-        onClose={jest.fn}
         safeAppId={25}
       />,
     )
@@ -370,7 +331,6 @@ describe('SignMessage', () => {
         name="Test App"
         message="Hello world!"
         requestId="123"
-        onClose={jest.fn}
         safeAppId={25}
       />,
     )
@@ -396,7 +356,6 @@ describe('SignMessage', () => {
         name="Test App"
         message="Hello world!"
         requestId="123"
-        onClose={jest.fn}
         safeAppId={25}
       />,
     )
@@ -445,13 +404,7 @@ describe('SignMessage', () => {
     jest.spyOn(useSafeMessages, 'useSafeMessage').mockReturnValue(msg)
 
     const { getByText } = render(
-      <SignMessage
-        logoUri="www.fake.com/test.png"
-        name="Test App"
-        message={messageText}
-        requestId="123"
-        onClose={jest.fn}
-      />,
+      <SignMessage logoUri="www.fake.com/test.png" name="Test App" message={messageText} requestId="123" />,
     )
 
     await waitFor(() => {
@@ -484,7 +437,6 @@ describe('SignMessage', () => {
         name="Test App"
         message="Hello world!"
         requestId="123"
-        onClose={jest.fn}
         safeAppId={25}
       />,
     )
@@ -526,7 +478,6 @@ describe('SignMessage', () => {
         name="Test App"
         message="Hello world!"
         requestId="123"
-        onClose={jest.fn}
         safeAppId={25}
       />,
     )

--- a/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
+++ b/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
@@ -132,7 +132,7 @@ export type ConfirmProps = BaseProps & {
 
 const SignMessage = ({ message, safeAppId, requestId }: ProposeProps | ConfirmProps): ReactElement => {
   // Hooks & variables
-  const { onClose } = useContext(TxModalContext)
+  const { setTxFlow } = useContext(TxModalContext)
   const { palette } = useTheme()
   const { safe } = useSafeInfo()
   const isOwner = useIsSafeOwner()
@@ -155,7 +155,7 @@ const SignMessage = ({ message, safeAppId, requestId }: ProposeProps | ConfirmPr
     safeMessageHash,
     requestId,
     safeAppId,
-    onClose,
+    () => setTxFlow(undefined),
   )
 
   return (

--- a/src/components/tx-flow/index.tsx
+++ b/src/components/tx-flow/index.tsx
@@ -53,8 +53,13 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
     if (!txFlow) {
       return
     }
-    router.events.on('routeChangeStart', handleShowWarning)
-    return () => router.events.off('routeChangeStart', handleShowWarning)
+
+    router.events.on('beforeHistoryChange', handleShowWarning) // Back button
+    router.events.on('routeChangeStart', handleShowWarning) // Navigation
+    return () => {
+      router.events.off('beforeHistoryChange', handleShowWarning)
+      router.events.off('routeChangeStart', handleShowWarning)
+    }
   }, [txFlow, router, handleShowWarning])
 
   return (

--- a/src/components/tx-flow/index.tsx
+++ b/src/components/tx-flow/index.tsx
@@ -8,19 +8,17 @@ const noop = () => {}
 type TxModalContextType = {
   txFlow: ReactNode | undefined
   setTxFlow: (txFlow: TxModalContextType['txFlow'], onClose?: () => void) => void
-  onClose: () => void
 }
 
 export const TxModalContext = createContext<TxModalContextType>({
   txFlow: undefined,
   setTxFlow: noop,
-  onClose: noop,
 })
 
 export const TxModalProvider = ({ children }: { children: ReactNode }): ReactElement => {
   const [txFlow, setFlow] = useState<TxModalContextType['txFlow']>(undefined)
   const [showWarning, setShowWarning] = useState(false)
-  const [onClose, setOnClose] = useState<TxModalContextType['onClose']>(noop)
+  const [, setOnClose] = useState<Parameters<TxModalContextType['setTxFlow']>[1]>(noop)
   const router = useRouter()
 
   const handleShowWarning = useCallback(() => {
@@ -31,7 +29,7 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
     setShowWarning(false)
   }, [setShowWarning])
 
-  const handleExitFlow = useCallback(() => {
+  const handleModalClose = useCallback(() => {
     setOnClose((prevOnClose) => {
       prevOnClose?.()
       return noop
@@ -42,10 +40,13 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
 
   const setTxFlow = useCallback(
     (txFlow: TxModalContextType['txFlow'], onClose?: () => void) => {
+      if (!txFlow) {
+        handleCloseWarning()
+      }
       setFlow(txFlow)
       setOnClose(() => onClose ?? noop)
     },
-    [setFlow, setOnClose],
+    [setFlow, setOnClose, handleCloseWarning],
   )
 
   // Show the modal if user navigates
@@ -64,7 +65,7 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
 
   return (
     <>
-      <TxModalContext.Provider value={{ txFlow, setTxFlow, onClose }}>
+      <TxModalContext.Provider value={{ txFlow, setTxFlow }}>
         {children}
 
         <TxModalDialog open={!!txFlow} onClose={handleShowWarning}>
@@ -72,7 +73,7 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
         </TxModalDialog>
       </TxModalContext.Provider>
 
-      <TxFlowExitWarning open={showWarning} onCancel={handleCloseWarning} onClose={handleExitFlow} />
+      <TxFlowExitWarning open={showWarning} onCancel={handleCloseWarning} onClose={handleModalClose} />
     </>
   )
 }


### PR DESCRIPTION
## What it solves

Resolves direct exit of new transaction flow

## How this PR fixes it

A confirmation dialog is now shown when exiting or navigating away from the new transaction flow which needs to first be accepted.

## How to test it

Create a transaction, attempt to close the flow/navigate away with back button and observe the new confirmation dialog.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/38e3e468-d941-4deb-9fa5-11caaa3fa1c3)

![alert](https://github.com/safe-global/safe-wallet-web/assets/20442784/52a22e76-10f8-413a-946a-3f453431beb6)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
