### PR TITLE
[PoC] feat: use WalletConnect outside of Safe Apps

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -14,6 +14,7 @@ import useChainId from '@/hooks/useChainId'
 import SafeLogo from '@/public/images/logo.svg'
 import Link from 'next/link'
 import useSafeAddress from '@/hooks/useSafeAddress'
+import { WalletConnect } from '@/components/common/WalletConnect'
 
 type HeaderProps = {
   onMenuToggle?: Dispatch<SetStateAction<boolean>>
@@ -57,6 +58,10 @@ const Header = ({ onMenuToggle }: HeaderProps): ReactElement => {
           <SafeTokenWidget />
         </div>
       )}
+
+      <div className={classnames(css.element, css.hideMobile)}>
+        <WalletConnect />
+      </div>
 
       <div className={classnames(css.element, css.hideMobile)}>
         <NotificationCenter />

--- a/src/components/common/WalletConnect/index.tsx
+++ b/src/components/common/WalletConnect/index.tsx
@@ -1,0 +1,55 @@
+import Icon from '@web3-onboard/walletconnect/dist/icon'
+import { IconButton, Popover } from '@mui/material'
+import { useState } from 'react'
+import type { ReactElement } from 'react'
+import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
+
+import { getOrigin } from '@/components/safe-apps/utils'
+import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
+import { useBrowserPermissions } from '@/hooks/safe-apps/permissions'
+import AppFrame from '@/components/safe-apps/AppFrame'
+import WalletIcon from '@/components/common/WalletIcon'
+
+const NAME = 'WalletConnect'
+const appUrl = 'https://safe-apps.dev.5afe.dev/wallet-connect'
+
+const WalletConnectModal = ({ app }: { app: SafeAppData }): ReactElement => {
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
+  const { getAllowedFeaturesList } = useBrowserPermissions()
+
+  return (
+    <>
+      <IconButton onClick={(e) => setAnchorEl(e.currentTarget)}>
+        <WalletIcon provider={NAME} icon={Icon} />
+      </IconButton>
+      <Popover
+        open={!!anchorEl}
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        keepMounted // We must keep the modal mounted to maintain connection
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+        sx={{ marginTop: 1, '> div > div': { height: '600px' }, '& .MuiPaper-root': { width: '500px' } }}
+      >
+        <AppFrame appUrl={appUrl} allowedFeaturesList={getAllowedFeaturesList(getOrigin(app.url))} />
+      </Popover>
+    </>
+  )
+}
+
+export const WalletConnect = () => {
+  const [safeApps] = useRemoteSafeApps()
+  const app = safeApps?.find((app) => app.name === NAME)
+
+  if (!app) {
+    return null
+  }
+
+  return <WalletConnectModal app={app} />
+}


### PR DESCRIPTION
## What it solves

Makes WalletConnect a first-class citizen

## How this PR fixes it

A new WC icon in the header mounts an `AppFrame`, loading the WC Safe App in the background. This allows for interaction with the Safe, no longer needing to keep the WC Safe App open.

## How to test it

1. Open the Safe and connect to an EOA.
2. Open the new WC modal by clicking on the icon on the header.
3. Connect to another Safe or DApp via WC.
4. You can exit the modal and navigate around the Safe, but still transact via WC.

## Screenshots

The bottom Safe is connected to an EOA, whilst the top on connects via WC:

![wc header](https://github.com/safe-global/safe-wallet-web/assets/20442784/18be0fbe-032e-4051-adb5-f006e5652a81)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
