### PR TITLE
fix: Hide confirmation dialog if set via setTxFlow

### DIFF
--- a/src/components/sidebar/NewTxButton/index.tsx
+++ b/src/components/sidebar/NewTxButton/index.tsx
@@ -10,7 +10,7 @@ const NewTxButton = (): ReactElement => {
   const { setTxFlow } = useContext(TxModalContext)
 
   const onClick = () => {
-    setTxFlow(<NewTxMenu />)
+    setTxFlow(<NewTxMenu />, undefined, false)
     trackEvent(OVERVIEW_EVENTS.NEW_TRANSACTION)
   }
 

--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -149,7 +149,6 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: number; recommendedNo
                       readOnly,
                     }}
                     className={css.input}
-                    title={field.value}
                     sx={{
                       minWidth: `clamp(1ch, ${field.value.length}ch, 200px)`,
                     }}

--- a/src/components/tx-flow/flows/NewTx/index.tsx
+++ b/src/components/tx-flow/flows/NewTx/index.tsx
@@ -20,10 +20,6 @@ const NewTxMenu = () => {
     setTxFlow(<TokenTransferFlow />)
   }, [setTxFlow])
 
-  const onNavigate = useCallback(() => {
-    setTxFlow(undefined)
-  }, [setTxFlow])
-
   const progress = 10
 
   return (
@@ -53,7 +49,7 @@ const NewTxMenu = () => {
 
               <SendTokensButton onClick={onTokensClick} sx={buttonSx} />
 
-              <SendNFTsButton onClick={onNavigate} sx={buttonSx} />
+              <SendNFTsButton sx={buttonSx} />
 
               {txBuilder?.app && (
                 <>
@@ -62,7 +58,7 @@ const NewTxMenu = () => {
                     interaction
                   </Typography>
 
-                  <TxBuilderButton onClick={onNavigate} sx={buttonSx} />
+                  <TxBuilderButton sx={buttonSx} />
                 </>
               )}
             </Grid>

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -83,7 +83,7 @@ const ExecuteForm = ({
 
     try {
       const executedTxId = await executeTx(txOptions, safeTx, txId, origin, willRelay)
-      setTxFlow(<SuccessScreen txId={executedTxId} />)
+      setTxFlow(<SuccessScreen txId={executedTxId} />, undefined, false)
     } catch (_err) {
       const err = asError(_err)
       logError(Errors._804, err)


### PR DESCRIPTION
## What it solves

Part of #2067 

## How this PR fixes it

- Uses the browser native confirmation dialog
- Prevents navigation if user cancels
- Adds another option to `setTxFlow` to bypass confirmation dialog

## How to test it

1. Open a Safe
2. Create new transaction
3. Navigate away
4. Observe no confirmation dialog
5. Click on Send tokens
6. Try to navigate away or close the window
7. Observe a confirmation dialog

## Screenshots
<img width="932" alt="Screenshot 2023-07-05 at 15 21 33" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/9bcaf87b-b092-44af-aa93-06d199610d9f">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
