### PR TITLE
fix: trim/remove leading zeros from values

### DIFF
--- a/src/components/common/NumberField/index.test.ts
+++ b/src/components/common/NumberField/index.test.ts
@@ -1,0 +1,13 @@
+import { _formatNumber } from '.'
+
+describe('NumberField', () => {
+  it('should trim the value', () => {
+    expect(_formatNumber('  123  ')).toBe('123')
+    expect(_formatNumber('  0.001  ')).toBe('0.001')
+  })
+
+  it('should remove the leading zeros', () => {
+    expect(_formatNumber('000123')).toBe('123')
+    expect(_formatNumber('0000.001')).toBe('0.001')
+  })
+})

--- a/src/components/common/NumberField/index.tsx
+++ b/src/components/common/NumberField/index.tsx
@@ -3,8 +3,40 @@ import { forwardRef } from 'react'
 import type { TextFieldProps } from '@mui/material'
 import type { ReactElement } from 'react'
 
-const NumberField = forwardRef<HTMLInputElement, TextFieldProps>((props, ref): ReactElement => {
-  return <TextField autoComplete="off" ref={ref} {...props} />
+export const _formatNumber = (value: string) => {
+  value = value.trim()
+
+  if (value === '') {
+    return value
+  }
+
+  // Remove leading zeros from the string
+  value = value.replace(/^0+/, '')
+
+  if (value === '') {
+    return '0'
+  }
+
+  // If the string starts with a decimal point, add a leading zero
+  if (value.startsWith('.')) {
+    value = '0' + value
+  }
+
+  return value
+}
+
+const NumberField = forwardRef<HTMLInputElement, TextFieldProps>(({ onChange, ...props }, ref): ReactElement => {
+  return (
+    <TextField
+      autoComplete="off"
+      ref={ref}
+      onChange={(event) => {
+        event.target.value = _formatNumber(event.target.value)
+        return onChange?.(event)
+      }}
+      {...props}
+    />
+  )
 })
 
 NumberField.displayName = 'NumberField'

--- a/src/components/common/TokenAmountInput/index.tsx
+++ b/src/components/common/TokenAmountInput/index.tsx
@@ -67,6 +67,10 @@ const TokenAmountInput = ({
           {...register(TokenAmountFields.amount, {
             required: true,
             validate: validate ?? validateAmount,
+            onChange: (event) => {
+              event.target.value = event.target.value.trim()
+              return event
+            },
           })}
         />
         <Divider orientation="vertical" flexItem />

--- a/src/components/common/TokenAmountInput/index.tsx
+++ b/src/components/common/TokenAmountInput/index.tsx
@@ -67,10 +67,6 @@ const TokenAmountInput = ({
           {...register(TokenAmountFields.amount, {
             required: true,
             validate: validate ?? validateAmount,
-            onChange: (event) => {
-              event.target.value = event.target.value.trim()
-              return event
-            },
           })}
         />
         <Divider orientation="vertical" flexItem />


### PR DESCRIPTION
## What it solves

Resolves #2281

## How this PR fixes it

The value of the `NumberField` component now trims and removes leading zeros.

## How to test it

The aforementioned component is used in:

- Token amount field
- `safeTxGas` field
- Transaction filter: amount, nonce fields
- Advanced params: wallet nonce, max prio fee, max fee/gas price fields
- Approval editor: value field
- Transaction nonce field

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
