### PR TITLE
Fix: checked box color in CookieBanner

### DIFF
--- a/src/components/common/CookieBanner/styles.module.css
+++ b/src/components/common/CookieBanner/styles.module.css
@@ -22,3 +22,11 @@
     bottom: 0;
   }
 }
+
+.container :global(.Mui-checked) {
+  color: var(--color-background-paper);
+}
+
+.container :global(.Mui-checked.Mui-disabled) {
+  opacity: 0.5;
+}


### PR DESCRIPTION
## What it solves

Resolves #2198

## How this PR fixes it
Overrides the MUI colors in CSS.

## Screenshots
<img width="452" alt="Screenshot 2023-06-29 at 10 31 37" src="https://github.com/safe-global/safe-wallet-web/assets/381895/50c65acf-9cad-4e6f-904b-1e3912410c96">
<img width="425" alt="Screenshot 2023-06-29 at 10 31 30" src="https://github.com/safe-global/safe-wallet-web/assets/381895/286c1358-be32-4a59-892f-1fde9c9e057e">