### PR TITLE
Persist tx flow on reload

### DIFF
--- a/src/components/address-book/AddressBookTable/index.tsx
+++ b/src/components/address-book/AddressBookTable/index.tsx
@@ -22,7 +22,6 @@ import NoEntriesIcon from '@/public/images/address-book/no-entries.svg'
 import { useCurrentChain } from '@/hooks/useChains'
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
 import { TxModalContext } from '@/components/tx-flow'
-import TokenTransferFlow from '@/components/tx-flow/flows/TokenTransfer'
 import CheckWallet from '@/components/common/CheckWallet'
 
 const headCells = [
@@ -118,7 +117,7 @@ const AddressBookTable = () => {
                     variant="contained"
                     color="primary"
                     size="small"
-                    onClick={() => setTxFlow(<TokenTransferFlow recipient={address} />)}
+                    onClick={() => setTxFlow({ component: 'TokenTransferFlow', props: { recipient: address } })}
                     disabled={!isOk}
                   >
                     Send

--- a/src/components/balances/AssetsTable/index.tsx
+++ b/src/components/balances/AssetsTable/index.tsx
@@ -19,7 +19,6 @@ import { useHideAssets } from './useHideAssets'
 import CheckWallet from '@/components/common/CheckWallet'
 import useSpendingLimit from '@/hooks/useSpendingLimit'
 import { TxModalContext } from '@/components/tx-flow'
-import TokenTransferFlow from '@/components/tx-flow/flows/TokenTransfer'
 
 const skeletonCells: EnhancedTableProps['rows'][0]['cells'] = {
   asset: {
@@ -140,7 +139,7 @@ const AssetsTable = ({
   const selectedAssetCount = visibleAssets?.filter((item) => isAssetSelected(item.tokenInfo.address)).length || 0
 
   const onSendClick = (tokenAddress: string) => {
-    setTxFlow(<TokenTransferFlow tokenAddress={tokenAddress} />)
+    setTxFlow({ component: 'TokenTransferFlow', props: { tokenAddress } })
   }
 
   const rows = loading

--- a/src/components/nfts/NftCollections/index.tsx
+++ b/src/components/nfts/NftCollections/index.tsx
@@ -11,7 +11,6 @@ import NftGrid from '../NftGrid'
 import NftSendForm from '../NftSendForm'
 import NftPreviewModal from '../NftPreviewModal'
 import { TxModalContext } from '@/components/tx-flow'
-import NftTransferFlow from '@/components/tx-flow/flows/NftTransfer'
 
 const NftCollections = (): ReactElement => {
   // Track the current NFT page url
@@ -39,7 +38,7 @@ const NftCollections = (): ReactElement => {
 
       if (selectedNfts.length) {
         // Show the NFT transfer modal
-        setTxFlow(<NftTransferFlow tokens={selectedNfts} />)
+        setTxFlow({ component: 'NftTransferFlow', props: { tokens: selectedNfts } })
 
         // Track how many NFTs are being sent
         trackEvent({ ...NFT_EVENTS.SEND, label: selectedNfts.length })

--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -49,9 +49,6 @@ import useGetSafeInfo from './useGetSafeInfo'
 import { hasFeature, FEATURES } from '@/utils/chains'
 import { selectTokenList, selectOnChainSigning, TOKEN_LISTS } from '@/store/settingsSlice'
 import { TxModalContext } from '@/components/tx-flow'
-import SafeAppsTxFlow from '@/components/tx-flow/flows/SafeAppsTx'
-import SignMessageFlow from '@/components/tx-flow/flows/SignMessage'
-import SignMessageOnChainFlow from '@/components/tx-flow/flows/SignMessageOnChain'
 
 const UNKNOWN_APP_NAME = 'Unknown Safe App'
 
@@ -114,7 +111,7 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement 
       }
 
       setCurrentRequestId(requestId)
-      setTxFlow(<SafeAppsTxFlow data={data} />, onTxFlowClose)
+      setTxFlow({ component: 'SafeAppsTxFlow', props: { data } }, onTxFlowClose)
     },
     onSignMessage: (
       message: string | EIP712TypedData,
@@ -129,27 +126,29 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement 
 
       if (signOffChain) {
         setTxFlow(
-          <SignMessageFlow
-            logoUri={safeAppFromManifest?.iconUrl || ''}
-            name={safeAppFromManifest?.name || ''}
-            message={message}
-            safeAppId={remoteApp?.id}
-            requestId={requestId}
-          />,
+          {
+            component: 'SignMessageFlow',
+            props: {
+              logoUri: safeAppFromManifest?.iconUrl || '',
+              name: safeAppFromManifest?.name || '',
+              message,
+              safeAppId: remoteApp?.id,
+              requestId,
+            },
+          },
           onTxFlowClose,
         )
       } else {
-        setTxFlow(
-          <SignMessageOnChainFlow
-            props={{
-              app: safeAppFromManifest,
-              appId: remoteApp?.id,
-              requestId,
-              message,
-              method,
-            }}
-          />,
-        )
+        setTxFlow({
+          component: 'SignMessageOnChainFlow',
+          props: {
+            app: safeAppFromManifest,
+            appId: remoteApp?.id,
+            requestId,
+            message,
+            method,
+          },
+        })
       }
     },
     onGetPermissions: getPermissions,

--- a/src/components/safe-messages/SignMsgButton/index.tsx
+++ b/src/components/safe-messages/SignMsgButton/index.tsx
@@ -10,7 +10,6 @@ import { MESSAGE_EVENTS } from '@/services/analytics/events/txList'
 import useIsSafeMessageSignableBy from '@/hooks/messages/useIsSafeMessageSignableBy'
 import useIsSafeMessagePending from '@/hooks/messages/useIsSafeMessagePending'
 import { TxModalContext } from '@/components/tx-flow'
-import SignMessageFlow from '@/components/tx-flow/flows/SignMessage'
 
 const SignMsgButton = ({ msg, compact = false }: { msg: SafeMessage; compact?: boolean }): ReactElement => {
   const wallet = useWallet()
@@ -20,7 +19,7 @@ const SignMsgButton = ({ msg, compact = false }: { msg: SafeMessage; compact?: b
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()
-    setTxFlow(<SignMessageFlow {...msg} />)
+    setTxFlow({ component: 'SignMessageFlow', props: msg })
   }
 
   const isDisabled = !isSignable || isPending

--- a/src/components/settings/ContractVersion/index.tsx
+++ b/src/components/settings/ContractVersion/index.tsx
@@ -9,7 +9,6 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import InfoIcon from '@/public/images/notifications/info.svg'
 import { TxModalContext } from '@/components/tx-flow'
-import UpdateSafeFlow from '@/components/tx-flow/flows/UpdateSafe'
 import ExternalLink from '@/components/common/ExternalLink'
 import CheckWallet from '@/components/common/CheckWallet'
 
@@ -52,7 +51,11 @@ export const ContractVersion = () => {
 
               <CheckWallet>
                 {(isOk) => (
-                  <Button onClick={() => setTxFlow(<UpdateSafeFlow />)} variant="contained" disabled={!isOk}>
+                  <Button
+                    onClick={() => setTxFlow({ component: 'UpdateSafeFlow' })}
+                    variant="contained"
+                    disabled={!isOk}
+                  >
                     Update
                   </Button>
                 )}

--- a/src/components/settings/RequiredConfirmations/index.tsx
+++ b/src/components/settings/RequiredConfirmations/index.tsx
@@ -1,7 +1,6 @@
 import { Box, Button, Grid, Typography } from '@mui/material'
 import Track from '@/components/common/Track'
 import { SETTINGS_EVENTS } from '@/services/analytics'
-import ChangeThresholdFlow from '@/components/tx-flow/flows/ChangeThreshold'
 import CheckWallet from '@/components/common/CheckWallet'
 import { useContext } from 'react'
 import { TxModalContext } from '@/components/tx-flow'
@@ -29,7 +28,11 @@ export const RequiredConfirmation = ({ threshold, owners }: { threshold: number;
               <CheckWallet>
                 {(isOk) => (
                   <Track {...SETTINGS_EVENTS.SETUP.CHANGE_THRESHOLD}>
-                    <Button onClick={() => setTxFlow(<ChangeThresholdFlow />)} variant="contained" disabled={!isOk}>
+                    <Button
+                      onClick={() => setTxFlow({ component: 'ChangeThresholdFlow' })}
+                      variant="contained"
+                      disabled={!isOk}
+                    >
                       Change
                     </Button>
                   </Track>

--- a/src/components/settings/SafeModules/index.tsx
+++ b/src/components/settings/SafeModules/index.tsx
@@ -4,7 +4,6 @@ import { Paper, Grid, Typography, Box, IconButton, SvgIcon } from '@mui/material
 
 import css from './styles.module.css'
 import ExternalLink from '@/components/common/ExternalLink'
-import RemoveModuleFlow from '@/components/tx-flow/flows/RemoveModule'
 import DeleteIcon from '@/public/images/common/delete.svg'
 import CheckWallet from '@/components/common/CheckWallet'
 import { useContext } from 'react'
@@ -34,7 +33,7 @@ const ModuleDisplay = ({ moduleAddress, chainId, name }: { moduleAddress: string
       <CheckWallet>
         {(isOk) => (
           <IconButton
-            onClick={() => setTxFlow(<RemoveModuleFlow address={moduleAddress} />)}
+            onClick={() => setTxFlow({ component: 'RemoveModuleFlow', props: { address: moduleAddress } })}
             color="error"
             size="small"
             disabled={!isOk}

--- a/src/components/settings/SpendingLimits/SpendingLimitsTable.tsx
+++ b/src/components/settings/SpendingLimits/SpendingLimitsTable.tsx
@@ -7,7 +7,6 @@ import EthHashInfo from '@/components/common/EthHashInfo'
 import { useContext, useMemo } from 'react'
 import type { SpendingLimitState } from '@/store/spendingLimitsSlice'
 import { BigNumber } from '@ethersproject/bignumber'
-import RemoveSpendingLimitFlow from '@/components/tx-flow/flows/RemoveSpendingLimit'
 import { TxModalContext } from '@/components/tx-flow'
 import Track from '@/components/common/Track'
 import { SETTINGS_EVENTS } from '@/services/analytics/events/settings'
@@ -121,7 +120,9 @@ export const SpendingLimitsTable = ({
                       {(isOk) => (
                         <Track {...SETTINGS_EVENTS.SPENDING_LIMIT.REMOVE_LIMIT}>
                           <IconButton
-                            onClick={() => setTxFlow(<RemoveSpendingLimitFlow spendingLimit={spendingLimit} />)}
+                            onClick={() =>
+                              setTxFlow({ component: 'RemoveSpendingLimitFlow', props: { spendingLimit } })
+                            }
                             color="error"
                             size="small"
                             disabled={!isOk}

--- a/src/components/settings/SpendingLimits/index.tsx
+++ b/src/components/settings/SpendingLimits/index.tsx
@@ -6,7 +6,6 @@ import { useSelector } from 'react-redux'
 import { selectSpendingLimits, selectSpendingLimitsLoading } from '@/store/spendingLimitsSlice'
 import { FEATURES } from '@/utils/chains'
 import { useHasFeature } from '@/hooks/useChains'
-import NewSpendingLimitFlow from '@/components/tx-flow/flows/NewSpendingLimit'
 import { SETTINGS_EVENTS } from '@/services/analytics'
 import CheckWallet from '@/components/common/CheckWallet'
 import Track from '@/components/common/Track'
@@ -39,7 +38,7 @@ const SpendingLimits = () => {
                 {(isOk) => (
                   <Track {...SETTINGS_EVENTS.SPENDING_LIMIT.NEW_LIMIT}>
                     <Button
-                      onClick={() => setTxFlow(<NewSpendingLimitFlow />)}
+                      onClick={() => setTxFlow({ component: 'NewSpendingLimitFlow' })}
                       sx={{ mt: 2 }}
                       variant="contained"
                       disabled={!isOk}

--- a/src/components/settings/TransactionGuards/index.tsx
+++ b/src/components/settings/TransactionGuards/index.tsx
@@ -11,7 +11,6 @@ import DeleteIcon from '@/public/images/common/delete.svg'
 import CheckWallet from '@/components/common/CheckWallet'
 import { useContext } from 'react'
 import { TxModalContext } from '@/components/tx-flow'
-import RemoveGuardFlow from '@/components/tx-flow/flows/RemoveGuard'
 
 const NoTransactionGuard = () => {
   return (
@@ -30,7 +29,7 @@ const GuardDisplay = ({ guardAddress, chainId }: { guardAddress: string; chainId
       <CheckWallet>
         {(isOk) => (
           <IconButton
-            onClick={() => setTxFlow(<RemoveGuardFlow address={guardAddress} />)}
+            onClick={() => setTxFlow({ component: 'RemoveGuardFlow', props: { address: guardAddress } })}
             color="error"
             size="small"
             disabled={!isOk}

--- a/src/components/settings/owner/OwnerList/index.tsx
+++ b/src/components/settings/owner/OwnerList/index.tsx
@@ -1,12 +1,9 @@
 import EthHashInfo from '@/components/common/EthHashInfo'
-import AddOwnerFlow from '@/components/tx-flow/flows/AddOwner'
 import useAddressBook from '@/hooks/useAddressBook'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { Box, Grid, Typography, Button, SvgIcon, Tooltip, IconButton } from '@mui/material'
 import { useContext, useMemo } from 'react'
 import { EditOwnerDialog } from '../EditOwnerDialog'
-import ReplaceOwnerFlow from '@/components/tx-flow/flows/ReplaceOwner'
-import RemoveOwnerFlow from '@/components/tx-flow/flows/RemoveOwner'
 import EnhancedTable from '@/components/common/EnhancedTable'
 import AddIcon from '@/public/images/common/add.svg'
 import Track from '@/components/common/Track'
@@ -51,7 +48,7 @@ export const OwnerList = () => {
                     <Track {...SETTINGS_EVENTS.SETUP.REPLACE_OWNER}>
                       <Tooltip title="Replace owner">
                         <IconButton
-                          onClick={() => setTxFlow(<ReplaceOwnerFlow address={address} />)}
+                          onClick={() => setTxFlow({ component: 'ReplaceOwnerFlow', props: { address } })}
                           size="small"
                           disabled={!isOk}
                         >
@@ -70,7 +67,7 @@ export const OwnerList = () => {
                       <Track {...SETTINGS_EVENTS.SETUP.REMOVE_OWNER}>
                         <Tooltip title="Remove owner">
                           <IconButton
-                            onClick={() => setTxFlow(<RemoveOwnerFlow name={name} address={address} />)}
+                            onClick={() => setTxFlow({ component: 'RemoveOwnerFlow', props: { name, address } })}
                             size="small"
                             disabled={!isOk}
                           >
@@ -111,7 +108,7 @@ export const OwnerList = () => {
               {(isOk) => (
                 <Track {...SETTINGS_EVENTS.SETUP.ADD_OWNER}>
                   <Button
-                    onClick={() => setTxFlow(<AddOwnerFlow />)}
+                    onClick={() => setTxFlow({ component: 'AddOwnerFlow' })}
                     variant="text"
                     startIcon={<SvgIcon component={AddIcon} inheritViewBox fontSize="small" />}
                     disabled={!isOk}

--- a/src/components/sidebar/NewTxButton/index.tsx
+++ b/src/components/sidebar/NewTxButton/index.tsx
@@ -4,13 +4,12 @@ import css from './styles.module.css'
 import { OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
 import CheckWallet from '@/components/common/CheckWallet'
 import { TxModalContext } from '@/components/tx-flow'
-import NewTxMenu from '@/components/tx-flow/flows/NewTx'
 
 const NewTxButton = (): ReactElement => {
   const { setTxFlow } = useContext(TxModalContext)
 
   const onClick = () => {
-    setTxFlow(<NewTxMenu />, undefined, false)
+    setTxFlow({ component: 'NewTxMenu' }, undefined, false)
     trackEvent(OVERVIEW_EVENTS.NEW_TRANSACTION)
   }
 

--- a/src/components/transactions/BatchExecuteButton/index.tsx
+++ b/src/components/transactions/BatchExecuteButton/index.tsx
@@ -4,7 +4,6 @@ import { BatchExecuteHoverContext } from '@/components/transactions/BatchExecute
 import { useAppSelector } from '@/store'
 import { selectPendingTxs } from '@/store/pendingTxsSlice'
 import useBatchedTxs from '@/hooks/useBatchedTxs'
-import ExecuteBatchFlow from '@/components/tx-flow/flows/ExecuteBatch'
 import { trackEvent } from '@/services/analytics'
 import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
 import useWallet from '@/hooks/wallets/useWallet'
@@ -37,7 +36,7 @@ const BatchExecuteButton = () => {
       label: batchableTransactions.length,
     })
 
-    setTxFlow(<ExecuteBatchFlow txs={batchableTransactions} />)
+    setTxFlow({ component: 'ExecuteBatchFlow', props: { txs: batchableTransactions } })
   }
 
   return (

--- a/src/components/transactions/ExecuteTxButton/index.tsx
+++ b/src/components/transactions/ExecuteTxButton/index.tsx
@@ -15,7 +15,6 @@ import CheckWallet from '@/components/common/CheckWallet'
 import { useSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 import { getTxButtonTooltip } from '@/components/transactions/utils'
 import { TxModalContext } from '@/components/tx-flow'
-import ConfirmTxFlow from '@/components/tx-flow/flows/ConfirmTx'
 
 const ExecuteTxButton = ({
   txSummary,
@@ -38,7 +37,7 @@ const ExecuteTxButton = ({
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()
-    setTxFlow(<ConfirmTxFlow txSummary={txSummary} />)
+    setTxFlow({ component: 'ConfirmTxFlow', props: { txSummary } })
   }
 
   const onMouseEnter = () => {

--- a/src/components/transactions/RejectTxButton/index.tsx
+++ b/src/components/transactions/RejectTxButton/index.tsx
@@ -13,7 +13,6 @@ import CheckWallet from '@/components/common/CheckWallet'
 import { useSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 import { getTxButtonTooltip } from '@/components/transactions/utils'
 import { TxModalContext } from '@/components/tx-flow'
-import ReplaceTxMenu from '@/components/tx-flow/flows/ReplaceTx'
 
 const RejectTxButton = ({
   txSummary,
@@ -33,7 +32,7 @@ const RejectTxButton = ({
 
   const openReplacementModal = () => {
     if (!txNonce) return
-    setTxFlow(<ReplaceTxMenu txNonce={txNonce} />)
+    setTxFlow({ component: 'ReplaceTxMenu', props: { txNonce } })
   }
 
   return (

--- a/src/components/transactions/SignTxButton/index.tsx
+++ b/src/components/transactions/SignTxButton/index.tsx
@@ -14,7 +14,6 @@ import CheckWallet from '@/components/common/CheckWallet'
 import { useSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 import { getTxButtonTooltip } from '@/components/transactions/utils'
 import { TxModalContext } from '@/components/tx-flow'
-import ConfirmTxFlow from '@/components/tx-flow/flows/ConfirmTx'
 
 const SignTxButton = ({
   txSummary,
@@ -35,7 +34,7 @@ const SignTxButton = ({
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()
-    setTxFlow(<ConfirmTxFlow txSummary={txSummary} />)
+    setTxFlow({ component: 'ConfirmTxFlow', props: { txSummary } })
   }
 
   return (

--- a/src/components/transactions/TxDetails/TxData/Transfer/TransferActions.tsx
+++ b/src/components/transactions/TxDetails/TxData/Transfer/TransferActions.tsx
@@ -8,7 +8,6 @@ import ListItemText from '@mui/material/ListItemText'
 import useAddressBook from '@/hooks/useAddressBook'
 import EntryDialog from '@/components/address-book/EntryDialog'
 import ContextMenu from '@/components/common/ContextMenu'
-import TokenTransferFlow from '@/components/tx-flow/flows/TokenTransfer'
 import type { Transfer } from '@safe-global/safe-gateway-typescript-sdk'
 import { TransferDirection } from '@safe-global/safe-gateway-typescript-sdk'
 import { ZERO_ADDRESS } from '@safe-global/safe-core-sdk/dist/src/utils/constants'
@@ -80,7 +79,14 @@ const TransferActions = ({ address, txInfo }: { address: string; txInfo: Transfe
               <MenuItem
                 onClick={() => {
                   handleCloseContextMenu()
-                  setTxFlow(<TokenTransferFlow recipient={recipient} tokenAddress={tokenAddress} amount={amount} />)
+                  setTxFlow({
+                    component: 'TokenTransferFlow',
+                    props: {
+                      recipient,
+                      tokenAddress,
+                      amount,
+                    },
+                  })
                 }}
                 disabled={!isOk}
               >

--- a/src/components/tx-flow/flows/NewTx/index.tsx
+++ b/src/components/tx-flow/flows/NewTx/index.tsx
@@ -2,7 +2,6 @@ import { useCallback, useContext } from 'react'
 import { SendNFTsButton, SendTokensButton, TxBuilderButton } from '@/components/tx-flow/common/TxButton'
 import { Container, Grid, Paper, SvgIcon, Typography } from '@mui/material'
 import { TxModalContext } from '../../'
-import TokenTransferFlow from '../TokenTransfer'
 import AssetsIcon from '@/public/images/sidebar/assets.svg'
 import LoadingSpinner, { SpinnerStatus } from '@/components/new-safe/create/steps/StatusStep/LoadingSpinner'
 import { useTxBuilderApp } from '@/hooks/safe-apps/useTxBuilderApp'
@@ -17,7 +16,7 @@ const NewTxMenu = () => {
   const { setTxFlow } = useContext(TxModalContext)
 
   const onTokensClick = useCallback(() => {
-    setTxFlow(<TokenTransferFlow />)
+    setTxFlow({ component: 'TokenTransferFlow' })
   }, [setTxFlow])
 
   const progress = 10

--- a/src/components/tx-flow/flows/ReplaceTx/index.tsx
+++ b/src/components/tx-flow/flows/ReplaceTx/index.tsx
@@ -9,8 +9,6 @@ import { isCustomTxInfo } from '@/utils/transaction-guards'
 import css from './styles.module.css'
 import { useContext } from 'react'
 import { TxModalContext } from '../..'
-import TokenTransferFlow from '../TokenTransfer'
-import RejectTx from '../RejectTx'
 import TxLayout from '@/components/tx-flow/common/TxLayout'
 import TxCard from '@/components/tx-flow/common/TxCard'
 
@@ -67,7 +65,10 @@ const ReplaceTxMenu = ({ txNonce }: { txNonce: number }) => {
 
         <div className={css.buttons}>
           <div>
-            <SendTokensButton onClick={() => setTxFlow(<TokenTransferFlow txNonce={txNonce} />)} sx={btnWidth} />
+            <SendTokensButton
+              onClick={() => setTxFlow({ component: 'TokenTransferFlow', props: { txNonce } })}
+              sx={btnWidth}
+            />
           </div>
 
           <Typography variant="body2" className={css.or}>
@@ -82,7 +83,7 @@ const ReplaceTxMenu = ({ txNonce }: { txNonce: number }) => {
             >
               <span style={{ width: '100%' }}>
                 <Button
-                  onClick={() => setTxFlow(<RejectTx txNonce={txNonce} />)}
+                  onClick={() => setTxFlow({ component: 'RejectTx', props: { txNonce } })}
                   variant="outlined"
                   fullWidth
                   sx={btnWidth}

--- a/src/components/tx-flow/index.tsx
+++ b/src/components/tx-flow/index.tsx
@@ -76,7 +76,7 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
     })
     dispatch(clearNewTx(pathname))
     setQueryParam(undefined)
-  }, [dispatch, pathname, setQueryParam, setOnClose, setQueryParam])
+  }, [dispatch, pathname, setOnClose, setQueryParam])
 
   const handleShowWarning = useCallback(() => {
     if (!shouldWarn) {
@@ -100,7 +100,7 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
       setOnClose(() => onClose ?? noop)
       setShouldWarn(shouldWarn ?? true)
     },
-    [dispatch, router, pathname, setOnClose, setQueryParam],
+    [dispatch, pathname, setOnClose, setQueryParam],
   )
 
   // Show the confirmation dialog if user navigates

--- a/src/components/tx-flow/index.tsx
+++ b/src/components/tx-flow/index.tsx
@@ -1,37 +1,60 @@
-import { createContext, type ReactElement, type ReactNode, useState, useEffect, useCallback } from 'react'
+import { createContext, type ReactElement, type ReactNode, useState, useEffect, useCallback, type ComponentProps } from 'react'
 import { useRouter } from 'next/router'
 import TxModalDialog from '@/components/common/TxModalDialog'
 import { useAppDispatch, useAppSelector } from '@/store'
 import { selectNewTxById, setNewTx, clearNewTx } from '@/store/newTxsSlice'
 
+// All flows
+import NewTxMenu from '@/components/tx-flow/flows/NewTx'
+import RemoveModuleFlow from '@/components/tx-flow/flows/RemoveModule'
+import RemoveGuardFlow from '@/components/tx-flow/flows/RemoveGuard'
+import ReplaceOwnerFlow from '@/components/tx-flow/flows/ReplaceOwner'
+import RemoveOwnerFlow from '@/components/tx-flow/flows/RemoveOwner'
+import AddOwnerFlow from '@/components/tx-flow/flows/AddOwner'
+import UpdateSafeFlow from '@/components/tx-flow/flows/UpdateSafe'
+import NewSpendingLimitFlow from '@/components/tx-flow/flows/NewSpendingLimit'
+import RemoveSpendingLimitFlow from '@/components/tx-flow/flows/RemoveSpendingLimit'
+import ChangeThresholdFlow from '@/components/tx-flow/flows/ChangeThreshold'
+import TokenTransferFlow from '@/components/tx-flow/flows/TokenTransfer'
+import RejectTx from '@/components/tx-flow/flows/RejectTx'
+import SuccessScreen from '@/components/tx-flow/flows/SuccessScreen'
+import SafeAppsTxFlow from '@/components/tx-flow/flows/SafeAppsTx'
+import SignMessageFlow from '@/components/tx-flow/flows/SignMessage'
+import SignMessageOnChainFlow from '@/components/tx-flow/flows/SignMessageOnChain'
+import ExecuteBatchFlow from '@/components/tx-flow/flows/ExecuteBatch'
+import ConfirmTxFlow from '@/components/tx-flow/flows/ConfirmTx'
+import ReplaceTxMenu from '@/components/tx-flow/flows/ReplaceTx'
+import NftTransferFlow from '@/components/tx-flow/flows/NftTransfer'
+
+
 const Flows = {
-  NewTxMenu: require('@/components/tx-flow/flows/NewTx').default,
-  RemoveModuleFlow: require('@/components/tx-flow/flows/RemoveModule').default,
-  RemoveGuardFlow: require('@/components/tx-flow/flows/RemoveGuard').default,
-  ReplaceOwnerFlow: require('@/components/tx-flow/flows/ReplaceOwner').default,
-  RemoveOwnerFlow: require('@/components/tx-flow/flows/RemoveOwner').default,
-  AddOwnerFlow: require('@/components/tx-flow/flows/AddOwner').default,
-  UpdateSafeFlow: require('@/components/tx-flow/flows/UpdateSafe').default,
-  NewSpendingLimitFlow: require('@/components/tx-flow/flows/NewSpendingLimit').default,
-  RemoveSpendingLimitFlow: require('@/components/tx-flow/flows/RemoveSpendingLimit').default,
-  ChangeThresholdFlow: require('@/components/tx-flow/flows/ChangeThreshold').default,
-  TokenTransferFlow: require('@/components/tx-flow/flows/TokenTransfer').default,
-  RejectTx: require('@/components/tx-flow/flows/RejectTx').default,
-  SuccessScreen: require('@/components/tx-flow/flows/SuccessScreen').default,
-  SafeAppsTxFlow: require('@/components/tx-flow/flows/SafeAppsTx').default,
-  SignMessageFlow: require('@/components/tx-flow/flows/SignMessage').default,
-  SignMessageOnChainFlow: require('@/components/tx-flow/flows/SignMessageOnChain').default,
-  ExecuteBatchFlow: require('@/components/tx-flow/flows/ExecuteBatch').default,
-  ConfirmTxFlow: require('@/components/tx-flow/flows/ConfirmTx').default,
-  ReplaceTxMenu: require('@/components/tx-flow/flows/ReplaceTx').default,
-  NftTransferFlow: require('@/components/tx-flow/flows/NftTransfer').default,
+  NewTxMenu,
+  RemoveModuleFlow,
+  RemoveGuardFlow,
+  ReplaceOwnerFlow,
+  RemoveOwnerFlow,
+  AddOwnerFlow,
+  UpdateSafeFlow,
+  NewSpendingLimitFlow,
+  RemoveSpendingLimitFlow,
+  ChangeThresholdFlow,
+  TokenTransferFlow,
+  RejectTx,
+  SuccessScreen,
+  SafeAppsTxFlow,
+  SignMessageFlow,
+  SignMessageOnChainFlow,
+  ExecuteBatchFlow,
+  ConfirmTxFlow,
+  ReplaceTxMenu,
+  NftTransferFlow,
 }
 
 const noop = () => {}
 
-export type TxFlow = {
-  component: keyof typeof Flows
-  props?: any
+export type TxFlow<T extends keyof typeof Flows> = {
+  component: T
+  props?: ComponentProps<typeof Flows[T]>
 }
 
 type TxModalContextType = {

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -16,7 +16,6 @@ import { hasRemainingRelays } from '@/utils/relaying'
 import type { SignOrExecuteProps } from '.'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { TxModalContext } from '@/components/tx-flow'
-import { SuccessScreen } from '@/components/tx-flow/flows/SuccessScreen'
 import useGasLimit from '@/hooks/useGasLimit'
 import AdvancedParams, { useAdvancedParams } from '../AdvancedParams'
 import { asError } from '@/services/exceptions/utils'
@@ -83,7 +82,7 @@ const ExecuteForm = ({
 
     try {
       const executedTxId = await executeTx(txOptions, safeTx, txId, origin, willRelay)
-      setTxFlow(<SuccessScreen txId={executedTxId} />, undefined, false)
+      setTxFlow({ component: 'SuccessScreen', props: { txId: executedTxId } }, undefined, false)
     } catch (_err) {
       const err = asError(_err)
       logError(Errors._804, err)

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -20,6 +20,7 @@ import { addressBookSlice } from './addressBookSlice'
 import { notificationsSlice } from './notificationsSlice'
 import { getPreloadedState, persistState } from './persistStore'
 import { pendingTxsSlice } from './pendingTxsSlice'
+import { newTxsSlice } from './newTxsSlice'
 import { addedSafesListener, addedSafesSlice } from './addedSafesSlice'
 import { settingsSlice } from './settingsSlice'
 import { cookiesSlice } from './cookiesSlice'
@@ -39,6 +40,7 @@ const rootReducer = combineReducers({
   [addressBookSlice.name]: addressBookSlice.reducer,
   [notificationsSlice.name]: notificationsSlice.reducer,
   [pendingTxsSlice.name]: pendingTxsSlice.reducer,
+  [newTxsSlice.name]: newTxsSlice.reducer,
   [addedSafesSlice.name]: addedSafesSlice.reducer,
   [settingsSlice.name]: settingsSlice.reducer,
   [cookiesSlice.name]: cookiesSlice.reducer,
@@ -53,6 +55,7 @@ const persistedSlices: (keyof PreloadedState<RootState>)[] = [
   sessionSlice.name,
   addressBookSlice.name,
   pendingTxsSlice.name,
+  newTxsSlice.name,
   addedSafesSlice.name,
   settingsSlice.name,
   cookiesSlice.name,

--- a/src/store/newTxsSlice.ts
+++ b/src/store/newTxsSlice.ts
@@ -1,0 +1,33 @@
+import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { RootState } from '@/store'
+import type { TxFlow } from '@/components/tx-flow'
+
+export type NewTxsState = {
+  [id: string]: TxFlow
+}
+
+const initialState: NewTxsState = {}
+
+export const newTxsSlice = createSlice({
+  name: 'newTxs',
+  initialState,
+  reducers: {
+    setNewTx: (state, action: PayloadAction<{ id: string; txFlow: TxFlow }>) => {
+      state[action.payload.id] = action.payload.txFlow
+    },
+    clearNewTx: (state, action: PayloadAction<string>) => {
+      delete state[action.payload]
+    },
+  },
+})
+
+export const { setNewTx, clearNewTx } = newTxsSlice.actions
+
+const selectNewTxs = (state: RootState): NewTxsState => {
+  return state[newTxsSlice.name]
+}
+
+export const selectNewTxById = createSelector(
+  [selectNewTxs, (_: RootState, id: string) => id],
+  (newTxs, id) => newTxs[id],
+)


### PR DESCRIPTION
When you open a new tx modal and reload the page, the popup will reappear.

It doesn't save the internal state, however, only the external props.

It also changes the URL to have a `tx=true` query param which makes the Back button close the modal.