### PR TITLE
fix: make tx check widgets `sticky`

### DIFF
--- a/src/components/tx-flow/common/TxLayout/index.tsx
+++ b/src/components/tx-flow/common/TxLayout/index.tsx
@@ -120,11 +120,9 @@ const TxLayout = ({
                     />
                   )}
 
-                  <Box mt={2}>
+                  <Box className={css.sticky} mt={2}>
                     <RedefineMessage />
-                  </Box>
 
-                  <Box mt={2}>
                     <TxSimulationMessage />
                   </Box>
                 </Grid>

--- a/src/components/tx-flow/common/TxLayout/index.tsx
+++ b/src/components/tx-flow/common/TxLayout/index.tsx
@@ -120,7 +120,7 @@ const TxLayout = ({
                     />
                   )}
 
-                  <Box className={css.sticky} mt={2}>
+                  <Box className={css.sticky}>
                     <RedefineMessage />
 
                     <TxSimulationMessage />

--- a/src/components/tx-flow/common/TxLayout/styles.module.css
+++ b/src/components/tx-flow/common/TxLayout/styles.module.css
@@ -88,6 +88,7 @@
   gap: var(--space-2);
   position: sticky;
   top: var(--space-2);
+  margin-top: var(--space-2);
 }
 
 @media (max-width: 899.95px) {

--- a/src/components/tx-flow/common/TxLayout/styles.module.css
+++ b/src/components/tx-flow/common/TxLayout/styles.module.css
@@ -82,6 +82,14 @@
   display: none;
 }
 
+.sticky {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  position: sticky;
+  top: var(--space-2);
+}
+
 @media (max-width: 899.95px) {
   .widget {
     position: absolute;


### PR DESCRIPTION
## What it solves

Resolves positioning of security check widgets

## How this PR fixes it

The messages from Redefine/Tenderly are now `sticky` when scrolling down the transaction flow step.

## How to test it

Open a Safe on a chain that supports Redefine and create a transaction, then simulate with Tenderly. Ensure the returned messages are higher than the window height and scroll down the step. Observe the `sticky` messages.

## Screenshots

![sticky tx checks](https://github.com/safe-global/safe-wallet-web/assets/20442784/550e682a-39ee-49f0-8d4f-9c96108f0bf5)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
