### PR TITLE
feature: Helm chart for Kubernetes deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ coverage
 .DS_Store
 .idea
 dist
+charts

--- a/.github/workflows/helm-build-test.yml
+++ b/.github/workflows/helm-build-test.yml
@@ -1,0 +1,109 @@
+---
+
+name: 'Package Helm chart'
+
+on:
+  pull_request:
+    paths:
+      - "charts/safe-wallet-web/**"
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+jobs:
+  bump_version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Bump Chart version
+        run: |
+          helm_chart_version=$(grep '^version:' Chart.yaml | sed 's/.*: //')
+          git_tag=$(git tag -l helm-${helm_chart_version})
+          echo "Workspace version is helm-${helm_chart_version} while tagged is ${git_tag}"
+          if [ "${git_tag}" = "helm-${helm_chart_version}" ]; then
+            patch_number=$(echo $helm_chart_version | sed 's/.*\.//')
+            release_number=$(echo $helm_chart_version | sed "s/\.${patch_number}//")
+            bump_version=${release_number}.$((patch_number + 1))
+            echo "The helm chart version ${git_tag} already exists, bumping to version helm-${bump_version}";
+            sed -i "s/^version: ${helm_chart_version}/version: ${bump_version}/" Chart.yaml
+            echo "version_bumped=true" >> $GITHUB_ENV
+          fi
+        working-directory: 'charts/safe-wallet-web/'
+      - name: Commit and push
+        if: ${{ env.version_bumped }}
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Bump Helm chart version
+          repository: .
+          commit_user_name: CI robot
+          commit_user_email: noreply@safe.global
+          commit_author: CI robot <noreply@safe.global>
+          skip_fetch: false
+          skip_checkout: false
+          create_branch: false
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Lint
+        run: |
+          helm dependency update
+          helm lint
+        working-directory: 'charts/safe-wallet-web/'
+
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get Helm chart version
+        run: |
+          HELM_CHART_VERSION=$(grep '^version:' Chart.yaml | sed 's/.*: //')
+          echo "HELM_CHART_VERSION=${HELM_CHART_VERSION}" >> $GITHUB_ENV
+        working-directory: 'charts/safe-wallet-web/'
+
+      - name: Helm Package
+        run: helm package . --version ${{ env.HELM_CHART_VERSION }}
+        working-directory: 'charts/safe-wallet-web/'
+  generate-readme:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Install readme-generator-for-helm
+        run: npm install -g @bitnami/readme-generator-for-helm@2.5.0
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          fetch-depth: 0
+
+      - name: Execute readme-generator-for-helm
+        run: |
+          readme-generator --values "charts/safe-wallet-web/values.yaml" --readme "charts/safe-wallet-web/README.md" --schema "/tmp/schema.json"
+          if git status -s | grep charts; then
+            echo "readme_updated=true" >>  $GITHUB_ENV
+          fi
+
+      - name: Commit and push
+        if: ${{ env.readme_updated }}
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update parameters README.md
+          repository: .
+          commit_user_name: CI robot
+          commit_user_email: noreply@safe.global
+          commit_author: CI robot <noreply@safe.global>

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ yalc.lock
 /public/sw.js.map
 /public/workbox-*.js
 /public/workbox-*.js.map
+
+# helm packages
+safe-wallet-web-*.tgz

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,5 @@ EXPOSE 8080
 ENV NODE_PORT 8080
 RUN npm install --global serve
 
-ENTRYPOINT [ "npx", "serve", "-p", ${NODE_PORT}, "out" ]
+ENTRYPOINT ["/bin/sh", "-c"]
+CMD [ "npx serve -p ${NODE_PORT} out" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ COPY package.json .
 ENV NODE_ENV production
 EXPOSE 8080
 ENV NODE_PORT 8080
+RUN npm install --global serve
 
-ENTRYPOINT [ "npx", "-y", "serve", "-p", ${NODE_PORT}, "out" ]
-#ENTRYPOINT ["npm", "run", "serve" ]
+ENTRYPOINT [ "npx", "serve", "-p", ${NODE_PORT}, "out" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,30 @@
-FROM node:16-alpine
-RUN apk add --no-cache libc6-compat git python3 py3-pip make g++
+FROM node:16 as builder
+
 WORKDIR /app
-COPY . .
-
-# install deps
-RUN yarn install
-
-ENV NODE_ENV production
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry during the build.
 ENV NEXT_TELEMETRY_DISABLED 1
 
-EXPOSE 3000
+COPY . .
+RUN yarn install
 
-ENV PORT 3000
+ENV NODE_ENV production
+RUN yarn build && \
+    yarn export
 
-CMD ["yarn", "static-serve"]
+
+
+FROM node:16-alpine
+#RUN apk add --no-cache libc6-compat git python3 py3-pip make g++
+WORKDIR /app
+COPY --from=builder /app/out /app/out
+COPY package.json .
+
+ENV NODE_ENV production
+EXPOSE 8080
+ENV NODE_PORT 8080
+
+ENTRYPOINT [ "npx", "-y", "serve", "-p", ${NODE_PORT}, "out" ]
+#ENTRYPOINT ["npm", "run", "serve" ]

--- a/charts/safe-wallet-web/.gitignore
+++ b/charts/safe-wallet-web/.gitignore
@@ -1,0 +1,1 @@
+values-testing.yaml

--- a/charts/safe-wallet-web/Chart.yaml
+++ b/charts/safe-wallet-web/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+name: safe-wallet-web
+version: 0.1.1
+appVersion: v1.9.1
+description: A Helm chart for Safe wallet web
+type: application
+icon: "https://raw.githubusercontent.com/safe-global/safe-core-sdk/main/assets/logo.png"

--- a/charts/safe-wallet-web/Chart.yaml
+++ b/charts/safe-wallet-web/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: safe-wallet-web
-version: 0.1.1
+version: 0.1.2
 appVersion: v1.9.1
 description: A Helm chart for Safe wallet web
 type: application

--- a/charts/safe-wallet-web/Chart.yaml
+++ b/charts/safe-wallet-web/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 name: safe-wallet-web
-version: 0.1.2
-appVersion: v1.9.1
+version: 0.1.3
+appVersion: v1.15.2
 description: A Helm chart for Safe wallet web
 type: application
 icon: "https://raw.githubusercontent.com/safe-global/safe-core-sdk/main/assets/logo.png"

--- a/charts/safe-wallet-web/README.md
+++ b/charts/safe-wallet-web/README.md
@@ -13,27 +13,27 @@ This chart packages the Safe wallet web resources.
 
 ### Installation Parameters
 
-| Name                       | Description                                                      | Value                         |
-| -------------------------- | ---------------------------------------------------------------- | ----------------------------- |
-| `replicas`                 | Replicas for deployment                                          | `1`                           |
-| `strategy`                 | Strategy for deployment                                          | `RollingUpdate`               |
-| `commonLabels`             | Labels to add to all related objects                             | `{}`                          |
-| `commonAnnotations`        | Annotations to to all related objects                            | `{}`                          |
-| `nodeSelector`             | Object containing node selection constraint to deployment        | `{}`                          |
-| `resources`                | Resource specification to deployment                             | `{}`                          |
-| `tolerations`              | Tolerations specifications to deployment                         | `[]`                          |
-| `affinity`                 | Affinity specifications to deployment                            | `{}`                          |
-| `image.registry`           | Docker registry to deployment                                    | `gcr.io`                      |
-| `image.repository`         | Docker image repository to deployment                            | `hoprassociation/safe-wallet` |
-| `image.tag`                | Docker image tag to deployment                                   | `""`                          |
-| `image.pullPolicy`         | Pull policy to deployment as deinfed in                          | `IfNotPresent`                |
-| `service.type`             | service type                                                     | `ClusterIP`                   |
-| `service.ports.number`     | service port number                                              | `8080`                        |
-| `service.ports.name`       | service port name                                                | `web`                         |
-| `service.sessionAffinity`  | Control where client requests go, to the same pod or round-robin | `None`                        |
-| `ingress.ingressClassName` | Name of the ingress class name to be used                        | `""`                          |
-| `ingress.hostname`         | Default host for the ingress record                              | `safe-wallet.cluster.local`   |
-| `ingress.annotations`      | Annotations to be added to ingress resources                     | `{}`                          |
+| Name                       | Description                                                      | Value                             |
+| -------------------------- | ---------------------------------------------------------------- | --------------------------------- |
+| `replicas`                 | Replicas for deployment                                          | `1`                               |
+| `strategy`                 | Strategy for deployment                                          | `RollingUpdate`                   |
+| `commonLabels`             | Labels to add to all related objects                             | `{}`                              |
+| `commonAnnotations`        | Annotations to to all related objects                            | `{}`                              |
+| `nodeSelector`             | Object containing node selection constraint to deployment        | `{}`                              |
+| `resources`                | Resource specification to deployment                             | `{}`                              |
+| `tolerations`              | Tolerations specifications to deployment                         | `[]`                              |
+| `affinity`                 | Affinity specifications to deployment                            | `{}`                              |
+| `image.registry`           | Docker registry to deployment                                    | `gcr.io`                          |
+| `image.repository`         | Docker image repository to deployment                            | `hoprassociation/safe-wallet-web` |
+| `image.tag`                | Docker image tag to deployment                                   | `""`                              |
+| `image.pullPolicy`         | Pull policy to deployment as deinfed in                          | `IfNotPresent`                    |
+| `service.type`             | service type                                                     | `ClusterIP`                       |
+| `service.ports.number`     | service port number                                              | `8080`                            |
+| `service.ports.name`       | service port name                                                | `web`                             |
+| `service.sessionAffinity`  | Control where client requests go, to the same pod or round-robin | `None`                            |
+| `ingress.ingressClassName` | Name of the ingress class name to be used                        | `""`                              |
+| `ingress.hostname`         | Default host for the ingress record                              | `safe-wallet.cluster.local`       |
+| `ingress.annotations`      | Annotations to be added to ingress resources                     | `{}`                              |
 
 ### Config Service Parameters
 

--- a/charts/safe-wallet-web/README.md
+++ b/charts/safe-wallet-web/README.md
@@ -13,46 +13,32 @@ This chart packages the Safe wallet web resources.
 
 ### Installation Parameters
 
-| Name                       | Description                                                      | Value                            |
-| -------------------------- | ---------------------------------------------------------------- | -------------------------------- |
-| `replicas`                 | Replicas for deployment                                          | `1`                              |
-| `strategy`                 | Strategy for deployment                                          | `RollingUpdate`                  |
-| `commonLabels`             | Labels to add to all related objects                             | `{}`                             |
-| `commonAnnotations`        | Annotations to to all related objects                            | `{}`                             |
-| `nodeSelector`             | Object containing node selection constraint to deployment        | `{}`                             |
-| `resources`                | Resource specification to deployment                             | `{}`                             |
-| `tolerations`              | Tolerations specifications to deployment                         | `[]`                             |
-| `affinity`                 | Affinity specifications to deployment                            | `{}`                             |
-| `image.registry`           | Docker registry to deployment                                    | `registry.hub.docker.com`        |
-| `image.repository`         | Docker image repository to deployment                            | `safeglobal/safe-config-service` |
-| `image.tag`                | Docker image tag to deployment                                   | `""`                             |
-| `image.pullPolicy`         | Pull policy to deployment as deinfed in                          | `IfNotPresent`                   |
-| `service.type`             | service type                                                     | `ClusterIP`                      |
-| `service.ports.number`     | service port number                                              | `80`                             |
-| `service.ports.name`       | service port name                                                | `nginx`                          |
-| `service.sessionAffinity`  | Control where client requests go, to the same pod or round-robin | `None`                           |
-| `service.socket.number`    | Number of the socket                                             | `8000`                           |
-| `service.socket.name`      | Name of the socket                                               | `gunicorn`                       |
-| `ingress.ingressClassName` | Name of the ingress class name to be used                        | `""`                             |
-| `ingress.hostname`         | Default host for the ingress record                              | `safe.cluster.local`             |
-| `ingress.annotations`      | Annotations to be added to ingress resources                     | `{}`                             |
+| Name                       | Description                                                      | Value                         |
+| -------------------------- | ---------------------------------------------------------------- | ----------------------------- |
+| `replicas`                 | Replicas for deployment                                          | `1`                           |
+| `strategy`                 | Strategy for deployment                                          | `RollingUpdate`               |
+| `commonLabels`             | Labels to add to all related objects                             | `{}`                          |
+| `commonAnnotations`        | Annotations to to all related objects                            | `{}`                          |
+| `nodeSelector`             | Object containing node selection constraint to deployment        | `{}`                          |
+| `resources`                | Resource specification to deployment                             | `{}`                          |
+| `tolerations`              | Tolerations specifications to deployment                         | `[]`                          |
+| `affinity`                 | Affinity specifications to deployment                            | `{}`                          |
+| `image.registry`           | Docker registry to deployment                                    | `gcr.io`                      |
+| `image.repository`         | Docker image repository to deployment                            | `hoprassociation/safe-wallet` |
+| `image.tag`                | Docker image tag to deployment                                   | `""`                          |
+| `image.pullPolicy`         | Pull policy to deployment as deinfed in                          | `IfNotPresent`                |
+| `service.type`             | service type                                                     | `ClusterIP`                   |
+| `service.ports.number`     | service port number                                              | `8080`                        |
+| `service.ports.name`       | service port name                                                | `web`                         |
+| `service.sessionAffinity`  | Control where client requests go, to the same pod or round-robin | `None`                        |
+| `ingress.ingressClassName` | Name of the ingress class name to be used                        | `""`                          |
+| `ingress.hostname`         | Default host for the ingress record                              | `safe-wallet.cluster.local`   |
+| `ingress.annotations`      | Annotations to be added to ingress resources                     | `{}`                          |
 
 ### Config Service Parameters
 
-| Name                                 | Description                                                                                                                                     | Value                                               |
-| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| `config.secretKey`                   | Config Service Secret Key. You should generate a random string of 50+ characters for this value in prod.                                        | `""`                                                |
-| `config.extraEnvVars`                | Add additional extra environment vairables to the configMap                                                                                     | `{}`                                                |
-| `config.cgw.url`                     | The Client Gateway URL. This is for triggering webhooks to invalidate its cache for example                                                     | `http://safe-client-gateway.safe.svc.cluster.local` |
-| `config.cgw.webToken`                | Flush Token                                                                                                                                     | `""`                                                |
-| `config.secretReferenceKey`          | Reference to an existing secret containing the following entries: SECRET_KEY, CGW_FLUSH_TOKEN                                                   | `""`                                                |
-| `config.pythonDontWriteBytecode`     | pythonDontWriteBytecode                                                                                                                         | `true`                                              |
-| `config.debug`                       | Enable debug                                                                                                                                    | `true`                                              |
-| `config.rootLogLevel`                | Log Level                                                                                                                                       | `DEBUG`                                             |
-| `config.django.allowedHosts`         | Allowed hosts                                                                                                                                   | `*`                                                 |
-| `config.postgres.secretReferenceKey` | Reference to an existing secret containing the following entries: POSTGRES_HOST, POSTGRES_PORT, POSTGRES_NAME, POSTGRES_USER, POSTGRES_PASSWORD | `""`                                                |
-| `config.postgres.username`           | PostgreSQL user                                                                                                                                 | `""`                                                |
-| `config.postgres.password`           | PostgreSQL user's password                                                                                                                      | `""`                                                |
-| `config.postgres.database`           | PostgreSQL database name                                                                                                                        | `safe-config`                                       |
-| `config.postgres.host`               | PostgreSQL server host                                                                                                                          | `""`                                                |
-| `config.postgres.port`               | PostgreSQL server port                                                                                                                          | `5432`                                              |
+| Name                        | Description                                                                                   | Value                                               |
+| --------------------------- | --------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `config.extraEnvVars`       | Add additional extra environment vairables to the configMap                                   | `{}`                                                |
+| `config.gatewayUrl`         | The Client Gateway URL. This is for triggering webhooks to invalidate its cache for example   | `http://safe-client-gateway.safe.svc.cluster.local` |
+| `config.secretReferenceKey` | Reference to an existing secret containing the following entries: SECRET_KEY, CGW_FLUSH_TOKEN | `""`                                                |

--- a/charts/safe-wallet-web/README.md
+++ b/charts/safe-wallet-web/README.md
@@ -1,0 +1,58 @@
+# Safe Wallet Web Chart
+
+This chart packages the Safe wallet web resources.
+
+## Parameters
+
+### Common parameters
+
+| Name               | Description                                        | Value |
+| ------------------ | -------------------------------------------------- | ----- |
+| `nameOverride`     | String to partially override common.names.fullname | `""`  |
+| `fullnameOverride` | String to fully override common.names.fullname     | `""`  |
+
+### Installation Parameters
+
+| Name                       | Description                                                      | Value                            |
+| -------------------------- | ---------------------------------------------------------------- | -------------------------------- |
+| `replicas`                 | Replicas for deployment                                          | `1`                              |
+| `strategy`                 | Strategy for deployment                                          | `RollingUpdate`                  |
+| `commonLabels`             | Labels to add to all related objects                             | `{}`                             |
+| `commonAnnotations`        | Annotations to to all related objects                            | `{}`                             |
+| `nodeSelector`             | Object containing node selection constraint to deployment        | `{}`                             |
+| `resources`                | Resource specification to deployment                             | `{}`                             |
+| `tolerations`              | Tolerations specifications to deployment                         | `[]`                             |
+| `affinity`                 | Affinity specifications to deployment                            | `{}`                             |
+| `image.registry`           | Docker registry to deployment                                    | `registry.hub.docker.com`        |
+| `image.repository`         | Docker image repository to deployment                            | `safeglobal/safe-config-service` |
+| `image.tag`                | Docker image tag to deployment                                   | `""`                             |
+| `image.pullPolicy`         | Pull policy to deployment as deinfed in                          | `IfNotPresent`                   |
+| `service.type`             | service type                                                     | `ClusterIP`                      |
+| `service.ports.number`     | service port number                                              | `80`                             |
+| `service.ports.name`       | service port name                                                | `nginx`                          |
+| `service.sessionAffinity`  | Control where client requests go, to the same pod or round-robin | `None`                           |
+| `service.socket.number`    | Number of the socket                                             | `8000`                           |
+| `service.socket.name`      | Name of the socket                                               | `gunicorn`                       |
+| `ingress.ingressClassName` | Name of the ingress class name to be used                        | `""`                             |
+| `ingress.hostname`         | Default host for the ingress record                              | `safe.cluster.local`             |
+| `ingress.annotations`      | Annotations to be added to ingress resources                     | `{}`                             |
+
+### Config Service Parameters
+
+| Name                                 | Description                                                                                                                                     | Value                                               |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `config.secretKey`                   | Config Service Secret Key. You should generate a random string of 50+ characters for this value in prod.                                        | `""`                                                |
+| `config.extraEnvVars`                | Add additional extra environment vairables to the configMap                                                                                     | `{}`                                                |
+| `config.cgw.url`                     | The Client Gateway URL. This is for triggering webhooks to invalidate its cache for example                                                     | `http://safe-client-gateway.safe.svc.cluster.local` |
+| `config.cgw.webToken`                | Flush Token                                                                                                                                     | `""`                                                |
+| `config.secretReferenceKey`          | Reference to an existing secret containing the following entries: SECRET_KEY, CGW_FLUSH_TOKEN                                                   | `""`                                                |
+| `config.pythonDontWriteBytecode`     | pythonDontWriteBytecode                                                                                                                         | `true`                                              |
+| `config.debug`                       | Enable debug                                                                                                                                    | `true`                                              |
+| `config.rootLogLevel`                | Log Level                                                                                                                                       | `DEBUG`                                             |
+| `config.django.allowedHosts`         | Allowed hosts                                                                                                                                   | `*`                                                 |
+| `config.postgres.secretReferenceKey` | Reference to an existing secret containing the following entries: POSTGRES_HOST, POSTGRES_PORT, POSTGRES_NAME, POSTGRES_USER, POSTGRES_PASSWORD | `""`                                                |
+| `config.postgres.username`           | PostgreSQL user                                                                                                                                 | `""`                                                |
+| `config.postgres.password`           | PostgreSQL user's password                                                                                                                      | `""`                                                |
+| `config.postgres.database`           | PostgreSQL database name                                                                                                                        | `safe-config`                                       |
+| `config.postgres.host`               | PostgreSQL server host                                                                                                                          | `""`                                                |
+| `config.postgres.port`               | PostgreSQL server port                                                                                                                          | `5432`                                              |

--- a/charts/safe-wallet-web/README.md
+++ b/charts/safe-wallet-web/README.md
@@ -13,27 +13,27 @@ This chart packages the Safe wallet web resources.
 
 ### Installation Parameters
 
-| Name                       | Description                                                      | Value                             |
-| -------------------------- | ---------------------------------------------------------------- | --------------------------------- |
-| `replicas`                 | Replicas for deployment                                          | `1`                               |
-| `strategy`                 | Strategy for deployment                                          | `RollingUpdate`                   |
-| `commonLabels`             | Labels to add to all related objects                             | `{}`                              |
-| `commonAnnotations`        | Annotations to to all related objects                            | `{}`                              |
-| `nodeSelector`             | Object containing node selection constraint to deployment        | `{}`                              |
-| `resources`                | Resource specification to deployment                             | `{}`                              |
-| `tolerations`              | Tolerations specifications to deployment                         | `[]`                              |
-| `affinity`                 | Affinity specifications to deployment                            | `{}`                              |
-| `image.registry`           | Docker registry to deployment                                    | `registry.hub.docker.com`             |
+| Name                       | Description                                                      | Value                        |
+| -------------------------- | ---------------------------------------------------------------- | ---------------------------- |
+| `replicas`                 | Replicas for deployment                                          | `1`                          |
+| `strategy`                 | Strategy for deployment                                          | `RollingUpdate`              |
+| `commonLabels`             | Labels to add to all related objects                             | `{}`                         |
+| `commonAnnotations`        | Annotations to to all related objects                            | `{}`                         |
+| `nodeSelector`             | Object containing node selection constraint to deployment        | `{}`                         |
+| `resources`                | Resource specification to deployment                             | `{}`                         |
+| `tolerations`              | Tolerations specifications to deployment                         | `[]`                         |
+| `affinity`                 | Affinity specifications to deployment                            | `{}`                         |
+| `image.registry`           | Docker registry to deployment                                    | `registry.hub.docker.com`    |
 | `image.repository`         | Docker image repository to deployment                            | `safeglobal/safe-wallet-web` |
-| `image.tag`                | Docker image tag to deployment                                   | `""`                              |
-| `image.pullPolicy`         | Pull policy to deployment as deinfed in                          | `IfNotPresent`                    |
-| `service.type`             | service type                                                     | `ClusterIP`                       |
-| `service.ports.number`     | service port number                                              | `8080`                            |
-| `service.ports.name`       | service port name                                                | `web`                             |
-| `service.sessionAffinity`  | Control where client requests go, to the same pod or round-robin | `None`                            |
-| `ingress.ingressClassName` | Name of the ingress class name to be used                        | `""`                              |
-| `ingress.hostname`         | Default host for the ingress record                              | `safe-wallet.cluster.local`       |
-| `ingress.annotations`      | Annotations to be added to ingress resources                     | `{}`                              |
+| `image.tag`                | Docker image tag to deployment                                   | `""`                         |
+| `image.pullPolicy`         | Pull policy to deployment as deinfed in                          | `IfNotPresent`               |
+| `service.type`             | service type                                                     | `ClusterIP`                  |
+| `service.ports.number`     | service port number                                              | `8080`                       |
+| `service.ports.name`       | service port name                                                | `web`                        |
+| `service.sessionAffinity`  | Control where client requests go, to the same pod or round-robin | `None`                       |
+| `ingress.ingressClassName` | Name of the ingress class name to be used                        | `""`                         |
+| `ingress.hostname`         | Default host for the ingress record                              | `safe-wallet.cluster.local`  |
+| `ingress.annotations`      | Annotations to be added to ingress resources                     | `{}`                         |
 
 ### Config Service Parameters
 

--- a/charts/safe-wallet-web/README.md
+++ b/charts/safe-wallet-web/README.md
@@ -41,4 +41,5 @@ This chart packages the Safe wallet web resources.
 | --------------------------- | --------------------------------------------------------------------------------------------- | --------------------------------------------------- |
 | `config.extraEnvVars`       | Add additional extra environment vairables to the configMap                                   | `{}`                                                |
 | `config.gatewayUrl`         | The Client Gateway URL. This is for triggering webhooks to invalidate its cache for example   | `http://safe-client-gateway.safe.svc.cluster.local` |
+| `config.isProduction`       |                                                                                               | `false`                                             |
 | `config.secretReferenceKey` | Reference to an existing secret containing the following entries: SECRET_KEY, CGW_FLUSH_TOKEN | `""`                                                |

--- a/charts/safe-wallet-web/README.md
+++ b/charts/safe-wallet-web/README.md
@@ -23,8 +23,8 @@ This chart packages the Safe wallet web resources.
 | `resources`                | Resource specification to deployment                             | `{}`                              |
 | `tolerations`              | Tolerations specifications to deployment                         | `[]`                              |
 | `affinity`                 | Affinity specifications to deployment                            | `{}`                              |
-| `image.registry`           | Docker registry to deployment                                    | `gcr.io`                          |
-| `image.repository`         | Docker image repository to deployment                            | `hoprassociation/safe-wallet-web` |
+| `image.registry`           | Docker registry to deployment                                    | `registry.hub.docker.com`             |
+| `image.repository`         | Docker image repository to deployment                            | `safeglobal/safe-wallet-web` |
 | `image.tag`                | Docker image tag to deployment                                   | `""`                              |
 | `image.pullPolicy`         | Pull policy to deployment as deinfed in                          | `IfNotPresent`                    |
 | `service.type`             | service type                                                     | `ClusterIP`                       |

--- a/charts/safe-wallet-web/templates/NOTES.txt
+++ b/charts/safe-wallet-web/templates/NOTES.txt
@@ -1,0 +1,2 @@
+[INFO] Safe Wallet Web Helm chart deployed successfully
+[INFO] Access to https://{{ .Values.ingress.hostname }}

--- a/charts/safe-wallet-web/templates/_helpers.tpl
+++ b/charts/safe-wallet-web/templates/_helpers.tpl
@@ -1,0 +1,41 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "safe-wallet-web.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "safe-wallet-web.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "safe-wallet-web.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Default labels
+*/}}
+{{- define "safe-wallet-web.labels" -}}
+helm.sh/chart: {{ include "safe-wallet-web.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ .Release.Name }}
+app.kubernetes.io/instance: {{ include "safe-wallet-web.name" . }}
+{{- end }}

--- a/charts/safe-wallet-web/templates/configmap.yaml
+++ b/charts/safe-wallet-web/templates/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- .Values.commonAnnotations | toYaml | nindent 4 }}
 {{- end }}
 data:
-  NEXT_PUBLIC_IS_PRODUCTION: "true"
+  NEXT_PUBLIC_IS_PRODUCTION: "{{- .Values.config.isProduction }}"
   NEXT_PUBLIC_SAFE_VERSION: "1.3.0"
   NEXT_PUBLIC_GATEWAY_URL_PRODUCTION: "{{- .Values.config.gatewayUrl }}"
 

--- a/charts/safe-wallet-web/templates/configmap.yaml
+++ b/charts/safe-wallet-web/templates/configmap.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "safe-wallet-web.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "safe-wallet-web.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- .Values.commonLabels | toYaml | nindent 4 }}
+    {{- end }}
+{{- if .Values.commonAnnotations }}
+  annotations:
+    {{- .Values.commonAnnotations | toYaml | nindent 4 }}
+{{- end }}
+data:
+  NEXT_PUBLIC_IS_PRODUCTION: true
+  NEXT_PUBLIC_SAFE_VERSION: 1.3.0
+  NEXT_PUBLIC_GATEWAY_URL_PRODUCTION: "{{- .Values.config.gatewayUrl }}"
+
+  {{- if .Values.config.extraEnvVars }}
+  {{ .Values.config.extraEnvVars | toYaml | nindent 2 }}
+  {{- end }}

--- a/charts/safe-wallet-web/templates/configmap.yaml
+++ b/charts/safe-wallet-web/templates/configmap.yaml
@@ -16,8 +16,11 @@ metadata:
 data:
   NEXT_PUBLIC_IS_PRODUCTION: "{{- .Values.config.isProduction }}"
   NEXT_PUBLIC_SAFE_VERSION: "1.3.0"
+  {{- if .Values.config.isProduction }}
   NEXT_PUBLIC_GATEWAY_URL_PRODUCTION: "{{- .Values.config.gatewayUrl }}"
-
+  {{- else }}
+  NEXT_PUBLIC_GATEWAY_URL_STAGING: "{{- .Values.config.gatewayUrl }}"
+  {{- end }}
   {{- if .Values.config.extraEnvVars }}
   {{ .Values.config.extraEnvVars | toYaml | nindent 2 }}
   {{- end }}

--- a/charts/safe-wallet-web/templates/configmap.yaml
+++ b/charts/safe-wallet-web/templates/configmap.yaml
@@ -14,8 +14,8 @@ metadata:
     {{- .Values.commonAnnotations | toYaml | nindent 4 }}
 {{- end }}
 data:
-  NEXT_PUBLIC_IS_PRODUCTION: true
-  NEXT_PUBLIC_SAFE_VERSION: 1.3.0
+  NEXT_PUBLIC_IS_PRODUCTION: "true"
+  NEXT_PUBLIC_SAFE_VERSION: "1.3.0"
   NEXT_PUBLIC_GATEWAY_URL_PRODUCTION: "{{- .Values.config.gatewayUrl }}"
 
   {{- if .Values.config.extraEnvVars }}

--- a/charts/safe-wallet-web/templates/deployment.yaml
+++ b/charts/safe-wallet-web/templates/deployment.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "safe-wallet-web.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "safe-wallet-web.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- .Values.commonLabels | toYaml | nindent 4 }}
+    {{- end }}
+{{- if .Values.commonAnnotations }}
+  annotations:
+    {{- .Values.commonAnnotations | toYaml | nindent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.replicas }}
+  strategy:
+    type: {{ .Values.strategy }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ include "safe-wallet-web.name" . }}
+      app.kubernetes.io/name: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ include "safe-wallet-web.name" . }}
+        app.kubernetes.io/name: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: web
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.resources }}
+        resources: {{- toYaml .Values.resources | nindent 12 }}
+        {{- else }}
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1024Mi
+          requests:
+            cpu: 100m
+            memory: 512Mi
+        {{- end }}
+        env:
+          - name: NODE_PORT
+            value: {{ .Values.service.ports.number }}
+        envFrom:
+          - configMapRef:
+              name: {{ include "safe-wallet-web.fullname" . }}
+        {{- if .Values.config.secretReferenceKey }}
+          - secretRef:
+              name: {{ .Values.config.secretReferenceKey }}
+        {{- end }}
+        ports:
+        - containerPort: {{ .Values.service.ports.number }}
+          name: {{ .Values.service.ports.name }}
+          protocol: TCP
+      serviceAccountName: {{ include "safe-wallet-web.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+

--- a/charts/safe-wallet-web/templates/deployment.yaml
+++ b/charts/safe-wallet-web/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
         {{- end }}
         env:
           - name: NODE_PORT
-            value: {{ .Values.service.ports.number }}
+            value: "{{ .Values.service.ports.number }}"
         envFrom:
           - configMapRef:
               name: {{ include "safe-wallet-web.fullname" . }}

--- a/charts/safe-wallet-web/templates/ingress.yaml
+++ b/charts/safe-wallet-web/templates/ingress.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "safe-wallet-web.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "safe-wallet-web.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- .Values.commonLabels | toYaml | nindent 4 }}
+    {{- end }}
+  annotations:
+  {{- if .Values.commonAnnotations }}
+    {{- .Values.commonAnnotations | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if .Values.ingress.annotations }}
+    {{- .Values.ingress.annotations | toYaml | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  rules:
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+                service:
+                    name: {{ include "safe-wallet-web.fullname" . }}
+                    port:
+                        name: {{ .Values.service.ports.name }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.hostname }}
+      secretName: {{ .Values.ingress.hostname }}-tls

--- a/charts/safe-wallet-web/templates/rbac.yaml
+++ b/charts/safe-wallet-web/templates/rbac.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "safe-wallet-web.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "safe-wallet-web.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- .Values.commonLabels | toYaml | nindent 4 }}
+    {{- end }}
+{{- if .Values.commonAnnotations }}
+  annotations:
+    {{- .Values.commonAnnotations | toYaml | nindent 4 }}
+{{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "safe-wallet-web.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "safe-wallet-web.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- .Values.commonLabels | toYaml | nindent 4 }}
+    {{- end }}
+{{- if .Values.commonAnnotations }}
+  annotations:
+    {{- .Values.commonAnnotations | toYaml | nindent 4 }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "safe-wallet-web.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "safe-wallet-web.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- .Values.commonLabels | toYaml | nindent 4 }}
+    {{- end }}
+{{- if .Values.commonAnnotations }}
+  annotations:
+    {{- .Values.commonAnnotations | toYaml | nindent 4 }}
+{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "safe-wallet-web.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "safe-wallet-web.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}

--- a/charts/safe-wallet-web/templates/service.yaml
+++ b/charts/safe-wallet-web/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "safe-wallet-web.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "safe-wallet-web.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- .Values.commonLabels | toYaml | nindent 4 }}
+    {{- end }}
+{{- if .Values.commonAnnotations }}
+  annotations:
+    {{- .Values.commonAnnotations | toYaml | nindent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.service.ports.number }}
+      name: {{ .Values.service.ports.name }}
+      targetPort: {{ .Values.service.ports.name }}
+      nodePort: null
+  selector:
+      app.kubernetes.io/instance: {{ include "safe-wallet-web.name" . }}
+      app.kubernetes.io/name: {{ .Release.Name }}

--- a/charts/safe-wallet-web/values.yaml
+++ b/charts/safe-wallet-web/values.yaml
@@ -1,0 +1,119 @@
+## @section Common parameters
+##
+
+## @param nameOverride String to partially override common.names.fullname
+##
+nameOverride: ""
+## @param fullnameOverride String to fully override common.names.fullname
+##
+fullnameOverride: ""
+
+## @section Installation Parameters
+##
+
+## @param replicas Replicas for deployment
+##
+replicas: 1
+
+## @param strategy Strategy for deployment
+##
+strategy: "RollingUpdate"
+
+## @param commonLabels [object] Labels to add to all related objects
+##
+commonLabels: {}
+
+## @param commonAnnotations [object] Annotations to to all related objects
+##
+commonAnnotations: {}
+
+## @param nodeSelector Object containing node selection constraint to deployment
+## https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+##
+nodeSelector: {}
+
+## @param resources Resource specification to deployment
+##
+resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+## @param tolerations Tolerations specifications to deployment
+##
+tolerations: []
+
+## @param affinity Affinity specifications to deployment
+##
+affinity: {}
+
+image:
+  ## @param image.registry Docker registry to deployment
+  ##
+  registry: gcr.io
+
+  ## @param image.repository Docker image repository to deployment
+  ##
+  repository: hoprassociation/safe-wallet
+
+  ## @param image.tag Docker image tag to deployment
+  ##
+  tag: ""
+
+  ## @param image.pullPolicy Pull policy to deployment as deinfed in 
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+
+service:
+  ## @param service.type service type
+  ##
+  type: ClusterIP
+  ports:
+    ## @param service.ports.number service port number
+    ##  
+    number: 8080
+    ## @param service.ports.name service port name
+    ##
+    name: web
+  ## @param service.sessionAffinity Control where client requests go, to the same pod or round-robin
+  ## Values: ClientIP or None
+  ## ref: https://kubernetes.io/docs/user-guide/services/
+  ##
+  sessionAffinity: None
+
+
+ingress:
+  ## @param ingress.ingressClassName Name of the ingress class name to be used
+  ##
+  ingressClassName: ""
+
+  ## @param ingress.hostname Default host for the ingress record
+  ##
+  hostname: safe-wallet.cluster.local
+
+  ## @param ingress.annotations Annotations to be added to ingress resources
+  ## @skipingress.annotations
+  ##
+  annotations: {}
+
+## @section Config Service Parameters
+
+config:
+
+  ## @param config.extraEnvVars Add additional extra environment vairables to the configMap
+  ##
+  extraEnvVars: {}
+
+  ## @param config.gatewayUrl The Client Gateway URL. This is for triggering webhooks to invalidate its cache for example
+  gatewayUrl: "http://safe-client-gateway.safe.svc.cluster.local"
+
+  ## @param config.secretReferenceKey Reference to an existing secret containing the following entries: SECRET_KEY, CGW_FLUSH_TOKEN
+  secretReferenceKey: ""

--- a/charts/safe-wallet-web/values.yaml
+++ b/charts/safe-wallet-web/values.yaml
@@ -61,7 +61,7 @@ image:
 
   ## @param image.repository Docker image repository to deployment
   ##
-  repository: hoprassociation/safe-wallet
+  repository: hoprassociation/safe-wallet-web
 
   ## @param image.tag Docker image tag to deployment
   ##

--- a/charts/safe-wallet-web/values.yaml
+++ b/charts/safe-wallet-web/values.yaml
@@ -57,11 +57,11 @@ affinity: {}
 image:
   ## @param image.registry Docker registry to deployment
   ##
-  registry: gcr.io
+  registry: registry.hub.docker.com
 
   ## @param image.repository Docker image repository to deployment
   ##
-  repository: hoprassociation/safe-wallet-web
+  repository: safeglobal/safe-wallet-web
 
   ## @param image.tag Docker image tag to deployment
   ##

--- a/charts/safe-wallet-web/values.yaml
+++ b/charts/safe-wallet-web/values.yaml
@@ -115,5 +115,8 @@ config:
   ## @param config.gatewayUrl The Client Gateway URL. This is for triggering webhooks to invalidate its cache for example
   gatewayUrl: "http://safe-client-gateway.safe.svc.cluster.local"
 
+  ## @param config.isProduction
+  isProduction: false
+
   ## @param config.secretReferenceKey Reference to an existing secret containing the following entries: SECRET_KEY, CGW_FLUSH_TOKEN
   secretReferenceKey: ""

--- a/scripts/build-and-push-helm-chart.sh
+++ b/scripts/build-and-push-helm-chart.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# exit on errors, undefined variables, ensure errors in pipes are not hidden
+set -Eeuo pipefail
+
+: ${1:?"1st parameter <version> missing"}
+: ${1:?"2nd parameter <repository> missing"}
+
+declare version repository
+version="${1}"
+repository="${2}"
+
+helm package charts/safe-wallet-web --version "${version}"
+
+helm push "safe-wallet-web-${version}.tgz" "${repository}"


### PR DESCRIPTION
## What it solves

The repository was lacking a Helm chart for Kubernetes deployment.

## How this PR fixes it

The Helm chart was added at `charts/safe-wallet-web`, a location adhering to Helm best-practises. The helper script at `scripts/build-and-publish-helm-chart.sh` can be used for releasing new versions of the Helm chart. Documentation of the chart is at `charts/safe-wallet-web`.

This chart is already used successfully to run the Safe infrastructure in Kubernetes.

## How to test it

Can be used in a local minikube setup.

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

## Sibling PRs

- https://github.com/safe-global/safe-transaction-service/pull/1601
- https://github.com/safe-global/safe-client-gateway/pull/1124
- https://github.com/safe-global/safe-config-service/pull/911