### PR TITLE
Fix: prevent an early redirect on the Safe Apps share page

### DIFF
--- a/src/pages/share/safe-app.tsx
+++ b/src/pages/share/safe-app.tsx
@@ -19,7 +19,7 @@ const ShareSafeApp = () => {
     )
   }
 
-  if (!appUrl || !validChain || !chain) {
+  if (router.isReady && (!appUrl || !validChain || !chain)) {
     router.push(AppRoutes.index)
     return null
   }
@@ -34,9 +34,7 @@ const ShareSafeApp = () => {
         <title>Safe Apps – Share</title>
       </Head>
 
-      <main>
-        <SafeAppLanding appUrl={appUrl} chain={chain} />
-      </main>
+      <main>{appUrl && chain && <SafeAppLanding appUrl={appUrl} chain={chain} />}</main>
     </>
   )
 }

--- a/src/pages/share/safe-app.tsx
+++ b/src/pages/share/safe-app.tsx
@@ -1,15 +1,24 @@
-import { Box, CircularProgress } from '@mui/material'
+import { useEffect } from 'react'
+import Head from 'next/head'
 import { useRouter } from 'next/router'
+import { Box, CircularProgress } from '@mui/material'
 import { useSafeAppUrl } from '@/hooks/safe-apps/useSafeAppUrl'
 import { useChainFromQueryParams } from '@/hooks/safe-apps/useChainFromQueryParams'
 import { SafeAppLanding } from '@/components/safe-apps/SafeAppLandingPage'
 import { AppRoutes } from '@/config/routes'
-import Head from 'next/head'
 
 const ShareSafeApp = () => {
   const router = useRouter()
   const appUrl = useSafeAppUrl()
   const { chain, validChain, loading: chainLoading, error: chainError } = useChainFromQueryParams()
+
+  useEffect(() => {
+    if (chainLoading) return
+
+    if (router.isReady && (!appUrl || !validChain || !chain)) {
+      router.push(AppRoutes.index)
+    }
+  }, [appUrl, validChain, chain, chainLoading, router])
 
   if (chainLoading) {
     return (
@@ -19,8 +28,7 @@ const ShareSafeApp = () => {
     )
   }
 
-  if (router.isReady && (!appUrl || !validChain || !chain)) {
-    router.push(AppRoutes.index)
+  if (!appUrl || !validChain || !chain) {
     return null
   }
 
@@ -34,7 +42,9 @@ const ShareSafeApp = () => {
         <title>Safe Apps – Share</title>
       </Head>
 
-      <main>{appUrl && chain && <SafeAppLanding appUrl={appUrl} chain={chain} />}</main>
+      <main>
+        <SafeAppLanding appUrl={appUrl} chain={chain} />
+      </main>
     </>
   )
 }


### PR DESCRIPTION
## What it solves

Resolves #2320

## How this PR fixes it

It should wait for the client-side router to kick in before attempting a redirect.

## How to test

Open this link:

https://fix_app_share--walletweb.review-wallet-web.5afe.dev/share/safe-app?appUrl=https%3A%2F%2Fsafe-apps.dev.5afe.dev%2Fdrain-safe&chain=gor

It should not redirect to the Dashboard.