### PR TITLE
fix: better UX for off-chain message signing

### DIFF
--- a/src/components/tx-flow/flows/SignMessage/SignMessage.test.tsx
+++ b/src/components/tx-flow/flows/SignMessage/SignMessage.test.tsx
@@ -1,5 +1,5 @@
 import { hexlify, hexZeroPad, toUtf8Bytes } from 'ethers/lib/utils'
-import type { ChainInfo, SafeInfo, SafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
+import type { ChainInfo, SafeInfo, SafeMessage, SafeMessageListPage } from '@safe-global/safe-gateway-typescript-sdk'
 import { SafeMessageListItemType } from '@safe-global/safe-gateway-typescript-sdk'
 
 import SignMessage from './SignMessage'
@@ -9,7 +9,6 @@ import * as useWalletHook from '@/hooks/wallets/useWallet'
 import * as useSafeInfoHook from '@/hooks/useSafeInfo'
 import * as useAsyncHook from '@/hooks/useAsync'
 import * as useChainsHook from '@/hooks/useChains'
-import * as useSafeMessages from '@/hooks/messages/useSafeMessages'
 import * as sender from '@/services/safe-messages/safeMsgSender'
 import * as onboard from '@/hooks/wallets/useOnboard'
 import { render, act, fireEvent, waitFor } from '@/tests/test-utils'
@@ -17,10 +16,22 @@ import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import type { EIP1193Provider, WalletState, AppState, OnboardAPI } from '@web3-onboard/core'
 import { generateSafeMessageHash } from '@/utils/safe-messages'
 import { getSafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
+import useSafeMessages from '@/hooks/messages/useSafeMessages'
 
 jest.mock('@safe-global/safe-gateway-typescript-sdk', () => ({
   ...jest.requireActual('@safe-global/safe-gateway-typescript-sdk'),
   getSafeMessage: jest.fn(),
+}))
+
+jest.mock('@/hooks/messages/useSafeMessages', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    page: {
+      results: [],
+    },
+    error: undefined,
+    loading: false,
+  })),
 }))
 
 let mockProvider = {
@@ -76,6 +87,8 @@ describe('SignMessage', () => {
   afterAll(() => {
     jest.useRealTimers()
   })
+
+  const mockUseSafeMessages = useSafeMessages as jest.Mock
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -295,7 +308,19 @@ describe('SignMessage', () => {
       confirmationsSubmitted: 1,
     } as unknown as SafeMessage
 
-    jest.spyOn(useSafeMessages, 'useSafeMessage').mockReturnValue(msg)
+    const msgs: {
+      page?: SafeMessageListPage
+      error?: string
+      loading: boolean
+    } = {
+      page: {
+        results: [msg],
+      },
+      error: undefined,
+      loading: false,
+    }
+
+    mockUseSafeMessages.mockReturnValue(msgs)
 
     const { getByText } = render(
       <SignMessage logoUri="www.fake.com/test.png" name="Test App" message={messageText} requestId="123" />,
@@ -457,7 +482,19 @@ describe('SignMessage', () => {
       confirmationsSubmitted: 1,
     } as unknown as SafeMessage
 
-    jest.spyOn(useSafeMessages, 'useSafeMessage').mockReturnValue(msg)
+    const msgs: {
+      page?: SafeMessageListPage
+      error?: string
+      loading: boolean
+    } = {
+      page: {
+        results: [msg],
+      },
+      error: undefined,
+      loading: false,
+    }
+
+    mockUseSafeMessages.mockReturnValue(msgs)
 
     const { getByText } = render(
       <SignMessage logoUri="www.fake.com/test.png" name="Test App" message={messageText} requestId="123" />,
@@ -478,7 +515,21 @@ describe('SignMessage', () => {
           address: hexZeroPad('0x3', 20),
         } as ConnectedWallet),
     )
-    jest.spyOn(useSafeMessages, 'useSafeMessage').mockReturnValue(undefined)
+
+    const msgs: {
+      page?: SafeMessageListPage
+      error?: string
+      loading: boolean
+    } = {
+      page: {
+        results: [],
+      },
+      error: undefined,
+      loading: false,
+    }
+
+    mockUseSafeMessages.mockReturnValue(msgs)
+
     jest.spyOn(useIsSafeOwnerHook, 'default').mockImplementation(() => true)
 
     jest.spyOn(useAsyncHook, 'default').mockReturnValue([undefined, new Error('SafeMessage not found'), false])
@@ -518,7 +569,19 @@ describe('SignMessage', () => {
     jest.spyOn(onboard, 'default').mockReturnValue(mockOnboard)
     jest.spyOn(useIsSafeOwnerHook, 'default').mockImplementation(() => true)
 
-    jest.spyOn(useSafeMessages, 'useSafeMessage').mockReturnValue(undefined)
+    const msgs: {
+      page?: SafeMessageListPage
+      error?: string
+      loading: boolean
+    } = {
+      page: {
+        results: [],
+      },
+      error: undefined,
+      loading: false,
+    }
+
+    mockUseSafeMessages.mockReturnValue(msgs)
 
     jest
       .spyOn(useAsyncHook, 'default')

--- a/src/components/tx-flow/flows/SignMessage/SignMessage.test.tsx
+++ b/src/components/tx-flow/flows/SignMessage/SignMessage.test.tsx
@@ -374,10 +374,6 @@ describe('SignMessage', () => {
       }),
     )
 
-    await act(() => {
-      jest.advanceTimersByTime(1000)
-    })
-
     expect(getByText('Message successfully signed')).toBeInTheDocument()
   })
 
@@ -555,10 +551,6 @@ describe('SignMessage', () => {
       fireEvent.click(button)
     })
 
-    await act(() => {
-      jest.advanceTimersByTime(1000)
-    })
-
     await waitFor(() => {
       expect(proposalSpy).toHaveBeenCalled()
       expect(getByText('Error confirming the message. Please try again.')).toBeInTheDocument()
@@ -611,11 +603,6 @@ describe('SignMessage', () => {
       fireEvent.click(button)
     })
 
-    await act(() => {
-      jest.advanceTimersByTime(1000)
-    })
-
-    // We automatically call the dispatch after 1 second
     expect(confirmationSpy).toHaveBeenCalled()
 
     await waitFor(() => {

--- a/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
+++ b/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
@@ -1,6 +1,18 @@
-import { Grid, Button, Box, Typography, SvgIcon, CardContent, CardActions } from '@mui/material'
+import {
+  Grid,
+  Button,
+  Box,
+  Typography,
+  SvgIcon,
+  CardContent,
+  CardActions,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+} from '@mui/material'
 import { useTheme } from '@mui/material/styles'
-import { useContext } from 'react'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import { useContext, useEffect, useState } from 'react'
 import { SafeMessageListItemType, SafeMessageStatus } from '@safe-global/safe-gateway-typescript-sdk'
 import type { ReactElement } from 'react'
 import type { SafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
@@ -25,6 +37,7 @@ import useHighlightHiddenTab from '@/hooks/useHighlightHiddenTab'
 import InfoBox from '@/components/safe-messages/InfoBox'
 import { DecodedMsg } from '@/components/safe-messages/DecodedMsg'
 import TxCard from '@/components/tx-flow/common/TxCard'
+import { dispatchPreparedSignature } from '@/services/safe-messages/safeMsgNotifications'
 
 const createSkeletonMessage = (confirmationsRequired: number): SafeMessage => {
   return {
@@ -64,9 +77,11 @@ const DialogHeader = ({ threshold }: { threshold: number }) => (
     <Typography variant="h4" textAlign="center" gutterBottom>
       Confirm message
     </Typography>
-    <Typography variant="body1" textAlign="center" mb={2}>
-      To sign this message, you need to collect <b>{threshold} owner signatures</b> of your Safe Account.
-    </Typography>
+    {threshold > 1 && (
+      <Typography variant="body1" textAlign="center" mb={2}>
+        To sign this message, collect signatures from <b>{threshold} owners</b> of your Safe Account.
+      </Typography>
+    )}
   </>
 )
 
@@ -116,6 +131,23 @@ const AlreadySignedByOwnerMessage = ({ hasSigned }: { hasSigned: boolean }) => {
   )
 }
 
+const SuccessCard = ({ safeMessage, onContinue }: { safeMessage: SafeMessage; onContinue: () => void }) => {
+  return (
+    <TxCard>
+      <Typography variant="h4" textAlign="center" gutterBottom>
+        Message successfully signed
+      </Typography>
+
+      <MsgSigners msg={safeMessage} showOnlyConfirmations showMissingSignatures />
+      <CardActions>
+        <Button variant="contained" color="primary" onClick={onContinue} disabled={!safeMessage.preparedSignature}>
+          Continue
+        </Button>
+      </CardActions>
+    </TxCard>
+  )
+}
+
 type BaseProps = Pick<SafeMessage, 'logoUri' | 'name' | 'message'>
 
 // Custom Safe Apps do not have a `safeAppId`
@@ -140,23 +172,46 @@ const SignMessage = ({ message, safeAppId, requestId }: ProposeProps | ConfirmPr
 
   const { decodedMessage, safeMessageMessage, safeMessageHash } = useDecodedSafeMessage(message, safe)
   const ongoingMessage = useSafeMessage(safeMessageHash)
+  const [safeMessage, setSafeMessage] = useState(ongoingMessage)
+
+  // Sync ongoing msg
+  useEffect(() => {
+    setSafeMessage(ongoingMessage)
+  }, [ongoingMessage])
+
   useHighlightHiddenTab()
 
   const decodedMessageAsString =
     typeof decodedMessage === 'string' ? decodedMessage : JSON.stringify(decodedMessage, null, 2)
 
-  const hasSigned = !!ongoingMessage?.confirmations.some(({ owner }) => owner.value === wallet?.address)
+  const hasSigned = !!safeMessage?.confirmations.some(({ owner }) => owner.value === wallet?.address)
+
+  const isFullySigned = !!safeMessage?.preparedSignature
 
   const isDisabled = !isOwner || hasSigned
 
   const { onSign, submitError } = useSyncSafeMessageSigner(
-    ongoingMessage,
+    safeMessage,
     decodedMessage,
     safeMessageHash,
     requestId,
     safeAppId,
     () => setTxFlow(undefined),
   )
+
+  const handleSign = async () => {
+    const updatedMessage = await onSign()
+    if (updatedMessage) {
+      setSafeMessage(updatedMessage)
+    }
+  }
+
+  const onContinue = async () => {
+    if (!safeMessage) {
+      return
+    }
+    await dispatchPreparedSignature(safeMessage, safeMessageHash, () => setTxFlow(undefined), requestId)
+  }
 
   return (
     <>
@@ -169,42 +224,52 @@ const SignMessage = ({ message, safeAppId, requestId }: ProposeProps | ConfirmPr
           </Typography>
           <DecodedMsg message={decodedMessage} isInModal />
 
-          <MessageHashField label="SafeMessage" hashValue={safeMessageMessage} />
-          <MessageHashField label="SafeMessage hash" hashValue={safeMessageHash} />
+          <Accordion sx={{ mt: 2, '&.Mui-expanded': { mt: 2 } }}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>SafeMessage details</AccordionSummary>
+            <AccordionDetails>
+              <MessageHashField label="SafeMessage" hashValue={safeMessageMessage} />
+              <MessageHashField label="SafeMessage hash" hashValue={safeMessageHash} />
+            </AccordionDetails>
+          </Accordion>
         </CardContent>
       </TxCard>
 
-      <TxCard>
-        <AlreadySignedByOwnerMessage hasSigned={hasSigned} />
+      {isFullySigned ? (
+        <SuccessCard onContinue={onContinue} safeMessage={safeMessage} />
+      ) : (
+        <>
+          <TxCard>
+            <AlreadySignedByOwnerMessage hasSigned={hasSigned} />
 
-        <InfoBox
-          title="Collect all the confirmations"
-          message={
-            requestId
-              ? 'Please keep this modal open until all signers confirm this message. Closing the modal will abort the signing request.'
-              : 'The signature will be submitted to the Safe App when the message is fully signed.'
-          }
-        >
-          <MsgSigners
-            msg={ongoingMessage || createSkeletonMessage(safe.threshold)}
-            showOnlyConfirmations
-            showMissingSignatures
-            backgroundColor={palette.info.background}
-          />
-        </InfoBox>
+            <InfoBox
+              title="Collect all the confirmations"
+              message={
+                requestId
+                  ? 'Please keep this modal open until all signers confirm this message. Closing the modal will abort the signing request.'
+                  : 'The signature will be submitted to the Safe App when the message is fully signed.'
+              }
+            >
+              <MsgSigners
+                msg={safeMessage || createSkeletonMessage(safe.threshold)}
+                showOnlyConfirmations
+                showMissingSignatures
+                backgroundColor={palette.info.background}
+              />
+            </InfoBox>
 
-        <WrongChainWarning />
+            <WrongChainWarning />
 
-        <MessageDialogError isOwner={isOwner} submitError={submitError} />
-      </TxCard>
-
-      <TxCard>
-        <CardActions>
-          <Button variant="contained" color="primary" onClick={onSign} disabled={isDisabled}>
-            Sign
-          </Button>
-        </CardActions>
-      </TxCard>
+            <MessageDialogError isOwner={isOwner} submitError={submitError} />
+          </TxCard>
+          <TxCard>
+            <CardActions>
+              <Button variant="contained" color="primary" onClick={handleSign} disabled={isDisabled}>
+                Sign
+              </Button>
+            </CardActions>
+          </TxCard>
+        </>
+      )}
     </>
   )
 }

--- a/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
+++ b/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
@@ -12,7 +12,7 @@ import {
 } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
-import { useContext, useEffect, useState } from 'react'
+import { useContext } from 'react'
 import { SafeMessageListItemType, SafeMessageStatus } from '@safe-global/safe-gateway-typescript-sdk'
 import type { ReactElement } from 'react'
 import type { SafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
@@ -24,7 +24,7 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import useWallet from '@/hooks/wallets/useWallet'
-import { useSafeMessage } from '@/hooks/messages/useSafeMessages'
+import useSafeMessage from '@/hooks/messages/useSafeMessage'
 import useOnboard, { switchWallet } from '@/hooks/wallets/useOnboard'
 import { TxModalContext } from '@/components/tx-flow'
 import CopyButton from '@/components/common/CopyButton'
@@ -171,13 +171,7 @@ const SignMessage = ({ message, safeAppId, requestId }: ProposeProps | ConfirmPr
   const wallet = useWallet()
 
   const { decodedMessage, safeMessageMessage, safeMessageHash } = useDecodedSafeMessage(message, safe)
-  const ongoingMessage = useSafeMessage(safeMessageHash)
-  const [safeMessage, setSafeMessage] = useState(ongoingMessage)
-
-  // Sync ongoing msg
-  useEffect(() => {
-    setSafeMessage(ongoingMessage)
-  }, [ongoingMessage])
+  const [safeMessage, setSafeMessage] = useSafeMessage(safeMessageHash)
 
   useHighlightHiddenTab()
 

--- a/src/hooks/loadables/useLoadSafeMessages.ts
+++ b/src/hooks/loadables/useLoadSafeMessages.ts
@@ -5,10 +5,21 @@ import type { SafeMessageListPage } from '@safe-global/safe-gateway-typescript-s
 import useAsync from '@/hooks/useAsync'
 import { logError, Errors } from '@/services/exceptions'
 import useSafeInfo from '@/hooks/useSafeInfo'
+import { POLLING_INTERVAL } from '@/config/constants'
+import useIntervalCounter from '@/hooks/useIntervalCounter'
 import type { AsyncResult } from '@/hooks/useAsync'
 
 export const useLoadSafeMessages = (): AsyncResult<SafeMessageListPage> => {
   const { safe, safeAddress, safeLoaded } = useSafeInfo()
+
+  // TODO: Remove manual polling when messagesTag is no longer cached on the backend
+  const [pollCount, resetPolling] = useIntervalCounter(POLLING_INTERVAL)
+
+  // Reset the counter when safe address/chainId changes
+  useEffect(() => {
+    resetPolling()
+  }, [resetPolling, safeAddress, safe.chainId])
+
   const [data, error, loading] = useAsync<SafeMessageListPage>(
     () => {
       if (!safeLoaded) {
@@ -17,7 +28,13 @@ export const useLoadSafeMessages = (): AsyncResult<SafeMessageListPage> => {
       return getSafeMessages(safe.chainId, safeAddress)
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [safeLoaded, safe.chainId, safeAddress, safe.messagesTag],
+    [
+      safeLoaded,
+      safe.chainId,
+      safeAddress,
+      // safe.messagesTag,
+      pollCount,
+    ],
     false,
   )
 

--- a/src/hooks/loadables/useLoadSafeMessages.ts
+++ b/src/hooks/loadables/useLoadSafeMessages.ts
@@ -5,21 +5,10 @@ import type { SafeMessageListPage } from '@safe-global/safe-gateway-typescript-s
 import useAsync from '@/hooks/useAsync'
 import { logError, Errors } from '@/services/exceptions'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import { POLLING_INTERVAL } from '@/config/constants'
-import useIntervalCounter from '@/hooks/useIntervalCounter'
 import type { AsyncResult } from '@/hooks/useAsync'
 
 export const useLoadSafeMessages = (): AsyncResult<SafeMessageListPage> => {
   const { safe, safeAddress, safeLoaded } = useSafeInfo()
-
-  // TODO: Remove manual polling when messagesTag is no longer cached on the backend
-  const [pollCount, resetPolling] = useIntervalCounter(POLLING_INTERVAL)
-
-  // Reset the counter when safe address/chainId changes
-  useEffect(() => {
-    resetPolling()
-  }, [resetPolling, safeAddress, safe.chainId])
-
   const [data, error, loading] = useAsync<SafeMessageListPage>(
     () => {
       if (!safeLoaded) {
@@ -28,13 +17,7 @@ export const useLoadSafeMessages = (): AsyncResult<SafeMessageListPage> => {
       return getSafeMessages(safe.chainId, safeAddress)
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      safeLoaded,
-      safe.chainId,
-      safeAddress,
-      // safe.messagesTag,
-      pollCount,
-    ],
+    [safeLoaded, safe.chainId, safeAddress, safe.messagesTag],
     false,
   )
 

--- a/src/hooks/messages/useSafeMessage.ts
+++ b/src/hooks/messages/useSafeMessage.ts
@@ -1,0 +1,22 @@
+import { isSafeMessageListItem } from '@/utils/safe-message-guards'
+import type { SafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
+import { useState, useEffect } from 'react'
+import useSafeMessages from './useSafeMessages'
+
+const useSafeMessage = (safeMessageHash: string) => {
+  const [safeMessage, setSafeMessage] = useState<SafeMessage | undefined>()
+
+  const messages = useSafeMessages()
+
+  const ongoingMessage = messages.page?.results
+    ?.filter(isSafeMessageListItem)
+    .find((msg) => msg.messageHash === safeMessageHash)
+
+  useEffect(() => {
+    setSafeMessage(ongoingMessage)
+  }, [ongoingMessage])
+
+  return [safeMessage, setSafeMessage] as const
+}
+
+export default useSafeMessage

--- a/src/hooks/messages/useSafeMessages.ts
+++ b/src/hooks/messages/useSafeMessages.ts
@@ -5,7 +5,6 @@ import { useAppSelector } from '@/store'
 import useAsync from '@/hooks/useAsync'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { selectSafeMessages } from '@/store/safeMessagesSlice'
-import { isSafeMessageListItem } from '@/utils/safe-message-guards'
 
 const useSafeMessages = (
   pageUrl?: string,
@@ -43,15 +42,6 @@ const useSafeMessages = (
         error: messagesState.error,
         loading: messagesState.loading,
       }
-}
-
-export const useSafeMessage = (safeMessageHash: string) => {
-  const messages = useSafeMessages()
-  const ongoingMessage = messages.page?.results
-    ?.filter(isSafeMessageListItem)
-    .find((msg) => msg.messageHash === safeMessageHash)
-
-  return ongoingMessage
 }
 
 export default useSafeMessages

--- a/src/hooks/messages/useSyncSafeMessageSigner.ts
+++ b/src/hooks/messages/useSyncSafeMessageSigner.ts
@@ -12,7 +12,7 @@ import { useEffect, useCallback, useState } from 'react'
 import useSafeInfo from '../useSafeInfo'
 import useOnboard from '../wallets/useOnboard'
 
-const HIDE_DELAY = 1000
+const HIDE_DELAY = 3000
 
 const fetchSafeMessage = async (safeMessageHash: string, chainId: string) => {
   let message: SafeMessage | undefined

--- a/src/hooks/messages/useSyncSafeMessageSigner.ts
+++ b/src/hooks/messages/useSyncSafeMessageSigner.ts
@@ -1,10 +1,32 @@
+import { Errors, logError } from '@/services/exceptions'
 import { asError } from '@/services/exceptions/utils'
 import { dispatchPreparedSignature } from '@/services/safe-messages/safeMsgNotifications'
 import { dispatchSafeMsgProposal, dispatchSafeMsgConfirmation } from '@/services/safe-messages/safeMsgSender'
-import { type EIP712TypedData, type SafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
+import {
+  getSafeMessage,
+  SafeMessageListItemType,
+  type EIP712TypedData,
+  type SafeMessage,
+} from '@safe-global/safe-gateway-typescript-sdk'
 import { useEffect, useCallback, useState } from 'react'
 import useSafeInfo from '../useSafeInfo'
 import useOnboard from '../wallets/useOnboard'
+
+const HIDE_DELAY = 1000
+
+const fetchSafeMessage = async (safeMessageHash: string, chainId: string) => {
+  let message: SafeMessage | undefined
+  try {
+    // fetchedMessage does not have a type because it is explicitly a message
+    const fetchedMessage = await getSafeMessage(chainId, safeMessageHash)
+    message = { ...fetchedMessage, type: SafeMessageListItemType.MESSAGE }
+  } catch (err) {
+    logError(Errors._613, err)
+    throw err
+  }
+
+  return message
+}
 
 const useSyncSafeMessageSigner = (
   message: SafeMessage | undefined,
@@ -20,9 +42,11 @@ const useSyncSafeMessageSigner = (
 
   // If the message gets updated in the messageSlice we dispatch it if the signature is complete
   useEffect(() => {
+    let timeout: NodeJS.Timeout | undefined
     if (message?.preparedSignature) {
-      dispatchPreparedSignature(safe.chainId, safeMessageHash, onClose, requestId)
+      timeout = setTimeout(() => dispatchPreparedSignature(message, safeMessageHash, onClose, requestId), HIDE_DELAY)
     }
+    return () => clearTimeout(timeout)
   }, [message, safe.chainId, safeMessageHash, onClose, requestId])
 
   const onSign = useCallback(async () => {
@@ -38,10 +62,14 @@ const useSyncSafeMessageSigner = (
       if (!message) {
         await dispatchSafeMsgProposal({ onboard, safe, message: decodedMessage, safeAppId })
 
+        // Fetch updated message
+        const updatedMsg = await fetchSafeMessage(safeMessageHash, safe.chainId)
+
         // If threshold 1, we do not want to wait for polling
         if (safe.threshold === 1) {
-          await dispatchPreparedSignature(safe.chainId, safeMessageHash, onClose, requestId)
+          setTimeout(() => dispatchPreparedSignature(updatedMsg, safeMessageHash, onClose, requestId), HIDE_DELAY)
         }
+        return updatedMsg
       } else {
         await dispatchSafeMsgConfirmation({ onboard, safe, message: decodedMessage })
 
@@ -51,10 +79,9 @@ const useSyncSafeMessageSigner = (
           return
         }
 
-        // If the last signature was added to the message, we can immediately dispatch the signature
-        if (message.confirmationsRequired <= message.confirmationsSubmitted + 1) {
-          dispatchPreparedSignature(safe.chainId, safeMessageHash, onClose, requestId)
-        }
+        const updatedMsg = await fetchSafeMessage(safeMessageHash, safe.chainId)
+        setTimeout(() => dispatchPreparedSignature(updatedMsg, safeMessageHash, onClose, requestId), HIDE_DELAY)
+        return updatedMsg
       }
     } catch (e) {
       setSubmitError(asError(e))

--- a/src/services/safe-messages/safeMsgNotifications.ts
+++ b/src/services/safe-messages/safeMsgNotifications.ts
@@ -1,5 +1,4 @@
-import { getSafeMessage, SafeMessageListItemType, type SafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
-import { logError, Errors } from '../exceptions'
+import type { SafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
 import { safeMsgDispatch, SafeMsgEvent } from './safeMsgEvents'
 
 const isMessageFullySigned = (message: SafeMessage): message is SafeMessage & { preparedSignature: string } => {
@@ -15,22 +14,11 @@ const isMessageFullySigned = (message: SafeMessage): message is SafeMessage & { 
  * @param requestId
  */
 export const dispatchPreparedSignature = async (
-  chainId: string,
+  message: SafeMessage,
   safeMessageHash: string,
   onClose: () => void,
   requestId?: string,
 ) => {
-  let message: SafeMessage | undefined
-  try {
-    const fetchedMessage = await getSafeMessage(chainId, safeMessageHash)
-
-    // fetchedMessage does not have a type because it is explicitly a message
-    message = { ...fetchedMessage, type: SafeMessageListItemType.MESSAGE }
-  } catch (err) {
-    logError(Errors._613, err)
-    throw err
-  }
-
   if (isMessageFullySigned(message)) {
     safeMsgDispatch(SafeMsgEvent.SIGNATURE_PREPARED, {
       messageHash: safeMessageHash,


### PR DESCRIPTION
## What it solves

Resolves #2019 

## How this PR fixes it
- Changes text
- Adds a Success Card
- Shows Success Card for 1s when message is fully signed
- immediately re-fetches message after signing

## How to test it
- Open a 2/3 Safe
- Create a message signing request through Wallet connect
- Add the first signature
  - Observe that it gets added immediately
- Change the owner
- Add a second signature
  - Observe new success card with Continue button
  - It should disappear after 1s

## Screenshots
![Screenshot 2023-08-08 at 16 48 51](https://github.com/safe-global/safe-wallet-web/assets/2670790/984113d5-a3c3-47e0-a84c-46cbf0dd1aa4)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
