### PR TITLE
fix: Handle relayed txs and errors in status screen

### DIFF
--- a/src/components/new-safe/create/steps/StatusStep/LoadingSpinner/styles.module.css
+++ b/src/components/new-safe/create/steps/StatusStep/LoadingSpinner/styles.module.css
@@ -11,7 +11,8 @@
   animation-play-state: paused;
 }
 
-.rectSuccess .rectCenter {
+.rectSuccess .rectCenter,
+.rectError .rectCenter {
   visibility: visible;
   transform: translateY(30px) translateX(30px) scale(1);
 }

--- a/src/components/tx-flow/flows/SuccessScreen/StatusMessage.tsx
+++ b/src/components/tx-flow/flows/SuccessScreen/StatusMessage.tsx
@@ -4,9 +4,10 @@ import LoadingSpinner, { SpinnerStatus } from '@/components/new-safe/create/step
 import { PendingStatus } from '@/store/pendingTxsSlice'
 import css from './styles.module.css'
 
-const getStep = (status: PendingStatus) => {
+const getStep = (status: PendingStatus, error?: Error) => {
   switch (status) {
     case PendingStatus.PROCESSING:
+    case PendingStatus.RELAYING:
       return {
         description: 'Transaction is now processing.',
         instruction: 'The transaction was confirmed and is now being processed.',
@@ -18,17 +19,17 @@ const getStep = (status: PendingStatus) => {
       }
     default:
       return {
-        description: 'Transaction was successful.',
-        instruction: '',
+        description: error ? 'Transaction failed' : 'Transaction was successful.',
+        instruction: error ? error.message : '',
       }
   }
 }
 
-const StatusMessage = ({ status, isError }: { status: PendingStatus; isError: boolean }) => {
-  const stepInfo = getStep(status)
+const StatusMessage = ({ status, error }: { status: PendingStatus; error?: Error }) => {
+  const stepInfo = getStep(status, error)
 
   const isSuccess = status === undefined
-  const spinnerStatus = isSuccess ? SpinnerStatus.SUCCESS : SpinnerStatus.PROCESSING
+  const spinnerStatus = error ? SpinnerStatus.ERROR : isSuccess ? SpinnerStatus.SUCCESS : SpinnerStatus.PROCESSING
 
   return (
     <>
@@ -39,7 +40,7 @@ const StatusMessage = ({ status, isError }: { status: PendingStatus; isError: bo
         </Typography>
       </Box>
       {stepInfo.instruction && (
-        <Box className={classNames(css.instructions, isError ? css.errorBg : css.infoBg)}>
+        <Box className={classNames(css.instructions, error ? css.errorBg : css.infoBg)}>
           <Typography variant="body2">{stepInfo.instruction}</Typography>
         </Box>
       )}

--- a/src/components/tx-flow/flows/SuccessScreen/StatusStepper.tsx
+++ b/src/components/tx-flow/flows/SuccessScreen/StatusStepper.tsx
@@ -5,7 +5,7 @@ import StatusStep from '@/components/new-safe/create/steps/StatusStep/StatusStep
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { PendingStatus } from '@/store/pendingTxsSlice'
 
-const StatusStepper = ({ status, txHash }: { status: PendingStatus; txHash: string }) => {
+const StatusStepper = ({ status, txHash }: { status: PendingStatus; txHash?: string }) => {
   const { safeAddress } = useSafeInfo()
 
   const isProcessing = status === PendingStatus.PROCESSING || status === PendingStatus.INDEXING || status === undefined

--- a/src/components/tx-flow/flows/SuccessScreen/index.tsx
+++ b/src/components/tx-flow/flows/SuccessScreen/index.tsx
@@ -1,7 +1,7 @@
+import { useRouter } from 'next/router'
 import StatusMessage from './StatusMessage'
 import StatusStepper from './StatusStepper'
 import { AppRoutes } from '@/config/routes'
-import useSafeAddress from '@/hooks/useSafeAddress'
 import { Button, Container, Divider, Paper } from '@mui/material'
 import classnames from 'classnames'
 import Link from 'next/link'
@@ -17,7 +17,7 @@ import { TxEvent, txSubscribe } from '@/services/tx/txEvents'
 export const SuccessScreen = ({ txId }: { txId: string }) => {
   const [localTxHash, setLocalTxHash] = useState<string>()
   const [error, setError] = useState<Error>()
-  const safeAddress = useSafeAddress()
+  const router = useRouter()
   const chain = useCurrentChain()
   const pendingTx = useAppSelector((state) => selectPendingTxById(state, txId))
   const { txHash = '', status } = pendingTx || {}
@@ -38,7 +38,7 @@ export const SuccessScreen = ({ txId }: { txId: string }) => {
 
   const homeLink: UrlObject = {
     pathname: AppRoutes.home,
-    query: { safe: safeAddress },
+    query: { safe: router.query.safe },
   }
 
   const txLink = chain && localTxHash ? getBlockExplorerLink(chain, localTxHash) : undefined


### PR DESCRIPTION
## What it solves

Resolves #2023 

## How this PR fixes it

- Handles Relayed transactions in Status screen
- Listens to the `TxEvent.FAILED` event in order to show an error state and message

## How to test it

1. Open a Safe
2. Queue a transaction that would fail
3. Execute the transaction via relayer (or any other method that will result in a TxEvent.FAILED event)
4. Observe the Status screen changing

## Screenshots
<img width="989" alt="Screenshot 2023-07-04 at 16 51 27" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/72ce62ed-056b-43b2-8f03-1b9f130efaa4">
<img width="948" alt="Screenshot 2023-07-04 at 16 50 56" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/84efa5f3-22ce-4851-a8a4-fa6a09e02e1f">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
