### PR TITLE
fix: show unsuccessful simulations correctly

### DIFF
--- a/src/components/tx/security/tenderly/index.tsx
+++ b/src/components/tx/security/tenderly/index.tsx
@@ -35,7 +35,7 @@ const TxSimulationBlock = ({ transactions, disabled, gasLimit }: TxSimulationPro
   const { safeTx } = useContext(SafeTxContext)
   const {
     simulation: { simulateTransaction, resetSimulation },
-    status: { isError, isSuccess, isCallTraceError, isLoading },
+    status: { isFinished, isError, isSuccess, isCallTraceError, isLoading },
   } = useContext(TxInfoContext)
 
   const handleSimulation = async () => {
@@ -99,16 +99,18 @@ const TxSimulationBlock = ({ transactions, disabled, gasLimit }: TxSimulationPro
               color: ({ palette }) => palette.text.secondary,
             }}
           />
-        ) : isError || isCallTraceError ? (
-          <Typography variant="body2" color="error.main" className={sharedCss.result}>
-            <SvgIcon component={CloseIcon} inheritViewBox fontSize="small" sx={{ verticalAlign: 'middle', mr: 1 }} />
-            Error
-          </Typography>
-        ) : isSuccess ? (
-          <Typography variant="body2" color="success.main" className={sharedCss.result}>
-            <SvgIcon component={CheckIcon} inheritViewBox fontSize="small" sx={{ verticalAlign: 'middle', mr: 1 }} />
-            Success
-          </Typography>
+        ) : isFinished ? (
+          !isSuccess || isError || isCallTraceError ? (
+            <Typography variant="body2" color="error.main" className={sharedCss.result}>
+              <SvgIcon component={CloseIcon} inheritViewBox fontSize="small" sx={{ verticalAlign: 'middle', mr: 1 }} />
+              Error
+            </Typography>
+          ) : (
+            <Typography variant="body2" color="success.main" className={sharedCss.result}>
+              <SvgIcon component={CheckIcon} inheritViewBox fontSize="small" sx={{ verticalAlign: 'middle', mr: 1 }} />
+              Success
+            </Typography>
+          )
         ) : (
           <Button
             variant="outlined"


### PR DESCRIPTION
## What it solves

Tenderly status for unsuccessful txs

Resolves #2301 

## How this PR fixes it
If a simulation finishes without being successful we show an Error state in the simulation component.

## How to test it
- Create a transaction that will revert (for instance send Safe token or add a duplicate owner, etc.)
- Simulate it
- Observe overall error state of the simulation

## Screenshots
![Screenshot 2023-07-26 at 16 40 20](https://github.com/safe-global/safe-wallet-web/assets/2670790/9a77c587-ec72-4a7d-aa77-b22e4f7f1fbc)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
