### PR TITLE
fix: Open custom safe apps on click

### DIFF
--- a/src/components/safe-apps/SafeAppCard/index.tsx
+++ b/src/components/safe-apps/SafeAppCard/index.tsx
@@ -19,7 +19,6 @@ import SafeAppTags from '@/components/safe-apps/SafeAppTags'
 import { isOptimizedForBatchTransactions } from '@/components/safe-apps/utils'
 import { AppRoutes } from '@/config/routes'
 import BatchIcon from '@/public/images/apps/batch-icon.svg'
-import { useOpenedSafeApps } from '@/hooks/safe-apps/useOpenedSafeApps'
 import css from './styles.module.css'
 
 export type SafeAppsViewMode = 'list-view' | 'grid-view'
@@ -111,7 +110,7 @@ const SafeAppCardGridView = ({
   openPreviewDrawer,
 }: SafeAppCardViewProps) => {
   return (
-    <SafeAppCardContainer safeApp={safeApp} safeAppUrl={safeAppUrl} onClickSafeApp={onClickSafeApp} height={'100%'}>
+    <SafeAppCardContainer safeAppUrl={safeAppUrl} onClickSafeApp={onClickSafeApp} height={'100%'}>
       {/* Safe App Header */}
       <CardHeader
         className={css.safeAppHeader}
@@ -168,7 +167,7 @@ const SafeAppCardListView = ({
   openPreviewDrawer,
 }: SafeAppCardViewProps) => {
   return (
-    <SafeAppCardContainer safeApp={safeApp} safeAppUrl={safeAppUrl} onClickSafeApp={onClickSafeApp}>
+    <SafeAppCardContainer safeAppUrl={safeAppUrl} onClickSafeApp={onClickSafeApp}>
       <CardContent sx={{ pb: '16px !important' }}>
         <Box display="flex" flexDirection="row" alignItems="center" gap={2}>
           <div className={css.safeAppIconContainer}>
@@ -204,7 +203,6 @@ const SafeAppCardListView = ({
 
 type SafeAppCardContainerProps = {
   onClickSafeApp?: () => void
-  safeApp?: SafeAppData
   safeAppUrl: string
   children: ReactNode
   height?: string
@@ -213,18 +211,15 @@ type SafeAppCardContainerProps = {
 
 export const SafeAppCardContainer = ({
   children,
-  safeApp,
   safeAppUrl,
   onClickSafeApp,
   height,
   className,
 }: SafeAppCardContainerProps) => {
-  const { openedSafeAppIds } = useOpenedSafeApps()
-
   const handleClickSafeApp = (event: SyntheticEvent) => {
-    if (safeApp && !openedSafeAppIds.includes(safeApp.id)) {
+    if (onClickSafeApp) {
       event.preventDefault()
-      onClickSafeApp?.()
+      onClickSafeApp()
     }
   }
 

--- a/src/components/safe-apps/SafeAppList/index.tsx
+++ b/src/components/safe-apps/SafeAppList/index.tsx
@@ -14,6 +14,7 @@ import useSafeAppPreviewDrawer from '@/hooks/safe-apps/useSafeAppPreviewDrawer'
 import css from './styles.module.css'
 import { Skeleton } from '@mui/material'
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
+import { useOpenedSafeApps } from '@/hooks/safe-apps/useOpenedSafeApps'
 
 type SafeAppListProps = {
   safeAppsList: SafeAppData[]
@@ -38,6 +39,7 @@ const SafeAppList = ({
 }: SafeAppListProps) => {
   const [safeAppsViewMode = GRID_VIEW_MODE, setSafeAppsViewMode] = useLocalStorage<SafeAppsViewMode>(VIEW_MODE_KEY)
   const { isPreviewDrawerOpen, previewDrawerApp, openPreviewDrawer, closePreviewDrawer } = useSafeAppPreviewDrawer()
+  const { openedSafeAppIds } = useOpenedSafeApps()
 
   const { filteredApps, query, setQuery, setSelectedCategories, setOptimizedWithBatchFilter, selectedCategories } =
     useSafeAppsFilters(safeAppsList)
@@ -48,11 +50,11 @@ const SafeAppList = ({
     (safeApp: SafeAppData) => {
       const isCustomApp = safeApp.id < 1
 
-      if (isCustomApp) return
+      if (isCustomApp || openedSafeAppIds.includes(safeApp.id)) return
 
       return () => openPreviewDrawer(safeApp)
     },
-    [openPreviewDrawer],
+    [openPreviewDrawer, openedSafeAppIds],
   )
 
   return (


### PR DESCRIPTION
## What it solves

Resolves #2349 

## How this PR fixes it

- Moves the check if a safe app was previously open further up the call tree into `handleSafeAppClick`

## How to test it

1. Open the custom safe apps tab
2. Add a custom safe app
3. Click on it
4. Observe that it directly opens
5. Navigate to the safe apps list
6. Click on a safe app
7. Observe that the drawer opens
8. Open that safe app
9. Navigate back to the safe apps list
10. Click on the same safe app again
11. Observe that it opens directly without a drawer

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
