### PR TITLE
[TX flow] Sticky close button

### DIFF
--- a/src/components/common/TxModalDialog/index.tsx
+++ b/src/components/common/TxModalDialog/index.tsx
@@ -38,7 +38,7 @@ const TxModalDialog = ({
             onClick={(e) => onClose?.(e, 'backdropClick')}
             size="small"
           >
-            <CloseIcon />
+            <CloseIcon fontSize="large" />
           </IconButton>
         </div>
       </DialogTitle>

--- a/src/components/common/TxModalDialog/styles.module.css
+++ b/src/components/common/TxModalDialog/styles.module.css
@@ -24,27 +24,20 @@
   flex: 1;
 }
 
-.dialog :global .MuiDialogTitle-root {
-  border-bottom: 2px solid var(--color-border-light);
-}
-
 .title {
   display: flex;
   align-items: center;
-  background-color: var(--color-background-paper);
   padding: 0;
-  margin-bottom: var(--space-8);
 }
 
 .buttons {
   margin-left: auto;
+  padding: var(--space-1);
 }
 
 .close {
   color: var(--color-border-main);
-  padding: var(--space-2);
-  border-left: 1px solid var(--color-border-light);
-  border-radius: 0;
+  padding: var(--space-1);
 }
 
 .paper {
@@ -56,6 +49,14 @@
   .dialog :global .MuiDialog-paper {
     min-width: 600px;
     margin: 0;
+  }
+}
+
+@media (min-width: 900px) {
+  .title {
+    position: sticky;
+    top: 0;
+    z-index: 1;
   }
 }
 
@@ -72,5 +73,10 @@
 
   .title {
     margin-bottom: var(--space-3);
+    background-color: var(--color-background-paper);
+  }
+
+  .close svg {
+    font-size: 1.5rem;
   }
 }

--- a/src/components/tx-flow/common/TxLayout/styles.module.css
+++ b/src/components/tx-flow/common/TxLayout/styles.module.css
@@ -75,6 +75,7 @@
   color: var(--color-text-primary);
   padding: var(--space-2);
   border-left: 1px solid var(--color-border-light);
+  border-right: 1px solid var(--color-border-light);
   border-radius: 0;
   width: 24px;
   height: 24px;
@@ -119,9 +120,9 @@
   .titleWrapper {
     position: absolute;
     top: 12px;
-    left: var(--space-3);
+    left: var(--space-2);
     margin-bottom: 0;
-    width: calc(100% - 154px);
+    width: calc(100% - 145px);
   }
 
   .title {


### PR DESCRIPTION
## What it solves

Part of #2067 

## How this PR fixes it

- Removes the colored top bar
- Makes the close button larger and sticky
- Keeps everything the same on mobile

## How to test it

1. Open a Safe and create a Transaction
2. Scroll down
3. Observe the Close button being sticky

## Screenshots

<img width="1263" alt="Screenshot 2023-07-11 at 13 37 08" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/a943a54b-9081-40f6-b0f0-f4c639a49ac4">

<img width="1234" alt="Screenshot 2023-07-11 at 13 37 16" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/dff9af7d-307a-4871-820e-3e2de82ee74c">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
