### PR TITLE
fix: Disable submit button for non-owners

### DIFF
--- a/src/components/transactions/ExecuteTxButton/index.tsx
+++ b/src/components/transactions/ExecuteTxButton/index.tsx
@@ -38,7 +38,7 @@ const ExecuteTxButton = ({
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()
-    setTxFlow(<ConfirmTxFlow txSummary={txSummary} />)
+    setTxFlow(<ConfirmTxFlow txSummary={txSummary} />, undefined, false)
   }
 
   const onMouseEnter = () => {

--- a/src/components/transactions/SignTxButton/index.tsx
+++ b/src/components/transactions/SignTxButton/index.tsx
@@ -35,7 +35,7 @@ const SignTxButton = ({
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()
-    setTxFlow(<ConfirmTxFlow txSummary={txSummary} />)
+    setTxFlow(<ConfirmTxFlow txSummary={txSummary} />, undefined, false)
   }
 
   return (

--- a/src/components/tx-flow/flows/RejectTx/index.tsx
+++ b/src/components/tx-flow/flows/RejectTx/index.tsx
@@ -8,7 +8,7 @@ type RejectTxProps = {
 
 const RejectTxFlow = ({ txNonce }: RejectTxProps): ReactElement => {
   return (
-    <TxLayout title="Reject transaction" step={0}>
+    <TxLayout title="Confirm transaction" subtitle="Reject" step={0}>
       <RejectTx txNonce={txNonce} />
     </TxLayout>
   )

--- a/src/components/tx/SignOrExecuteForm/NonOwnerError.tsx
+++ b/src/components/tx/SignOrExecuteForm/NonOwnerError.tsx
@@ -1,0 +1,11 @@
+import ErrorMessage from '@/components/tx/ErrorMessage'
+
+const NonOwnerError = () => {
+  return (
+    <ErrorMessage>
+      You are currently not an owner of this Safe Account and won&apos;t be able to submit this transaction.
+    </ErrorMessage>
+  )
+}
+
+export default NonOwnerError

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -12,7 +12,7 @@ import { TxModalContext } from '@/components/tx-flow'
 import { asError } from '@/services/exceptions/utils'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
 import { TxSecurityContext } from '../security/shared/TxSecurityContext'
-import css from '@/components/tx/SignOrExecuteForm/styles.module.css'
+import NonOwnerError from '@/components/tx/SignOrExecuteForm/NonOwnerError'
 
 const SignForm = ({
   safeTx,
@@ -64,16 +64,11 @@ const SignForm = ({
 
   return (
     <form onSubmit={handleSubmit}>
-      {/* Error messages */}
-      {isSubmittable && cannotPropose ? (
-        <ErrorMessage className={css.errorWrapper}>
-          You are currently not an owner of this Safe Account and won&apos;t be able to submit this transaction.
-        </ErrorMessage>
+      {cannotPropose ? (
+        <NonOwnerError />
       ) : (
         submitError && (
-          <ErrorMessage error={submitError} className={css.errorWrapper}>
-            Error submitting the transaction. Please try again.
-          </ErrorMessage>
+          <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
         )
       )}
 

--- a/src/components/tx/SignOrExecuteForm/styles.module.css
+++ b/src/components/tx/SignOrExecuteForm/styles.module.css
@@ -31,6 +31,10 @@
   color: var(--color-secondary-dark);
 }
 
+.params {
+  margin-bottom: var(--space-2);
+}
+
 .noBottomBorderRadius :global(.MuiPaper-root) {
   border-bottom-left-radius: 0 !important;
   border-bottom-right-radius: 0 !important;
@@ -40,10 +44,6 @@
   margin-top: -1px;
   border-top-left-radius: 0 !important;
   border-top-right-radius: 0 !important;
-}
-
-.errorWrapper {
-  margin-top: var(--space-2) !important;
 }
 
 .mobileTxCheckMessages,


### PR DESCRIPTION
## What it solves

Part of #2067 

## How this PR fixes it

- Adds the non-owner check back when executing a tx

## How to test it

1. Open a Safe
2. Create a new transaction
3. Swich to a non-owner wallet
4. Observe the Submit button is disabled and an error is shown
5. Switch to signing
6. Observe the Submit button is disabled and an error is shown
7. Go to a fully signed tx in the queue as a non-owner
8. Press the execute button
9. Observe the Submit button is enabled

## Screenshots
<img width="778" alt="Screenshot 2023-07-10 at 17 37 01" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/bf7ca3f4-9bf7-4cfd-8f04-64d2dd2fc3ae">
<img width="769" alt="Screenshot 2023-07-10 at 17 37 22" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/fcdda366-1743-4441-963b-0772d952ffec">
<img width="704" alt="Screenshot 2023-07-10 at 17 37 37" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/d0a3985d-a7f4-4da4-ac47-672ddddf75fc">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

