### PR TITLE
Fix: always keep the nonce of existing txs

### DIFF
--- a/src/components/tx-flow/SafeTxProvider.tsx
+++ b/src/components/tx-flow/SafeTxProvider.tsx
@@ -3,6 +3,7 @@ import type { Dispatch, ReactNode, SetStateAction, ReactElement } from 'react'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { createTx } from '@/services/tx/tx-sender'
 import { useRecommendedNonce, useSafeTxGas } from '../tx/SignOrExecuteForm/hooks'
+import { Errors, logError } from '@/services/exceptions'
 
 export const SafeTxContext = createContext<{
   safeTx?: SafeTransaction
@@ -27,8 +28,6 @@ export const SafeTxContext = createContext<{
   setNonceNeeded: () => {},
   setSafeTxGas: () => {},
 })
-
-// (err) => logError(Errors._103, err)
 
 const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => {
   const [safeTx, setSafeTx] = useState<SafeTransaction>()
@@ -57,6 +56,11 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
       .then(setSafeTx)
       .catch(setSafeTxError)
   }, [isSigned, finalNonce, finalSafeTxGas, safeTx?.data])
+
+  // Log errors
+  useEffect(() => {
+    safeTxError && logError(Errors._103, safeTxError)
+  }, [safeTxError])
 
   return (
     <SafeTxContext.Provider

--- a/src/components/tx-flow/flows/ConfirmTx/ConfirmProposedTx.tsx
+++ b/src/components/tx-flow/flows/ConfirmTx/ConfirmProposedTx.tsx
@@ -4,7 +4,7 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import { useChainId } from '@/hooks/useChainId'
 import useWallet from '@/hooks/wallets/useWallet'
 import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
-import { isExecutable, isSignableBy } from '@/utils/transaction-guards'
+import { isExecutable, isMultisigExecutionInfo, isSignableBy } from '@/utils/transaction-guards'
 import { Typography } from '@mui/material'
 import { createExistingTx } from '@/services/tx/tx-sender'
 import { SafeTxContext } from '../../SafeTxProvider'
@@ -21,11 +21,16 @@ const ConfirmProposedTx = ({ txSummary }: ConfirmProposedTxProps): ReactElement 
   const wallet = useWallet()
   const { safe, safeAddress } = useSafeInfo()
   const chainId = useChainId()
-  const { setSafeTx, setSafeTxError } = useContext(SafeTxContext)
+  const { setSafeTx, setSafeTxError, setNonce } = useContext(SafeTxContext)
 
   const txId = txSummary.id
+  const txNonce = isMultisigExecutionInfo(txSummary.executionInfo) ? txSummary.executionInfo.nonce : undefined
   const canExecute = isExecutable(txSummary, wallet?.address || '', safe)
   const canSign = isSignableBy(txSummary, wallet?.address || '')
+
+  useEffect(() => {
+    txNonce && setNonce(txNonce)
+  }, [setNonce, txNonce])
 
   useEffect(() => {
     createExistingTx(chainId, safeAddress, txId).then(setSafeTx).catch(setSafeTxError)


### PR DESCRIPTION
## What it solves

Solves a bug with delegated txs:
* A delegate address creates a tx with nonce N
* An actual owner address signs it
* Instead of signing the tx N, it creates another tx with a nonce N + 1

## How this PR fixes it

The tx confirmation flow will now always use the original transaction nonce and won't update it to the recommended nonce.

## How to test it

* Create an unsigned tx using MetaMask institutional or a delegate address.
* Sign it with an owner key
* Observe that it signed the original tx and not created a new tx