### PR TITLE
Fix: make tx modal higher than queue drawer

### DIFF
--- a/src/components/common/TxModalDialog/styles.module.css
+++ b/src/components/common/TxModalDialog/styles.module.css
@@ -1,7 +1,7 @@
 .dialog {
   top: 52px;
   left: 230px;
-  z-index: 3;
+  z-index: 1201;
   transition: left 225ms cubic-bezier(0, 0, 0.2, 1) 0ms;
 }
 


### PR DESCRIPTION
When you confirm a tx from the Apps Drawer, the Tx Modal should be on a higher layer.