### PR TITLE
fix: remove unnecessary hook

### DIFF
--- a/src/components/tx-flow/common/TxStatusWidget/index.tsx
+++ b/src/components/tx-flow/common/TxStatusWidget/index.tsx
@@ -8,7 +8,6 @@ import classnames from 'classnames'
 import css from './styles.module.css'
 import CloseIcon from '@mui/icons-material/Close'
 import useWallet from '@/hooks/wallets/useWallet'
-import { useDarkMode } from '@/hooks/useDarkMode'
 import SafeLogo from '@/public/images/logo-no-text.svg'
 
 const confirmedMessage = (threshold: number, confirmations: number) => {
@@ -30,7 +29,6 @@ const TxStatusWidget = ({
   handleClose: () => void
   isReplacement?: boolean
 }) => {
-  const isDarkMode = useDarkMode()
   const wallet = useWallet()
   const { safe } = useSafeInfo()
   const { threshold } = safe
@@ -73,15 +71,7 @@ const TxStatusWidget = ({
             <ListItemText primaryTypographyProps={{ fontWeight: 700 }}>
               {confirmedMessage(threshold, confirmationsSubmitted)}
               {canSign && (
-                <Typography
-                  variant="body2"
-                  component="span"
-                  className={css.badge}
-                  sx={({ palette }) => ({
-                    bgcolor: isDarkMode ? `${palette.primary.main}` : `${palette.secondary.main}`,
-                    color: isDarkMode ? `${palette.text.secondary}` : `${palette.text.primary}`,
-                  })}
-                >
+                <Typography variant="body2" component="span" className={css.badge}>
                   +1
                 </Typography>
               )}

--- a/src/components/tx-flow/common/TxStatusWidget/styles.module.css
+++ b/src/components/tx-flow/common/TxStatusWidget/styles.module.css
@@ -62,6 +62,13 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  background-color: var(--color-secondary-main);
+  color: var(--color-text-primary);
+}
+
+[data-theme='dark'] .badge {
+  background-color: var(--color-primary-main);
+  color: var(--color-text-secondary);
 }
 
 @media (max-width: 899.95px) {


### PR DESCRIPTION
## What it solves

Resolves unnecessary hook

## How this PR fixes it

The `TxStatusWidget` no longer requires `useDarkMode` to set the colour of the badge. Instead it now uses the `data-theme` attribute.

## How to test it

Create a transaction and switch between the light and dark mode. Observe the badge colour changing correctly.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
