### PR TITLE
fix: remove threshold from swap owner modal

### DIFF
--- a/src/components/tx-flow/flows/AddOwner/ChooseOwner.tsx
+++ b/src/components/tx-flow/flows/AddOwner/ChooseOwner.tsx
@@ -30,12 +30,19 @@ import { TOOLTIP_TITLES } from '@/components/tx-flow/common/constants'
 
 type FormData = Pick<AddOwnerFlowProps | ReplaceOwnerFlowProps, 'newOwner' | 'threshold'>
 
+export enum ChooseOwnerMode {
+  REPLACE,
+  ADD,
+}
+
 export const ChooseOwner = ({
   params,
   onSubmit,
+  mode,
 }: {
   params: AddOwnerFlowProps | ReplaceOwnerFlowProps
   onSubmit: (data: FormData) => void
+  mode: ChooseOwnerMode
 }) => {
   const { safe, safeAddress } = useSafeInfo()
 
@@ -116,55 +123,57 @@ export const ChooseOwner = ({
 
           <Divider className={commonCss.nestedDivider} />
 
-          <FormControl fullWidth>
-            <Typography variant="h6" fontWeight={700} mt={3}>
-              Threshold
-              <Tooltip title={TOOLTIP_TITLES.THRESHOLD} arrow placement="top">
-                <span>
-                  <SvgIcon
-                    component={InfoIcon}
-                    inheritViewBox
-                    color="border"
-                    fontSize="small"
-                    sx={{
-                      verticalAlign: 'middle',
-                      ml: 0.5,
-                    }}
+          {mode === ChooseOwnerMode.ADD && (
+            <FormControl fullWidth>
+              <Typography variant="h6" fontWeight={700} mt={3}>
+                Threshold
+                <Tooltip title={TOOLTIP_TITLES.THRESHOLD} arrow placement="top">
+                  <span>
+                    <SvgIcon
+                      component={InfoIcon}
+                      inheritViewBox
+                      color="border"
+                      fontSize="small"
+                      sx={{
+                        verticalAlign: 'middle',
+                        ml: 0.5,
+                      }}
+                    />
+                  </span>
+                </Tooltip>
+              </Typography>
+
+              <Typography variant="body2" mb={1}>
+                Any transaction requires the confirmation of:
+              </Typography>
+
+              <Grid container direction="row" alignItems="center" gap={2} pt={1}>
+                <Grid item>
+                  <Controller
+                    control={control}
+                    name="threshold"
+                    render={({ field }) => (
+                      <TextField select {...field}>
+                        {safe.owners.map((_, idx) => (
+                          <MenuItem key={idx + 1} value={idx + 1}>
+                            {idx + 1}
+                          </MenuItem>
+                        ))}
+                        {!params.removedOwner && (
+                          <MenuItem key={newNumberOfOwners} value={newNumberOfOwners}>
+                            {newNumberOfOwners}
+                          </MenuItem>
+                        )}
+                      </TextField>
+                    )}
                   />
-                </span>
-              </Tooltip>
-            </Typography>
-
-            <Typography variant="body2" mb={1}>
-              Any transaction requires the confirmation of:
-            </Typography>
-
-            <Grid container direction="row" alignItems="center" gap={2} pt={1}>
-              <Grid item>
-                <Controller
-                  control={control}
-                  name="threshold"
-                  render={({ field }) => (
-                    <TextField select {...field}>
-                      {safe.owners.map((_, idx) => (
-                        <MenuItem key={idx + 1} value={idx + 1}>
-                          {idx + 1}
-                        </MenuItem>
-                      ))}
-                      {!params.removedOwner && (
-                        <MenuItem key={newNumberOfOwners} value={newNumberOfOwners}>
-                          {newNumberOfOwners}
-                        </MenuItem>
-                      )}
-                    </TextField>
-                  )}
-                />
+                </Grid>
+                <Grid item>
+                  <Typography>out of {newNumberOfOwners} owner(s)</Typography>
+                </Grid>
               </Grid>
-              <Grid item>
-                <Typography>out of {newNumberOfOwners} owner(s)</Typography>
-              </Grid>
-            </Grid>
-          </FormControl>
+            </FormControl>
+          )}
 
           <Divider className={commonCss.nestedDivider} />
 

--- a/src/components/tx-flow/flows/AddOwner/index.tsx
+++ b/src/components/tx-flow/flows/AddOwner/index.tsx
@@ -1,6 +1,6 @@
 import TxLayout from '@/components/tx-flow/common/TxLayout'
 import useTxStepper from '@/components/tx-flow/useTxStepper'
-import { ChooseOwner } from '@/components/tx-flow/flows/AddOwner/ChooseOwner'
+import { ChooseOwner, ChooseOwnerMode } from '@/components/tx-flow/flows/AddOwner/ChooseOwner'
 import { ReviewOwner } from '@/components/tx-flow/flows/AddOwner/ReviewOwner'
 import SaveAddressIcon from '@/public/images/common/save-address.svg'
 import useSafeInfo from '@/hooks/useSafeInfo'
@@ -30,7 +30,12 @@ const AddOwnerFlow = () => {
   const { data, step, nextStep, prevStep } = useTxStepper<AddOwnerFlowProps>(defaultValues)
 
   const steps = [
-    <ChooseOwner key={0} params={data} onSubmit={(formData) => nextStep({ ...data, ...formData })} />,
+    <ChooseOwner
+      key={0}
+      params={data}
+      onSubmit={(formData) => nextStep({ ...data, ...formData })}
+      mode={ChooseOwnerMode.ADD}
+    />,
     <ReviewOwner key={1} params={data} />,
   ]
 

--- a/src/components/tx-flow/flows/ReplaceOwner/index.tsx
+++ b/src/components/tx-flow/flows/ReplaceOwner/index.tsx
@@ -2,7 +2,7 @@ import TxLayout from '@/components/tx-flow/common/TxLayout'
 import useTxStepper from '@/components/tx-flow/useTxStepper'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { ReviewOwner } from '../AddOwner/ReviewOwner'
-import { ChooseOwner } from '../AddOwner/ChooseOwner'
+import { ChooseOwner, ChooseOwnerMode } from '../AddOwner/ChooseOwner'
 import SaveAddressIcon from '@/public/images/common/save-address.svg'
 
 type Owner = {
@@ -28,7 +28,12 @@ const ReplaceOwnerFlow = ({ address }: { address: string }) => {
   const { data, step, nextStep, prevStep } = useTxStepper<ReplaceOwnerFlowProps>(defaultValues)
 
   const steps = [
-    <ChooseOwner key={0} params={data} onSubmit={(formData) => nextStep({ ...data, ...formData })} />,
+    <ChooseOwner
+      key={0}
+      params={data}
+      onSubmit={(formData) => nextStep({ ...data, ...formData })}
+      mode={ChooseOwnerMode.REPLACE}
+    />,
     <ReviewOwner key={1} params={data} />,
   ]
 


### PR DESCRIPTION
## What it solves
It is not possible to change the threshold when swapping owners.

## How this PR fixes it
Removes nonce input from `ReplaceOwner` flow.

## How to test it
- Replace an owner
- Observe that there is no input for the nonce anymore

## Screenshots
![Screenshot 2023-07-07 at 17 23 36](https://github.com/safe-global/safe-wallet-web/assets/2670790/0a8df065-3aa3-4fcf-ac39-cb840aaa6817)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
