### PR TITLE
feat: add subtitle to confirmation flow

### DIFF
--- a/src/components/transactions/TxInfo/index.tsx
+++ b/src/components/transactions/TxInfo/index.tsx
@@ -97,7 +97,7 @@ const SettingsChangeTx = ({ info }: { info: SettingsChange }): ReactElement => {
   return <></>
 }
 
-const TxInfo = ({ info }: { info: TransactionInfo }): ReactElement => {
+const TxInfo = ({ info, ...rest }: { info: TransactionInfo; omitSign?: boolean; withLogo?: boolean }): ReactElement => {
   const chainId = useChainId()
 
   if (isSettingsChangeTxInfo(info)) {
@@ -109,7 +109,7 @@ const TxInfo = ({ info }: { info: TransactionInfo }): ReactElement => {
   }
 
   if (isTransferTxInfo(info)) {
-    return <TransferTx info={info} />
+    return <TransferTx info={info} {...rest} />
   }
 
   if (isCustomTxInfo(info)) {

--- a/src/components/tx-flow/flows/ConfirmTx/index.tsx
+++ b/src/components/tx-flow/flows/ConfirmTx/index.tsx
@@ -1,10 +1,24 @@
 import type { TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import TxLayout from '@/components/tx-flow/common/TxLayout'
 import ConfirmProposedTx from './ConfirmProposedTx'
+import { useTransactionType } from '@/hooks/useTransactionType'
+import TxInfo from '@/components/transactions/TxInfo'
 
 const ConfirmTxFlow = ({ txSummary }: { txSummary: TransactionSummary }) => {
+  const { text } = useTransactionType(txSummary)
+
   return (
-    <TxLayout title="Confirm transaction" step={0} txSummary={txSummary}>
+    <TxLayout
+      title="Confirm transaction"
+      subtitle={
+        <>
+          {text}&nbsp;
+          <TxInfo info={txSummary.txInfo} withLogo={false} omitSign />
+        </>
+      }
+      step={0}
+      txSummary={txSummary}
+    >
       <ConfirmProposedTx txSummary={txSummary} />
     </TxLayout>
   )


### PR DESCRIPTION
## What it solves

Resolves missing subtitle in confirmation flow.

## How this PR fixes it

The summary type and info has been added as the subtitle to the transaction confirmation flow.

## How to test it

Execute a queued transaction and observe the correct subtitle in the transaction flow.

## Screenshots

![confirmation subtitle](https://github.com/safe-global/safe-wallet-web/assets/20442784/154fd322-f048-4e81-8c35-21fca73083bf)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
