### PR TITLE
fix: disable transition + backdrop of modals

### DIFF
--- a/src/components/common/TxModalDialog/index.tsx
+++ b/src/components/common/TxModalDialog/index.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement } from 'react'
+import { Fragment, type ReactElement } from 'react'
 import { IconButton } from '@mui/material'
 import { Dialog, DialogTitle, type DialogProps } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
@@ -24,7 +24,8 @@ const TxModalDialog = ({
       scroll={fullScreen ? 'paper' : 'body'}
       className={css.dialog}
       onClick={(e) => e.stopPropagation()}
-      slots={{ backdrop: 'div' }}
+      TransitionComponent={Fragment}
+      slots={{ backdrop: Fragment }}
       PaperProps={{
         className: css.paper,
       }}


### PR DESCRIPTION
## What it solves

Resolves workaround to hide modal backdrop

## How this PR fixes it

This replaces the `TransitionComponent` and `slot.backdrop` with a `Fragment`, removing the open transition and backdrop from `TxModalDialog`.

## How to test it

Create a transaction and observe no transition when opening the modal, as well as no `MuiDialog-backdrop` in the DOM:

Previous error:

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/05f2dcee-59d7-4469-aa1e-da2d341ed357)

Now:

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/e84ba3dd-8e13-4521-ab57-92f47b632adc)

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
