### PR TITLE
Chore: escape quotes in release action

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
         if: github.event.pull_request.merged == true
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
@@ -22,23 +22,20 @@ jobs:
         run: |
           NEW_VERSION=$(node -p 'require("./package.json").version')
           echo "version=v$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "${{ github.event.pull_request.body }}" > CHANGELOG.md
 
       - name: Create a git tag
         if: github.event.pull_request.merged == true
-        run: git tag $NEW_VERSION && git push --tags
-        env:
-          NEW_VERSION: ${{ steps.version.outputs.version }}
+        run: git tag ${{ steps.version.outputs.version }} && git push --tags
 
       - name: GitHub release
         if: success()
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         id: create_release
         with:
           draft: true
           prerelease: false
-          release_name: ${{ steps.version.outputs.version }}
+          name: ${{ steps.version.outputs.version }}
           tag_name: ${{ steps.version.outputs.version }}
-          body_path: CHANGELOG.md
+          body: ${{ github.event.pull_request.body }}
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## What it solves

The release action pastes the contents of the RC pull request into a bash variable using an echo command, but if the PR description contains a quote it breaks the bash syntax.

E.g.
```
Remove "What's new"
```