### PR TITLE
fix: Update message signing link in settings

### DIFF
--- a/src/components/settings/SafeAppsSigningMethod/index.tsx
+++ b/src/components/settings/SafeAppsSigningMethod/index.tsx
@@ -3,6 +3,7 @@ import { SETTINGS_EVENTS, trackEvent } from '@/services/analytics'
 import { useAppDispatch, useAppSelector } from '@/store'
 import { selectOnChainSigning, setOnChainSigning } from '@/store/settingsSlice'
 import { FormControlLabel, Checkbox, Paper, Typography, FormGroup, Grid } from '@mui/material'
+import { HelpCenterArticle } from '@/config/constants'
 
 export const SafeAppsSigningMethod = () => {
   const onChainSigning = useAppSelector(selectOnChainSigning)
@@ -27,10 +28,7 @@ export const SafeAppsSigningMethod = () => {
           <Typography mb={2}>
             This setting determines how the {'Safe{Wallet}'} will sign message requests from Safe Apps. Gasless,
             off-chain signing is used by default. Learn more about message signing{' '}
-            <ExternalLink href="https://help.safe.global/en/articles/7021891-what-are-signed-messages">
-              here
-            </ExternalLink>
-            .
+            <ExternalLink href={HelpCenterArticle.SIGNED_MESSAGES}>here</ExternalLink>.
           </Typography>
           <FormGroup>
             <FormControlLabel


### PR DESCRIPTION
## What it solves

Resolves https://github.com/5afe/safe-support/issues/229

## How this PR fixes it

- Updates the link in settings

## How to test it

1. Open the settings page
2. Go to Safe Apps
3. Press the sign message link
4. Help center article should open