### PR TITLE
fix: Show unlimited approval amount in readonly mode

### DIFF
--- a/src/components/tx-flow/flows/TokenTransfer/SendAmountBlock.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/SendAmountBlock.tsx
@@ -4,6 +4,7 @@ import { Grid, Typography } from '@mui/material'
 import css from './styles.module.css'
 import TokenIcon from '@/components/common/TokenIcon'
 import { formatAmountPrecise } from '@/utils/formatNumber'
+import { PSEUDO_APPROVAL_VALUES } from '@/components/tx/ApprovalEditor/utils/approvals'
 
 export const AmountBlock = ({
   amount,
@@ -19,7 +20,11 @@ export const AmountBlock = ({
       <TokenIcon logoUri={tokenInfo.logoUri} tokenSymbol={tokenInfo.symbol} />
       <Typography fontWeight="bold">{tokenInfo.symbol}</Typography>
       {children}
-      <Typography>{formatAmountPrecise(amount, tokenInfo.decimals)}</Typography>
+      {amount === PSEUDO_APPROVAL_VALUES.UNLIMITED ? (
+        <Typography>{PSEUDO_APPROVAL_VALUES.UNLIMITED}</Typography>
+      ) : (
+        <Typography>{formatAmountPrecise(amount, tokenInfo.decimals)}</Typography>
+      )}
     </Grid>
   )
 }

--- a/src/components/tx/ApprovalEditor/ApprovalEditor.test.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalEditor.test.tsx
@@ -9,6 +9,7 @@ import { getMultiSendCallOnlyContractAddress } from '@/services/contracts/safeCo
 import { type SafeSignature, type SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { getAllByTestId } from '@testing-library/dom'
 import { ApprovalEditorForm } from '@/components/tx/ApprovalEditor/ApprovalEditorForm'
+import Approvals from '@/components/tx/ApprovalEditor/Approvals'
 
 const ERC20_INTERFACE = ERC20__factory.createInterface()
 
@@ -237,7 +238,7 @@ describe('ApprovalEditor', () => {
             amountFormatted: '0.1',
           }
 
-          const result = render(<ApprovalEditorForm approvalInfos={[mockApprovalInfo]} />)
+          const result = render(<Approvals approvalInfos={[mockApprovalInfo]} />)
 
           const approvalItem = result.getByTestId('approval-item')
 

--- a/src/components/tx/ApprovalEditor/ApprovalEditorForm.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalEditorForm.tsx
@@ -1,5 +1,4 @@
-import PrefixedEthHashInfo from '@/components/common/EthHashInfo'
-import { Grid, Typography, IconButton, SvgIcon, List, ListItem, Alert } from '@mui/material'
+import { IconButton, SvgIcon, List, ListItem } from '@mui/material'
 import { FormProvider, useForm } from 'react-hook-form'
 import css from './styles.module.css'
 import CheckIcon from '@mui/icons-material/Check'
@@ -8,7 +7,7 @@ import { ApprovalValueField } from './ApprovalValueField'
 import { MODALS_EVENTS } from '@/services/analytics'
 import Track from '@/components/common/Track'
 import { useMemo } from 'react'
-import SendAmountBlock from '@/components/tx-flow/flows/TokenTransfer/SendAmountBlock'
+import ApprovalItem from '@/components/tx/ApprovalEditor/ApprovalItem'
 
 export type ApprovalEditorFormData = {
   approvals: string[]
@@ -19,9 +18,8 @@ export const ApprovalEditorForm = ({
   updateApprovals,
 }: {
   approvalInfos: ApprovalInfo[]
-  updateApprovals?: (newApprovals: string[]) => void
+  updateApprovals: (newApprovals: string[]) => void
 }) => {
-  const isReadonly = updateApprovals === undefined
   const initialApprovals = useMemo(() => approvalInfos.map((info) => info.amountFormatted), [approvalInfos])
 
   const formMethods = useForm<ApprovalEditorFormData>({
@@ -38,7 +36,6 @@ export const ApprovalEditorForm = ({
   } = formMethods
 
   const onSave = () => {
-    if (isReadonly) return
     const formData = getValues('approvals')
     updateApprovals(formData)
     reset({ approvals: formData })
@@ -49,45 +46,21 @@ export const ApprovalEditorForm = ({
       <List className={css.approvalsList}>
         {approvalInfos.map((tx, idx) => (
           <ListItem key={tx.tokenAddress + tx.spender} disablePadding data-testid="approval-item">
-            <Alert icon={false} variant="outlined" severity="warning" className={css.alert}>
-              <Grid container gap={1} justifyContent="space-between">
-                <Grid item display="flex" xs={12} flexDirection="row" alignItems="center" gap={1}>
-                  {isReadonly ? (
-                    tx.tokenInfo && (
-                      <SendAmountBlock amount={initialApprovals[idx]} tokenInfo={tx.tokenInfo} title="Token" />
-                    )
-                  ) : (
-                    <>
-                      <ApprovalValueField name={`approvals.${idx}`} tx={tx} readonly={isReadonly} />
-                      <Track {...MODALS_EVENTS.EDIT_APPROVALS}>
-                        <IconButton
-                          className={css.iconButton}
-                          onClick={onSave}
-                          disabled={!!errors.approvals || !dirtyFields.approvals?.[idx]}
-                          title="Save"
-                        >
-                          <SvgIcon component={CheckIcon} />
-                        </IconButton>
-                      </Track>
-                    </>
-                  )}
-                </Grid>
-
-                <Grid item container display="flex" xs={12} alignItems="center" gap={1}>
-                  <Grid item xs={2}>
-                    <Typography color="text.secondary" variant="body2">
-                      Spender
-                    </Typography>
-                  </Grid>
-
-                  <Grid item>
-                    <Typography fontSize="14px">
-                      <PrefixedEthHashInfo address={tx.spender} hasExplorer showAvatar={false} shortAddress={false} />
-                    </Typography>
-                  </Grid>
-                </Grid>
-              </Grid>
-            </Alert>
+            <ApprovalItem spender={tx.spender}>
+              <>
+                <ApprovalValueField name={`approvals.${idx}`} tx={tx} />
+                <Track {...MODALS_EVENTS.EDIT_APPROVALS}>
+                  <IconButton
+                    className={css.iconButton}
+                    onClick={onSave}
+                    disabled={!!errors.approvals || !dirtyFields.approvals?.[idx]}
+                    title="Save"
+                  >
+                    <SvgIcon component={CheckIcon} />
+                  </IconButton>
+                </Track>
+              </>
+            </ApprovalItem>
           </ListItem>
         ))}
       </List>

--- a/src/components/tx/ApprovalEditor/ApprovalItem.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalItem.tsx
@@ -1,0 +1,32 @@
+import { type ReactElement } from 'react'
+import { Alert, Grid, Typography } from '@mui/material'
+import css from '@/components/tx/ApprovalEditor/styles.module.css'
+import PrefixedEthHashInfo from '@/components/common/EthHashInfo'
+
+const ApprovalItem = ({ spender, children }: { spender: string; children: ReactElement }) => {
+  return (
+    <Alert icon={false} variant="outlined" severity="warning" className={css.alert}>
+      <Grid container gap={1} justifyContent="space-between">
+        <Grid item display="flex" xs={12} flexDirection="row" alignItems="center" gap={1}>
+          {children}
+        </Grid>
+
+        <Grid item container display="flex" xs={12} alignItems="center" gap={1}>
+          <Grid item xs={2}>
+            <Typography color="text.secondary" variant="body2">
+              Spender
+            </Typography>
+          </Grid>
+
+          <Grid item>
+            <Typography fontSize="14px">
+              <PrefixedEthHashInfo address={spender} hasExplorer showAvatar={false} shortAddress={false} />
+            </Typography>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Alert>
+  )
+}
+
+export default ApprovalItem

--- a/src/components/tx/ApprovalEditor/ApprovalValueField.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalValueField.tsx
@@ -15,15 +15,7 @@ const ApprovalOption = ({ menuItemProps, value }: { menuItemProps: MenuItemProps
   )
 }
 
-export const ApprovalValueField = ({
-  name,
-  readonly = false,
-  tx,
-}: {
-  name: string
-  readonly?: boolean
-  tx: ApprovalInfo
-}) => {
+export const ApprovalValueField = ({ name, tx }: { name: string; tx: ApprovalInfo }) => {
   const { control } = useFormContext()
   const selectValues = Object.values(PSEUDO_APPROVAL_VALUES)
 
@@ -59,8 +51,6 @@ export const ApprovalValueField = ({
       onInputChange={(_, value) => {
         onChange(value)
       }}
-      readOnly={readonly}
-      disabled={readonly}
       disableClearable
       selectOnFocus
       componentsProps={{
@@ -87,7 +77,6 @@ export const ApprovalValueField = ({
                 paddingLeft: 1,
                 flexWrap: 'nowrap !important',
               },
-              readOnly: readonly,
               startAdornment: (
                 <Box display="flex" flexDirection="row" alignItems="center" gap="4px">
                   <TokenIcon size={32} logoUri={tx.tokenInfo?.logoUri} tokenSymbol={tx.tokenInfo?.symbol} />

--- a/src/components/tx/ApprovalEditor/Approvals.tsx
+++ b/src/components/tx/ApprovalEditor/Approvals.tsx
@@ -1,0 +1,28 @@
+import { Grid, List, ListItem } from '@mui/material'
+
+import { type ApprovalInfo } from '@/components/tx/ApprovalEditor/hooks/useApprovalInfos'
+import css from './styles.module.css'
+import SendAmountBlock from '@/components/tx-flow/flows/TokenTransfer/SendAmountBlock'
+import ApprovalItem from '@/components/tx/ApprovalEditor/ApprovalItem'
+
+const Approvals = ({ approvalInfos }: { approvalInfos: ApprovalInfo[] }) => {
+  return (
+    <List className={css.approvalsList}>
+      {approvalInfos.map((tx) => {
+        if (!tx.tokenInfo) return <></>
+
+        return (
+          <ListItem key={tx.tokenAddress + tx.spender} disablePadding data-testid="approval-item">
+            <ApprovalItem spender={tx.spender}>
+              <Grid container gap={1} alignItems="center">
+                <SendAmountBlock amount={tx.amountFormatted} tokenInfo={tx.tokenInfo} title="Token" />
+              </Grid>
+            </ApprovalItem>
+          </ListItem>
+        )
+      })}
+    </List>
+  )
+}
+
+export default Approvals

--- a/src/components/tx/ApprovalEditor/index.tsx
+++ b/src/components/tx/ApprovalEditor/index.tsx
@@ -7,6 +7,7 @@ import { useApprovalInfos } from './hooks/useApprovalInfos'
 import { decodeSafeTxToBaseTransactions } from '@/utils/transactions'
 import EditIcon from '@/public/images/common/edit.svg'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
+import Approvals from '@/components/tx/ApprovalEditor/Approvals'
 
 const Title = () => {
   return (
@@ -40,14 +41,14 @@ export const ApprovalEditor = ({
 
   const extractedTxs = decodeSafeTxToBaseTransactions(safeTransaction)
 
-  // If a callback is handed in, we update the txs on change, otherwise a `undefined` callback will change the form to readonly
-  const updateApprovals =
-    updateTransaction === undefined
-      ? undefined
-      : (approvals: string[]) => {
-          const updatedTxs = updateApprovalTxs(approvals, readableApprovals, extractedTxs)
-          updateTransaction(updatedTxs)
-        }
+  const updateApprovals = (approvals: string[]) => {
+    if (!updateTransaction) return
+
+    const updatedTxs = updateApprovalTxs(approvals, readableApprovals, extractedTxs)
+    updateTransaction(updatedTxs)
+  }
+
+  const isReadOnly = updateTransaction === undefined
 
   return (
     <Box display="flex" flexDirection="column" gap={2} mb={3}>
@@ -56,6 +57,8 @@ export const ApprovalEditor = ({
         <Alert severity="error">Error while decoding approval transactions.</Alert>
       ) : loading || !readableApprovals ? (
         <Skeleton variant="rounded" height={126} />
+      ) : isReadOnly ? (
+        <Approvals approvalInfos={readableApprovals} />
       ) : (
         <ApprovalEditorForm approvalInfos={readableApprovals} updateApprovals={updateApprovals} />
       )}


### PR DESCRIPTION
## What it solves

Part of #2067 

## How this PR fixes it

- Extracts readonly part from `ApprovalEditorForm`
- Displays Unlimited approvals correctly in readonly mode

## How to test it

1. Open a Safe with queued approvals (unlimited and limited)
2. Observe the values are displayed correctly

## ToDos

- [ ] Write tests for `ApprovalEditor` and the new components

## Screenshots

<img width="709" alt="Screenshot 2023-07-03 at 16 50 47" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/e36b0500-28aa-46f5-a00c-7393e0784e72">
<img width="713" alt="Screenshot 2023-07-03 at 16 50 58" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/be23a82a-c227-43cf-b816-0afb42e7ccbe">
<img width="731" alt="Screenshot 2023-07-03 at 16 51 22" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/ae32beb4-b4d1-4518-ab7a-32c660ab7db1">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
