### PR TITLE
fix: execute icon colour in dark mode

### DIFF
--- a/src/components/tx/SignOrExecuteForm/styles.module.css
+++ b/src/components/tx/SignOrExecuteForm/styles.module.css
@@ -31,6 +31,14 @@
   color: var(--color-secondary-dark);
 }
 
+[data-theme='dark'] .execute {
+  background-color: var(--color-success-background);
+}
+
+[data-theme='dark'] .execute svg {
+  color: var(--color-success-dark);
+}
+
 .params {
   margin-bottom: var(--space-2);
 }


### PR DESCRIPTION
## What it solves

Resolves incorrect colour

## How this PR fixes it

The colour of the "Execute" icon on the transaction flow is now green in dark mode.

## How to test it

Observe the correct colour on the transaction flow in dark mode.

## Screenshots

![execute icon](https://github.com/safe-global/safe-wallet-web/assets/20442784/78c77b74-5e48-4057-9a2b-808d40f0e96f)

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
