### PR TITLE
fix: increase `min-width` of nonce field

### DIFF
--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -54,16 +54,11 @@ const NonceFormOption = memo(function NonceFormOption({
   )
 })
 
-const getFieldMinWidth = (value: string, showRecommendedNonceButton?: boolean): string => {
-  const MIN_CHARS = 4
+const getFieldMinWidth = (value: string): string => {
+  const MIN_CHARS = 5
   const MAX_WIDTH = '200px'
 
-  const extraWidth = `${showRecommendedNonceButton ? 32 : 8}px`
-
-  return `clamp(calc(${MIN_CHARS}ch + ${extraWidth}), calc(${Math.max(
-    MIN_CHARS,
-    value.length,
-  )}ch + ${extraWidth}), ${MAX_WIDTH})`
+  return `clamp(calc(${MIN_CHARS}ch + 6px), calc(${Math.max(MIN_CHARS, value.length)}ch + 6px), ${MAX_WIDTH})`
 }
 
 enum TxNonceFormFieldNames {
@@ -182,7 +177,7 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
                       },
                     ])}
                     sx={{
-                      minWidth: getFieldMinWidth(field.value, showRecommendedNonceButton),
+                      minWidth: getFieldMinWidth(field.value),
                     }}
                   />
                 </Tooltip>

--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -54,6 +54,18 @@ const NonceFormOption = memo(function NonceFormOption({
   )
 })
 
+const getFieldMinWidth = (value: string, showRecommendedNonceButton?: boolean): string => {
+  const MIN_CHARS = 4
+  const MAX_WIDTH = '200px'
+
+  const extraWidth = `${showRecommendedNonceButton ? 32 : 8}px`
+
+  return `clamp(calc(${MIN_CHARS}ch + ${extraWidth}), calc(${Math.max(
+    MIN_CHARS,
+    value.length,
+  )}ch + ${extraWidth}), ${MAX_WIDTH})`
+}
+
 enum TxNonceFormFieldNames {
   NONCE = 'nonce',
 }
@@ -114,8 +126,6 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
 
         const showRecommendedNonceButton = recommendedNonce !== field.value
 
-        const extraWidth = showRecommendedNonceButton ? 32 : 8
-
         return (
           <Autocomplete
             value={field.value}
@@ -172,9 +182,7 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
                       },
                     ])}
                     sx={{
-                      minWidth: `clamp(calc(1ch + ${extraWidth}px), calc(${
-                        field.value.toString().length
-                      }ch + ${extraWidth}px), 200px)`,
+                      minWidth: getFieldMinWidth(field.value, showRecommendedNonceButton),
                     }}
                   />
                 </Tooltip>
@@ -188,6 +196,8 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
   )
 }
 
+const skeletonMinWidth = getFieldMinWidth('')
+
 const TxNonce = () => {
   const { nonce, recommendedNonce } = useContext(SafeTxContext)
 
@@ -198,7 +208,7 @@ const TxNonce = () => {
         #
       </Typography>
       {nonce === undefined || recommendedNonce === undefined ? (
-        <Skeleton width="70px" height="38px" />
+        <Skeleton width={skeletonMinWidth} height="38px" />
       ) : (
         <TxNonceForm nonce={nonce.toString()} recommendedNonce={recommendedNonce.toString()} />
       )}


### PR DESCRIPTION
## What it solves

Increase `min-width` of nonce field

## How this PR fixes it

The "base" `min-width` of the nonce field has been increased to 4 characters as per design request.

## How to test it

Create a transaction and observe the increased `min-width` of the nonce field.

## Screenshots

![nonce](https://github.com/safe-global/safe-wallet-web/assets/20442784/3575f929-cedc-40b1-ad84-0f2773e10792)

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
