### PR TITLE
fix: show error for reverted txs

### DIFF
--- a/src/components/tx-flow/flows/SuccessScreen/index.tsx
+++ b/src/components/tx-flow/flows/SuccessScreen/index.tsx
@@ -29,14 +29,8 @@ export const SuccessScreen = ({ txId }: { txId: string }) => {
   }, [txHash])
 
   useEffect(() => {
-    const unsubFns: Array<() => void> = []
-    unsubFns.push(
-      txSubscribe(TxEvent.FAILED, (detail) => {
-        if (detail.txId === txId) setError(detail.error)
-      }),
-    )
-    unsubFns.push(
-      txSubscribe(TxEvent.REVERTED, (detail) => {
+    const unsubFns: Array<() => void> = ([TxEvent.FAILED, TxEvent.REVERTED] as const).map((event) =>
+      txSubscribe(event, (detail) => {
         if (detail.txId === txId) setError(detail.error)
       }),
     )

--- a/src/components/tx-flow/flows/SuccessScreen/index.tsx
+++ b/src/components/tx-flow/flows/SuccessScreen/index.tsx
@@ -29,11 +29,19 @@ export const SuccessScreen = ({ txId }: { txId: string }) => {
   }, [txHash])
 
   useEffect(() => {
-    const unsubscribe = txSubscribe(TxEvent.FAILED, (detail) => {
-      if (detail.txId === txId) setError(detail.error)
-    })
+    const unsubFns: Array<() => void> = []
+    unsubFns.push(
+      txSubscribe(TxEvent.FAILED, (detail) => {
+        if (detail.txId === txId) setError(detail.error)
+      }),
+    )
+    unsubFns.push(
+      txSubscribe(TxEvent.REVERTED, (detail) => {
+        if (detail.txId === txId) setError(detail.error)
+      }),
+    )
 
-    return unsubscribe
+    return () => unsubFns.forEach((unsubscribe) => unsubscribe())
   }, [txId])
 
   const homeLink: UrlObject = {


### PR DESCRIPTION
## What it solves
Reverted transactions looked like successful transactions.

## How this PR fixes it
- Subscribes to the `TxEvent.REVERTED` event and displays an error on revert.

## How to test it
- Create any tx
- reduce the gas limit by a bit
- Execute the tx
- Wait for it to revert

## Screenshots
![Screenshot 2023-07-25 at 12 12 24](https://github.com/safe-global/safe-wallet-web/assets/2670790/1d387525-a55d-4243-a32a-de8a6a38ebb4)



## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
