### PR TITLE
Fix: re-connecting a locked wallet

### DIFF
--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -179,17 +179,15 @@ export const useInitOnboard = () => {
     }
 
     // Connect to the last connected wallet
-    enableWallets().then(() => {
+    enableWallets().then(async () => {
       if (onboard.state.get().wallets.length > 0) return
 
       const label = lastWalletStorage.get()
-      if (!label) return
+      const isUnlocked = label && (await isWalletUnlocked(label))
+      if (!isUnlocked) return
 
-      isWalletUnlocked(label).then((isUnlocked) => {
-        isUnlocked &&
-          connectWallet(onboard, {
-            autoSelect: { label, disableModals: false },
-          })
+      connectWallet(onboard, {
+        autoSelect: { label, disableModals: true },
       })
     })
   }, [chain, onboard])

--- a/src/utils/__tests__/wallet.test.ts
+++ b/src/utils/__tests__/wallet.test.ts
@@ -1,0 +1,53 @@
+import { isWalletUnlocked, WalletNames } from '../wallets'
+
+describe('utils/wallet', () => {
+  it('should check if MetaMask is unlocked and return false', async () => {
+    // mock window.ethereum
+    Object.defineProperty(window, 'ethereum', {
+      value: {
+        isMetaMask: true,
+        selectedAddress: '0x123',
+        isConnected: () => true,
+        _metamask: {
+          isUnlocked: () => Promise.resolve(false),
+        },
+      },
+      writable: true,
+    })
+    const result = await isWalletUnlocked(WalletNames.METAMASK)
+    expect(result).toBe(false)
+  })
+
+  it('should check if MetaMask is unlocked and return true', async () => {
+    // mock window.ethereum
+    Object.defineProperty(window, 'ethereum', {
+      value: {
+        isMetaMask: true,
+        selectedAddress: '0x123',
+        isConnected: () => true,
+        _metamask: {
+          isUnlocked: () => Promise.resolve(true),
+        },
+      },
+      writable: true,
+    })
+    const result = await isWalletUnlocked(WalletNames.METAMASK)
+    expect(result).toBe(true)
+  })
+
+  it('should check if WalletConnect is unlocked', async () => {
+    window.localStorage.setItem('walletconnect', 'true')
+
+    expect(await isWalletUnlocked(WalletNames.WALLET_CONNECT)).toBe(true)
+    expect(await isWalletUnlocked(WalletNames.WALLET_CONNECT_V2)).toBe(true)
+
+    window.localStorage.removeItem('walletconnect')
+
+    expect(await isWalletUnlocked(WalletNames.WALLET_CONNECT)).toBe(false)
+    expect(await isWalletUnlocked(WalletNames.WALLET_CONNECT_V2)).toBe(false)
+  })
+
+  it('should return false for unhandled wallets', async () => {
+    expect(await isWalletUnlocked('PINEAPPLE')).toBe(false)
+  })
+})

--- a/src/utils/__tests__/wallet.test.ts
+++ b/src/utils/__tests__/wallet.test.ts
@@ -35,15 +35,23 @@ describe('utils/wallet', () => {
     expect(result).toBe(true)
   })
 
-  it('should check if WalletConnect is unlocked', async () => {
+  it('should check if WalletConnect v1 is unlocked', async () => {
     window.localStorage.setItem('walletconnect', 'true')
 
     expect(await isWalletUnlocked(WalletNames.WALLET_CONNECT)).toBe(true)
-    expect(await isWalletUnlocked(WalletNames.WALLET_CONNECT_V2)).toBe(true)
 
     window.localStorage.removeItem('walletconnect')
 
     expect(await isWalletUnlocked(WalletNames.WALLET_CONNECT)).toBe(false)
+  })
+
+  it('should check if WalletConnect v2 is unlocked', async () => {
+    window.localStorage.setItem('wc@2:client:0.3//session', '[{"topic":"123"}]')
+
+    expect(await isWalletUnlocked(WalletNames.WALLET_CONNECT_V2)).toBe(true)
+
+    window.localStorage.removeItem('wc@2:client:0.3//session')
+
     expect(await isWalletUnlocked(WalletNames.WALLET_CONNECT_V2)).toBe(false)
   })
 

--- a/src/utils/wallets.ts
+++ b/src/utils/wallets.ts
@@ -37,8 +37,14 @@ export const isWalletUnlocked = async (walletName: string): Promise<boolean> => 
     return (await window.ethereum?._metamask?.isUnlocked?.()) || false
   }
 
-  // Wallet connect creates a localStorage entry when connected and removes it when disconnected
-  if (walletName === WalletNames.WALLET_CONNECT || walletName === WalletNames.WALLET_CONNECT_V2) {
+  // WalletConnect v2
+  if (walletName === WalletNames.WALLET_CONNECT_V2) {
+    const wcSession = window.localStorage.getItem('wc@2:client:0.3//session')
+    return !!wcSession && wcSession !== '[]'
+  }
+
+  // WalletConnect v1 creates a localStorage entry when connected and removes it when disconnected
+  if (walletName === WalletNames.WALLET_CONNECT) {
     return window.localStorage.getItem('walletconnect') !== null
   }
 

--- a/src/utils/wallets.ts
+++ b/src/utils/wallets.ts
@@ -32,17 +32,13 @@ export const WalletNames = {
 export const isWalletUnlocked = async (walletName: string): Promise<boolean> => {
   if (typeof window === 'undefined') return false
 
-  if (window.ethereum?.isConnected?.()) {
-    return true
-  }
-
   // Only MetaMask exposes a method to check if the wallet is unlocked
   if (walletName === WalletNames.METAMASK) {
-    return window.ethereum?._metamask?.isUnlocked?.() || false
+    return (await window.ethereum?._metamask?.isUnlocked?.()) || false
   }
 
   // Wallet connect creates a localStorage entry when connected and removes it when disconnected
-  if (walletName === WalletNames.WALLET_CONNECT) {
+  if (walletName === WalletNames.WALLET_CONNECT || walletName === WalletNames.WALLET_CONNECT_V2) {
     return window.localStorage.getItem('walletconnect') !== null
   }
 


### PR DESCRIPTION
## What it solves

Resolves #2306

## How this PR fixes it

The cause of the bug was that
* `window.ethereum.isConnected()` returns true even if MetaMask is locked
* We didn't await the promise from `_metamask.isUnlocked` and it always returning false

I've removed `isConnected` and made it wait for the promise. Also added custom logic for WC v2 and tests for it.
