### PR TITLE
fix: Align decoded tx ui for batch execute

### DIFF
--- a/src/components/transactions/BatchExecuteButton/index.tsx
+++ b/src/components/transactions/BatchExecuteButton/index.tsx
@@ -37,7 +37,7 @@ const BatchExecuteButton = () => {
       label: batchableTransactions.length,
     })
 
-    setTxFlow(<ExecuteBatchFlow txs={batchableTransactions} />)
+    setTxFlow(<ExecuteBatchFlow txs={batchableTransactions} />, undefined, false)
   }
 
   return (

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from 'react'
 import type { Dispatch, ReactElement, SetStateAction } from 'react'
 import type { AccordionProps } from '@mui/material/Accordion/Accordion'
 import SingleTxDecoded from '@/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded'
-import { Box, Button, Divider, Stack } from '@mui/material'
+import { Button, Divider, Stack } from '@mui/material'
 import css from './styles.module.css'
 import classnames from 'classnames'
 
@@ -15,14 +15,16 @@ type MultisendProps = {
   compact?: boolean
 }
 
-const MultisendActionsHeader = ({
+export const MultisendActionsHeader = ({
   setOpen,
   amount,
   compact = false,
+  title = 'All actions',
 }: {
   setOpen: Dispatch<SetStateAction<Record<number, boolean> | undefined>>
   amount: number
   compact?: boolean
+  title?: string
 }) => {
   const onClickAll = (expanded: boolean) => () => {
     setOpen(Array(amount).fill(expanded))
@@ -30,7 +32,7 @@ const MultisendActionsHeader = ({
 
   return (
     <div className={classnames(css.actionsHeader, { [css.compactHeader]: compact })}>
-      All actions
+      {title}
       <Stack direction="row" divider={<Divider className={css.divider} />}>
         <Button onClick={onClickAll(true)} variant="text">
           Expand all
@@ -83,7 +85,7 @@ export const Multisend = ({
     <>
       <MultisendActionsHeader setOpen={setOpenMap} amount={multiSendTransactions.length} compact={compact} />
 
-      <Box display="flex" flexDirection="column" className={compact ? css.compact : ''}>
+      <div className={compact ? css.compact : ''}>
         {multiSendTransactions.map(({ dataDecoded, data, value, to, operation }, index) => {
           const onChange: AccordionProps['onChange'] = (_, expanded) => {
             setOpenMap((prev) => ({
@@ -111,7 +113,7 @@ export const Multisend = ({
             />
           )
         })}
-      </Box>
+      </div>
     </>
   )
 }

--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
@@ -1,7 +1,7 @@
 .actionsHeader {
   border-bottom: 1px solid var(--color-border-light);
   cursor: auto !important;
-  padding-left: 16px;
+  padding-left: 0;
   padding-right: 0;
   display: flex;
   justify-content: space-between;
@@ -21,6 +21,11 @@
   margin-top: 14px;
   margin-bottom: 14px;
   border: 1px solid var(--color-border-light);
+}
+
+.compact {
+  display: flex;
+  flex-direction: column;
 }
 
 .compact > div:first-child {

--- a/src/components/tx-flow/flows/ExecuteBatch/DecodedTxs.tsx
+++ b/src/components/tx-flow/flows/ExecuteBatch/DecodedTxs.tsx
@@ -4,51 +4,69 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import extractTxInfo from '@/services/tx/extractTxInfo'
 import { isCustomTxInfo, isNativeTokenTransfer, isTransferTxInfo } from '@/utils/transaction-guards'
 import SingleTxDecoded from '@/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded'
+import css from '@/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css'
+import { useState } from 'react'
+import { MultisendActionsHeader } from '@/components/transactions/TxDetails/TxData/DecodedData/Multisend'
+import { type AccordionProps } from '@mui/material/Accordion/Accordion'
 
 const DecodedTxs = ({ txs }: { txs: TransactionDetails[] | undefined }) => {
+  const [openMap, setOpenMap] = useState<Record<number, boolean>>()
   const { safeAddress } = useSafeInfo()
 
   if (!txs) return null
 
   return (
-    <Box mt={1} display="flex" flexDirection="column" gap={1}>
-      {txs.map((transaction, idx) => {
-        if (!transaction.txData) return null
+    <>
+      <MultisendActionsHeader title="Batched transactions" setOpen={setOpenMap} amount={txs.length} compact />
 
-        const { txParams } = extractTxInfo(transaction, safeAddress)
+      <Box className={css.compact}>
+        {txs.map((transaction, idx) => {
+          if (!transaction.txData) return null
 
-        let decodedDataParams: DataDecoded = {
-          method: '',
-          parameters: undefined,
-        }
+          const onChange: AccordionProps['onChange'] = (_, expanded) => {
+            setOpenMap((prev) => ({
+              ...prev,
+              [idx]: expanded,
+            }))
+          }
 
-        if (isCustomTxInfo(transaction.txInfo) && transaction.txInfo.isCancellation) {
-          decodedDataParams.method = 'On-chain rejection'
-        }
+          const { txParams } = extractTxInfo(transaction, safeAddress)
 
-        if (isTransferTxInfo(transaction.txInfo) && isNativeTokenTransfer(transaction.txInfo.transferInfo)) {
-          decodedDataParams.method = 'transfer'
-        }
+          let decodedDataParams: DataDecoded = {
+            method: '',
+            parameters: undefined,
+          }
 
-        const dataDecoded = transaction.txData.dataDecoded || decodedDataParams
+          if (isCustomTxInfo(transaction.txInfo) && transaction.txInfo.isCancellation) {
+            decodedDataParams.method = 'On-chain rejection'
+          }
 
-        return (
-          <SingleTxDecoded
-            key={transaction.txId}
-            tx={{
-              dataDecoded,
-              data: txParams.data,
-              value: txParams.value,
-              to: txParams.to,
-              operation: 0,
-            }}
-            txData={transaction.txData}
-            actionTitle={`${idx + 1}`}
-            showDelegateCallWarning={false}
-          />
-        )
-      })}
-    </Box>
+          if (isTransferTxInfo(transaction.txInfo) && isNativeTokenTransfer(transaction.txInfo.transferInfo)) {
+            decodedDataParams.method = 'transfer'
+          }
+
+          const dataDecoded = transaction.txData.dataDecoded || decodedDataParams
+
+          return (
+            <SingleTxDecoded
+              key={transaction.txId}
+              tx={{
+                dataDecoded,
+                data: txParams.data,
+                value: txParams.value,
+                to: txParams.to,
+                operation: 0,
+              }}
+              txData={transaction.txData}
+              actionTitle={`${idx + 1}`}
+              showDelegateCallWarning={false}
+              expanded={openMap?.[idx] ?? false}
+              onChange={onChange}
+            />
+          )
+        })}
+      </Box>
+    </>
   )
 }
 

--- a/src/components/tx-flow/flows/ExecuteBatch/ReviewBatch.tsx
+++ b/src/components/tx-flow/flows/ExecuteBatch/ReviewBatch.tsx
@@ -145,9 +145,6 @@ export const ReviewBatch = ({ params }: { params: ExecuteBatchFlowProps }) => {
         )}
 
         <div>
-          <Typography variant="body2" color="text.secondary">
-            Batched transactions:
-          </Typography>
           <DecodedTxs txs={txsWithDetails} />
         </div>
       </TxCard>
@@ -198,7 +195,7 @@ export const ReviewBatch = ({ params }: { params: ExecuteBatchFlowProps }) => {
             <CheckWallet allowNonOwner={true}>
               {(isOk) => (
                 <Button variant="contained" type="submit" disabled={!isOk || submitDisabled} onClick={handleSubmit}>
-                  Send
+                  Submit
                 </Button>
               )}
             </CheckWallet>

--- a/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
+++ b/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
@@ -5,7 +5,7 @@ import { Typography, Grid, Alert } from '@mui/material'
 
 import SpendingLimitLabel from '@/components/common/SpendingLimitLabel'
 import { getResetTimeOptions } from '@/components/transactions/TxDetails/TxData/SpendingLimits'
-import { AmountBlock } from '@/components/tx-flow/flows/TokenTransfer/SendAmountBlock'
+import SendAmountBlock from '@/components/tx-flow/flows/TokenTransfer/SendAmountBlock'
 import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import useBalances from '@/hooks/useBalances'
 import useChainId from '@/hooks/useChainId'
@@ -59,33 +59,26 @@ export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowPr
   return (
     <SignOrExecuteForm onSubmit={onFormSubmit}>
       {token && (
-        <Grid container gap={1} alignItems="center">
-          <Grid item xs={4} md={2}>
-            <Typography variant="body2" color="text.secondary">
-              Amount
-            </Typography>
-          </Grid>
-          <AmountBlock amount={params.amount} tokenInfo={token.tokenInfo}>
-            {!!existingSpendingLimit && (
-              <>
-                <Typography color="error" sx={{ textDecoration: 'line-through' }} component="span">
-                  {formatVisualAmount(BigNumber.from(existingSpendingLimit.amount), decimals)}
-                </Typography>
-                {'→'}
-              </>
-            )}
-          </AmountBlock>
-        </Grid>
+        <SendAmountBlock amount={params.amount} tokenInfo={token.tokenInfo} title="Amount">
+          {!!existingSpendingLimit && (
+            <>
+              <Typography color="error" sx={{ textDecoration: 'line-through' }} component="span">
+                {formatVisualAmount(BigNumber.from(existingSpendingLimit.amount), decimals)}
+              </Typography>
+              {'→'}
+            </>
+          )}
+        </SendAmountBlock>
       )}
 
       <Grid container gap={1} alignItems="center">
-        <Grid item xs={4} md={2}>
+        <Grid item md>
           <Typography variant="body2" color="text.secondary">
             Beneficiary
           </Typography>
         </Grid>
 
-        <Grid item>
+        <Grid item md={10}>
           <EthHashInfo
             address={params.beneficiary}
             shortAddress={false}
@@ -97,12 +90,12 @@ export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowPr
       </Grid>
 
       <Grid container gap={1} alignItems="center">
-        <Grid item xs={4} md={2}>
+        <Grid item md>
           <Typography variant="body2" color="text.secondary">
             Reset time
           </Typography>
         </Grid>
-        <Grid item>
+        <Grid item md={10}>
           {existingSpendingLimit ? (
             <>
               <SpendingLimitLabel

--- a/src/components/tx-flow/flows/RemoveSpendingLimit/RemoveSpendingLimit.tsx
+++ b/src/components/tx-flow/flows/RemoveSpendingLimit/RemoveSpendingLimit.tsx
@@ -9,7 +9,7 @@ import type { SpendingLimitState } from '@/store/spendingLimitsSlice'
 import { relativeTime } from '@/utils/date'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 import useBalances from '@/hooks/useBalances'
-import { AmountBlock } from '@/components/tx-flow/flows/TokenTransfer/SendAmountBlock'
+import SendAmountBlock from '@/components/tx-flow/flows/TokenTransfer/SendAmountBlock'
 import { safeFormatUnits } from '@/utils/formatters'
 import SpendingLimitLabel from '@/components/common/SpendingLimitLabel'
 import { createTx } from '@/services/tx/tx-sender'
@@ -49,35 +49,42 @@ export const RemoveSpendingLimit = ({ params }: { params: SpendingLimitState }) 
   return (
     <SignOrExecuteForm onSubmit={onFormSubmit}>
       {token && (
-        <Grid container gap={1} alignItems="center">
-          <Grid item xs={4} md={2}>
-            <Typography variant="body2" color="text.secondary">
-              Amount
-            </Typography>
-          </Grid>
-          <AmountBlock amount={safeFormatUnits(params.amount, token.tokenInfo.decimals)} tokenInfo={token.tokenInfo} />
-        </Grid>
+        <SendAmountBlock
+          amount={safeFormatUnits(params.amount, token.tokenInfo.decimals)}
+          tokenInfo={token.tokenInfo}
+          title="Amount"
+        />
       )}
 
       <Grid container gap={1} alignItems="center">
-        <Grid item xs={4} md={2}>
+        <Grid item md>
           <Typography variant="body2" color="text.secondary">
             Beneficiary
           </Typography>
         </Grid>
-        <EthHashInfo address={params.beneficiary} showCopyButton hasExplorer shortAddress={false} showAvatar={false} />
+        <Grid item md={10}>
+          <EthHashInfo
+            address={params.beneficiary}
+            showCopyButton
+            hasExplorer
+            shortAddress={false}
+            showAvatar={false}
+          />
+        </Grid>
       </Grid>
 
       <Grid container gap={1} alignItems="center">
-        <Grid item xs={4} md={2}>
+        <Grid item md>
           <Typography variant="body2" color="text.secondary">
             Reset time
           </Typography>
         </Grid>
-        <SpendingLimitLabel
-          label={relativeTime(params.lastResetMin, params.resetTimeMin)}
-          isOneTime={params.resetTimeMin === '0'}
-        />
+        <Grid item md={10}>
+          <SpendingLimitLabel
+            label={relativeTime(params.lastResetMin, params.resetTimeMin)}
+            isOneTime={params.resetTimeMin === '0'}
+          />
+        </Grid>
       </Grid>
     </SignOrExecuteForm>
   )

--- a/src/components/tx-flow/flows/TokenTransfer/SendAmountBlock.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/SendAmountBlock.tsx
@@ -6,7 +6,7 @@ import TokenIcon from '@/components/common/TokenIcon'
 import { formatAmountPrecise } from '@/utils/formatNumber'
 import { PSEUDO_APPROVAL_VALUES } from '@/components/tx/ApprovalEditor/utils/approvals'
 
-export const AmountBlock = ({
+const AmountBlock = ({
   amount,
   tokenInfo,
   children,


### PR DESCRIPTION
## What it solves

Part of #2067 

## How this PR fixes it

- Adds Expand/Collapse all buttons to batch execute
- Renames Batch execute submit button to "Submit"
- Doesn't show the confirm dialog when batch executing

## Other fixes

- Updates the spending limit components to use `SendAmountBlock` instead of `AmountBlock` since it supports a custom title now and is more in line with the rest of the layout

## How to test it

1. Open a Safe
2. Queue and confirm at least 2 transactions
3. Press Execute Batch
4. Observe the decoded tx ui with buttons

## Screenshots

<img width="734" alt="Screenshot 2023-07-11 at 17 04 50" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/7c4a93b0-914c-4b92-bbe6-a43a02a97611">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
