### PR TITLE
Fix: minimize queue drawer when tx modal is opened

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "homepage": "https://github.com/safe-global/safe-wallet-web",
   "license": "GPL-3.0",
   "type": "module",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "scripts": {
     "dev": "next dev",
     "start": "next dev",

--- a/src/components/common/TxModalDialog/styles.module.css
+++ b/src/components/common/TxModalDialog/styles.module.css
@@ -1,7 +1,7 @@
 .dialog {
   top: 52px;
   left: 230px;
-  z-index: 1201;
+  z-index: 3;
   transition: left 225ms cubic-bezier(0, 0, 0.2, 1) 0ms;
 }
 

--- a/src/components/safe-apps/AppFrame/useTransactionQueueBarState.ts
+++ b/src/components/safe-apps/AppFrame/useTransactionQueueBarState.ts
@@ -1,14 +1,20 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import useTxQueue from '@/hooks/useTxQueue'
+import { TxModalContext } from '@/components/tx-flow'
 
 const useTransactionQueueBarState = () => {
   const [expanded, setExpanded] = useState(false)
   const [dismissedByUser, setDismissedByUser] = useState(false)
   const { page = { results: [] } } = useTxQueue()
+  const { txFlow } = useContext(TxModalContext)
 
   const dismissQueueBar = useCallback((): void => {
     setDismissedByUser(true)
   }, [])
+
+  useEffect(() => {
+    if (txFlow) setExpanded(false)
+  }, [txFlow])
 
   return {
     expanded,


### PR DESCRIPTION
Setting a high z-index on the modal was a mistake because ot was covering the Safe List.

Instead, it will now collapse the bottom drawer when a tx modal is opened.