### PR TITLE
Feat: emoji identicons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ yalc.lock
 /public/sw.js.map
 /public/workbox-*.js
 /public/workbox-*.js.map
+/public/fallback*

--- a/public/fallback-_BhnCpEzQvANEPPDjEZ18.js
+++ b/public/fallback-_BhnCpEzQvANEPPDjEZ18.js
@@ -1,1 +1,0 @@
-(()=>{"use strict";self.fallback=async e=>"document"===e.destination?caches.match("/_offline",{ignoreSearch:!0}):Response.error()})();

--- a/public/fallback-_BhnCpEzQvANEPPDjEZ18.js
+++ b/public/fallback-_BhnCpEzQvANEPPDjEZ18.js
@@ -1,0 +1,1 @@
+(()=>{"use strict";self.fallback=async e=>"document"===e.destination?caches.match("/_offline",{ignoreSearch:!0}):Response.error()})();

--- a/src/components/balances/AssetsTable/index.test.tsx
+++ b/src/components/balances/AssetsTable/index.test.tsx
@@ -109,6 +109,7 @@ describe('AssetsTable', () => {
             onChainSigning: false,
           },
           transactionExecution: true,
+          addressEmojis: false,
         },
       },
     })
@@ -215,6 +216,7 @@ describe('AssetsTable', () => {
             onChainSigning: false,
           },
           transactionExecution: true,
+          addressEmojis: false,
         },
       },
     })
@@ -317,6 +319,7 @@ describe('AssetsTable', () => {
             onChainSigning: false,
           },
           transactionExecution: true,
+          addressEmojis: false,
         },
       },
     })
@@ -416,6 +419,7 @@ describe('AssetsTable', () => {
             onChainSigning: false,
           },
           transactionExecution: true,
+          addressEmojis: false,
         },
       },
     })

--- a/src/components/balances/HiddenTokenButton/index.test.tsx
+++ b/src/components/balances/HiddenTokenButton/index.test.tsx
@@ -87,6 +87,7 @@ describe('HiddenTokenToggle', () => {
             onChainSigning: false,
           },
           transactionExecution: true,
+          addressEmojis: false,
         },
       },
     })

--- a/src/components/batch/BatchSidebar/styles.module.css
+++ b/src/components/batch/BatchSidebar/styles.module.css
@@ -21,6 +21,10 @@
   margin: var(--space-3) 0;
 }
 
+.txs {
+  width: 100%;
+}
+
 .txs ul {
   padding: 0 var(--space-3) var(--space-3);
   display: flex;

--- a/src/components/common/ConnectWallet/AccountCenter.tsx
+++ b/src/components/common/ConnectWallet/AccountCenter.tsx
@@ -13,6 +13,7 @@ import ChainSwitcher from '../ChainSwitcher'
 import useAddressBook from '@/hooks/useAddressBook'
 import { type ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import WalletInfo, { UNKNOWN_CHAIN_NAME } from '../WalletInfo'
+import AddressEmoji from '../EthHashInfo/AddressEmoji'
 
 const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
@@ -78,7 +79,10 @@ const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
         sx={{ marginTop: 1 }}
       >
         <Paper className={css.popoverContainer}>
-          <Identicon address={wallet.address} />
+          <div className={css.identicon}>
+            <Identicon address={wallet.address} />
+            <AddressEmoji address={wallet.address} />
+          </div>
 
           <Typography variant="h5" className={css.addressName}>
             {addressBook[wallet.address] || wallet.ens}

--- a/src/components/common/ConnectWallet/styles.module.css
+++ b/src/components/common/ConnectWallet/styles.module.css
@@ -54,6 +54,10 @@
   gap: var(--space-2);
 }
 
+.identicon {
+  position: relative;
+}
+
 @media (max-width: 599.95px) {
   .buttonContainer button {
     font-size: 12px;

--- a/src/components/common/EthHashInfo/AddressEmoji.tsx
+++ b/src/components/common/EthHashInfo/AddressEmoji.tsx
@@ -1,0 +1,50 @@
+import { useAppSelector } from '@/store'
+import { selectSettings } from '@/store/settingsSlice'
+import { type ReactElement, useMemo } from 'react'
+import css from './styles.module.css'
+
+export function ethereumAddressToEmoji(address: string): string {
+  // Convert the Ethereum address from hexadecimal to decimal
+  const decimal = BigInt(address.slice(0, 6))
+
+  // Define the Unicode ranges for animal, fruit, and vegetable emojis
+  const unicodeRanges = [
+    [0x1f400, 0x1f43f],
+    [0x1f980, 0x1f994],
+    [0x1f345, 0x1f35f],
+    [0x1f950, 0x1f96b],
+  ]
+
+  // Calculate the total number of emojis
+  let totalEmojis = 0
+  for (let range of unicodeRanges) {
+    totalEmojis += range[1] - range[0] + 1
+  }
+
+  // Calculate the index by taking the modulo of the decimal by the number of emojis
+  let index = Number(decimal % BigInt(totalEmojis))
+
+  // Find the corresponding emoji
+  for (let range of unicodeRanges) {
+    if (index < range[1] - range[0] + 1) {
+      return String.fromCodePoint(range[0] + index)
+    } else {
+      index -= range[1] - range[0] + 1
+    }
+  }
+
+  return ''
+}
+
+const AddressEmoji = ({ address, size = 40 }: { address: string; size?: number }): ReactElement | null => {
+  const { addressEmojis } = useAppSelector(selectSettings)
+  const emoji = useMemo<string>(() => (addressEmojis ? ethereumAddressToEmoji(address) : ''), [address, addressEmojis])
+
+  return emoji ? (
+    <div className={css.emojiWrapper} style={{ fontSize: `${size * 0.7}px`, width: `${size}px`, height: `${size}px` }}>
+      {emoji}
+    </div>
+  ) : null
+}
+
+export default AddressEmoji

--- a/src/components/common/EthHashInfo/AddressEmoji.tsx
+++ b/src/components/common/EthHashInfo/AddressEmoji.tsx
@@ -3,23 +3,23 @@ import { useAppSelector } from '@/store'
 import { selectSettings } from '@/store/settingsSlice'
 import css from './styles.module.css'
 
+// Define the Unicode ranges for animal, fruit, and vegetable emojis
+const unicodeRanges = [
+  [0x1f400, 0x1f43f],
+  [0x1f980, 0x1f994],
+  [0x1f345, 0x1f35f],
+  [0x1f950, 0x1f96b],
+]
+
+// Calculate the total number of emojis
+let totalEmojis = 0
+for (let range of unicodeRanges) {
+  totalEmojis += range[1] - range[0] + 1
+}
+
 function ethereumAddressToEmoji(address: string): string {
   // Convert the Ethereum address from hexadecimal to decimal
   const decimal = BigInt(address.slice(0, 6))
-
-  // Define the Unicode ranges for animal, fruit, and vegetable emojis
-  const unicodeRanges = [
-    [0x1f400, 0x1f43f],
-    [0x1f980, 0x1f994],
-    [0x1f345, 0x1f35f],
-    [0x1f950, 0x1f96b],
-  ]
-
-  // Calculate the total number of emojis
-  let totalEmojis = 0
-  for (let range of unicodeRanges) {
-    totalEmojis += range[1] - range[0] + 1
-  }
 
   // Calculate the index by taking the modulo of the decimal by the number of emojis
   let index = Number(decimal % BigInt(totalEmojis))

--- a/src/components/common/EthHashInfo/AddressEmoji.tsx
+++ b/src/components/common/EthHashInfo/AddressEmoji.tsx
@@ -41,7 +41,7 @@ type EmojiProps = {
   size?: number
 }
 
-const Emoji = memo(function Emoji({ address, size = 40 }: EmojiProps): ReactElement {
+export const Emoji = memo(function Emoji({ address, size = 40 }: EmojiProps): ReactElement {
   return (
     <div className={css.emojiWrapper} style={{ fontSize: `${size * 0.7}px`, width: `${size}px`, height: `${size}px` }}>
       {ethereumAddressToEmoji(address)}

--- a/src/components/common/EthHashInfo/AddressEmoji.tsx
+++ b/src/components/common/EthHashInfo/AddressEmoji.tsx
@@ -1,9 +1,9 @@
+import { type ReactElement, memo } from 'react'
 import { useAppSelector } from '@/store'
 import { selectSettings } from '@/store/settingsSlice'
-import { type ReactElement, useMemo } from 'react'
 import css from './styles.module.css'
 
-export function ethereumAddressToEmoji(address: string): string {
+function ethereumAddressToEmoji(address: string): string {
   // Convert the Ethereum address from hexadecimal to decimal
   const decimal = BigInt(address.slice(0, 6))
 
@@ -36,15 +36,22 @@ export function ethereumAddressToEmoji(address: string): string {
   return ''
 }
 
-const AddressEmoji = ({ address, size = 40 }: { address: string; size?: number }): ReactElement | null => {
-  const { addressEmojis } = useAppSelector(selectSettings)
-  const emoji = useMemo<string>(() => (addressEmojis ? ethereumAddressToEmoji(address) : ''), [address, addressEmojis])
+type EmojiProps = {
+  address: string
+  size?: number
+}
 
-  return emoji ? (
+const Emoji = memo(function Emoji({ address, size = 40 }: EmojiProps): ReactElement {
+  return (
     <div className={css.emojiWrapper} style={{ fontSize: `${size * 0.7}px`, width: `${size}px`, height: `${size}px` }}>
-      {emoji}
+      {ethereumAddressToEmoji(address)}
     </div>
-  ) : null
+  )
+})
+
+const AddressEmoji = (props: EmojiProps): ReactElement | null => {
+  const { addressEmojis } = useAppSelector(selectSettings)
+  return addressEmojis ? <Emoji {...props} /> : null
 }
 
 export default AddressEmoji

--- a/src/components/common/EthHashInfo/index.test.tsx
+++ b/src/components/common/EthHashInfo/index.test.tsx
@@ -173,7 +173,7 @@ describe('EthHashInfo', () => {
 
       expect(container.querySelector('.icon')).toHaveAttribute(
         'style',
-        `background-image: url(${makeBlockie(MOCK_SAFE_ADDRESS)}); width: 40px; height: 40px;`,
+        `background-image: url(${makeBlockie(MOCK_SAFE_ADDRESS)}); width: 44px; height: 44px;`,
       )
     })
 

--- a/src/components/common/EthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/index.tsx
@@ -21,7 +21,7 @@ const PrefixedEthHashInfo = ({
   const addressBook = useAddressBook()
   const link = chain ? getBlockExplorerLink(chain, props.address) : undefined
   const name = showName ? props.name || addressBook[props.address] : undefined
-  const showEmoji = props.showAvatar !== false && !props.customAvatar
+  const showEmoji = settings.addressEmojis && props.showAvatar !== false && !props.customAvatar
 
   return (
     <div className={css.container}>

--- a/src/components/common/EthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/index.tsx
@@ -5,13 +5,14 @@ import useChainId from '@/hooks/useChainId'
 import { useAppSelector } from '@/store'
 import { selectSettings } from '@/store/settingsSlice'
 import { selectChainById } from '@/store/chainsSlice'
-
-import { getBlockExplorerLink } from '../../../utils/chains'
-
+import { getBlockExplorerLink } from '@/utils/chains'
 import type { EthHashInfoProps } from '@safe-global/safe-react-components'
+import css from './styles.module.css'
+import AddressEmoji from './AddressEmoji'
 
 const PrefixedEthHashInfo = ({
   showName = true,
+  avatarSize = 44,
   ...props
 }: EthHashInfoProps & { showName?: boolean }): ReactElement => {
   const settings = useAppSelector(selectSettings)
@@ -20,18 +21,24 @@ const PrefixedEthHashInfo = ({
   const addressBook = useAddressBook()
   const link = chain ? getBlockExplorerLink(chain, props.address) : undefined
   const name = showName ? props.name || addressBook[props.address] : undefined
+  const showEmoji = props.showAvatar !== false && !props.customAvatar
 
   return (
-    <EthHashInfo
-      prefix={chain?.shortName}
-      showPrefix={settings.shortName.show}
-      copyPrefix={settings.shortName.copy}
-      {...props}
-      name={name}
-      ExplorerButtonProps={{ title: link?.title || '', href: link?.href || '' }}
-    >
-      {props.children}
-    </EthHashInfo>
+    <div className={css.container}>
+      <EthHashInfo
+        prefix={chain?.shortName}
+        showPrefix={settings.shortName.show}
+        copyPrefix={settings.shortName.copy}
+        {...props}
+        name={name}
+        customAvatar={props.customAvatar}
+        ExplorerButtonProps={{ title: link?.title || '', href: link?.href || '' }}
+        avatarSize={avatarSize}
+      >
+        {props.children}
+      </EthHashInfo>
+      {showEmoji && <AddressEmoji address={props.address} size={avatarSize} />}
+    </div>
   )
 }
 

--- a/src/components/common/EthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/index.tsx
@@ -8,7 +8,7 @@ import { selectChainById } from '@/store/chainsSlice'
 import { getBlockExplorerLink } from '@/utils/chains'
 import type { EthHashInfoProps } from '@safe-global/safe-react-components'
 import css from './styles.module.css'
-import AddressEmoji from './AddressEmoji'
+import { Emoji } from './AddressEmoji'
 
 const PrefixedEthHashInfo = ({
   showName = true,
@@ -37,7 +37,7 @@ const PrefixedEthHashInfo = ({
       >
         {props.children}
       </EthHashInfo>
-      {showEmoji && <AddressEmoji address={props.address} size={avatarSize} />}
+      {showEmoji && <Emoji address={props.address} size={avatarSize} />}
     </div>
   )
 }

--- a/src/components/common/EthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/index.tsx
@@ -21,7 +21,7 @@ const PrefixedEthHashInfo = ({
   const addressBook = useAddressBook()
   const link = chain ? getBlockExplorerLink(chain, props.address) : undefined
   const name = showName ? props.name || addressBook[props.address] : undefined
-  const showEmoji = settings.addressEmojis && props.showAvatar !== false && !props.customAvatar
+  const showEmoji = settings.addressEmojis && props.showAvatar !== false && !props.customAvatar && avatarSize >= 20
 
   return (
     <div className={css.container}>

--- a/src/components/common/EthHashInfo/styles.module.css
+++ b/src/components/common/EthHashInfo/styles.module.css
@@ -8,7 +8,6 @@
   flex-direction: column;
   justify-content: center;
   position: absolute;
-  z-index: 1;
   top: 0;
   left: 0;
   border-radius: 100%;

--- a/src/components/common/EthHashInfo/styles.module.css
+++ b/src/components/common/EthHashInfo/styles.module.css
@@ -9,7 +9,8 @@
   justify-content: center;
   position: absolute;
   z-index: 1;
-  top: 0;
+  top: 50%;
+  transform: translateY(-50%);
   left: 0;
   border-radius: 100%;
   border: 2px solid var(--color-secondary-light);

--- a/src/components/common/EthHashInfo/styles.module.css
+++ b/src/components/common/EthHashInfo/styles.module.css
@@ -14,7 +14,7 @@
   border-radius: 100%;
   border: 2px solid var(--color-secondary-light);
   color: #000;
-  background-color: rgba(255, 255, 255, 0.6);
+  background-color: rgba(255, 255, 255, 0.5);
   text-shadow: -1px 0 0 var(--color-secondary-light), 0 -1px 0 var(--color-secondary-light),
     1px 0 0 var(--color-secondary-light), 0 1px 0 var(--color-secondary-light);
 }

--- a/src/components/common/EthHashInfo/styles.module.css
+++ b/src/components/common/EthHashInfo/styles.module.css
@@ -9,8 +9,7 @@
   justify-content: center;
   position: absolute;
   z-index: 1;
-  top: 50%;
-  transform: translateY(-50%);
+  top: 0;
   left: 0;
   border-radius: 100%;
   border: 2px solid var(--color-secondary-light);

--- a/src/components/common/EthHashInfo/styles.module.css
+++ b/src/components/common/EthHashInfo/styles.module.css
@@ -14,5 +14,7 @@
   border-radius: 100%;
   border: 2px solid var(--color-secondary-light);
   color: #000;
-  background-color: rgba(255, 255, 255, 0.75);
+  background-color: rgba(255, 255, 255, 0.6);
+  text-shadow: -1px 0 0 var(--color-secondary-light), 0 -1px 0 var(--color-secondary-light),
+    1px 0 0 var(--color-secondary-light), 0 1px 0 var(--color-secondary-light);
 }

--- a/src/components/common/EthHashInfo/styles.module.css
+++ b/src/components/common/EthHashInfo/styles.module.css
@@ -1,41 +1,18 @@
 .container {
+  position: relative;
+}
+
+.emojiWrapper {
+  text-align: center;
   display: flex;
-  align-items: center;
-  gap: 0.5em;
-  line-height: 1.4;
-}
-
-.avatar {
-  flex-shrink: 0;
-}
-
-.resizeAvatar,
-.resizeAvatar * {
-  width: 2.3em !important;
-  height: 2.3em !important;
-}
-
-.addressRow {
-  display: flex;
-  align-items: center;
-  gap: 0.25em;
-  white-space: nowrap;
-}
-
-.nameRow {
-  overflow: hidden;
-}
-
-.mobileAddress {
-  display: none;
-}
-
-@media (max-width: 599.95px) {
-  .mobileAddress {
-    display: inline-block;
-  }
-
-  .desktopAddress {
-    display: none;
-  }
+  flex-direction: column;
+  justify-content: center;
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  left: 0;
+  border-radius: 100%;
+  border: 2px solid var(--color-secondary-light);
+  color: #000;
+  background-color: rgba(255, 255, 255, 0.75);
 }

--- a/src/components/common/SafeIcon/index.tsx
+++ b/src/components/common/SafeIcon/index.tsx
@@ -3,6 +3,7 @@ import { Box } from '@mui/material'
 
 import css from './styles.module.css'
 import Identicon, { type IdenticonProps } from '../Identicon'
+import AddressEmoji from '../EthHashInfo/AddressEmoji'
 
 interface ThresholdProps {
   threshold: number | string
@@ -24,6 +25,7 @@ const SafeIcon = ({ address, threshold, owners, size }: SafeIconProps): ReactEle
   <div className={css.container}>
     {threshold && owners ? <Threshold threshold={threshold} owners={owners} /> : null}
     <Identicon address={address} size={size} />
+    <AddressEmoji address={address} size={size} />
   </div>
 )
 

--- a/src/components/common/SafeIcon/styles.module.css
+++ b/src/components/common/SafeIcon/styles.module.css
@@ -6,7 +6,7 @@
   position: absolute;
   top: -6px;
   right: -6px;
-  z-index: 1;
+  z-index: 2;
   border-radius: 100%;
   font-size: 12px;
   min-width: 24px;

--- a/src/components/settings/EmojiPreview/index.tsx
+++ b/src/components/settings/EmojiPreview/index.tsx
@@ -1,0 +1,23 @@
+import { Alert, Box, Chip, SvgIcon, Typography } from '@mui/material'
+import { ZERO_ADDRESS } from '@safe-global/safe-core-sdk/dist/src/utils/constants'
+import InfoIcon from '@/public/images/notifications/info.svg'
+import SafeIcon from '@/components/common/SafeIcon'
+
+const EmojiPreview = () => (
+  <>
+    <Chip label="New" color="secondary" sx={{ fontWeight: 'bold', borderRadius: 2 }} />
+
+    <Alert severity="success" sx={{ marginTop: 2, borderColor: 'secondary.main' }} icon={<></>}>
+      <SvgIcon component={InfoIcon} sx={{ marginRight: 1, verticalAlign: 'middle' }} color="secondary" />
+
+      <Typography component="span">Enable emojis for all Ethereum addresses and your Safe Accounts.</Typography>
+
+      <Box mt={1} display="flex" alignItems="center" gap={1}>
+        <SafeIcon address={ZERO_ADDRESS} />
+        <Typography variant="body2">{ZERO_ADDRESS}</Typography>
+      </Box>
+    </Alert>
+  </>
+)
+
+export default EmojiPreview

--- a/src/components/transactions/TxDetails/TxData/Transfer/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/Transfer/index.tsx
@@ -34,7 +34,7 @@ const TransferTxInfo = ({ txInfo, txStatus }: TransferTxInfoProps) => {
     <Box>
       <TransferTxInfoSummary txInfo={txInfo} txStatus={txStatus} />
       <Box display="flex" alignItems="center">
-        <EthHashInfo address={address} shortAddress={false} hasExplorer showCopyButton>
+        <EthHashInfo address={address} shortAddress={false} hasExplorer showCopyButton avatarSize={44}>
           <TransferActions address={address} txInfo={txInfo} />
         </EthHashInfo>
       </Box>

--- a/src/components/tx/SignOrExecuteForm/BatchButton.tsx
+++ b/src/components/tx/SignOrExecuteForm/BatchButton.tsx
@@ -17,7 +17,7 @@ const BatchButton = ({
     <Tooltip title={tooltip} placement="top">
       <span>
         <Track {...BATCH_EVENTS.BATCH_APPEND}>
-          <Button variant="outlined" onClick={onClick} disabled={disabled} sx={{ display: ['none', 'block'] }}>
+          <Button variant="outlined" onClick={onClick} disabled={disabled} sx={{ display: ['none', 'flex'] }}>
             <SvgIcon component={PlusIcon} inheritViewBox fontSize="small" sx={{ mr: 1 }} />
             Add to batch
           </Button>

--- a/src/pages/settings/appearance.tsx
+++ b/src/pages/settings/appearance.tsx
@@ -15,7 +15,7 @@ import SettingsHeader from '@/components/settings/SettingsHeader'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 import { useDarkMode } from '@/hooks/useDarkMode'
 import ExternalLink from '@/components/common/ExternalLink'
-import SafeIcon from '@/components/common/SafeIcon'
+import EmojiPreview from '@/components/settings/EmojiPreview'
 
 const Appearance: NextPage = () => {
   const dispatch = useAppDispatch()
@@ -49,7 +49,7 @@ const Appearance: NextPage = () => {
       <SettingsHeader />
 
       <main>
-        <Paper sx={{ padding: 4 }}>
+        <Paper sx={{ p: 4 }}>
           <Grid container spacing={3}>
             <Grid item lg={4} xs={12}>
               <Typography variant="h4" fontWeight="bold" mb={1}>
@@ -106,7 +106,7 @@ const Appearance: NextPage = () => {
             </Grid>
           </Grid>
 
-          <Grid container alignItems="center" marginTop={2} spacing={3}>
+          <Grid container spacing={3} mt={2}>
             <Grid item lg={4} xs={12}>
               <Typography variant="h4" fontWeight="bold">
                 Experimental
@@ -114,26 +114,16 @@ const Appearance: NextPage = () => {
             </Grid>
 
             <Grid item xs>
-              <Grid container alignItems="center" spacing={1}>
-                <Grid item>
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={settings.addressEmojis}
-                        onChange={handleToggle(setAddressEmojis, SETTINGS_EVENTS.APPEARANCE.ADDRESS_EMOJIS)}
-                      />
-                    }
-                    label="Enable emojis for Ethereum addresses"
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={settings.addressEmojis}
+                    onChange={handleToggle(setAddressEmojis, SETTINGS_EVENTS.APPEARANCE.ADDRESS_EMOJIS)}
                   />
-                </Grid>
-
-                <Grid item>
-                  <Typography color="border.main">Preview:</Typography>
-                </Grid>
-                <Grid item xs>
-                  <SafeIcon address="0x220866b1a2219f40e72f5c628b65d54268ca3a9d" />
-                </Grid>
-              </Grid>
+                }
+                label="Address emoji"
+              />
+              <EmojiPreview />
             </Grid>
           </Grid>
         </Paper>

--- a/src/pages/settings/appearance.tsx
+++ b/src/pages/settings/appearance.tsx
@@ -15,7 +15,7 @@ import SettingsHeader from '@/components/settings/SettingsHeader'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 import { useDarkMode } from '@/hooks/useDarkMode'
 import ExternalLink from '@/components/common/ExternalLink'
-import PrefixedEthHashInfo from '@/components/common/EthHashInfo'
+import SafeIcon from '@/components/common/SafeIcon'
 
 const Appearance: NextPage = () => {
   const dispatch = useAppDispatch()
@@ -123,7 +123,7 @@ const Appearance: NextPage = () => {
                         onChange={handleToggle(setAddressEmojis, SETTINGS_EVENTS.APPEARANCE.ADDRESS_EMOJIS)}
                       />
                     }
-                    label="Enable address emojis"
+                    label="Enable emojis for Ethereum addresses"
                   />
                 </Grid>
 
@@ -131,7 +131,7 @@ const Appearance: NextPage = () => {
                   <Typography color="border.main">Preview:</Typography>
                 </Grid>
                 <Grid item xs>
-                  <PrefixedEthHashInfo address="0x0000000000000000000000000000000000000000" />
+                  <SafeIcon address="0x220866b1a2219f40e72f5c628b65d54268ca3a9d" />
                 </Grid>
               </Grid>
             </Grid>

--- a/src/pages/settings/appearance.tsx
+++ b/src/pages/settings/appearance.tsx
@@ -4,11 +4,18 @@ import type { NextPage } from 'next'
 import Head from 'next/head'
 
 import { useAppDispatch, useAppSelector } from '@/store'
-import { selectSettings, setCopyShortName, setDarkMode, setShowShortName } from '@/store/settingsSlice'
+import {
+  selectSettings,
+  setCopyShortName,
+  setDarkMode,
+  setShowShortName,
+  setAddressEmojis,
+} from '@/store/settingsSlice'
 import SettingsHeader from '@/components/settings/SettingsHeader'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 import { useDarkMode } from '@/hooks/useDarkMode'
 import ExternalLink from '@/components/common/ExternalLink'
+import PrefixedEthHashInfo from '@/components/common/EthHashInfo'
 
 const Appearance: NextPage = () => {
   const dispatch = useAppDispatch()
@@ -16,11 +23,12 @@ const Appearance: NextPage = () => {
   const isDarkMode = useDarkMode()
 
   const handleToggle = (
-    action: typeof setCopyShortName | typeof setDarkMode | typeof setShowShortName,
+    action: typeof setCopyShortName | typeof setDarkMode | typeof setShowShortName | typeof setAddressEmojis,
     event:
       | typeof SETTINGS_EVENTS.APPEARANCE.PREPEND_PREFIXES
       | typeof SETTINGS_EVENTS.APPEARANCE.COPY_PREFIXES
-      | typeof SETTINGS_EVENTS.APPEARANCE.DARK_MODE,
+      | typeof SETTINGS_EVENTS.APPEARANCE.DARK_MODE
+      | typeof SETTINGS_EVENTS.APPEARANCE.ADDRESS_EMOJIS,
   ) => {
     return (_: ChangeEvent<HTMLInputElement>, checked: boolean) => {
       dispatch(action(checked))
@@ -95,6 +103,37 @@ const Appearance: NextPage = () => {
                 }
                 label="Dark mode"
               />
+            </Grid>
+          </Grid>
+
+          <Grid container alignItems="center" marginTop={2} spacing={3}>
+            <Grid item lg={4} xs={12}>
+              <Typography variant="h4" fontWeight="bold">
+                Experimental
+              </Typography>
+            </Grid>
+
+            <Grid item xs>
+              <Grid container alignItems="center" spacing={1}>
+                <Grid item>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={settings.addressEmojis}
+                        onChange={handleToggle(setAddressEmojis, SETTINGS_EVENTS.APPEARANCE.ADDRESS_EMOJIS)}
+                      />
+                    }
+                    label="Enable address emojis"
+                  />
+                </Grid>
+
+                <Grid item>
+                  <Typography color="border.main">Preview:</Typography>
+                </Grid>
+                <Grid item xs>
+                  <PrefixedEthHashInfo address="0x0000000000000000000000000000000000000000" />
+                </Grid>
+              </Grid>
             </Grid>
           </Grid>
         </Paper>

--- a/src/services/analytics/events/settings.ts
+++ b/src/services/analytics/events/settings.ts
@@ -48,6 +48,10 @@ export const SETTINGS_EVENTS = {
       action: 'Dark mode',
       category: SETTINGS_CATEGORY,
     },
+    ADDRESS_EMOJIS: {
+      action: 'Toggle address emojis',
+      category: SETTINGS_CATEGORY,
+    },
   },
   MODULES: {
     REMOVE_MODULE: {

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -42,6 +42,7 @@ export type SettingsState = {
     onChainSigning: boolean
   }
   transactionExecution: boolean
+  addressEmojis?: boolean
 }
 
 export const initialState: SettingsState = {
@@ -68,6 +69,7 @@ export const initialState: SettingsState = {
     onChainSigning: false,
   },
   transactionExecution: true,
+  addressEmojis: false,
 }
 
 export const settingsSlice = createSlice({
@@ -91,6 +93,9 @@ export const settingsSlice = createSlice({
     },
     setDarkMode: (state, { payload }: PayloadAction<SettingsState['theme']['darkMode']>) => {
       state.theme.darkMode = payload
+    },
+    setAddressEmojis: (state, { payload }: PayloadAction<SettingsState['addressEmojis']>) => {
+      state.addressEmojis = payload
     },
     setHiddenTokensForChain: (state, { payload }: PayloadAction<{ chainId: string; assets: string[] }>) => {
       const { chainId, assets } = payload
@@ -127,6 +132,7 @@ export const {
   setCopyShortName,
   setQrShortName,
   setDarkMode,
+  setAddressEmojis,
   setHiddenTokensForChain,
   setTokenList,
   setRpc,

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -42,7 +42,7 @@ export type SettingsState = {
     onChainSigning: boolean
   }
   transactionExecution: boolean
-  addressEmojis?: boolean
+  addressEmojis: boolean
 }
 
 export const initialState: SettingsState = {


### PR DESCRIPTION
Experimental feature: deterministic emojis for Ethereum addresses.

## What it solves

For each displayed address, an emoji is derived based on the address. This helps identify addresses more easily and helps memorize which is which.

## How this PR fixes it

This PR adds an experimental toggle in the Appearance Settings that enables address emojis (off by default).
<img width="1082" alt="Screenshot 2023-07-26 at 11 47 57" src="https://github.com/safe-global/safe-wallet-web/assets/381895/6de13a99-4124-4a7f-afe3-1e7e234b2f06">

## Screenshots
<img width="241" alt="Screenshot 2023-07-26 at 11 58 04" src="https://github.com/safe-global/safe-wallet-web/assets/381895/347cb8f4-5d21-4c49-95fa-68dd198b3b02">
<img width="682" alt="Screenshot 2023-07-26 at 11 57 45" src="https://github.com/safe-global/safe-wallet-web/assets/381895/0eaa8c99-741b-43c4-a5b4-dd277d56dbde">
<img width="1087" alt="Screenshot 2023-07-26 at 11 57 24" src="https://github.com/safe-global/safe-wallet-web/assets/381895/66e04fc0-fda0-4661-9217-dd2534fd39f0">
<img width="474" alt="Screenshot 2023-07-26 at 11 56 46" src="https://github.com/safe-global/safe-wallet-web/assets/381895/ed629f42-2367-4ebe-a1c9-dac0d4c7c654">

