### PR TITLE
fix: change threshold flow style + titles

### DIFF
--- a/src/components/tx-flow/flows/AddOwner/index.tsx
+++ b/src/components/tx-flow/flows/AddOwner/index.tsx
@@ -35,7 +35,13 @@ const AddOwnerFlow = () => {
   ]
 
   return (
-    <TxLayout title="New transaction" subtitle="Add owner" icon={SaveAddressIcon} step={step} onBack={prevStep}>
+    <TxLayout
+      title={step === 0 ? 'New transaction' : 'Confirm transaction'}
+      subtitle="Add owner"
+      icon={SaveAddressIcon}
+      step={step}
+      onBack={prevStep}
+    >
       {steps}
     </TxLayout>
   )

--- a/src/components/tx-flow/flows/ChangeThreshold/ChooseThreshold.tsx
+++ b/src/components/tx-flow/flows/ChangeThreshold/ChooseThreshold.tsx
@@ -1,0 +1,107 @@
+import { Controller, useForm } from 'react-hook-form'
+import { TextField, MenuItem, Button, CardActions, Divider, Typography, Box, Grid } from '@mui/material'
+import type { ReactElement } from 'react'
+
+import useSafeInfo from '@/hooks/useSafeInfo'
+import TxCard from '@/components/tx-flow/common/TxCard'
+import { ChangeThresholdFlowFieldNames } from '@/components/tx-flow/flows/ChangeThreshold'
+import type { ChangeThresholdFlowProps } from '@/components/tx-flow/flows/ChangeThreshold'
+
+import commonCss from '@/components/tx-flow/common/styles.module.css'
+
+export const ChooseThreshold = ({
+  params,
+  onSubmit,
+}: {
+  params: ChangeThresholdFlowProps
+  onSubmit: (data: ChangeThresholdFlowProps) => void
+}): ReactElement => {
+  const { safe } = useSafeInfo()
+
+  const formMethods = useForm<ChangeThresholdFlowProps>({
+    defaultValues: params,
+    mode: 'onChange',
+  })
+
+  const newThreshold = formMethods.watch(ChangeThresholdFlowFieldNames.threshold)
+
+  return (
+    <TxCard>
+      <div>
+        <Typography variant="h3" fontWeight="700">
+          Threshold
+        </Typography>
+        <Typography>Any transaction will require the confirmation of:</Typography>
+      </div>
+
+      <form onSubmit={formMethods.handleSubmit(onSubmit)}>
+        <Box mb={2}>
+          <Controller
+            control={formMethods.control}
+            rules={{
+              validate: (value) => {
+                if (value === safe.threshold) {
+                  return `Current policy is already set to ${safe.threshold}.`
+                }
+              },
+            }}
+            name={ChangeThresholdFlowFieldNames.threshold}
+            render={({ field, fieldState }) => {
+              const isError = !!fieldState.error
+
+              return (
+                <Grid container direction="row" gap={2} alignItems="center">
+                  <Grid item>
+                    <TextField select {...field} error={isError}>
+                      {safe.owners.map((_, idx) => (
+                        <MenuItem key={idx + 1} value={idx + 1}>
+                          {idx + 1}
+                        </MenuItem>
+                      ))}
+                    </TextField>
+                  </Grid>
+
+                  <Grid item>
+                    <Typography>out of {safe.owners.length} owner(s)</Typography>
+                  </Grid>
+
+                  <Grid item xs={12}>
+                    {isError ? (
+                      <Typography color="error" mb={2}>
+                        {fieldState.error?.message}
+                      </Typography>
+                    ) : (
+                      <Typography mb={2}>
+                        {fieldState.isDirty ? 'Previous policy was ' : 'Current policy is '}
+                        <b>
+                          {safe.threshold} out of {safe.owners.length}
+                        </b>
+                        .
+                      </Typography>
+                    )}
+                  </Grid>
+                </Grid>
+              )
+            }}
+          />
+        </Box>
+
+        <Divider className={commonCss.nestedDivider} />
+
+        <CardActions>
+          <Button
+            variant="contained"
+            type="submit"
+            disabled={
+              !!formMethods.formState.errors[ChangeThresholdFlowFieldNames.threshold] ||
+              // Prevent initial submit before field was interacted with
+              newThreshold === safe.threshold
+            }
+          >
+            Next
+          </Button>
+        </CardActions>
+      </form>
+    </TxCard>
+  )
+}

--- a/src/components/tx-flow/flows/ChangeThreshold/ReviewChangeThreshold.tsx
+++ b/src/components/tx-flow/flows/ChangeThreshold/ReviewChangeThreshold.tsx
@@ -1,69 +1,40 @@
 import useSafeInfo from '@/hooks/useSafeInfo'
-import { useContext, useEffect, useState } from 'react'
-import { Grid, MenuItem, Select, type SelectChangeEvent, Typography } from '@mui/material'
+import { useContext, useEffect } from 'react'
+import { Typography } from '@mui/material'
+
 import { createUpdateThresholdTx } from '@/services/tx/tx-sender'
 import { SETTINGS_EVENTS, trackEvent } from '@/services/analytics'
 import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
+import { ChangeThresholdFlowFieldNames } from '@/components/tx-flow/flows/ChangeThreshold'
+import type { ChangeThresholdFlowProps } from '@/components/tx-flow/flows/ChangeThreshold'
 
-const ReviewChangeThreshold = () => {
+const ReviewChangeThreshold = ({ params }: { params: ChangeThresholdFlowProps }) => {
   const { safe } = useSafeInfo()
-  const [selectedThreshold, setSelectedThreshold] = useState<number>(safe.threshold)
-  const [isChanged, setChanged] = useState<boolean>(false)
-  const isSameThreshold = selectedThreshold === safe.threshold
+  const newThreshold = params[ChangeThresholdFlowFieldNames.threshold]
 
   const { setSafeTx, setSafeTxError } = useContext(SafeTxContext)
 
   useEffect(() => {
-    if (!selectedThreshold) return
-
-    createUpdateThresholdTx(selectedThreshold).then(setSafeTx).catch(setSafeTxError)
-  }, [selectedThreshold, setSafeTx, setSafeTxError])
-
-  const handleChange = (event: SelectChangeEvent<number>) => {
-    const newThreshold = parseInt(event.target.value.toString())
-    setSelectedThreshold(newThreshold)
-    setChanged(true)
-  }
+    createUpdateThresholdTx(newThreshold).then(setSafeTx).catch(setSafeTxError)
+  }, [newThreshold, setSafeTx, setSafeTxError])
 
   const onChangeThreshold = () => {
     trackEvent({ ...SETTINGS_EVENTS.SETUP.OWNERS, label: safe.owners.length })
-    trackEvent({ ...SETTINGS_EVENTS.SETUP.THRESHOLD, label: selectedThreshold })
+    trackEvent({ ...SETTINGS_EVENTS.SETUP.THRESHOLD, label: newThreshold })
   }
 
   return (
-    <SignOrExecuteForm onSubmit={onChangeThreshold} disableSubmit={isSameThreshold}>
-      <Typography mb={2}>Any transaction will require the confirmation of:</Typography>
-
-      <Grid container direction="row" gap={1} alignItems="center" mb={2}>
-        <Grid item xs={2}>
-          <Select value={selectedThreshold} onChange={handleChange} fullWidth>
-            {safe.owners.map((_, idx) => (
-              <MenuItem key={idx + 1} value={idx + 1}>
-                {idx + 1}
-              </MenuItem>
-            ))}
-          </Select>
-        </Grid>
-
-        <Grid item>
-          <Typography>out of {safe.owners.length} owner(s)</Typography>
-        </Grid>
-      </Grid>
-
-      {isChanged && isSameThreshold ? (
-        <Typography color="error" mb={2}>
-          Current policy is already set to {safe.threshold}
+    <SignOrExecuteForm onSubmit={onChangeThreshold}>
+      <div>
+        <Typography variant="body2" color="text.secondary" mb={0.5}>
+          Any transaction will require the confirmation of:
         </Typography>
-      ) : (
-        <Typography mb={2}>
-          {isChanged ? 'Previous policy was ' : 'Current policy is '}
-          <b>
-            {safe.threshold} out of {safe.owners.length}
-          </b>
-          .
+
+        <Typography>
+          <b>{newThreshold}</b> out of <b>{safe.owners.length} owner(s)</b>
         </Typography>
-      )}
+      </div>
     </SignOrExecuteForm>
   )
 }

--- a/src/components/tx-flow/flows/ChangeThreshold/ReviewChangeThreshold.tsx
+++ b/src/components/tx-flow/flows/ChangeThreshold/ReviewChangeThreshold.tsx
@@ -1,6 +1,6 @@
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { useContext, useEffect } from 'react'
-import { Typography } from '@mui/material'
+import { Box, Divider, Typography } from '@mui/material'
 
 import { createUpdateThresholdTx } from '@/services/tx/tx-sender'
 import { SETTINGS_EVENTS, trackEvent } from '@/services/analytics'
@@ -8,6 +8,8 @@ import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { ChangeThresholdFlowFieldNames } from '@/components/tx-flow/flows/ChangeThreshold'
 import type { ChangeThresholdFlowProps } from '@/components/tx-flow/flows/ChangeThreshold'
+
+import commonCss from '@/components/tx-flow/common/styles.module.css'
 
 const ReviewChangeThreshold = ({ params }: { params: ChangeThresholdFlowProps }) => {
   const { safe } = useSafeInfo()
@@ -35,6 +37,9 @@ const ReviewChangeThreshold = ({ params }: { params: ChangeThresholdFlowProps })
           <b>{newThreshold}</b> out of <b>{safe.owners.length} owner(s)</b>
         </Typography>
       </div>
+      <Box my={1}>
+        <Divider className={commonCss.nestedDivider} />
+      </Box>
     </SignOrExecuteForm>
   )
 }

--- a/src/components/tx-flow/flows/ChangeThreshold/index.tsx
+++ b/src/components/tx-flow/flows/ChangeThreshold/index.tsx
@@ -1,10 +1,39 @@
 import TxLayout from '@/components/tx-flow/common/TxLayout'
 import ReviewChangeThreshold from '@/components/tx-flow/flows/ChangeThreshold/ReviewChangeThreshold'
+import useTxStepper from '@/components/tx-flow/useTxStepper'
+import SaveAddressIcon from '@/public/images/common/save-address.svg'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import { ChooseThreshold } from '@/components/tx-flow/flows/ChangeThreshold/ChooseThreshold'
+
+export enum ChangeThresholdFlowFieldNames {
+  threshold = 'threshold',
+}
+
+export type ChangeThresholdFlowProps = {
+  [ChangeThresholdFlowFieldNames.threshold]: number
+}
 
 const ChangeThresholdFlow = () => {
+  const { safe } = useSafeInfo()
+
+  const { data, step, nextStep, prevStep } = useTxStepper<ChangeThresholdFlowProps>({
+    [ChangeThresholdFlowFieldNames.threshold]: safe.threshold,
+  })
+
+  const steps = [
+    <ChooseThreshold key={0} params={data} onSubmit={(formData) => nextStep(formData)} />,
+    <ReviewChangeThreshold key={1} params={data} />,
+  ]
+
   return (
-    <TxLayout title="Change threshold">
-      <ReviewChangeThreshold />
+    <TxLayout
+      title={step === 0 ? 'New transaction' : 'Confirm transaction'}
+      subtitle="Add owner"
+      icon={SaveAddressIcon}
+      step={step}
+      onBack={prevStep}
+    >
+      {steps}
     </TxLayout>
   )
 }

--- a/src/components/tx-flow/flows/ChangeThreshold/index.tsx
+++ b/src/components/tx-flow/flows/ChangeThreshold/index.tsx
@@ -28,7 +28,7 @@ const ChangeThresholdFlow = () => {
   return (
     <TxLayout
       title={step === 0 ? 'New transaction' : 'Confirm transaction'}
-      subtitle="Add owner"
+      subtitle="Change threshold"
       icon={SaveAddressIcon}
       step={step}
       onBack={prevStep}

--- a/src/components/tx-flow/flows/NftTransfer/index.tsx
+++ b/src/components/tx-flow/flows/NftTransfer/index.tsx
@@ -32,7 +32,13 @@ const NftTransferFlow = ({ txNonce, ...params }: NftTransferFlowProps) => {
   ]
 
   return (
-    <TxLayout title="New transaction" subtitle="Send NFTs" icon={NftIcon} step={step} onBack={prevStep}>
+    <TxLayout
+      title={step === 0 ? 'New transaction' : 'Confirm transaction'}
+      subtitle="Send NFTs"
+      icon={NftIcon}
+      step={step}
+      onBack={prevStep}
+    >
       {steps}
     </TxLayout>
   )

--- a/src/components/tx-flow/flows/TokenTransfer/index.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/index.tsx
@@ -54,7 +54,13 @@ const TokenTransferFlow = ({ txNonce, ...params }: TokenTransferFlowProps) => {
   ]
 
   return (
-    <TxLayout title="New transaction" subtitle="Send tokens" icon={AssetsIcon} step={step} onBack={prevStep}>
+    <TxLayout
+      title={step === 0 ? 'New transaction' : 'Confirm transaction'}
+      subtitle="Send tokens"
+      icon={AssetsIcon}
+      step={step}
+      onBack={prevStep}
+    >
       {steps}
     </TxLayout>
   )


### PR DESCRIPTION
## What it solves

Resolves incorrect styling of change threshold flow and wrong flow titles.

## How this PR fixes it

The change threshold flow has been updated to align with [the designs](https://www.figma.com/file/ptTs6lDBeUuLNySroJ5PiF/Web-Master-File?type=design&node-id=1-5&mode=design&t=GSwvc7AZCbfsRX19-0).

A few incorrect titles were adjusted to switch between "New transaction" and "Confirm transaction" accordingly.

## How to test it

- Change the threshold via the settings and observe the new styling, correctly validated.
- Create an add owner, NFT or token transfer transaction and observe the initial title is "New transaction" and when going to the second step it is "Confirm transaction".

## Screenshots

![threshold](https://github.com/safe-global/safe-wallet-web/assets/20442784/6cd7bd4f-38d5-47a1-b83e-f34c4ab9c953)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
