### PR TITLE
Fix: mobile pairing check

### DIFF
--- a/src/services/pairing/__tests__/utils.test.ts
+++ b/src/services/pairing/__tests__/utils.test.ts
@@ -27,15 +27,18 @@ describe('Pairing utils', () => {
 
   describe('isPairingSupported', () => {
     it('should return true if the wallet is enabled', () => {
-      const result = isPairingSupported(['walletConnect'])
+      const disabledWallets = ['walletConnect']
+      const result = isPairingSupported(disabledWallets)
       expect(result).toBe(true)
     })
 
     it('should return false if the wallet is disabled', () => {
-      const result1 = isPairingSupported([])
-      expect(result1).toBe(false)
+      const disabledWallets1: string[] = []
+      const result1 = isPairingSupported(disabledWallets1)
+      expect(result1).toBe(true)
 
-      const result2 = isPairingSupported(['safeMobile'])
+      const disabledWallets2 = ['safeMobile']
+      const result2 = isPairingSupported(disabledWallets2)
       expect(result2).toBe(false)
     })
   })

--- a/src/services/pairing/utils.ts
+++ b/src/services/pairing/utils.ts
@@ -30,7 +30,7 @@ export const killPairingSession = (connector: InstanceType<typeof WalletConnect>
 }
 
 export const isPairingSupported = (disabledWallets?: string[]) => {
-  return !!disabledWallets?.length && !disabledWallets.includes(CGW_NAMES[WALLET_KEYS.PAIRING] as string)
+  return disabledWallets && !disabledWallets.includes(CGW_NAMES[WALLET_KEYS.PAIRING] as string)
 }
 
 export const _isPairingSessionExpired = (session: IWalletConnectSession): boolean => {


### PR DESCRIPTION
## What it solves

Resolves #2316

## How this PR fixes it

The disabled wallets list can be empty, and it doesn't mean the pairing module is disabled...

## How to test

* Go to the config-service admin on staging
* Enable ALL wallets for some chain
* Go to that chain and observe that mobile pairing is visible in the connection popup