### PR TITLE
fix: Replace transaction with 0 nonce

### DIFF
--- a/src/components/transactions/RejectTxButton/index.tsx
+++ b/src/components/transactions/RejectTxButton/index.tsx
@@ -32,7 +32,7 @@ const RejectTxButton = ({
   const tooltipTitle = getTxButtonTooltip('Replace', { hasSafeSDK: !!safeSDK })
 
   const openReplacementModal = () => {
-    if (!txNonce) return
+    if (txNonce === undefined) return
     setTxFlow(<ReplaceTxMenu txNonce={txNonce} />)
   }
 


### PR DESCRIPTION
## What it solves

Resolves #2360 

## How this PR fixes it

- Adjust nonce undefined check so it doesn't fail for nonce 0

## How to test it

1. Open a newly created 2/n safe
2. Create a new transaction
3. Go to queue and press the reject button
4. Observe the replace tx flow opening

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
