### PR TITLE
fix: minimum fee of 0.1 gwei on optimism

### DIFF
--- a/src/hooks/useGasPrice.ts
+++ b/src/hooks/useGasPrice.ts
@@ -8,7 +8,7 @@ import { useWeb3ReadOnly } from '../hooks/wallets/web3'
 import { Errors, logError } from '@/services/exceptions'
 import { FEATURES, hasFeature } from '@/utils/chains'
 import { asError } from '@/services/exceptions/utils'
-import { adjustGasEstimationForChain } from '@/utils/gas'
+import { adjustGasPriceEstimationForChain } from '@/utils/gas'
 
 export type EstimatedGasPrice = {
   maxFeePerGas: BigNumber | undefined
@@ -80,12 +80,12 @@ const useGasPrice = (): AsyncResult<EstimatedGasPrice> => {
       const maxFee = gasPrice || (isEIP1559 ? feeData?.maxFeePerGas : feeData?.gasPrice) || undefined
       const maxPrioFee = (isEIP1559 && feeData?.maxPriorityFeePerGas) || undefined
 
-      const gasEstimation = {
+      const gasPriceEstimation = {
         maxFeePerGas: maxFee,
         maxPriorityFeePerGas: maxPrioFee,
       }
 
-      return adjustGasEstimationForChain(gasEstimation, chain?.chainId)
+      return adjustGasPriceEstimationForChain(gasPriceEstimation, chain?.chainId)
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [gasPriceConfigs, provider, counter, isEIP1559],

--- a/src/utils/gas.ts
+++ b/src/utils/gas.ts
@@ -1,0 +1,19 @@
+import chains from '@/config/chains'
+import type { EstimatedGasPrice } from '@/hooks/useGasPrice'
+import { BigNumber } from 'ethers'
+
+const OPTIMISM_MINIMUM_BASE_FEE_WEI = BigNumber.from(100000000)
+
+export const adjustGasEstimationForChain = (gas: EstimatedGasPrice, chainId: string | undefined) => {
+  if (chainId === chains.oeth) {
+    // On Optimism we lower bound the base fee to 0.1 gwei because the base fee can spike quite fast
+    return {
+      ...gas,
+      maxFeePerGas: gas.maxFeePerGas?.lt(OPTIMISM_MINIMUM_BASE_FEE_WEI)
+        ? OPTIMISM_MINIMUM_BASE_FEE_WEI
+        : gas.maxFeePerGas,
+    }
+  }
+
+  return gas
+}

--- a/src/utils/gas.ts
+++ b/src/utils/gas.ts
@@ -4,14 +4,15 @@ import { BigNumber } from 'ethers'
 
 const OPTIMISM_MINIMUM_BASE_FEE_WEI = BigNumber.from(100000000)
 
-export const adjustGasEstimationForChain = (gas: EstimatedGasPrice, chainId: string | undefined) => {
+export const adjustGasPriceEstimationForChain = (gas: EstimatedGasPrice, chainId: string | undefined) => {
   if (chainId === chains.oeth) {
     // On Optimism we lower bound the base fee to 0.1 gwei because the base fee can spike quite fast
+    const maxFeePerGas = gas.maxFeePerGas?.lt(OPTIMISM_MINIMUM_BASE_FEE_WEI)
+      ? OPTIMISM_MINIMUM_BASE_FEE_WEI
+      : gas.maxFeePerGas
     return {
       ...gas,
-      maxFeePerGas: gas.maxFeePerGas?.lt(OPTIMISM_MINIMUM_BASE_FEE_WEI)
-        ? OPTIMISM_MINIMUM_BASE_FEE_WEI
-        : gas.maxFeePerGas,
+      maxFeePerGas,
     }
   }
 


### PR DESCRIPTION
## What it solves

Resolves #2222 

## How this PR fixes it
Uses a minimum gas price of 0.1 gwei.

## How to test it
- Create different txs on Optimism:
  - Safe creation
  - Safe transactions
  - Batch txs
  - Spending limit txs

Ideally we should also enable EIP-1559 after this PR gets merged. I could only test it locally by overwriting my local state.

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
