### PR TITLE
fix: update token price tooltip

### DIFF
--- a/src/components/balances/AssetsTable/index.tsx
+++ b/src/components/balances/AssetsTable/index.tsx
@@ -181,7 +181,11 @@ const AssetsTable = ({
                 <>
                   <FiatValue value={item.fiatBalance} />
                   {rawFiatValue === 0 && (
-                    <Tooltip title="Value may be zero due to missing token price information" placement="top" arrow>
+                    <Tooltip
+                      title="Provided values are indicative and we are unable to accommodate pricing requests for individual assets"
+                      placement="top"
+                      arrow
+                    >
                       <span>
                         <SvgIcon
                           component={InfoIcon}


### PR DESCRIPTION
## What it solves

Resolves #2252

## How this PR fixes it

This updates the token price tooltip for those with a fiat value of 0 to: "Provided values are indicative and we are unable to accommodate pricing requests for individual assets".

## How to test it

Hover over the warning next to a token that has a fiat value of 0 and observe the new tooltip title.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/dd65d486-8f84-4439-99b8-c6ad07dac379)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
