### PR TITLE
<fix: whitespace in pending tx dashboard>

### DIFF
--- a/src/components/dashboard/PendingTxs/PendingTxListItem.tsx
+++ b/src/components/dashboard/PendingTxs/PendingTxListItem.tsx
@@ -61,7 +61,7 @@ const PendingTx = ({ transaction }: PendingTxType): ReactElement => {
             )}
           </Box>
 
-          <Box gridArea="icon" marginLeft="12px">
+          <Box gridArea="icon" marginLeft="0px">
             <ChevronRight color="border" />
           </Box>
         </Box>

--- a/src/components/dashboard/PendingTxs/styles.module.css
+++ b/src/components/dashboard/PendingTxs/styles.module.css
@@ -1,7 +1,9 @@
 .gridContainer {
   width: 100%;
-  display: grid;
-  grid-gap: 4px;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 3px;
   align-items: center;
   padding: 8px 16px;
   background-color: var(--color-background-paper);


### PR DESCRIPTION
## What it solves
This PR solves the excess whitespace on the pending trasaction dashboard

Resolves #2060

## How this PR fixes it
This PR fixes it by changing the grid to flex and then added a justify-content of space between which will spread out the items evenly and finally, flex-wrap was added to wrap up the item as the screen gets smaller so that their will no be an overflow as the screen gets smaller.

After styling the flex, the was another excess whitespace between the SvgIcon and ChevronRight icons and so i had to reduce the 12px marginleft on the ChevronRight tag at line 64 of the pendingTxListItem component to 0px to eliminate the excess whitespace 

The only concern i have is the container name which is .grid-container. I'm thinking that since the style has been changed from grid to flex, I thought that the container name should also be changed

## How to test it

## Screenshots
![Picture](https://github.com/safe-global/safe-wallet-web/assets/97669038/e821e36a-bcf9-4986-bb48-f27e308c0961)

## Checklist
* [ ✔] I've tested the branch on mobile 📱
![Picture1](https://github.com/safe-global/safe-wallet-web/assets/97669038/bb366a31-8f7a-4860-afd3-307633f87bd7)

* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
