### PR TITLE
fix: autoconnect to WC v2 on mobile

### DIFF
--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -118,7 +118,7 @@ export const connectWallet = async (
   // On mobile, automatically choose WalletConnect if there is no injected wallet
   if (!options && isMobile() && !hasInjectedWallet()) {
     options = {
-      autoSelect: WalletNames.WALLET_CONNECT,
+      autoSelect: WalletNames.WALLET_CONNECT_V2,
     }
   }
 

--- a/src/utils/wallets.ts
+++ b/src/utils/wallets.ts
@@ -24,6 +24,7 @@ export const isWalletRejection = (err: EthersError | Error): boolean => {
 export const WalletNames = {
   METAMASK: ProviderLabel.MetaMask,
   WALLET_CONNECT: WALLET_CONNECT_V1_MODULE_NAME,
+  WALLET_CONNECT_V2: 'WalletConnect',
   SAFE_MOBILE_PAIRING: PAIRING_MODULE_LABEL,
 }
 


### PR DESCRIPTION
## What it solves

Prevents auto-connection to WC v1 on mobile

## How this PR fixes it

On mobile, we autoconnect to WC if there is no injected wallet present. However, this was not updated to be WC v2. This adjusts the `connectWallet` logic accordingly.

## How to test it

1. Open the PR deployment on mobile and attempt to connect a wallet with no injected wallet present. Observe the WC v2 modal.
2. Open the PR deployment on mobile and attempt to connect a wallet with an injected wallet present, e.g. Firefox w/ MetaMask. Observe the onboard modal.

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
