### PR TITLE
fix: replacement nonce dropdown style

### DIFF
--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -12,6 +12,7 @@ import {
   MenuItem,
   Typography,
   ListSubheader,
+  type ListSubheaderProps,
 } from '@mui/material'
 import { Controller, useForm } from 'react-hook-form'
 
@@ -29,17 +30,24 @@ import { isRejectionTx } from '@/utils/transactions'
 import css from './styles.module.css'
 import classNames from 'classnames'
 
-const CustomPopper = function ({ className, ...props }: PopperProps) {
-  return (
-    <Popper
-      {...props}
-      // Doesn't display correctly on mobile if in CSS module
-      sx={{ minWidth: '300px !important' }}
-      className={classNames(className, css.popper)}
-      placement="bottom-start"
-    />
-  )
+const CustomPopper = function ({
+  // Don't set width of Popper to that of the field
+  style: _,
+  className,
+  ...props
+}: PopperProps) {
+  return <Popper {...props} className={classNames(className, css.popper)} placement="bottom-start" />
 }
+
+const NonceFormHeader = memo(function NonceFormSubheader({ children, ...props }: ListSubheaderProps) {
+  return (
+    <ListSubheader {...props} disableSticky>
+      <Typography variant="caption" fontWeight={700} color="text.secondary">
+        {children}
+      </Typography>
+    </ListSubheader>
+  )
+})
 
 const NonceFormOption = memo(function NonceFormOption({
   nonce,
@@ -64,7 +72,9 @@ const NonceFormOption = memo(function NonceFormOption({
 
   return (
     <MenuItem {...menuItemProps}>
-      <b>{nonce}</b>&nbsp;- {`${label || 'New'} transaction`}
+      <Typography variant="body2">
+        <b>{nonce}</b>&nbsp;- {`${label || 'New'} transaction`}
+      </Typography>
     </MenuItem>
   )
 })
@@ -128,7 +138,7 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
       render={({ field, fieldState }) => {
         if (readOnly) {
           return (
-            <Typography fontWeight={700} ml={-1}>
+            <Typography variant="body2" fontWeight={700} ml={-1}>
               {nonce}
             </Typography>
           )
@@ -157,16 +167,8 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
 
               return (
                 <>
-                  {isRecommendedNonce && (
-                    <ListSubheader>
-                      <b>Recommended nonce</b>
-                    </ListSubheader>
-                  )}
-                  {isInitialPreviousNonce && (
-                    <ListSubheader sx={{ pt: 3 }}>
-                      <b>Already in queue</b>
-                    </ListSubheader>
-                  )}
+                  {isRecommendedNonce && <NonceFormHeader>Recommended nonce</NonceFormHeader>}
+                  {isInitialPreviousNonce && <NonceFormHeader sx={{ pt: 3 }}>Already in queue</NonceFormHeader>}
                   <NonceFormOption key={option} menuItemProps={props} nonce={option} />
                 </>
               )

--- a/src/components/tx-flow/common/TxNonce/styles.module.css
+++ b/src/components/tx-flow/common/TxNonce/styles.module.css
@@ -1,3 +1,16 @@
+.popper :global .MuiAutocomplete-paper {
+  margin-top: calc(var(--space-1) / 2);
+  padding-top: var(--space-2);
+  padding-bottom: var(--space-2);
+  border: 1px solid var(--color-border-light);
+}
+
+.popper :global .MuiAutocomplete-option,
+.popper :global .MuiListSubheader-root {
+  padding-left: var(--space-4);
+  padding-right: var(--space-4);
+}
+
 .input :global .MuiOutlinedInput-root {
   padding: 0;
 }

--- a/src/components/tx-flow/common/TxNonce/styles.module.css
+++ b/src/components/tx-flow/common/TxNonce/styles.module.css
@@ -5,10 +5,19 @@
   border: 1px solid var(--color-border-light);
 }
 
+.popper :global .MuiAutocomplete-listbox {
+  max-height: unset;
+}
+
+.popper :global .MuiListSubheader-root {
+  line-height: 22px;
+  margin-bottom: var(--space-1);
+}
+
 .popper :global .MuiAutocomplete-option,
 .popper :global .MuiListSubheader-root {
-  padding-left: var(--space-4);
-  padding-right: var(--space-4);
+  padding-left: var(--space-3);
+  padding-right: var(--space-3);
 }
 
 .input :global .MuiOutlinedInput-root {

--- a/src/components/tx-flow/common/TxNonce/styles.module.css
+++ b/src/components/tx-flow/common/TxNonce/styles.module.css
@@ -1,7 +1,7 @@
 .popper :global .MuiAutocomplete-paper {
   margin-top: calc(var(--space-1) / 2);
-  padding-top: var(--space-2);
-  padding-bottom: var(--space-2);
+  padding-top: var(--space-1);
+  padding-bottom: var(--space-1);
   border: 1px solid var(--color-border-light);
 }
 


### PR DESCRIPTION
## What it solves

Resolves #2304

## How this PR fixes it

The design of the replacement nonce dropdown has been aligned with [the designs](https://www.figma.com/file/ptTs6lDBeUuLNySroJ5PiF/Web-Master-File?type=design&node-id=1-5&mode=design&t=WbShkKUISF7wNfbP-0).

## How to test it

Opent the transaction flow on a Safe and observe the recommended nonce in the dropdown list (as well as other queued transactions, if they exist).

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/aea5ba17-b501-4406-aea9-a1d637091016)

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
