### PR TITLE
fix: don't close flow in Safe Apps

### DIFF
--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -260,7 +260,6 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement 
       if (safeAppRequestId && currentRequestId === safeAppRequestId) {
         trackSafeAppEvent(SAFE_APPS_EVENTS.PROPOSE_TRANSACTION, appName)
         communicator?.send({ safeTxHash }, safeAppRequestId)
-        setTxFlow(undefined)
       }
     })
 
@@ -271,7 +270,6 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement 
     const unsubscribe = safeMsgSubscribe(SafeMsgEvent.SIGNATURE_PREPARED, ({ messageHash, requestId, signature }) => {
       if (requestId && currentRequestId === requestId) {
         communicator?.send({ messageHash, signature }, requestId)
-        setTxFlow(undefined)
       }
     })
 

--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -264,7 +264,7 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement 
     })
 
     return unsubscribe
-  }, [appName, chainId, communicator, currentRequestId, setTxFlow])
+  }, [appName, chainId, communicator, currentRequestId])
 
   useEffect(() => {
     const unsubscribe = safeMsgSubscribe(SafeMsgEvent.SIGNATURE_PREPARED, ({ messageHash, requestId, signature }) => {
@@ -274,7 +274,7 @@ const AppFrame = ({ appUrl, allowedFeaturesList }: AppFrameProps): ReactElement 
     })
 
     return unsubscribe
-  }, [communicator, currentRequestId, setTxFlow])
+  }, [communicator, currentRequestId])
 
   if (!safeLoaded) {
     return <div />


### PR DESCRIPTION
## What it solves

Resolves #2286

## How this PR fixes it

The Safe App transaction flow is no longer closed via the communicator.

## How to test it

Observe that the Safe App transaction flow closes in the following instances:

- Queuing a transaction
- Successfully preparing an off-chain signature

Observe that the Safe App transaction flow _doesn't_ close in the following instance:

- Executing a transaction

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
