### PR TITLE
fix: Validation for spending limits

### DIFF
--- a/src/components/common/TokenAmountInput/index.tsx
+++ b/src/components/common/TokenAmountInput/index.tsx
@@ -80,7 +80,7 @@ const TokenAmountInput = ({
           {...register(TokenAmountFields.tokenAddress, {
             required: true,
             onChange: () => {
-              resetField(TokenAmountFields.amount, { defaultValue: '0' })
+              resetField(TokenAmountFields.amount, { defaultValue: '' })
             },
           })}
           value={tokenAddress}

--- a/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
+++ b/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
@@ -12,7 +12,6 @@ import useChainId from '@/hooks/useChainId'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 import { createNewSpendingLimitTx } from '@/services/tx/tx-sender'
 import { selectSpendingLimits } from '@/store/spendingLimitsSlice'
-import { relativeTime } from '@/utils/date'
 import { formatVisualAmount } from '@/utils/formatters'
 import type { SpendingLimitState } from '@/store/spendingLimitsSlice'
 import type { NewSpendingLimitFlowProps } from '.'
@@ -56,14 +55,22 @@ export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowPr
     })
   }
 
+  const existingAmount = existingSpendingLimit
+    ? formatVisualAmount(BigNumber.from(existingSpendingLimit?.amount), decimals)
+    : undefined
+
+  const oldResetTime = existingSpendingLimit
+    ? getResetTimeOptions(chainId).find((time) => time.value === existingSpendingLimit?.resetTimeMin)?.label
+    : undefined
+
   return (
     <SignOrExecuteForm onSubmit={onFormSubmit}>
       {token && (
         <SendAmountBlock amount={params.amount} tokenInfo={token.tokenInfo} title="Amount">
-          {!!existingSpendingLimit && (
+          {existingAmount && existingAmount !== params.amount && (
             <>
               <Typography color="error" sx={{ textDecoration: 'line-through' }} component="span">
-                {formatVisualAmount(BigNumber.from(existingSpendingLimit.amount), decimals)}
+                {existingAmount}
               </Typography>
               {'→'}
             </>
@@ -109,7 +116,7 @@ export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowPr
                           display="inline"
                           component="span"
                         >
-                          {relativeTime(existingSpendingLimit.lastResetMin, existingSpendingLimit.resetTimeMin)}
+                          {oldResetTime}
                         </Typography>
                         {' → '}
                       </>

--- a/src/components/tx-flow/flows/RemoveGuard/index.tsx
+++ b/src/components/tx-flow/flows/RemoveGuard/index.tsx
@@ -8,7 +8,7 @@ export type RemoveGuardFlowProps = {
 
 const RemoveGuardFlow = ({ address }: RemoveGuardFlowProps) => {
   return (
-    <TxLayout title="Remove guard">
+    <TxLayout title="Confirm transaction" subtitle="Remove guard">
       <ReviewRemoveGuard params={{ address }} />
     </TxLayout>
   )


### PR DESCRIPTION
## What it solves

Part of #2067 

## How this PR fixes it

- Pass in validation to `TokenAmountInput` and make the Max field optional
- Remove amount validation for spending limits
- Adjust spending limit replacement UI when values don't change
- Update Remove Guard title text

## Other changes

- Resets the amount to an empty string instead of 0 when switching tokens

## How to test it

1. Open a Safe
2. Overwrite an existing spending limit but don't change any values
3. Observe no Max button visible
4. It should be possible to type in a larger amount than is available for a given token
5. Observe no strike-through values on screen
6. Change the reset time
7. Observe the old reset time is striked through and has its original value and not the relative time

## Screenshots

<img width="721" alt="Screenshot 2023-07-12 at 11 25 44" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/6d4544fa-df5c-4b80-aa18-961a26426688">

<img width="733" alt="Screenshot 2023-07-12 at 11 26 10" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/37b362a5-9480-4df9-bb5b-387cda75b998">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
