### PR TITLE
Fix: tx can have been created w/o signatures

### DIFF
--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -8,7 +8,7 @@ import { useCurrentChain } from '@/hooks/useChains'
 import { getTxOptions } from '@/utils/transactions'
 import useIsValidExecution from '@/hooks/useIsValidExecution'
 import CheckWallet from '@/components/common/CheckWallet'
-import { useImmediatelyExecutable, useIsExecutionLoop, useTxActions } from './hooks'
+import { useIsExecutionLoop, useTxActions } from './hooks'
 import { useRelaysBySafe } from '@/hooks/useRemainingRelays'
 import useWalletCanRelay from '@/hooks/useWalletCanRelay'
 import { ExecutionMethod, ExecutionMethodSelector } from '../ExecutionMethodSelector'
@@ -34,6 +34,7 @@ const ExecuteForm = ({
   disableSubmit = false,
   origin,
   onlyExecute,
+  isCreation,
 }: SignOrExecuteProps & {
   safeTx?: SafeTransaction
 }): ReactElement => {
@@ -50,8 +51,6 @@ const ExecuteForm = ({
   const { needsRiskConfirmation, isRiskConfirmed, setIsRiskIgnored } = useContext(TxSecurityContext)
 
   // Check that the transaction is executable
-  const isCreation = safeTx?.signatures.size === 0
-  const isNewExecutableTx = useImmediatelyExecutable() && isCreation
   const isExecutionLoop = useIsExecutionLoop()
 
   // We default to relay, but the option is only shown if we canRelay
@@ -136,10 +135,8 @@ const ExecuteForm = ({
           </ErrorMessage>
         ) : executionValidationError || gasLimitError ? (
           <ErrorMessage error={executionValidationError || gasLimitError}>
-            This transaction will most likely fail.{' '}
-            {isNewExecutableTx
-              ? 'To save gas costs, avoid creating the transaction.'
-              : 'To save gas costs, reject this transaction.'}
+            This transaction will most likely fail.
+            {` To save gas costs, ${isCreation ? 'avoid creating' : 'reject'} this transaction.`}
           </ErrorMessage>
         ) : (
           submitError && (

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -23,6 +23,7 @@ const SignForm = ({
   origin,
   isBatch,
   isBatchable,
+  isCreation,
 }: SignOrExecuteProps & {
   safeTx?: SafeTransaction
 }): ReactElement => {
@@ -36,7 +37,6 @@ const SignForm = ({
   const { setTxFlow } = useContext(TxModalContext)
   const { needsRiskConfirmation, isRiskConfirmed, setIsRiskIgnored } = useContext(TxSecurityContext)
   const hasSigned = useAlreadySigned(safeTx)
-  const isCreation = !txId
 
   // On modal submit
   const handleSubmit = async (e: SyntheticEvent, isAddingToBatch = false) => {

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -37,7 +37,7 @@ const SignOrExecuteForm = (props: SignOrExecuteProps): ReactElement => {
   const { transactionExecution } = useAppSelector(selectSettings)
   const [shouldExecute, setShouldExecute] = useState<boolean>(transactionExecution)
   const { safeTx, safeTxError } = useContext(SafeTxContext)
-  const isCreation = safeTx?.signatures.size === 0
+  const isCreation = !props.txId
   const isNewExecutableTx = useImmediatelyExecutable() && isCreation
   const isCorrectNonce = useValidateNonce(safeTx)
   const [decodedData, decodedDataError, decodedDataLoading] = useDecodeTx(safeTx)

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -31,6 +31,7 @@ export type SignOrExecuteProps = {
   onlyExecute?: boolean
   disableSubmit?: boolean
   origin?: string
+  isCreation?: boolean
 }
 
 const SignOrExecuteForm = (props: SignOrExecuteProps): ReactElement => {
@@ -93,9 +94,9 @@ const SignOrExecuteForm = (props: SignOrExecuteProps): ReactElement => {
         <RiskConfirmationError />
 
         {willExecute ? (
-          <ExecuteForm {...props} safeTx={safeTx} />
+          <ExecuteForm {...props} safeTx={safeTx} isCreation={isCreation} />
         ) : (
-          <SignForm {...props} safeTx={safeTx} isBatchable={isBatchable} />
+          <SignForm {...props} safeTx={safeTx} isBatchable={isBatchable} isCreation={isCreation} />
         )}
       </TxCard>
     </>


### PR DESCRIPTION
## What it solves

Delegate txs can be unsigned but still be in the queue, so the definition of `isCreation` should be the absence of a tx id.

## How to test

* Create a transaction as a delegate
* Confirm the transaction as an owner
* Observe that it no longer says "Create" anywhere in the confirmation tx flow like it did before