### PR TITLE
chore: fix network name selection in E2E

### DIFF
--- a/cypress/e2e/smoke/create_safe_simple.cy.js
+++ b/cypress/e2e/smoke/create_safe_simple.cy.js
@@ -11,7 +11,7 @@ describe('Create Safe form', () => {
     cy.contains('button', 'Accept selection').click()
 
     // Ensure wallet is connected to correct chain via header
-    cy.contains('E2E Wallet @ Görli')
+    cy.contains(/E2E Wallet @ G(ö|oe)rli/)
 
     cy.contains('Create new Account').click()
   })
@@ -33,7 +33,9 @@ describe('Create Safe form', () => {
 
     // Switch back to Görli
     cy.get('[data-cy="create-safe-select-network"]').click()
-    cy.contains('li span', 'Görli').click()
+
+    // Prevent Base Mainnet Goerli from being selected
+    cy.contains('li span', /^G(ö|oe)rli$/).click()
 
     cy.contains('button', 'Next').click()
   })

--- a/cypress/e2e/smoke/nfts.cy.js
+++ b/cypress/e2e/smoke/nfts.cy.js
@@ -18,7 +18,7 @@ describe('Assets > NFTs', () => {
       cy.get('tbody tr:first-child').contains('td:first-child', 'BillyNFT721')
       cy.get('tbody tr:first-child').contains('td:first-child', '0x0000...816D')
 
-      cy.get('tbody tr:first-child').contains('td:nth-child(2)', 'Kitaro #261')
+      cy.get('tbody tr:first-child').contains('td:nth-child(2)', 'Kitaro World #261')
 
       cy.get(
         'tbody tr:first-child td:nth-child(3) a[href="https://testnets.opensea.io/assets/0x000000000faE8c6069596c9C805A1975C657816D/443"]',
@@ -30,7 +30,7 @@ describe('Assets > NFTs', () => {
       cy.get('tbody tr:first-child td:nth-child(2)').click()
 
       // Modal
-      cy.get('div[role="dialog"]').contains('Kitaro #261')
+      cy.get('div[role="dialog"]').contains('Kitaro World #261')
 
       // Prevent Base Mainnet Goerli from being selected
       cy.get('div[role="dialog"]').contains(/^G(ö|oe)rli$/)

--- a/cypress/e2e/smoke/nfts.cy.js
+++ b/cypress/e2e/smoke/nfts.cy.js
@@ -6,7 +6,7 @@ describe('Assets > NFTs', () => {
 
     cy.visit(`/balances/nfts?safe=${TEST_SAFE}`)
     cy.contains('button', 'Accept selection').click()
-    cy.contains('E2E Wallet @ Görli')
+    cy.contains(/E2E Wallet @ G(ö|oe)rli/)
   })
 
   describe('should have NFTs', () => {
@@ -31,7 +31,9 @@ describe('Assets > NFTs', () => {
 
       // Modal
       cy.get('div[role="dialog"]').contains('Kitaro #261')
-      cy.get('div[role="dialog"]').contains('Görli')
+
+      // Prevent Base Mainnet Goerli from being selected
+      cy.get('div[role="dialog"]').contains(/^G(ö|oe)rli$/)
       cy.get('div[role="dialog"]').contains(
         'a[href="https://testnets.opensea.io/assets/0x000000000faE8c6069596c9C805A1975C657816D/443"]',
         'View on OpenSea',


### PR DESCRIPTION
## What it solves

Resolves failing E2Es

## How this PR fixes it

After aligning the names of "Goerli" on our chain config. our smoke tests stopped working as it was selecting "Görli".

This updates the smokes to match the both.

## How to test it

Run the `create_safe_simple.cy.js` and `nfts.cy.js` smokes and observe them passing.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
