### PR TITLE
fix: recipient title alignment

### DIFF
--- a/src/components/tx-flow/flows/TokenTransfer/SendToBlock.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/SendToBlock.tsx
@@ -4,12 +4,12 @@ import EthHashInfo from '@/components/common/EthHashInfo'
 const SendToBlock = ({ address, title = 'To' }: { address: string; title?: string }) => {
   return (
     <Grid container gap={1} alignItems="center">
-      <Grid item xs={4} md={2}>
-        <Typography variant="body2" color="text.secondary">
+      <Grid item md>
+        <Typography variant="body2" color="text.secondary" noWrap>
           {title}
         </Typography>
       </Grid>
-      <Grid item>
+      <Grid item xs={8} md={10}>
         <Typography variant="body2" component="div">
           <EthHashInfo address={address} shortAddress={false} hasExplorer showCopyButton />
         </Typography>


### PR DESCRIPTION
## What it solves

Resolves title misalignment

## How this PR fixes it

The `Grid` within the `SendToBlock` has been adjusted, allowing the address to "decide" the alignment.

## How to test it

1. Create a standard transaction and observe the correct alignment of the "To" title and address.
2. Create a Safe Apps transaction and observe the correct alignment of the "Interact with (and send n ETH to):" title and address.

## Screenshots

Standard transaction:

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/d622ef19-ceac-4d8f-9828-3611c93f435b)

Safe Apps transaction:

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/ed5dfdb8-1963-4c19-aed8-89e30547f66c)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
