### PR TITLE
Fix: load plausible analytics only on prod and official domain

### DIFF
--- a/src/components/common/MetaTags/index.tsx
+++ b/src/components/common/MetaTags/index.tsx
@@ -1,4 +1,4 @@
-import { IS_PRODUCTION } from '@/config/constants'
+import { IS_PRODUCTION, IS_OFFICIAL_HOST } from '@/config/constants'
 import { ContentSecurityPolicy, StrictTransportSecurity } from '@/config/securityHeaders'
 import { lightPalette, darkPalette } from '@safe-global/safe-react-components'
 
@@ -45,7 +45,9 @@ const MetaTags = ({ prefetchUrl }: { prefetchUrl: string }) => (
     <link rel="mask-icon" href="/favicons/safari-pinned-tab.svg" color="#000" />
 
     {/* Plausible Analytics */}
-    <script defer data-domain="app.safe.global" src="https://plausible.io/js/script.js"></script>
+    {IS_PRODUCTION && IS_OFFICIAL_HOST && (
+      <script defer data-domain="app.safe.global" src="https://plausible.io/js/script.js"></script>
+    )}
   </>
 )
 


### PR DESCRIPTION
A small adjustment for #2307 – avoid loading the new analytics script in non-prod envs and in forked UIs.