### PR TITLE
fix: Reopen QR modal in safe creation

### DIFF
--- a/src/components/common/AddressInput/index.tsx
+++ b/src/components/common/AddressInput/index.tsx
@@ -50,6 +50,7 @@ const AddressInput = ({
     formState: { errors },
     trigger,
   } = useFormContext()
+
   const currentChain = useCurrentChain()
   const rawValueRef = useRef<string>('')
   const watchedValue = useWatch({ name, control })
@@ -153,8 +154,12 @@ const AddressInput = ({
             return parsePrefixedAddress(cleanValue).address
           },
 
-          validate: async () => {
+          validate: async (inputValue) => {
             const value = rawValueRef.current
+
+            // Validation unmounts QR code otherwise
+            if (inputValue === value) return
+
             if (value) {
               setIsValidating(true)
               const result = validatePrefixed(value) || (await validate?.(parsePrefixedAddress(value).address))


### PR DESCRIPTION
## What it solves

Fix for #2280 

## How this PR fixes it

- Only runs the validation if the value has changed

## How to test it

1. Open Safe creation
2. Add an owner
3. Press the QR button and select an address
4. Press it again and observe it opens again

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
