### PR TITLE
Fix: warn if tx was already signed by connected wallet

### DIFF
--- a/cypress/e2e/smoke/create_tx.cy.js
+++ b/cypress/e2e/smoke/create_tx.cy.js
@@ -69,7 +69,7 @@ describe('Queue a transaction on 1/N', () => {
     cy.contains('Estimated fee').should('exist')
 
     // Asserting the sponsored info is present
-    cy.contains('Execute').should('be.visible')
+    cy.contains('Execute').scrollIntoView().should('be.visible')
 
     cy.get('span').contains('Estimated fee').next().should('have.css', 'text-decoration-line', 'line-through')
     cy.contains('Transactions per hour')
@@ -103,7 +103,7 @@ describe('Queue a transaction on 1/N', () => {
       .type(currentNonce + 10, { force: true })
       .type('{enter}', { force: true })
 
-    cy.contains('Submit').click()
+    cy.contains('Sign').click()
   })
 
   it('should click the notification and see the transaction queued', () => {

--- a/cypress/e2e/smoke/nfts.cy.js
+++ b/cypress/e2e/smoke/nfts.cy.js
@@ -84,7 +84,7 @@ describe('Assets > NFTs', () => {
       cy.contains('1')
       cy.contains('2')
       cy.get('b:contains("safeTransferFrom")').should('have.length', 2)
-      cy.contains('button:not([disabled])', 'Submit')
+      cy.contains('button:not([disabled])', 'Execute')
     })
   })
 })

--- a/src/components/tx-flow/common/TxLayout/index.tsx
+++ b/src/components/tx-flow/common/TxLayout/index.tsx
@@ -9,11 +9,10 @@ import { TxInfoProvider } from '@/components/tx-flow/TxInfoProvider'
 import TxNonce from '../TxNonce'
 import TxStatusWidget from '../TxStatusWidget'
 import css from './styles.module.css'
-import { TxSimulationMessage } from '@/components/tx/security/tenderly'
 import SafeLogo from '@/public/images/logo-no-text.svg'
-import { RedefineMessage } from '@/components/tx/security/redefine'
 import { TxSecurityProvider } from '@/components/tx/security/shared/TxSecurityContext'
 import ChainIndicator from '@/components/common/ChainIndicator'
+import SecurityWarnings from '@/components/tx/security/SecurityWarnings'
 
 const TxLayoutHeader = ({
   hideNonce,
@@ -147,9 +146,7 @@ const TxLayout = ({
                   )}
 
                   <Box className={css.sticky}>
-                    <RedefineMessage />
-
-                    <TxSimulationMessage />
+                    <SecurityWarnings />
                   </Box>
                 </Grid>
               </Grid>

--- a/src/components/tx-flow/common/TxLayout/styles.module.css
+++ b/src/components/tx-flow/common/TxLayout/styles.module.css
@@ -1,5 +1,5 @@
 .container {
-  margin-top: 42px;
+  margin-top: 10px;
 }
 
 .header {

--- a/src/components/tx-flow/flows/NewTx/styles.module.css
+++ b/src/components/tx-flow/flows/NewTx/styles.module.css
@@ -1,7 +1,3 @@
-.container {
-  margin-top: 50px;
-}
-
 .chain {
   align-self: flex-end;
   margin-bottom: var(--space-2);

--- a/src/components/tx-flow/flows/SuccessScreen/index.tsx
+++ b/src/components/tx-flow/flows/SuccessScreen/index.tsx
@@ -2,23 +2,26 @@ import StatusMessage from './StatusMessage'
 import StatusStepper from './StatusStepper'
 import { Button, Container, Divider, Paper } from '@mui/material'
 import classnames from 'classnames'
+import Link from 'next/link'
 import css from './styles.module.css'
 import { useAppSelector } from '@/store'
 import { selectPendingTxById } from '@/store/pendingTxsSlice'
-import { useCallback, useContext, useEffect, useState } from 'react'
-import { getBlockExplorerLink } from '@/utils/chains'
+import { useEffect, useState, useCallback, useContext } from 'react'
+import { getTxLink } from '@/hooks/useTxNotifications'
 import { useCurrentChain } from '@/hooks/useChains'
 import { TxEvent, txSubscribe } from '@/services/tx/txEvents'
+import useSafeInfo from '@/hooks/useSafeInfo'
 import { TxModalContext } from '../..'
 
 export const SuccessScreen = ({ txId }: { txId: string }) => {
   const [localTxHash, setLocalTxHash] = useState<string>()
   const [error, setError] = useState<Error>()
   const { setTxFlow } = useContext(TxModalContext)
-  const pendingTx = useAppSelector((state) => selectPendingTxById(state, txId))
-  const { txHash = '', status } = pendingTx || {}
   const chain = useCurrentChain()
-  const txLink = chain && localTxHash ? getBlockExplorerLink(chain, localTxHash) : undefined
+  const pendingTx = useAppSelector((state) => selectPendingTxById(state, txId))
+  const { safeAddress } = useSafeInfo()
+  const { txHash = '', status } = pendingTx || {}
+  const txLink = chain && getTxLink(txId, chain, safeAddress)
 
   useEffect(() => {
     if (!txHash) return
@@ -67,9 +70,11 @@ export const SuccessScreen = ({ txId }: { txId: string }) => {
 
       <div className={classnames(css.row, css.buttons)}>
         {txLink && (
-          <Button href={txLink.href} target="_blank" rel="noreferrer" variant="outlined" size="small">
-            View transaction
-          </Button>
+          <Link {...txLink} passHref target="_blank" rel="noreferrer">
+            <Button variant="outlined" size="small">
+              View transaction
+            </Button>
+          </Link>
         )}
 
         <Button variant="contained" size="small" onClick={onFinishClick}>

--- a/src/components/tx-flow/flows/SuccessScreen/index.tsx
+++ b/src/components/tx-flow/flows/SuccessScreen/index.tsx
@@ -71,8 +71,8 @@ export const SuccessScreen = ({ txId }: { txId: string }) => {
       <Divider />
       <div className={classnames(css.row, css.buttons)}>
         <Link href={homeLink} passHref>
-          <Button variant="outlined" size="small">
-            Back to dashboard
+          <Button variant="contained" size="small">
+            Finish
           </Button>
         </Link>
         {txLink && (

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -154,7 +154,7 @@ const ExecuteForm = ({
           <CheckWallet allowNonOwner={onlyExecute}>
             {(isOk) => (
               <Button variant="contained" type="submit" disabled={!isOk || submitDisabled}>
-                Submit
+                Execute
               </Button>
             )}
           </CheckWallet>

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -5,7 +5,7 @@ import ErrorMessage from '@/components/tx/ErrorMessage'
 import { logError, Errors } from '@/services/exceptions'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import CheckWallet from '@/components/common/CheckWallet'
-import { useTxActions } from './hooks'
+import { useAlreadySigned, useTxActions } from './hooks'
 import type { SignOrExecuteProps } from '.'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { TxModalContext } from '@/components/tx-flow'
@@ -32,6 +32,7 @@ const SignForm = ({
   const { signTx } = useTxActions()
   const { setTxFlow } = useContext(TxModalContext)
   const { needsRiskConfirmation, isRiskConfirmed, setIsRiskIgnored } = useContext(TxSecurityContext)
+  const hasSigned = useAlreadySigned(safeTx)
 
   // On modal submit
   const handleSubmit = async (e: SyntheticEvent) => {
@@ -64,6 +65,8 @@ const SignForm = ({
 
   return (
     <form onSubmit={handleSubmit}>
+      {hasSigned && <ErrorMessage level="warning">You have already signed this transaction.</ErrorMessage>}
+
       {cannotPropose ? (
         <NonOwnerError />
       ) : (
@@ -79,7 +82,7 @@ const SignForm = ({
         <CheckWallet>
           {(isOk) => (
             <Button variant="contained" type="submit" disabled={!isOk || submitDisabled}>
-              Submit
+              Sign
             </Button>
           )}
         </CheckWallet>

--- a/src/components/tx/SignOrExecuteForm/hooks.ts
+++ b/src/components/tx/SignOrExecuteForm/hooks.ts
@@ -179,3 +179,10 @@ export const useSafeTxGas = (safeTx: SafeTransaction | undefined): number | unde
 
   return safeTxGas
 }
+
+export const useAlreadySigned = (safeTx: SafeTransaction | undefined): boolean => {
+  const wallet = useWallet()
+  const hasSigned =
+    safeTx && wallet && (safeTx.signatures.has(wallet.address.toLowerCase()) || safeTx.signatures.has(wallet.address))
+  return Boolean(hasSigned)
+}

--- a/src/components/tx/security/SecurityWarnings.tsx
+++ b/src/components/tx/security/SecurityWarnings.tsx
@@ -1,0 +1,11 @@
+import { RedefineMessage } from './redefine'
+import { TxSimulationMessage } from './tenderly'
+
+const SecurityWarnings = () => (
+  <>
+    <RedefineMessage />
+    <TxSimulationMessage />
+  </>
+)
+
+export default SecurityWarnings

--- a/src/hooks/useTxNotifications.ts
+++ b/src/hooks/useTxNotifications.ts
@@ -43,21 +43,17 @@ enum Variant {
 
 const successEvents = [TxEvent.PROPOSED, TxEvent.SIGNATURE_PROPOSED, TxEvent.ONCHAIN_SIGNATURE_SUCCESS, TxEvent.SUCCESS]
 
-const getTxLink = (txId: string, chain: ChainInfo, safeAddress: string): { href: LinkProps['href']; title: string } => {
+export const getTxLink = (
+  txId: string,
+  chain: ChainInfo,
+  safeAddress: string,
+): { href: LinkProps['href']; title: string } => {
   return {
     href: {
       pathname: AppRoutes.transactions.tx,
       query: { id: txId, safe: `${chain?.shortName}:${safeAddress}` },
     },
     title: 'View transaction',
-  }
-}
-
-const getTxExplorerLink = (txHash: string, chain: ChainInfo): { href: LinkProps['href']; title: string } => {
-  const { href } = getExplorerLink(txHash, chain.blockExplorerUriTemplate)
-  return {
-    href,
-    title: 'View on explorer',
   }
 }
 
@@ -90,7 +86,11 @@ const useTxNotifications = (): void => {
             detailedMessage: isError ? detail.error.message : undefined,
             groupKey,
             variant: isError ? Variant.ERROR : isSuccess ? Variant.SUCCESS : Variant.INFO,
-            link: txId ? getTxLink(txId, chain, safeAddress) : txHash ? getTxExplorerLink(txHash, chain) : undefined,
+            link: txId
+              ? getTxLink(txId, chain, safeAddress)
+              : txHash
+              ? getExplorerLink(txHash, chain.blockExplorerUriTemplate)
+              : undefined,
           }),
         )
       }),

--- a/src/services/pairing/__tests__/utils.test.ts
+++ b/src/services/pairing/__tests__/utils.test.ts
@@ -27,15 +27,18 @@ describe('Pairing utils', () => {
 
   describe('isPairingSupported', () => {
     it('should return true if the wallet is enabled', () => {
-      const result = isPairingSupported(['walletConnect'])
+      const disabledWallets = ['walletConnect']
+      const result = isPairingSupported(disabledWallets)
       expect(result).toBe(true)
     })
 
     it('should return false if the wallet is disabled', () => {
-      const result1 = isPairingSupported([])
-      expect(result1).toBe(false)
+      const disabledWallets1: string[] = []
+      const result1 = isPairingSupported(disabledWallets1)
+      expect(result1).toBe(true)
 
-      const result2 = isPairingSupported(['safeMobile'])
+      const disabledWallets2 = ['safeMobile']
+      const result2 = isPairingSupported(disabledWallets2)
       expect(result2).toBe(false)
     })
   })

--- a/src/services/pairing/utils.ts
+++ b/src/services/pairing/utils.ts
@@ -30,7 +30,7 @@ export const killPairingSession = (connector: InstanceType<typeof WalletConnect>
 }
 
 export const isPairingSupported = (disabledWallets?: string[]) => {
-  return !!disabledWallets?.length && !disabledWallets.includes(CGW_NAMES[WALLET_KEYS.PAIRING] as string)
+  return disabledWallets && !disabledWallets.includes(CGW_NAMES[WALLET_KEYS.PAIRING] as string)
 }
 
 export const _isPairingSessionExpired = (session: IWalletConnectSession): boolean => {


### PR DESCRIPTION
## What it solves

Resolves #2321

Technically, nothing bad will happen if you sign a tx with the same owner twice. It will just overwrite the first signature.
But still good to warn about that.

However, I would keep the Sign button enabled because there can be a situation when a tx is signed locally, but sending it to the backend failed. In this case signing again is helpful.

In addition to that, some small stylistic adjustments in the tx flow.

## How this PR fixes it

Shows a warning is the tx has already been signed by the connect wallet.
<img width="661" alt="Screenshot 2023-07-28 at 10 49 06" src="https://github.com/safe-global/safe-wallet-web/assets/381895/67d8570b-2193-4656-b004-75e877bc71e1">