### PR TITLE
fix: Check execute checkbox if execution is the only option

### DIFF
--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -185,7 +185,11 @@ const SignOrExecuteForm = ({
             <DecodedTx tx={tx} txId={txId} />
 
             {canExecute && (
-              <ExecuteCheckbox checked={shouldExecute} onChange={handleExecuteCheckboxChange} disabled={onlyExecute} />
+              <ExecuteCheckbox
+                checked={shouldExecute || onlyExecute}
+                onChange={handleExecuteCheckboxChange}
+                disabled={onlyExecute}
+              />
             )}
 
             <AdvancedParams


### PR DESCRIPTION
## What it solves

Fixes a regression found [here](https://github.com/safe-global/safe-wallet-web/pull/2219#issuecomment-1621185990)

## How this PR fixes it

- Keeps the execute checkbox checked if execution is the only option

## How to test it

1. Open a 1/1 Safe
2. Create a new transaction
3. Uncheck the execute checkbox and queue the transaction
4. Go to the queue
5. Execute the transaction
6. Observe the checkbox is checked

## Screenshots
<img width="639" alt="Screenshot 2023-07-05 at 10 24 01" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/cc22cc09-89fa-4fcf-a92b-60d1b42ac0da">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
