### PR TITLE
fix: also format `inputProps['onChange']`

### DIFF
--- a/src/components/common/NumberField/index.tsx
+++ b/src/components/common/NumberField/index.tsx
@@ -35,6 +35,17 @@ const NumberField = forwardRef<HTMLInputElement, TextFieldProps>(({ onChange, ..
         return onChange?.(event)
       }}
       {...props}
+      inputProps={{
+        ...props.inputProps,
+        // Autocomplete passes `onChange` in `inputProps`
+        onChange: (event) => {
+          // inputProps['onChange'] is generically typed
+          if ('value' in event.target && typeof event.target.value === 'string') {
+            event.target.value = _formatNumber(event.target.value)
+            return props.inputProps?.onChange?.(event)
+          }
+        },
+      }}
     />
   )
 })


### PR DESCRIPTION
## What it solves

Resolves unformatted nonce

## How this PR fixes it

The transaction nonce field did not inherit the formatting added in https://github.com/safe-global/safe-wallet-web/pull/2284 (trimming/removing leading zeros). This fixes the issue.

## How to test it

Edit the transaction nonce and observe that it's not possible to enter spaces or leading zeros.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
