### PR TITLE
Fix: load plausible analytics only on prod and official domain + add to CSP

### DIFF
--- a/src/components/common/MetaTags/index.tsx
+++ b/src/components/common/MetaTags/index.tsx
@@ -1,4 +1,4 @@
-import { IS_PRODUCTION } from '@/config/constants'
+import { IS_PRODUCTION, IS_OFFICIAL_HOST } from '@/config/constants'
 import { ContentSecurityPolicy, StrictTransportSecurity } from '@/config/securityHeaders'
 import { lightPalette, darkPalette } from '@safe-global/safe-react-components'
 
@@ -45,7 +45,9 @@ const MetaTags = ({ prefetchUrl }: { prefetchUrl: string }) => (
     <link rel="mask-icon" href="/favicons/safari-pinned-tab.svg" color="#000" />
 
     {/* Plausible Analytics */}
-    <script defer data-domain="app.safe.global" src="https://plausible.io/js/script.js"></script>
+    {IS_PRODUCTION && IS_OFFICIAL_HOST && (
+      <script defer data-domain="app.safe.global" src="https://plausible.io/js/script.js"></script>
+    )}
   </>
 )
 

--- a/src/config/securityHeaders.ts
+++ b/src/config/securityHeaders.ts
@@ -12,14 +12,14 @@ import { CYPRESS_MNEMONIC, IS_PRODUCTION } from '@/config/constants'
 export const ContentSecurityPolicy = `
  default-src 'self';
  connect-src 'self' *;
- script-src 'self' https://www.google-analytics.com https://ssl.google-analytics.com 'unsafe-inline' https://*.getbeamer.com https://www.googletagmanager.com https://*.ingest.sentry.io https://sentry.io ${
+ script-src 'self' https://www.google-analytics.com https://ssl.google-analytics.com 'unsafe-inline' https://*.getbeamer.com https://www.googletagmanager.com https://*.ingest.sentry.io https://sentry.io https://plausible.io ${
    !IS_PRODUCTION || /* TODO: remove after moving cypress to görli and testing in staging again!! */ CYPRESS_MNEMONIC
      ? "'unsafe-eval'"
      : ''
  };
  frame-src *;
  style-src 'self' 'unsafe-inline' https://*.getbeamer.com https://*.googleapis.com;
- font-src 'self' data:; 
+ font-src 'self' data:;
  worker-src 'self' blob:;
  img-src * data:;
 `


### PR DESCRIPTION
A small adjustment for https://github.com/safe-global/safe-wallet-web/pull/2307.
* Avoid loading the new analytics script in non-prod envs and in forked UIs
* Add the plausible host to the allowed script hosts in the CSP.