### PR TITLE
fix: Show recommended nonce in list

### DIFF
--- a/src/components/tx-flow/common/TxButton.tsx
+++ b/src/components/tx-flow/common/TxButton.tsx
@@ -7,29 +7,36 @@ import { AppRoutes } from '@/config/routes'
 import Track from '@/components/common/Track'
 import { MODALS_EVENTS } from '@/services/analytics'
 
-const TxButton = ({ sx, ...props }: ButtonProps) => (
-  <Button variant="contained" sx={{ '& svg path': { fill: 'currentColor' }, ...sx }} fullWidth {...props} />
-)
+const buttonSx = {
+  height: '58px',
+  '& svg path': { fill: 'currentColor' },
+}
 
-export const SendTokensButton = (props: ButtonProps) => (
-  <Track {...MODALS_EVENTS.SEND_FUNDS}>
-    <TxButton {...props}>Send tokens</TxButton>
-  </Track>
-)
+export const SendTokensButton = ({ onClick, sx }: { onClick: () => void; sx?: ButtonProps['sx'] }) => {
+  return (
+    <Track {...MODALS_EVENTS.SEND_FUNDS}>
+      <Button onClick={onClick} variant="contained" sx={sx ?? buttonSx} fullWidth>
+        Send tokens
+      </Button>
+    </Track>
+  )
+}
 
-export const SendNFTsButton = (props: ButtonProps) => {
+export const SendNFTsButton = () => {
   const router = useRouter()
 
   return (
     <Track {...MODALS_EVENTS.SEND_COLLECTIBLE}>
       <Link href={{ pathname: AppRoutes.balances.nfts, query: { safe: router.query.safe } }} passHref>
-        <TxButton {...props}>Send NFTs</TxButton>
+        <Button variant="contained" sx={buttonSx} fullWidth>
+          Send NFTs
+        </Button>
       </Link>
     </Track>
   )
 }
 
-export const TxBuilderButton = (props: ButtonProps) => {
+export const TxBuilderButton = () => {
   const txBuilder = useTxBuilderApp()
   if (!txBuilder?.app) return null
 
@@ -37,13 +44,11 @@ export const TxBuilderButton = (props: ButtonProps) => {
     <Track {...MODALS_EVENTS.CONTRACT_INTERACTION}>
       <Link href={txBuilder.link} passHref>
         <a style={{ width: '100%' }}>
-          <TxButton variant="outlined" {...props}>
+          <Button variant="outlined" sx={buttonSx} fullWidth>
             Transaction Builder
-          </TxButton>
+          </Button>
         </a>
       </Link>
     </Track>
   )
 }
-
-export default TxButton

--- a/src/components/tx-flow/flows/NewTx/index.tsx
+++ b/src/components/tx-flow/flows/NewTx/index.tsx
@@ -11,8 +11,6 @@ import NewTxIcon from '@/public/images/transactions/new-tx.svg'
 
 import css from './styles.module.css'
 
-const buttonSx = { height: '58px' }
-
 const NewTxMenu = () => {
   const txBuilder = useTxBuilderApp()
   const { setTxFlow } = useContext(TxModalContext)
@@ -50,9 +48,9 @@ const NewTxMenu = () => {
                 Assets
               </Typography>
 
-              <SendTokensButton onClick={onTokensClick} sx={buttonSx} />
+              <SendTokensButton onClick={onTokensClick} />
 
-              <SendNFTsButton sx={buttonSx} />
+              <SendNFTsButton />
 
               {txBuilder?.app && (
                 <>
@@ -61,7 +59,7 @@ const NewTxMenu = () => {
                     interaction
                   </Typography>
 
-                  <TxBuilderButton sx={buttonSx} />
+                  <TxBuilderButton />
                 </>
               )}
             </Grid>

--- a/src/components/tx-flow/flows/TokenTransfer/styles.module.css
+++ b/src/components/tx-flow/flows/TokenTransfer/styles.module.css
@@ -1,6 +1,5 @@
 .token {
   display: flex;
-  justify-content: center;
   align-items: center;
   gap: var(--space-1);
 }


### PR DESCRIPTION
## What it solves

Part of #2067 

## How this PR fixes it

- Shows the recommended nonce as an item in the autocomplete list
- Converts `nonce` and `recommendedNonce` to strings for the form component

### Other fixes

- Fixes a ref error resulting from `TxButton`

## How to test it

1. Open a Safe
2. Create a new transaction
3. Click into the nonce field
4. You should see the recommended nonce
5. The recommended nonce value should be highlighted in the list
6. Type in a different value
7. You should see the reset to recommended nonce button
8. Select the recommended nonce from the list
9. The reset button should disappear

## Screenshots

<img width="409" alt="Screenshot 2023-07-10 at 15 37 19" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/34d8cc0a-a778-46d1-b628-278c70d610f7">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
