### PR TITLE
fix: centralise flow + reduce success screen width

### DIFF
--- a/src/components/common/TxModalDialog/styles.module.css
+++ b/src/components/common/TxModalDialog/styles.module.css
@@ -38,6 +38,7 @@
 .close {
   color: var(--color-border-main);
   padding: var(--space-1);
+  background-color: var(--color-border-light);
 }
 
 .paper {
@@ -74,6 +75,10 @@
   .title {
     margin-bottom: var(--space-3);
     background-color: var(--color-background-paper);
+  }
+
+  .close {
+    background-color: unset;
   }
 
   .close svg {

--- a/src/components/tx-flow/common/TxLayout/index.tsx
+++ b/src/components/tx-flow/common/TxLayout/index.tsx
@@ -92,28 +92,29 @@ const TxLayout = ({
     <SafeTxProvider>
       <TxInfoProvider>
         <TxSecurityProvider>
-          <Container className={css.container}>
-            <Grid container alignItems="center" justifyContent="center">
-              <Grid item container xs={12}>
-                <Grid item xs={12} md={7} className={css.titleWrapper}>
-                  <Typography variant="h3" component="div" fontWeight="700" className={css.title}>
-                    {title}
-                  </Typography>
+          <>
+            {/* Header status button */}
+            <IconButton
+              className={css.statusButton}
+              aria-label="Transaction status"
+              size="large"
+              onClick={toggleStatus}
+            >
+              <SafeLogo width={16} height={16} />
+            </IconButton>
 
-                  <ChainIndicator inline />
-                </Grid>
-                <IconButton
-                  className={css.statusButton}
-                  aria-label="Transaction status"
-                  size="large"
-                  onClick={toggleStatus}
-                >
-                  <SafeLogo width={16} height={16} />
-                </IconButton>
-              </Grid>
-
-              <Grid item container xs={12} gap={3}>
+            <Container className={css.container}>
+              <Grid container gap={3} justifyContent="center">
+                {/* Main content */}
                 <Grid item xs={12} md={7}>
+                  <div className={css.titleWrapper}>
+                    <Typography variant="h3" component="div" fontWeight="700" className={css.title}>
+                      {title}
+                    </Typography>
+
+                    <ChainIndicator inline />
+                  </div>
+
                   <Paper className={css.header}>
                     <Box className={css.progressBar}>
                       <ProgressBar value={progress} />
@@ -133,6 +134,7 @@ const TxLayout = ({
                   </div>
                 </Grid>
 
+                {/* Sidebar */}
                 <Grid item xs={12} md={4} className={classnames(css.widget, { [css.active]: statusVisible })}>
                   {statusVisible && (
                     <TxStatusWidget
@@ -151,8 +153,8 @@ const TxLayout = ({
                   </Box>
                 </Grid>
               </Grid>
-            </Grid>
-          </Container>
+            </Container>
+          </>
         </TxSecurityProvider>
       </TxInfoProvider>
     </SafeTxProvider>

--- a/src/components/tx-flow/common/TxLayout/styles.module.css
+++ b/src/components/tx-flow/common/TxLayout/styles.module.css
@@ -11,7 +11,8 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: var(--space-3);
+  /* Remove height of progress bar */
+  padding: calc(var(--space-3) - 6px) var(--space-3) var(--space-3);
   border-bottom: 1px solid var(--color-border-light);
 }
 
@@ -103,6 +104,11 @@
   margin-bottom: var(--space-2);
 }
 
+.widget {
+  /* Height of transaction type title */
+  margin-top: 46px;
+}
+
 @media (max-width: 899.95px) {
   .widget {
     position: absolute;
@@ -111,6 +117,7 @@
     width: 100%;
     height: 100%;
     z-index: -1;
+    margin-top: unset;
   }
 
   .widget.active {

--- a/src/components/tx-flow/common/TxStatusWidget/index.tsx
+++ b/src/components/tx-flow/common/TxStatusWidget/index.tsx
@@ -47,8 +47,8 @@ const TxStatusWidget = ({
   return (
     <Paper>
       <div className={css.header}>
-        <SafeLogo width={32} height={32} className={css.logo} />
-        <Typography variant="h6" fontWeight="700" className={css.title}>
+        <Typography fontWeight="700" display="flex" alignItems="center" gap={1}>
+          <SafeLogo width={16} height={16} className={css.logo} />
           Transaction status
         </Typography>
         <IconButton className={css.close} aria-label="close" onClick={handleClose} size="small">

--- a/src/components/tx-flow/common/TxStatusWidget/styles.module.css
+++ b/src/components/tx-flow/common/TxStatusWidget/styles.module.css
@@ -1,13 +1,12 @@
 .header {
-  padding: var(--space-3);
+  padding: var(--space-4) var(--space-3);
   display: flex;
   flex-direction: column;
-  align-items: center;
   gap: var(--space-1);
 }
 
 .content {
-  padding: var(--space-3);
+  padding: var(--space-2);
 }
 
 .status {
@@ -83,11 +82,11 @@
     margin-left: 16px;
   }
 
-  .title {
-    font-size: 16px;
-  }
-
   .close {
     display: flex;
+  }
+
+  .content {
+    padding: var(--space-3);
   }
 }

--- a/src/components/tx-flow/flows/NewTx/index.tsx
+++ b/src/components/tx-flow/flows/NewTx/index.tsx
@@ -23,7 +23,7 @@ const NewTxMenu = () => {
 
   return (
     <Container className={css.container}>
-      <Grid container>
+      <Grid container justifyContent="center">
         {/* Alignment of `TxLayout` */}
         <Grid item xs={12} md={11} display="flex" flexDirection="column">
           <ChainIndicator inline className={css.chain} />

--- a/src/components/tx-flow/flows/SuccessScreen/index.tsx
+++ b/src/components/tx-flow/flows/SuccessScreen/index.tsx
@@ -51,8 +51,9 @@ export const SuccessScreen = ({ txId }: { txId: string }) => {
       disableGutters
       sx={{
         textAlign: 'center',
+        maxWidth: `${900 - 75}px`, // md={11}
       }}
-      maxWidth="md"
+      maxWidth={false}
     >
       <div className={css.row}>
         <StatusMessage status={status} error={error} />


### PR DESCRIPTION
## What it solves

Resolves [design inconsistencies](https://www.notion.so/safe-global/New-Transaction-flow-b15e2dc487ca406c908d0e4fb8271704#6c3f7beb913f40ea9cda25ad177f4478)

## How this PR fixes it

- Transaction status widget has been made more compact
- The close button now has a background colour]
- Success screen width has been reduced
- All transaction flow modals are centred (new transaction, flow and success screen)

## How to test it

Use the transaction creation flow, executing a transaction and observe the above.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/47221393-cc73-4038-941f-7453598fcda0)

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/e04c5663-4d2c-4d53-a8cf-19856807bbf9)

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/8bdc6ec2-4524-4db8-9cac-488aa2865a22)

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/d7de2e26-c290-49fe-b771-eb4345c9b1b1)

---

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/c6440599-441c-4359-aa01-8508172d58b5)

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/b7397f3c-d936-49d6-b95e-526d8ad0d354)

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/14046e76-8dc8-4594-a297-d9b20b98d29f)

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
