### PR TITLE
fix: Show Tenderly fail if there is a call trace error

### DIFF
--- a/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/styles.module.css
@@ -1,7 +1,7 @@
 .actionsHeader {
   border-bottom: 1px solid var(--color-border-light);
   cursor: auto !important;
-  padding-left: 0;
+  padding-left: var(--space-2);
   padding-right: 0;
   display: flex;
   justify-content: space-between;
@@ -10,6 +10,7 @@
 
 .compactHeader {
   border: 0;
+  padding-left: 0;
 }
 
 .actionsHeader button {

--- a/src/components/tx-flow/TxInfoProvider.tsx
+++ b/src/components/tx-flow/TxInfoProvider.tsx
@@ -1,23 +1,67 @@
 import { createContext } from 'react'
 
 import { useSimulation, type UseSimulationReturn } from '@/components/tx/security/tenderly/useSimulation'
-import { FETCH_STATUS } from '@/components/tx/security/tenderly/types'
+import { FETCH_STATUS, type TenderlySimulation } from '@/components/tx/security/tenderly/types'
+
+const getCallTraceErrors = (simulation?: TenderlySimulation) => {
+  if (!simulation || !simulation.simulation.status) {
+    return []
+  }
+
+  return simulation.transaction.call_trace.filter((call) => call.error)
+}
+
+type SimulationStatus = {
+  isLoading: boolean
+  isFinished: boolean
+  isSuccess: boolean
+  isCallTraceError: boolean
+  isError: boolean
+}
 
 export const TxInfoContext = createContext<{
   simulation: UseSimulationReturn
+  status: SimulationStatus
 }>({
   simulation: {
     simulateTransaction: () => {},
     simulation: undefined,
-    simulationRequestStatus: FETCH_STATUS.NOT_ASKED,
+    _simulationRequestStatus: FETCH_STATUS.NOT_ASKED,
     simulationLink: '',
     requestError: undefined,
     resetSimulation: () => {},
+  },
+  status: {
+    isLoading: false,
+    isFinished: false,
+    isSuccess: false,
+    isCallTraceError: false,
+    isError: false,
   },
 })
 
 export const TxInfoProvider = ({ children }: { children: JSX.Element }) => {
   const simulation = useSimulation()
 
-  return <TxInfoContext.Provider value={{ simulation }}>{children}</TxInfoContext.Provider>
+  const isLoading = simulation._simulationRequestStatus === FETCH_STATUS.LOADING
+
+  const isFinished =
+    simulation._simulationRequestStatus === FETCH_STATUS.SUCCESS ||
+    simulation._simulationRequestStatus === FETCH_STATUS.ERROR
+
+  const isSuccess = simulation.simulation?.simulation.status || false
+
+  // Safe can emit failure event even though Tenderly simulation succeeds
+  const isCallTraceError = isSuccess && getCallTraceErrors(simulation.simulation).length > 0
+  const isError = simulation._simulationRequestStatus === FETCH_STATUS.ERROR
+
+  const status = {
+    isLoading,
+    isFinished,
+    isSuccess,
+    isCallTraceError,
+    isError,
+  }
+
+  return <TxInfoContext.Provider value={{ simulation, status }}>{children}</TxInfoContext.Provider>
 }

--- a/src/components/tx/security/tenderly/__tests__/useSimulation.test.ts
+++ b/src/components/tx/security/tenderly/__tests__/useSimulation.test.ts
@@ -30,12 +30,12 @@ describe('useSimulation()', () => {
 
   it('should have the correct initial values', () => {
     const { result } = renderHook(() => useSimulation())
-    const { simulation, simulationLink, requestError: simulationError, simulationRequestStatus } = result.current
+    const { simulation, simulationLink, requestError: simulationError, _simulationRequestStatus } = result.current
 
     expect(simulation).toBeUndefined()
     expect(simulationLink).not.toBeUndefined()
     expect(simulationError).toBeUndefined()
-    expect(simulationRequestStatus).toEqual(FETCH_STATUS.NOT_ASKED)
+    expect(_simulationRequestStatus).toEqual(FETCH_STATUS.NOT_ASKED)
   })
 
   it('should set simulationError on errors and errors can be reset.', async () => {
@@ -84,8 +84,8 @@ describe('useSimulation()', () => {
     )
 
     await waitFor(() => {
-      const { simulationRequestStatus, requestError: simulationError } = result.current
-      expect(simulationRequestStatus).toEqual(FETCH_STATUS.ERROR)
+      const { _simulationRequestStatus, requestError: simulationError } = result.current
+      expect(_simulationRequestStatus).toEqual(FETCH_STATUS.ERROR)
       expect(simulationError).toEqual('404 not found')
     })
 
@@ -95,7 +95,7 @@ describe('useSimulation()', () => {
       result.current.resetSimulation()
     })
 
-    expect(result.current.simulationRequestStatus).toEqual(FETCH_STATUS.NOT_ASKED)
+    expect(result.current._simulationRequestStatus).toEqual(FETCH_STATUS.NOT_ASKED)
     expect(result.current.requestError).toBeUndefined()
   })
 
@@ -153,8 +153,8 @@ describe('useSimulation()', () => {
     )
 
     await waitFor(() => {
-      const { simulationRequestStatus, simulation } = result.current
-      expect(simulationRequestStatus).toEqual(FETCH_STATUS.SUCCESS)
+      const { _simulationRequestStatus, simulation } = result.current
+      expect(_simulationRequestStatus).toEqual(FETCH_STATUS.SUCCESS)
       expect(simulation?.simulation.status).toBeTruthy()
       expect(simulation?.simulation.id).toEqual('123')
     })
@@ -165,7 +165,7 @@ describe('useSimulation()', () => {
       result.current.resetSimulation()
     })
 
-    expect(result.current.simulationRequestStatus).toEqual(FETCH_STATUS.NOT_ASKED)
+    expect(result.current._simulationRequestStatus).toEqual(FETCH_STATUS.NOT_ASKED)
     expect(result.current.simulation).toBeUndefined()
   })
 
@@ -223,8 +223,8 @@ describe('useSimulation()', () => {
     )
 
     await waitFor(() => {
-      const { simulationRequestStatus, simulation } = result.current
-      expect(simulationRequestStatus).toEqual(FETCH_STATUS.SUCCESS)
+      const { _simulationRequestStatus, simulation } = result.current
+      expect(_simulationRequestStatus).toEqual(FETCH_STATUS.SUCCESS)
       expect(simulation?.simulation.status).toBeTruthy()
       expect(simulation?.simulation.id).toEqual('123')
     })

--- a/src/components/tx/security/tenderly/index.tsx
+++ b/src/components/tx/security/tenderly/index.tsx
@@ -43,12 +43,14 @@ const TxSimulationBlock = ({ transactions, disabled, gasLimit }: TxSimulationPro
   const isDarkMode = useDarkMode()
   const { safeTx } = useContext(SafeTxContext)
   const {
-    simulation: { simulateTransaction, simulationRequestStatus, resetSimulation },
+    simulation: { simulation, simulateTransaction, simulationRequestStatus, resetSimulation },
   } = useContext(TxInfoContext)
 
   const isLoading = simulationRequestStatus === FETCH_STATUS.LOADING
   const isSuccess = simulationRequestStatus === FETCH_STATUS.SUCCESS
   const isError = simulationRequestStatus === FETCH_STATUS.ERROR
+
+  const isCallTraceError = isSuccess && getCallTraceErrors(simulation).length > 0
 
   const handleSimulation = async () => {
     if (!wallet) {
@@ -111,15 +113,15 @@ const TxSimulationBlock = ({ transactions, disabled, gasLimit }: TxSimulationPro
               color: ({ palette }) => palette.text.secondary,
             }}
           />
+        ) : isError || isCallTraceError ? (
+          <Typography variant="body2" color="error.main" className={sharedCss.result}>
+            <SvgIcon component={CloseIcon} inheritViewBox fontSize="small" sx={{ verticalAlign: 'middle', mr: 1 }} />
+            Error
+          </Typography>
         ) : isSuccess ? (
           <Typography variant="body2" color="success.main" className={sharedCss.result}>
             <SvgIcon component={CheckIcon} inheritViewBox fontSize="small" sx={{ verticalAlign: 'middle', mr: 1 }} />
             Success
-          </Typography>
-        ) : isError ? (
-          <Typography variant="body2" color="error.main" className={sharedCss.result}>
-            <SvgIcon component={CloseIcon} inheritViewBox fontSize="small" sx={{ verticalAlign: 'middle', mr: 1 }} />
-            Error
           </Typography>
         ) : (
           <Button

--- a/src/components/tx/security/tenderly/index.tsx
+++ b/src/components/tx/security/tenderly/index.tsx
@@ -10,10 +10,8 @@ import { useDarkMode } from '@/hooks/useDarkMode'
 import CircularProgress from '@mui/material/CircularProgress'
 import ExternalLink from '@/components/common/ExternalLink'
 import { useCurrentChain } from '@/hooks/useChains'
-import { FETCH_STATUS } from '@/components/tx/security/tenderly/types'
 import { isTxSimulationEnabled } from '@/components/tx/security/tenderly/utils'
 import type { SimulationTxParams } from '@/components/tx/security/tenderly/utils'
-import type { TenderlySimulation } from '@/components/tx/security/tenderly/types'
 
 import css from './styles.module.css'
 import sharedCss from '@/components/tx/security/shared/styles.module.css'
@@ -27,14 +25,6 @@ export type TxSimulationProps = {
   disabled: boolean
 }
 
-const getCallTraceErrors = (simulation?: TenderlySimulation) => {
-  if (!simulation || !simulation.simulation.status) {
-    return []
-  }
-
-  return simulation.transaction.call_trace.filter((call) => call.error)
-}
-
 // TODO: Investigate resetting on gasLimit change as we are not simulating with the gasLimit of the tx
 // otherwise remove all usage of gasLimit in simulation. Note: this was previously being done.
 const TxSimulationBlock = ({ transactions, disabled, gasLimit }: TxSimulationProps): ReactElement => {
@@ -43,14 +33,9 @@ const TxSimulationBlock = ({ transactions, disabled, gasLimit }: TxSimulationPro
   const isDarkMode = useDarkMode()
   const { safeTx } = useContext(SafeTxContext)
   const {
-    simulation: { simulation, simulateTransaction, simulationRequestStatus, resetSimulation },
+    simulation: { simulateTransaction, resetSimulation },
+    status: { isError, isSuccess, isCallTraceError, isLoading },
   } = useContext(TxInfoContext)
-
-  const isLoading = simulationRequestStatus === FETCH_STATUS.LOADING
-  const isSuccess = simulation?.simulation.status
-  const isError = simulationRequestStatus === FETCH_STATUS.ERROR
-
-  const isCallTraceError = isSuccess && getCallTraceErrors(simulation).length > 0
 
   const handleSimulation = async () => {
     if (!wallet) {
@@ -151,19 +136,13 @@ export const TxSimulation = (props: TxSimulationProps): ReactElement | null => {
 
 export const TxSimulationMessage = () => {
   const {
-    simulation: { simulationRequestStatus, simulationLink, simulation, requestError },
+    simulation: { simulationLink, simulation, requestError },
+    status: { isError, isSuccess, isCallTraceError, isFinished },
   } = useContext(TxInfoContext)
-
-  const isFinished = simulationRequestStatus === FETCH_STATUS.SUCCESS || simulationRequestStatus === FETCH_STATUS.ERROR
 
   if (!isFinished) {
     return null
   }
-
-  const isSuccess = simulation?.simulation.status
-  // Safe can emit failure event even though Tenderly simulation succeeds
-  const isCallTraceError = isSuccess && getCallTraceErrors(simulation).length > 0
-  const isError = simulationRequestStatus === FETCH_STATUS.ERROR
 
   if (!isSuccess || isError || isCallTraceError) {
     return (

--- a/src/components/tx/security/tenderly/index.tsx
+++ b/src/components/tx/security/tenderly/index.tsx
@@ -47,7 +47,7 @@ const TxSimulationBlock = ({ transactions, disabled, gasLimit }: TxSimulationPro
   } = useContext(TxInfoContext)
 
   const isLoading = simulationRequestStatus === FETCH_STATUS.LOADING
-  const isSuccess = simulationRequestStatus === FETCH_STATUS.SUCCESS
+  const isSuccess = simulation?.simulation.status
   const isError = simulationRequestStatus === FETCH_STATUS.ERROR
 
   const isCallTraceError = isSuccess && getCallTraceErrors(simulation).length > 0

--- a/src/components/tx/security/tenderly/index.tsx
+++ b/src/components/tx/security/tenderly/index.tsx
@@ -27,6 +27,7 @@ export type TxSimulationProps = {
 
 // TODO: Investigate resetting on gasLimit change as we are not simulating with the gasLimit of the tx
 // otherwise remove all usage of gasLimit in simulation. Note: this was previously being done.
+// TODO: Test this component
 const TxSimulationBlock = ({ transactions, disabled, gasLimit }: TxSimulationProps): ReactElement => {
   const { safe } = useSafeInfo()
   const wallet = useWallet()
@@ -134,6 +135,7 @@ export const TxSimulation = (props: TxSimulationProps): ReactElement | null => {
   return <TxSimulationBlock {...props} />
 }
 
+// TODO: Test this component
 export const TxSimulationMessage = () => {
   const {
     simulation: { simulationLink, simulation, requestError },

--- a/src/components/tx/security/tenderly/useSimulation.ts
+++ b/src/components/tx/security/tenderly/useSimulation.ts
@@ -9,7 +9,7 @@ import { asError } from '@/services/exceptions/utils'
 
 export type UseSimulationReturn =
   | {
-      simulationRequestStatus: FETCH_STATUS.NOT_ASKED | FETCH_STATUS.ERROR | FETCH_STATUS.LOADING
+      _simulationRequestStatus: FETCH_STATUS.NOT_ASKED | FETCH_STATUS.ERROR | FETCH_STATUS.LOADING
       simulation: undefined
       simulateTransaction: (params: SimulationTxParams) => void
       simulationLink: string
@@ -17,7 +17,7 @@ export type UseSimulationReturn =
       resetSimulation: () => void
     }
   | {
-      simulationRequestStatus: FETCH_STATUS.SUCCESS
+      _simulationRequestStatus: FETCH_STATUS.SUCCESS
       simulation: TenderlySimulation
       simulateTransaction: (params: SimulationTxParams) => void
       simulationLink: string
@@ -63,7 +63,8 @@ export const useSimulation = (): UseSimulationReturn => {
 
   return {
     simulateTransaction,
-    simulationRequestStatus,
+    // This is only used by the provider
+    _simulationRequestStatus: simulationRequestStatus,
     simulation,
     simulationLink,
     requestError,


### PR DESCRIPTION
## What it solves

Fixes for #2067 

## How this PR fixes it

- Checks if there is a call trace error for the tenderly message
- Adds back the padding for decoded txs if its not compact

## How to test it

1. Open a Safe and simulate a transaction that has a call trace error
2. Observe the button showing Fail instead of Success

## Screenshots
<img width="414" alt="Screenshot 2023-07-13 at 16 49 29" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/c97537bd-0d2e-4870-be72-a3f10a9fcc5e">
<img width="1186" alt="Screenshot 2023-07-13 at 16 49 53" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/697679c2-31ee-41de-bdc9-c859df2ddac1">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
