### PR TITLE
fix: Adjust decoded tx ui

### DIFF
--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -7,6 +7,7 @@ import type { AccordionProps } from '@mui/material/Accordion/Accordion'
 import SingleTxDecoded from '@/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded'
 import { Box, Button, Divider, Stack } from '@mui/material'
 import css from './styles.module.css'
+import classnames from 'classnames'
 
 type MultisendProps = {
   txData?: TransactionData
@@ -17,16 +18,18 @@ type MultisendProps = {
 const MultisendActionsHeader = ({
   setOpen,
   amount,
+  compact = false,
 }: {
   setOpen: Dispatch<SetStateAction<Record<number, boolean> | undefined>>
   amount: number
+  compact?: boolean
 }) => {
   const onClickAll = (expanded: boolean) => () => {
     setOpen(Array(amount).fill(expanded))
   }
 
   return (
-    <div className={css.actionsHeader}>
+    <div className={classnames(css.actionsHeader, { [css.compactHeader]: compact })}>
       All actions
       <Stack direction="row" divider={<Divider className={css.divider} />}>
         <Button onClick={onClickAll(true)} variant="text">
@@ -78,9 +81,9 @@ export const Multisend = ({
 
   return (
     <>
-      <MultisendActionsHeader setOpen={setOpenMap} amount={multiSendTransactions.length} />
+      <MultisendActionsHeader setOpen={setOpenMap} amount={multiSendTransactions.length} compact={compact} />
 
-      <Box display="flex" flexDirection="column" gap={compact ? 1 : undefined}>
+      <Box display="flex" flexDirection="column" className={compact ? css.compact : ''}>
         {multiSendTransactions.map(({ dataDecoded, data, value, to, operation }, index) => {
           const onChange: AccordionProps['onChange'] = (_, expanded) => {
             setOpenMap((prev) => ({
@@ -101,8 +104,8 @@ export const Multisend = ({
               }}
               txData={txData}
               showDelegateCallWarning={showDelegateCallWarning}
-              actionTitle={`Action ${index + 1}`}
-              variant="elevation"
+              actionTitle={`${index + 1}`}
+              variant={compact ? 'outlined' : 'elevation'}
               expanded={openMap?.[index] ?? false}
               onChange={onChange}
             />

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
@@ -29,7 +29,6 @@
 }
 
 .compact > div ~ div {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
+  border-radius: 0;
   margin-top: -1px !important;
 }

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
@@ -32,3 +32,8 @@
   border-radius: 0;
   margin-top: -1px !important;
 }
+
+.compact > div:hover,
+.compact > div:global(.Mui-expanded) {
+  border-color: var(--color-border-light);
+}

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
@@ -8,6 +8,10 @@
   align-items: center;
 }
 
+.compactHeader {
+  border: 0;
+}
+
 .actionsHeader button {
   padding-left: 18px;
   padding-right: 18px;
@@ -17,4 +21,15 @@
   margin-top: 14px;
   margin-bottom: 14px;
   border: 1px solid var(--color-border-light);
+}
+
+.compact > div:first-child {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.compact > div ~ div {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  margin-top: -1px !important;
 }

--- a/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
@@ -57,7 +57,7 @@ export const SingleTxDecoded = ({
     <Accordion variant={variant} expanded={expanded} onChange={onChange}>
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
         <div className={css.summary}>
-          <CodeIcon />
+          <CodeIcon color="border" fontSize="small" />
           <Typography>{actionTitle}</Typography>
           <Typography ml="8px">
             <b>{method}</b>

--- a/src/components/tx-flow/common/TxStatusWidget/index.tsx
+++ b/src/components/tx-flow/common/TxStatusWidget/index.tsx
@@ -44,7 +44,7 @@ const TxStatusWidget = ({
   return (
     <Paper>
       <div className={css.header}>
-        <SafeLogo width={32} height={32} />
+        <SafeLogo width={32} height={32} className={css.logo} />
         <Typography variant="h6" fontWeight="700" className={css.title}>
           Transaction status
         </Typography>

--- a/src/components/tx-flow/common/TxStatusWidget/styles.module.css
+++ b/src/components/tx-flow/common/TxStatusWidget/styles.module.css
@@ -71,8 +71,8 @@
   }
 
   .logo {
-    width: 16px;
-    height: 16px;
+    width: 24px;
+    height: 24px;
     margin-left: 16px;
   }
 

--- a/src/components/tx/DecodedTx/index.test.tsx
+++ b/src/components/tx/DecodedTx/index.test.tsx
@@ -179,8 +179,8 @@ describe('DecodedTx', () => {
     await waitFor(() => {
       expect(result.queryByText('multi Send')).toBeInTheDocument()
       expect(result.queryByText('transactions(bytes):')).toBeInTheDocument()
-      expect(result.queryByText('Action 1')).toBeInTheDocument()
-      expect(result.queryByText('Action 2')).toBeInTheDocument()
+      expect(result.queryByText('1')).toBeInTheDocument()
+      expect(result.queryByText('2')).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
## What it solves

Part of #2067 

## How this PR fixes it

- Uses the `compact` prop to display DecodedTxs with the alternative design

## How to test it

1. Open a Safe
2. Create a multisend transaction
3. Observe the new design
4. Navigate to the history and expand a multisend transaction
5. Observe that it still looks like it used to

## Screenshots

<img width="710" alt="Screenshot 2023-07-05 at 16 17 59" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/a6e64d9c-9abf-4408-9f15-d2fd0a7e63d9">

<img width="864" alt="Screenshot 2023-07-05 at 16 18 19" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/4e630750-baf5-4087-ae38-4c0bcdf212c4">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
