### PR TITLE
fix: use the deployment by `chainId`

### DIFF
--- a/src/components/settings/FallbackHandler/__tests__/index.test.tsx
+++ b/src/components/settings/FallbackHandler/__tests__/index.test.tsx
@@ -45,6 +45,43 @@ describe('FallbackHandler', () => {
     })
   })
 
+  it('should render the Fallback Handler without warning when one that is not a default address is set', async () => {
+    const OPTIMISM_FALLBACK_HANDLER = '0x69f4D1788e39c87893C980c06EdF4b7f686e2938'
+
+    // Optimism is not a "default" address
+    expect(OPTIMISM_FALLBACK_HANDLER).not.toBe(GOERLI_FALLBACK_HANDLER)
+
+    jest.spyOn(useSafeInfoHook, 'default').mockImplementation(
+      () =>
+        ({
+          safe: {
+            version: '1.3.0',
+            chainId: '10',
+            fallbackHandler: {
+              value: OPTIMISM_FALLBACK_HANDLER,
+              name: 'FallbackHandlerName',
+            },
+          },
+        } as unknown as ReturnType<typeof useSafeInfoHook.default>),
+    )
+
+    const fbHandler = render(<FallbackHandler />)
+
+    await waitFor(() => {
+      expect(
+        fbHandler.queryByText(
+          'The fallback handler adds fallback logic for funtionality that may not be present in the Safe contract. Learn more about the fallback handler',
+        ),
+      ).toBeDefined()
+
+      expect(fbHandler.getByText(OPTIMISM_FALLBACK_HANDLER)).toBeDefined()
+
+      expect(fbHandler.getByText('FallbackHandlerName')).toBeDefined()
+
+      expect(fbHandler.queryByText('An unofficial fallback handler is currently set.')).not.toBeInTheDocument()
+    })
+  })
+
   it('should use the official deployment name if the address is official but no known name is present', async () => {
     jest.spyOn(useSafeInfoHook, 'default').mockImplementation(
       () =>

--- a/src/components/settings/FallbackHandler/index.tsx
+++ b/src/components/settings/FallbackHandler/index.tsx
@@ -33,7 +33,8 @@ export const FallbackHandler = (): ReactElement | null => {
     return null
   }
 
-  const isOfficial = !!safe.fallbackHandler && safe.fallbackHandler.value === fallbackHandlerDeployment?.defaultAddress
+  const isOfficial =
+    !!safe.fallbackHandler && safe.fallbackHandler.value === fallbackHandlerDeployment?.networkAddresses[safe.chainId]
 
   const tooltip = !safe.fallbackHandler ? (
     <>

--- a/src/hooks/coreSDK/safeCoreSDK.ts
+++ b/src/hooks/coreSDK/safeCoreSDK.ts
@@ -76,8 +76,8 @@ export const initSafeSDK = async ({
     const safeL1Deployment = getSafeSingletonDeployment({ network: chainId, version: safeVersion })
     const safeL2Deployment = getSafeL2SingletonDeployment({ network: chainId, version: safeVersion })
 
-    isL1SafeMasterCopy = masterCopy === safeL1Deployment?.defaultAddress
-    const isL2SafeMasterCopy = masterCopy === safeL2Deployment?.defaultAddress
+    isL1SafeMasterCopy = masterCopy === safeL1Deployment?.networkAddresses[chainId]
+    const isL2SafeMasterCopy = masterCopy === safeL2Deployment?.networkAddresses[chainId]
 
     // Unknown deployment, which we do not want to support
     if (!isL1SafeMasterCopy && !isL2SafeMasterCopy) {

--- a/src/services/security/modules/DelegateCallModule/index.ts
+++ b/src/services/security/modules/DelegateCallModule/index.ts
@@ -30,7 +30,7 @@ export class DelegateCallModule implements SecurityModule<DelegateCallModuleRequ
     // We need not check for nested delegate calls as we only use MultiSendCallOnly in the UI
     const multiSendDeployment = getMultiSendCallOnlyDeployment({ network: chainId, version: safeVersion ?? undefined })
 
-    return multiSendDeployment?.defaultAddress !== safeTransaction.data.to
+    return multiSendDeployment?.networkAddresses[chainId] !== safeTransaction.data.to
   }
 
   async scanTransaction(request: DelegateCallModuleRequest): Promise<SecurityResponse<DelegateCallModuleResponse>> {


### PR DESCRIPTION
## What it solves

Fallback handler/unsupported mastercopy warnings on non-default addressed chains

## How this PR fixes it

The deployment address of the current chain is no longer assumed to be ["default"](https://github.com/safe-global/safe-deployments/blob/main/src/assets/v1.3.0/gnosis_safe.json#L2), but is instead [referenced by `chainId`](https://github.com/safe-global/safe-deployments/blob/main/src/assets/v1.3.0/gnosis_safe.json#L7).

All instances of `defaultAddress` have been chanced to `networkAddresses[chainId]`.

## How to test it

- Open a non-supported mastercopy and observe the warning, as well as no warning on official deployments.
- Open a Safe with a fallback handler (of non-default address) set and observe no warning in the settings that it is unofficial. When an unofficial on is set, however, it should still warn.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
