### PR TITLE
fix: align transaction links

### DIFF
--- a/src/components/tx-flow/flows/SuccessScreen/index.tsx
+++ b/src/components/tx-flow/flows/SuccessScreen/index.tsx
@@ -10,9 +10,10 @@ import css from './styles.module.css'
 import { useAppSelector } from '@/store'
 import { selectPendingTxById } from '@/store/pendingTxsSlice'
 import { useEffect, useState } from 'react'
-import { getBlockExplorerLink } from '@/utils/chains'
+import { getTxLink } from '@/hooks/useTxNotifications'
 import { useCurrentChain } from '@/hooks/useChains'
 import { TxEvent, txSubscribe } from '@/services/tx/txEvents'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 export const SuccessScreen = ({ txId }: { txId: string }) => {
   const [localTxHash, setLocalTxHash] = useState<string>()
@@ -20,6 +21,7 @@ export const SuccessScreen = ({ txId }: { txId: string }) => {
   const router = useRouter()
   const chain = useCurrentChain()
   const pendingTx = useAppSelector((state) => selectPendingTxById(state, txId))
+  const { safeAddress } = useSafeInfo()
   const { txHash = '', status } = pendingTx || {}
 
   useEffect(() => {
@@ -43,7 +45,7 @@ export const SuccessScreen = ({ txId }: { txId: string }) => {
     query: { safe: router.query.safe },
   }
 
-  const txLink = chain && localTxHash ? getBlockExplorerLink(chain, localTxHash) : undefined
+  const txLink = chain && getTxLink(txId, chain, safeAddress)
 
   return (
     <Container
@@ -76,9 +78,11 @@ export const SuccessScreen = ({ txId }: { txId: string }) => {
           </Button>
         </Link>
         {txLink && (
-          <Button href={txLink.href} target="_blank" rel="noreferrer" variant="outlined" size="small">
-            View transaction
-          </Button>
+          <Link {...txLink} passHref target="_blank" rel="noreferrer">
+            <Button variant="outlined" size="small">
+              View transaction
+            </Button>
+          </Link>
         )}
       </div>
     </Container>

--- a/src/hooks/useTxNotifications.ts
+++ b/src/hooks/useTxNotifications.ts
@@ -43,21 +43,17 @@ enum Variant {
 
 const successEvents = [TxEvent.PROPOSED, TxEvent.SIGNATURE_PROPOSED, TxEvent.ONCHAIN_SIGNATURE_SUCCESS, TxEvent.SUCCESS]
 
-const getTxLink = (txId: string, chain: ChainInfo, safeAddress: string): { href: LinkProps['href']; title: string } => {
+export const getTxLink = (
+  txId: string,
+  chain: ChainInfo,
+  safeAddress: string,
+): { href: LinkProps['href']; title: string } => {
   return {
     href: {
       pathname: AppRoutes.transactions.tx,
       query: { id: txId, safe: `${chain?.shortName}:${safeAddress}` },
     },
     title: 'View transaction',
-  }
-}
-
-const getTxExplorerLink = (txHash: string, chain: ChainInfo): { href: LinkProps['href']; title: string } => {
-  const { href } = getExplorerLink(txHash, chain.blockExplorerUriTemplate)
-  return {
-    href,
-    title: 'View on explorer',
   }
 }
 
@@ -90,7 +86,11 @@ const useTxNotifications = (): void => {
             detailedMessage: isError ? detail.error.message : undefined,
             groupKey,
             variant: isError ? Variant.ERROR : isSuccess ? Variant.SUCCESS : Variant.INFO,
-            link: txId ? getTxLink(txId, chain, safeAddress) : txHash ? getTxExplorerLink(txHash, chain) : undefined,
+            link: txId
+              ? getTxLink(txId, chain, safeAddress)
+              : txHash
+              ? getExplorerLink(txHash, chain.blockExplorerUriTemplate)
+              : undefined,
           }),
         )
       }),

--- a/src/services/pairing/__tests__/utils.test.ts
+++ b/src/services/pairing/__tests__/utils.test.ts
@@ -27,15 +27,18 @@ describe('Pairing utils', () => {
 
   describe('isPairingSupported', () => {
     it('should return true if the wallet is enabled', () => {
-      const result = isPairingSupported(['walletConnect'])
+      const disabledWallets = ['walletConnect']
+      const result = isPairingSupported(disabledWallets)
       expect(result).toBe(true)
     })
 
     it('should return false if the wallet is disabled', () => {
-      const result1 = isPairingSupported([])
-      expect(result1).toBe(false)
+      const disabledWallets1: string[] = []
+      const result1 = isPairingSupported(disabledWallets1)
+      expect(result1).toBe(true)
 
-      const result2 = isPairingSupported(['safeMobile'])
+      const disabledWallets2 = ['safeMobile']
+      const result2 = isPairingSupported(disabledWallets2)
       expect(result2).toBe(false)
     })
   })

--- a/src/services/pairing/utils.ts
+++ b/src/services/pairing/utils.ts
@@ -30,7 +30,7 @@ export const killPairingSession = (connector: InstanceType<typeof WalletConnect>
 }
 
 export const isPairingSupported = (disabledWallets?: string[]) => {
-  return !!disabledWallets?.length && !disabledWallets.includes(CGW_NAMES[WALLET_KEYS.PAIRING] as string)
+  return disabledWallets && !disabledWallets.includes(CGW_NAMES[WALLET_KEYS.PAIRING] as string)
 }
 
 export const _isPairingSessionExpired = (session: IWalletConnectSession): boolean => {


### PR DESCRIPTION
## What it solves

Resolves differing/duplicate link

## How this PR fixes it

Our notification links to the transaction in our URI, whereas the button to "View transaction" linked to the block explorer. As there is already a link to the explorer in the `EthHashInfo`, the button has now been changed to align with the notification instead.

## How to test it

Create an execute a transaction and observe that button/notification transaction links navigate to the Safe UI, whereas the `EthHashInfo` to the block explorer.

Note: links are marked in the screenshot below.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/997f190b-8ab6-47aa-be58-43714f819645)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
