### PR TITLE
fix: limit `origin` length

### DIFF
--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -180,6 +180,8 @@ export const getQueuedTransactionCount = (txPage?: TransactionListPage): string 
 }
 
 export const getTxOrigin = (app?: SafeAppData): string | undefined => {
+  const MAX_ORIGIN_LENGTH = 200
+
   if (!app) {
     return
   }
@@ -187,7 +189,18 @@ export const getTxOrigin = (app?: SafeAppData): string | undefined => {
   let origin: string | undefined
 
   try {
-    origin = JSON.stringify({ name: app.name, url: app.url })
+    const maxNameLength =
+      MAX_ORIGIN_LENGTH -
+      JSON.stringify({
+        name: '', // Must include empty string to avoid including the length of `undefined`
+        url: '',
+      }).length
+    const maxUrlLength = maxNameLength - app.name.length
+
+    origin = JSON.stringify({
+      name: app.name.slice(0, maxNameLength),
+      url: app.url.slice(0, maxUrlLength),
+    })
   } catch (e) {
     logError(Errors._808, e)
   }


### PR DESCRIPTION
## What it solves

Resolves #2180

## How this PR fixes it

The `origin` is now limited to a total of 200 characters as follows. The `name` can be as long as necessary as long as it's less than 200 characters and the `url` is takes up the remaining characters

## How to test it

See issue description.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
