### PR TITLE
fix: Adjust z-index of new flow

### DIFF
--- a/src/components/common/PageLayout/styles.module.css
+++ b/src/components/common/PageLayout/styles.module.css
@@ -37,7 +37,7 @@
 
 .sidebarTogglePosition {
   position: fixed;
-  z-index: 2;
+  z-index: 4;
   left: 0;
   top: 0;
   /* mimics MUI drawer animation */

--- a/src/components/common/TxModalDialog/styles.module.css
+++ b/src/components/common/TxModalDialog/styles.module.css
@@ -1,7 +1,7 @@
 .dialog {
   top: 52px;
   left: 230px;
-  z-index: 1;
+  z-index: 3;
   transition: left 225ms cubic-bezier(0, 0, 0.2, 1) 0ms;
 }
 


### PR DESCRIPTION
## What it solves

Part of #2067 

## How to test it

1. Open safe apps list
2. Press New transaction
3. There are no overlays from the list
4. Open a Safe app
5. Press New transaction
6. The sidebar expand button is visible

## Screenshots

<img width="1286" alt="Screenshot 2023-07-07 at 10 25 03" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/c57ceccf-5936-48b0-ab81-555ae04e6adb">
<img width="1331" alt="Screenshot 2023-07-07 at 10 25 17" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/5f8ea580-d6aa-4e80-afc9-13de99b8144e">


## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
