### PR TITLE
fix: Review send NFT view full width

### DIFF
--- a/src/components/tx-flow/flows/NftTransfer/ReviewNftBatch.tsx
+++ b/src/components/tx-flow/flows/NftTransfer/ReviewNftBatch.tsx
@@ -40,14 +40,16 @@ const ReviewNftBatch = ({ params, onSubmit, txNonce }: ReviewNftBatchProps): Rea
 
   return (
     <SignOrExecuteForm onSubmit={onSubmit}>
-      <Grid container gap={1} flexWrap="nowrap" mb={2}>
-        <Grid item xs={2} flexShrink={0}>
+      <Grid container gap={1} mb={2}>
+        <Grid item md>
           <Typography variant="body2" color="text.secondary">
             Send
           </Typography>
         </Grid>
 
-        <NftItems tokens={tokens} />
+        <Grid item xs md={10}>
+          <NftItems tokens={tokens} />
+        </Grid>
       </Grid>
 
       <SendToBlock address={params.recipient} />


### PR DESCRIPTION
## What it solves

Part of #2067 

## How this PR fixes it

- Changes the NFT view to take up the available space

## How to test it

1. Open a Safe
2. Create an NFT transfer
3. Observe the NFT list taking up the whole space

## Screenshots
<img width="702" alt="Screenshot 2023-07-10 at 17 57 47" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/1209c042-61e4-472b-abeb-3da589f8df28">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
