### PR TITLE
fix: don't warn for send NFTs or tx builder

### DIFF
--- a/src/components/tx-flow/common/TxButton.tsx
+++ b/src/components/tx-flow/common/TxButton.tsx
@@ -11,15 +11,13 @@ const TxButton = ({ sx, ...props }: ButtonProps) => (
   <Button variant="contained" sx={{ '& svg path': { fill: 'currentColor' }, ...sx }} fullWidth {...props} />
 )
 
-export const SendTokensButton = ({ onClick, ...props }: ButtonProps) => (
+export const SendTokensButton = (props: ButtonProps) => (
   <Track {...MODALS_EVENTS.SEND_FUNDS}>
-    <TxButton onClick={onClick} {...props}>
-      Send tokens
-    </TxButton>
+    <TxButton {...props}>Send tokens</TxButton>
   </Track>
 )
 
-export const SendNFTsButton = ({ onClick, ...props }: ButtonProps) => {
+export const SendNFTsButton = (props: ButtonProps) => {
   const router = useRouter()
 
   return (
@@ -31,7 +29,7 @@ export const SendNFTsButton = ({ onClick, ...props }: ButtonProps) => {
   )
 }
 
-export const TxBuilderButton = ({ ...props }: ButtonProps) => {
+export const TxBuilderButton = (props: ButtonProps) => {
   const txBuilder = useTxBuilderApp()
   if (!txBuilder?.app) return null
 

--- a/src/components/tx-flow/flows/NewTx/index.tsx
+++ b/src/components/tx-flow/flows/NewTx/index.tsx
@@ -20,6 +20,10 @@ const NewTxMenu = () => {
     setTxFlow(<TokenTransferFlow />)
   }, [setTxFlow])
 
+  const onNavigate = useCallback(() => {
+    setTxFlow(undefined)
+  }, [setTxFlow])
+
   const progress = 10
 
   return (
@@ -49,7 +53,7 @@ const NewTxMenu = () => {
 
               <SendTokensButton onClick={onTokensClick} sx={buttonSx} />
 
-              <SendNFTsButton sx={buttonSx} />
+              <SendNFTsButton onClick={onNavigate} sx={buttonSx} />
 
               {txBuilder?.app && (
                 <>
@@ -58,7 +62,7 @@ const NewTxMenu = () => {
                     interaction
                   </Typography>
 
-                  <TxBuilderButton sx={buttonSx} />
+                  <TxBuilderButton onClick={onNavigate} sx={buttonSx} />
                 </>
               )}
             </Grid>

--- a/src/components/tx-flow/index.tsx
+++ b/src/components/tx-flow/index.tsx
@@ -2,11 +2,12 @@ import { createContext, type ReactElement, type ReactNode, useState, useEffect, 
 import TxModalDialog from '@/components/common/TxModalDialog'
 import { useRouter } from 'next/router'
 import { TxFlowExitWarning } from '@/components/tx-flow/common/TxFlowExitWarning'
+import NewTxMenu from './flows/NewTx'
 
 const noop = () => {}
 
 type TxModalContextType = {
-  txFlow: ReactNode | undefined
+  txFlow: JSX.Element | undefined
   setTxFlow: (txFlow: TxModalContextType['txFlow'], onClose?: () => void) => void
   setFullWidth: (fullWidth: boolean) => void
 }
@@ -16,6 +17,8 @@ export const TxModalContext = createContext<TxModalContextType>({
   setTxFlow: noop,
   setFullWidth: noop,
 })
+
+const newTxMenu = <NewTxMenu />
 
 export const TxModalProvider = ({ children }: { children: ReactNode }): ReactElement => {
   const [txFlow, setFlow] = useState<TxModalContextType['txFlow']>(undefined)
@@ -54,14 +57,13 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
 
   // Show the modal if user navigates
   useEffect(() => {
-    if (!txFlow) {
+    const shouldWarn = txFlow && txFlow.type !== newTxMenu.type
+    if (!shouldWarn) {
       return
     }
 
-    router.events.on('beforeHistoryChange', handleShowWarning) // Back button
-    router.events.on('routeChangeStart', handleShowWarning) // Navigation
+    router.events.on('routeChangeStart', handleShowWarning)
     return () => {
-      router.events.off('beforeHistoryChange', handleShowWarning)
       router.events.off('routeChangeStart', handleShowWarning)
     }
   }, [txFlow, router, handleShowWarning])


### PR DESCRIPTION
## What it solves

Resolves incorrect warning

## How this PR fixes it

The warning is only shown when in a transaction flow that is *not* the new transaction menu.

## How to test it

- Observe no warning when clicking "Send NFTs" or "Transaction Builder" in the new transaction menu.
- Observe warnings should still appear when in a transaction flow.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
