### PR TITLE
feat: show redefine warnings on mobile

### DIFF
--- a/src/components/tx/SignOrExecuteForm/TxChecks.tsx
+++ b/src/components/tx/SignOrExecuteForm/TxChecks.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement, useContext } from 'react'
-import { TxSimulation } from '@/components/tx/security/tenderly'
+import { TxSimulation, TxSimulationMessage } from '@/components/tx/security/tenderly'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { Box, Typography } from '@mui/material'
 import { Redefine, RedefineMessage } from '@/components/tx/security/redefine'
@@ -15,9 +15,13 @@ const TxChecks = (): ReactElement => {
 
       <TxSimulation disabled={false} transactions={safeTx} />
 
+      <Box className={css.mobileTxCheckMessages}>
+        <TxSimulationMessage />
+      </Box>
+
       <Redefine />
 
-      <Box className={css.mobileRedefineMessages}>
+      <Box className={css.mobileTxCheckMessages}>
         <RedefineMessage />
       </Box>
     </>

--- a/src/components/tx/SignOrExecuteForm/TxChecks.tsx
+++ b/src/components/tx/SignOrExecuteForm/TxChecks.tsx
@@ -1,8 +1,10 @@
 import { type ReactElement, useContext } from 'react'
 import { TxSimulation } from '@/components/tx/security/tenderly'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
-import { Typography } from '@mui/material'
-import { Redefine } from '@/components/tx/security/redefine'
+import { Box, Typography } from '@mui/material'
+import { Redefine, RedefineMessage } from '@/components/tx/security/redefine'
+
+import css from './styles.module.css'
 
 const TxChecks = (): ReactElement => {
   const { safeTx } = useContext(SafeTxContext)
@@ -11,9 +13,13 @@ const TxChecks = (): ReactElement => {
     <>
       <Typography variant="h5">Transaction checks</Typography>
 
+      <TxSimulation disabled={false} transactions={safeTx} />
+
       <Redefine />
 
-      <TxSimulation disabled={false} transactions={safeTx} />
+      <Box className={css.mobileRedefineMessages}>
+        <RedefineMessage />
+      </Box>
     </>
   )
 }

--- a/src/components/tx/SignOrExecuteForm/styles.module.css
+++ b/src/components/tx/SignOrExecuteForm/styles.module.css
@@ -45,3 +45,13 @@
 .errorWrapper {
   margin-top: var(--space-2) !important;
 }
+
+.mobileRedefineMessages {
+  display: none;
+}
+
+@media (max-width: 899.95px) {
+  .mobileRedefineMessages {
+    display: block;
+  }
+}

--- a/src/components/tx/SignOrExecuteForm/styles.module.css
+++ b/src/components/tx/SignOrExecuteForm/styles.module.css
@@ -46,12 +46,12 @@
   margin-top: var(--space-2) !important;
 }
 
-.mobileRedefineMessages {
+.mobileTxCheckMessages {
   display: none;
 }
 
 @media (max-width: 899.95px) {
-  .mobileRedefineMessages {
+  .mobileTxCheckMessages {
     display: block;
   }
 }


### PR DESCRIPTION
## What it solves
- adds RedefineMessage to TxChecks for small screens
- changes order of Redefine scan results and Tenderly Simulation

## How to test it
- Open app in mobile or in a small window
- create transaction
- observe redefine results under the "Scan for risks" box

## Screenshots
![Screenshot 2023-07-05 at 15 57 18](https://github.com/safe-global/safe-wallet-web/assets/2670790/68c0a5e9-f3d5-49f0-8162-ba0cf604a552)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
