### PR TITLE
Feat: load analytics in cookie-less mode

### DIFF
--- a/src/components/common/CookieBanner/index.tsx
+++ b/src/components/common/CookieBanner/index.tsx
@@ -72,9 +72,8 @@ export const CookieBanner = ({
         <Grid container alignItems="center">
           <Grid item xs>
             <Typography variant="body2" mb={2}>
-              By clicking &quot;Accept all&quot; you agree to the use of the tools listed below and their corresponding{' '}
-              <span style={{ whiteSpace: 'nowrap' }}>3rd-party</span> cookies.{' '}
-              <ExternalLink href={AppRoutes.cookie}>Cookie policy</ExternalLink>
+              By clicking &quot;Accept all&quot; you agree to the use of the tools listed below and their corresponding
+              cookies. <ExternalLink href={AppRoutes.cookie}>Cookie policy</ExternalLink>
             </Typography>
 
             <Grid container alignItems="center" gap={4}>
@@ -84,6 +83,7 @@ export const CookieBanner = ({
                   <br />
                   <Typography variant="body2">Locally stored data for core functionality</Typography>
                 </Box>
+
                 <Box mb={2}>
                   <CookieCheckbox
                     checkboxProps={{ ...register(CookieType.UPDATES), id: 'beamer' }}
@@ -93,16 +93,16 @@ export const CookieBanner = ({
                   <br />
                   <Typography variant="body2">New features and product announcements</Typography>
                 </Box>
+
                 <Box>
                   <CookieCheckbox
                     checkboxProps={{ ...register(CookieType.ANALYTICS), id: 'ga' }}
-                    label="Google Analytics"
+                    label="Analytics"
                     checked={watch(CookieType.ANALYTICS)}
                   />
                   <br />
                   <Typography variant="body2">
-                    Help us make the app better. We never track your Safe Account address or wallet addresses, or any
-                    transaction data.
+                    Opt in for Google Analytics cookies to help us analyze app usage patterns.
                   </Typography>
                 </Box>
               </Grid>

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -14,7 +14,8 @@ declare global {
     }
     beamer_config?: BeamerConfig
     Beamer?: BeamerMethods
-    dataLayer?: DataLayerArgs['dataLayer']
+    dataLayer?: any[]
+    gtag?: (...args: any[]) => void
     Cypress?
   }
 }

--- a/src/services/analytics/TagManager.ts
+++ b/src/services/analytics/TagManager.ts
@@ -2,8 +2,6 @@ import Cookies from 'js-cookie'
 
 import { IS_PRODUCTION } from '@/config/constants'
 
-type DataLayer = Record<string, unknown>
-
 export type TagManagerArgs = {
   // GTM id, e.g. GTM-000000
   gtmId: string
@@ -11,8 +9,6 @@ export type TagManagerArgs = {
   auth: string
   // GTM environment, e.g. env-00.
   preview: string
-  // Object that contains all of the information that you want to pass to GTM
-  dataLayer?: DataLayer
 }
 
 const DATA_LAYER_NAME = 'dataLayer'
@@ -38,18 +34,40 @@ const TagManager = {
 
     return script
   },
-  isInitialized: () => {
-    const GTM_SCRIPT = 'https://www.googletagmanager.com/gtm.js'
 
-    return !!document.querySelector(`[src^="${GTM_SCRIPT}"]`)
+  dataLayer: (data: Record<string, any>) => {
+    window[DATA_LAYER_NAME] = window[DATA_LAYER_NAME] || []
+    window[DATA_LAYER_NAME].push(data)
+
+    if (!IS_PRODUCTION) {
+      console.info('[GTM] -', data)
+    }
   },
+
   initialize: (args: TagManagerArgs) => {
-    if (TagManager.isInitialized()) {
-      return
+    window[DATA_LAYER_NAME] = window[DATA_LAYER_NAME] || []
+    // This function MUST be in `window`, otherwise GTM Consent Mode just doesn't work
+    ;(window as any).gtag = function () {
+      window[DATA_LAYER_NAME].push(arguments)
     }
 
-    // Initialize dataLayer (with configuration)
-    window[DATA_LAYER_NAME] = args.dataLayer ? [args.dataLayer] : []
+    // Consent mode
+    ;(window as any).gtag('consent', 'default', {
+      ad_storage: 'denied',
+      analytics_storage: 'denied',
+      functionality_storage: 'granted',
+      personalization_storage: 'denied',
+      security_storage: 'granted',
+      wait_for_update: 500,
+    })
+
+    TagManager.dataLayer({
+      // Block JS variables and custom scripts
+      // @see https://developers.google.com/tag-platform/tag-manager/web/restrict
+      'gtm.blocklist': ['j', 'jsm', 'customScripts'],
+      pageLocation: `${location.origin}${location.pathname}`,
+      pagePath: location.pathname,
+    })
 
     const script = TagManager._getScript(args)
 
@@ -57,21 +75,17 @@ const TagManager = {
     // { "gtm.start": new Date().getTime(), event: "gtm.js" }
     document.head.insertBefore(script, document.head.childNodes[0])
   },
-  dataLayer: (dataLayer: DataLayer) => {
-    if (!TagManager.isInitialized()) {
-      return
-    }
 
-    window[DATA_LAYER_NAME].push(dataLayer)
-
-    if (!IS_PRODUCTION) {
-      console.info('[GTM] -', dataLayer)
-    }
+  enableCookies: () => {
+    ;(window as any).gtag('consent', 'update', {
+      analytics_storage: 'granted',
+    })
   },
-  disable: () => {
-    if (!TagManager.isInitialized()) {
-      return
-    }
+
+  disableCookies: () => {
+    ;(window as any).gtag('consent', 'update', {
+      analytics_storage: 'denied',
+    })
 
     const GTM_COOKIE_LIST = ['_ga', '_gat', '_gid']
 

--- a/src/services/analytics/TagManager.ts
+++ b/src/services/analytics/TagManager.ts
@@ -47,12 +47,12 @@ const TagManager = {
   initialize: (args: TagManagerArgs) => {
     window[DATA_LAYER_NAME] = window[DATA_LAYER_NAME] || []
     // This function MUST be in `window`, otherwise GTM Consent Mode just doesn't work
-    ;(window as any).gtag = function () {
-      window[DATA_LAYER_NAME].push(arguments)
+    window.gtag = function () {
+      window[DATA_LAYER_NAME]?.push(arguments)
     }
 
     // Consent mode
-    ;(window as any).gtag('consent', 'default', {
+    window.gtag('consent', 'default', {
       ad_storage: 'denied',
       analytics_storage: 'denied',
       functionality_storage: 'granted',
@@ -77,13 +77,13 @@ const TagManager = {
   },
 
   enableCookies: () => {
-    ;(window as any).gtag('consent', 'update', {
+    window.gtag('consent', 'update', {
       analytics_storage: 'granted',
     })
   },
 
   disableCookies: () => {
-    ;(window as any).gtag('consent', 'update', {
+    window.gtag('consent', 'update', {
       analytics_storage: 'denied',
     })
 

--- a/src/services/analytics/TagManager.ts
+++ b/src/services/analytics/TagManager.ts
@@ -77,13 +77,13 @@ const TagManager = {
   },
 
   enableCookies: () => {
-    window.gtag('consent', 'update', {
+    window.gtag?.('consent', 'update', {
       analytics_storage: 'granted',
     })
   },
 
   disableCookies: () => {
-    window.gtag('consent', 'update', {
+    window.gtag?.('consent', 'update', {
       analytics_storage: 'denied',
     })
 

--- a/src/services/analytics/TagManager.ts
+++ b/src/services/analytics/TagManager.ts
@@ -87,9 +87,12 @@ const TagManager = {
       analytics_storage: 'denied',
     })
 
-    const GTM_COOKIE_LIST = ['_ga', '_gat', '_gid']
+    const GA_COOKIE_LIST = ['_ga', '_gat', '_gid']
+    const GA_PREFIX = '_ga_'
+    const allCookies = document.cookie.split(';').map((cookie) => cookie.split('=')[0].trim())
+    const gaCookies = allCookies.filter((cookie) => cookie.startsWith(GA_PREFIX))
 
-    GTM_COOKIE_LIST.forEach((cookie) => {
+    GA_COOKIE_LIST.concat(gaCookies).forEach((cookie) => {
       Cookies.remove(cookie, {
         path: '/',
         domain: `.${location.host.split('.').slice(-2).join('.')}`,

--- a/src/services/analytics/__tests__/TagManager.test.ts
+++ b/src/services/analytics/__tests__/TagManager.test.ts
@@ -117,12 +117,18 @@ describe('TagManager', () => {
         preview: MOCK_PREVIEW,
       })
 
+      document.cookie = '_ga=GA123;'
+      document.cookie = '_ga_JB9NXCRJ0G=GS123;'
+      document.cookie = '_gat=GA123;'
+      document.cookie = '_gid=GI123;'
+
       TagManager.disableCookies()
 
       const path = '/'
       const domain = '.localhost'
 
       expect(Cookies.remove).toHaveBeenCalledWith('_ga', { path, domain })
+      expect(Cookies.remove).toHaveBeenCalledWith('_ga_JB9NXCRJ0G', { path, domain })
       expect(Cookies.remove).toHaveBeenCalledWith('_gat', { path, domain })
       expect(Cookies.remove).toHaveBeenCalledWith('_gid', { path, domain })
 

--- a/src/services/analytics/__tests__/TagManager.test.ts
+++ b/src/services/analytics/__tests__/TagManager.test.ts
@@ -51,18 +51,6 @@ describe('TagManager', () => {
     })
   })
 
-  describe('TagManager.isInitialized', () => {
-    it('should return false if no script is found', () => {
-      expect(TagManager.isInitialized()).toBe(false)
-    })
-
-    it('should return true if a script is found', () => {
-      TagManager.initialize({ gtmId: MOCK_ID, auth: MOCK_AUTH, preview: MOCK_PREVIEW })
-
-      expect(TagManager.isInitialized()).toBe(true)
-    })
-  })
-
   describe('TagManager.initialize', () => {
     it('should initialize TagManager', () => {
       TagManager.initialize({ gtmId: MOCK_ID, auth: MOCK_AUTH, preview: MOCK_PREVIEW })
@@ -80,35 +68,27 @@ describe('TagManager', () => {
         TagManager._getScript({ gtmId: MOCK_ID, auth: MOCK_AUTH, preview: MOCK_PREVIEW }),
       )
 
-      expect(window.dataLayer).toHaveLength(1)
-      expect(window.dataLayer[0]).toStrictEqual({ event: 'gtm.js', 'gtm.start': expect.any(Number) })
-    })
-
-    it('should not re-initialize the scripts if previously enabled', async () => {
-      const getScriptSpy = jest.spyOn(gtm.default, '_getScript')
-
-      TagManager.initialize({ gtmId: MOCK_ID, auth: MOCK_AUTH, preview: MOCK_PREVIEW })
-      TagManager.initialize({ gtmId: MOCK_ID, auth: MOCK_AUTH, preview: MOCK_PREVIEW })
-
-      expect(getScriptSpy).toHaveBeenCalledTimes(1)
-    })
-
-    it('should push to the dataLayer if povided', () => {
-      TagManager.initialize({ gtmId: MOCK_ID, auth: MOCK_AUTH, preview: MOCK_PREVIEW, dataLayer: { test: '456' } })
-
-      expect(window.dataLayer).toHaveLength(2)
-      expect(window.dataLayer[0]).toStrictEqual({ test: '456' })
-      expect(window.dataLayer[1]).toStrictEqual({ event: 'gtm.js', 'gtm.start': expect.any(Number) })
+      expect(window.dataLayer).toHaveLength(3)
+      expect(window.dataLayer[0][0]).toBe('consent')
+      expect(window.dataLayer[0][1]).toBe('default')
+      expect(window.dataLayer[0][2]).toStrictEqual({
+        ad_storage: 'denied',
+        analytics_storage: 'denied',
+        functionality_storage: 'granted',
+        personalization_storage: 'denied',
+        security_storage: 'granted',
+        wait_for_update: 500,
+      })
+      expect(window.dataLayer[1]).toStrictEqual({
+        'gtm.blocklist': ['j', 'jsm', 'customScripts'],
+        pageLocation: 'http://localhost/balances',
+        pagePath: '/balances',
+      })
+      expect(window.dataLayer[2]).toStrictEqual({ event: 'gtm.js', 'gtm.start': expect.any(Number) })
     })
   })
 
   describe('TagManager.dataLayer', () => {
-    it('should not push to the dataLayer if not initialized', () => {
-      TagManager.dataLayer({ test: '456' })
-
-      expect(window.dataLayer).toBeUndefined()
-    })
-
     it('should push data to the dataLayer', () => {
       expect(window.dataLayer).toBeUndefined()
 
@@ -118,34 +98,26 @@ describe('TagManager', () => {
         preview: MOCK_PREVIEW,
       })
 
-      expect(window.dataLayer).toHaveLength(1)
-      expect(window.dataLayer[0]).toStrictEqual({ event: 'gtm.js', 'gtm.start': expect.any(Number) })
+      expect(window.dataLayer).toHaveLength(3)
 
       TagManager.dataLayer({
         test: '123',
       })
 
-      expect(window.dataLayer).toHaveLength(2)
-      expect(window.dataLayer[1]).toStrictEqual({ test: '123' })
+      expect(window.dataLayer).toHaveLength(4)
+      expect(window.dataLayer[3]).toStrictEqual({ test: '123' })
     })
   })
 
   describe('TagManager.disable', () => {
-    it('should not remove GA cookies and reload if not mounted', () => {
-      TagManager.disable()
-
-      expect(Cookies.remove).not.toHaveBeenCalled()
-
-      expect(global.location.reload).not.toHaveBeenCalled()
-    })
-    it('should remove GA cookies and reload if mounted', () => {
+    it('should remove GA cookies and reload', () => {
       TagManager.initialize({
         gtmId: MOCK_ID,
         auth: MOCK_AUTH,
         preview: MOCK_PREVIEW,
       })
 
-      TagManager.disable()
+      TagManager.disableCookies()
 
       const path = '/'
       const domain = '.localhost'

--- a/src/services/analytics/__tests__/TagManager.test.ts
+++ b/src/services/analytics/__tests__/TagManager.test.ts
@@ -69,9 +69,9 @@ describe('TagManager', () => {
       )
 
       expect(window.dataLayer).toHaveLength(3)
-      expect(window.dataLayer[0][0]).toBe('consent')
-      expect(window.dataLayer[0][1]).toBe('default')
-      expect(window.dataLayer[0][2]).toStrictEqual({
+      expect(window.dataLayer?.[0][0]).toBe('consent')
+      expect(window.dataLayer?.[0][1]).toBe('default')
+      expect(window.dataLayer?.[0][2]).toStrictEqual({
         ad_storage: 'denied',
         analytics_storage: 'denied',
         functionality_storage: 'granted',
@@ -79,12 +79,12 @@ describe('TagManager', () => {
         security_storage: 'granted',
         wait_for_update: 500,
       })
-      expect(window.dataLayer[1]).toStrictEqual({
+      expect(window.dataLayer?.[1]).toStrictEqual({
         'gtm.blocklist': ['j', 'jsm', 'customScripts'],
         pageLocation: 'http://localhost/balances',
         pagePath: '/balances',
       })
-      expect(window.dataLayer[2]).toStrictEqual({ event: 'gtm.js', 'gtm.start': expect.any(Number) })
+      expect(window.dataLayer?.[2]).toStrictEqual({ event: 'gtm.js', 'gtm.start': expect.any(Number) })
     })
   })
 
@@ -105,7 +105,7 @@ describe('TagManager', () => {
       })
 
       expect(window.dataLayer).toHaveLength(4)
-      expect(window.dataLayer[3]).toStrictEqual({ test: '123' })
+      expect(window.dataLayer?.[3]).toStrictEqual({ test: '123' })
     })
   })
 

--- a/src/services/analytics/gtm.ts
+++ b/src/services/analytics/gtm.ts
@@ -46,7 +46,7 @@ export const gtmSetChainId = (chainId: string): void => {
   _chainId = chainId
 }
 
-export const gtmInit = (pagePath: string): void => {
+export const gtmInit = (): void => {
   const GTM_ENVIRONMENT = IS_PRODUCTION ? GTM_ENV_AUTH.LIVE : GTM_ENV_AUTH.DEVELOPMENT
 
   if (!GOOGLE_TAG_MANAGER_ID || !GTM_ENVIRONMENT.auth) {
@@ -57,17 +57,11 @@ export const gtmInit = (pagePath: string): void => {
   TagManager.initialize({
     gtmId: GOOGLE_TAG_MANAGER_ID,
     ...GTM_ENVIRONMENT,
-    dataLayer: {
-      pageLocation: `${location.origin}${pagePath}`,
-      pagePath,
-      // Block JS variables and custom scripts
-      // @see https://developers.google.com/tag-platform/tag-manager/web/restrict
-      'gtm.blocklist': ['j', 'jsm', 'customScripts'],
-    },
   })
 }
 
-export const gtmClear = TagManager.disable
+export const gtmEnableCookies = TagManager.enableCookies
+export const gtmDisableCookies = TagManager.disableCookies
 
 type GtmEvent = {
   event: EventType

--- a/src/services/analytics/useMetaEvents.ts
+++ b/src/services/analytics/useMetaEvents.ts
@@ -10,52 +10,52 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import useHiddenTokens from '@/hooks/useHiddenTokens'
 
 // Track meta events on app load
-const useMetaEvents = (isAnalyticsEnabled: boolean) => {
+const useMetaEvents = () => {
   const chainId = useChainId()
   const { safeAddress } = useSafeInfo()
 
   // Total added safes
   const totalAddedSafes = useAppSelector(selectTotalAdded)
   useEffect(() => {
-    if (!isAnalyticsEnabled || totalAddedSafes === 0) return
+    if (totalAddedSafes === 0) return
 
     gtmTrack({
       ...OVERVIEW_EVENTS.TOTAL_ADDED_SAFES,
       label: totalAddedSafes.toString(),
     })
-  }, [isAnalyticsEnabled, totalAddedSafes])
+  }, [totalAddedSafes])
 
   // Queue size
   const queue = useAppSelector(selectQueuedTransactions)
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const safeQueue = useMemo(() => queue, [safeAddress, queue !== undefined])
   useEffect(() => {
-    if (!isAnalyticsEnabled || !safeQueue) return
+    if (!safeQueue) return
 
     gtmTrack({
       ...TX_LIST_EVENTS.QUEUED_TXS,
       label: safeQueue.length.toString(),
     })
-  }, [isAnalyticsEnabled, safeQueue])
+  }, [safeQueue])
 
   // Tokens
   const { balances } = useBalances()
   const totalTokens = balances?.items.length || 0
   useEffect(() => {
-    if (!isAnalyticsEnabled || !safeAddress || totalTokens <= 0) return
+    if (!safeAddress || totalTokens <= 0) return
 
     gtmTrack({ ...ASSETS_EVENTS.DIFFERING_TOKENS, label: totalTokens })
-  }, [isAnalyticsEnabled, totalTokens, safeAddress, chainId])
+  }, [totalTokens, safeAddress, chainId])
 
   // Manually hidden tokens
   const hiddenTokens = useHiddenTokens()
   const totalHiddenFromBalance =
     balances?.items.filter((item) => hiddenTokens.includes(item.tokenInfo.address)).length || 0
   useEffect(() => {
-    if (!isAnalyticsEnabled || !safeAddress || totalTokens <= 0) return
+    if (!safeAddress || totalTokens <= 0) return
 
     gtmTrack({ ...ASSETS_EVENTS.HIDDEN_TOKENS, label: totalHiddenFromBalance })
-  }, [isAnalyticsEnabled, safeAddress, totalHiddenFromBalance, totalTokens])
+  }, [safeAddress, totalHiddenFromBalance, totalTokens])
 }
 
 export default useMetaEvents


### PR DESCRIPTION
## What it solves

We want to make GA more useful by tracking 100% of users. GA4 has a so-called "consent mode" which doesn't set any cookies and doesn't require a cookie consent. This PR enables this mode, and enables GA cookies only if the user opts in.

See https://www.notion.so/safe-global/Client-side-analytics-improvements-152dad5585d6410b8e6cfb20334d6c05

## How to test it

* Open the branch preview site
* Observe that GTM events are fired w/o accepting the Cookie Banner
* Check that the GA script is loaded with `gcs: G100` parameter (which means cookies are disabled).
* Check that no _ga cookies are set
* Press "Accept all" in the cookie banner
* Observe that GA cookies are added
* Observe that GA requests now contain `gcs: G101` param (meaning cookies are enabled)

