### PR TITLE
fix: reduce space between name and address

### DIFF
--- a/src/components/transactions/TxDetails/Summary/TxDataRow/index.tsx
+++ b/src/components/transactions/TxDetails/Summary/TxDataRow/index.tsx
@@ -31,7 +31,11 @@ export const generateDataRowValue = (
   switch (type) {
     case 'hash':
     case 'address':
-      return <EthHashInfo address={value} hasExplorer={hasExplorer} showAvatar={false} showCopyButton />
+      return (
+        <div className={css.address}>
+          <EthHashInfo address={value} hasExplorer={hasExplorer} showAvatar={false} showCopyButton />
+        </div>
+      )
     case 'rawData':
       return (
         <div className={css.rawData}>

--- a/src/components/transactions/TxDetails/Summary/TxDataRow/styles.module.css
+++ b/src/components/transactions/TxDetails/Summary/TxDataRow/styles.module.css
@@ -26,6 +26,11 @@
   align-items: center;
 }
 
+/* 2nd only exists if there is address book entry */
+.address > div > div > div:nth-child(2) {
+  margin-top: -4px;
+}
+
 @media (max-width: 599.95px) {
   .gridRow {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## What it solves

Unclear spacing

## How this PR fixes it

This reduces the margin between the address and name (if it exists) within the transaction details for clarity.

## How to test it

Ensure an address is in the address book and create a transaction to that address. Observe the reduced margin between the name/address.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/21477226-e226-4005-9b42-4f9b20a1a8e6)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
