### PR TITLE
fix: Hide reset nonce button

### DIFF
--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -151,7 +151,7 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: number; recommendedNo
                     className={css.input}
                     title={field.value}
                     sx={{
-                      minWidth: `clamp(1em, ${field.value.length}em, 200px)`,
+                      minWidth: `clamp(1ch, ${field.value.length}ch, 200px)`,
                     }}
                   />
                 </Tooltip>

--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -136,24 +136,23 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: number; recommendedNo
                     InputProps={{
                       ...params.InputProps,
                       name: field.name,
-                      endAdornment: (
-                        <InputAdornment position="end" className={css.adornment}>
-                          <Tooltip title="Reset to recommended nonce">
-                            <IconButton
-                              onClick={resetNonce}
-                              size="small"
-                              color="primary"
-                              disabled={readOnly || recommendedNonce.toString() === field.value}
-                            >
-                              <RotateLeftIcon fontSize="small" />
-                            </IconButton>
-                          </Tooltip>
-                        </InputAdornment>
-                      ),
+                      endAdornment:
+                        !readOnly && recommendedNonce.toString() !== field.value ? (
+                          <InputAdornment position="end" className={css.adornment}>
+                            <Tooltip title="Reset to recommended nonce">
+                              <IconButton onClick={resetNonce} size="small" color="primary">
+                                <RotateLeftIcon fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                          </InputAdornment>
+                        ) : null,
                       readOnly,
                     }}
                     className={css.input}
-                    sx={{ width: `${field.value.length}em`, minWidth: '5em', maxWidth: '200px' }}
+                    title={field.value}
+                    sx={{
+                      minWidth: `clamp(1em, ${field.value.length}em, 200px)`,
+                    }}
                   />
                 </Tooltip>
               )

--- a/src/components/tx-flow/common/TxNonce/styles.module.css
+++ b/src/components/tx-flow/common/TxNonce/styles.module.css
@@ -4,10 +4,12 @@
 
 .input input {
   font-weight: bold;
-  padding-right: 6px !important;
+  padding-right: 30px !important;
 }
 
 .adornment {
   margin-left: 0;
   margin-right: 4px;
+  position: absolute;
+  right: 0;
 }


### PR DESCRIPTION
## What it solves

Part of #2067

## How this PR fixes it

- Hides the reset nonce button instead of disabling it
- Shows the value as the title when hovering

## How to test it

1. Open a Safe
2. Create a new transaction
3. Observe the input field being smaller
4. Observe the reset nonce button not visible
5. Change the nonce
6. Observe the reset nonce button is visible

## Screenshots
<img width="246" alt="Screenshot 2023-07-04 at 10 41 14" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/8a84fee7-0d9c-4918-9dc5-6b29ff3ff1fd">
<img width="201" alt="Screenshot 2023-07-04 at 10 41 23" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/eb23e8ea-b9c6-4e26-8aec-a241f1ec3f6a">
<img width="264" alt="Screenshot 2023-07-04 at 10 41 35" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/0abd740f-7356-4e95-ac55-da2e198e0032">

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
