### PR TITLE
fix: TxFlow submit button alignment, error message spacing

### DIFF
--- a/src/components/tx-flow/common/TxLayout/styles.module.css
+++ b/src/components/tx-flow/common/TxLayout/styles.module.css
@@ -36,7 +36,7 @@
   margin-top: var(--space-3);
 }
 
-.step :global(.MuiCardActions-root) button[type='submit'] {
+.step :global(.MuiCardActions-root) > * {
   align-self: flex-end;
 }
 

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -96,7 +96,6 @@ const ExecuteForm = ({
   }
 
   const submitDisabled = !safeTx || !isSubmittable || disableSubmit || isValidExecutionLoading || isExecutionLoop
-  const hasError = isExecutionLoop || executionValidationError || gasLimitError || submitError
 
   return (
     <>
@@ -123,25 +122,23 @@ const ExecuteForm = ({
         )}
 
         {/* Error messages */}
-        {hasError && (
-          <div className={css.errorWrapper}>
-            {isExecutionLoop ? (
-              <ErrorMessage>
-                Cannot execute a transaction from the Safe Account itself, please connect a different account.
-              </ErrorMessage>
-            ) : executionValidationError || gasLimitError ? (
-              <ErrorMessage error={executionValidationError || gasLimitError}>
-                This transaction will most likely fail.{' '}
-                {isNewExecutableTx
-                  ? 'To save gas costs, avoid creating the transaction.'
-                  : 'To save gas costs, reject this transaction.'}
-              </ErrorMessage>
-            ) : (
-              submitError && (
-                <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
-              )
-            )}
-          </div>
+        {isExecutionLoop ? (
+          <ErrorMessage className={css.errorWrapper}>
+            Cannot execute a transaction from the Safe Account itself, please connect a different account.
+          </ErrorMessage>
+        ) : executionValidationError || gasLimitError ? (
+          <ErrorMessage error={executionValidationError || gasLimitError} className={css.errorWrapper}>
+            This transaction will most likely fail.{' '}
+            {isNewExecutableTx
+              ? 'To save gas costs, avoid creating the transaction.'
+              : 'To save gas costs, reject this transaction.'}
+          </ErrorMessage>
+        ) : (
+          submitError && (
+            <ErrorMessage error={submitError} className={css.errorWrapper}>
+              Error submitting the transaction. Please try again.
+            </ErrorMessage>
+          )
         )}
 
         <Divider className={commonCss.nestedDivider} sx={{ pt: 3 }} />

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -96,6 +96,7 @@ const ExecuteForm = ({
   }
 
   const submitDisabled = !safeTx || !isSubmittable || disableSubmit || isValidExecutionLoading || isExecutionLoop
+  const hasError = isExecutionLoop || executionValidationError || gasLimitError || submitError
 
   return (
     <>
@@ -122,21 +123,25 @@ const ExecuteForm = ({
         )}
 
         {/* Error messages */}
-        {isExecutionLoop ? (
-          <ErrorMessage>
-            Cannot execute a transaction from the Safe Account itself, please connect a different account.
-          </ErrorMessage>
-        ) : executionValidationError || gasLimitError ? (
-          <ErrorMessage error={executionValidationError || gasLimitError}>
-            This transaction will most likely fail.{' '}
-            {isNewExecutableTx
-              ? 'To save gas costs, avoid creating the transaction.'
-              : 'To save gas costs, reject this transaction.'}
-          </ErrorMessage>
-        ) : (
-          submitError && (
-            <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
-          )
+        {hasError && (
+          <div className={css.errorWrapper}>
+            {isExecutionLoop ? (
+              <ErrorMessage>
+                Cannot execute a transaction from the Safe Account itself, please connect a different account.
+              </ErrorMessage>
+            ) : executionValidationError || gasLimitError ? (
+              <ErrorMessage error={executionValidationError || gasLimitError}>
+                This transaction will most likely fail.{' '}
+                {isNewExecutableTx
+                  ? 'To save gas costs, avoid creating the transaction.'
+                  : 'To save gas costs, reject this transaction.'}
+              </ErrorMessage>
+            ) : (
+              submitError && (
+                <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
+              )
+            )}
+          </div>
         )}
 
         <Divider className={commonCss.nestedDivider} sx={{ pt: 3 }} />

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -12,6 +12,7 @@ import { TxModalContext } from '@/components/tx-flow'
 import { asError } from '@/services/exceptions/utils'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
 import { TxSecurityContext } from '../security/shared/TxSecurityContext'
+import css from '@/components/tx/SignOrExecuteForm/styles.module.css'
 
 const SignForm = ({
   safeTx,
@@ -65,12 +66,14 @@ const SignForm = ({
     <form onSubmit={handleSubmit}>
       {/* Error messages */}
       {isSubmittable && cannotPropose ? (
-        <ErrorMessage>
+        <ErrorMessage className={css.errorWrapper}>
           You are currently not an owner of this Safe Account and won&apos;t be able to submit this transaction.
         </ErrorMessage>
       ) : (
         submitError && (
-          <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
+          <ErrorMessage error={submitError} className={css.errorWrapper}>
+            Error submitting the transaction. Please try again.
+          </ErrorMessage>
         )
       )}
 

--- a/src/components/tx/SignOrExecuteForm/styles.module.css
+++ b/src/components/tx/SignOrExecuteForm/styles.module.css
@@ -41,3 +41,7 @@
   border-top-left-radius: 0 !important;
   border-top-right-radius: 0 !important;
 }
+
+.errorWrapper {
+  margin-top: var(--space-2);
+}

--- a/src/components/tx/SignOrExecuteForm/styles.module.css
+++ b/src/components/tx/SignOrExecuteForm/styles.module.css
@@ -43,5 +43,5 @@
 }
 
 .errorWrapper {
-  margin-top: var(--space-2);
+  margin-top: var(--space-2) !important;
 }


### PR DESCRIPTION
## What it solves

Part of #2067 

## How this PR fixes it

- Aligns the submit button to the right at all times
- Adds spacing above error messages

## How to test it

1. Open a Safe
2. Confirm an existing transaction
3. Switch to a wallet thats not an owner
4. Observe the Submit button still aligned to the right
5. Create a transaction that will fail
6. Observe enough space above the error message

## Screenshots

<img width="743" alt="Screenshot 2023-07-04 at 16 49 38" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/f5b1e404-1a45-4a2b-b74f-dbcac8b83793">

<img width="714" alt="Screenshot 2023-07-04 at 16 49 55" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/55861041-6fae-4cd3-9f40-e9c6230dfe8b">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
