### PR TITLE
Fix: clear batch on confirm

### DIFF
--- a/src/components/batch/BatchSidebar/index.tsx
+++ b/src/components/batch/BatchSidebar/index.tsx
@@ -24,7 +24,7 @@ const BatchSidebar = ({ isOpen, onToggle }: { isOpen: boolean; onToggle: (open: 
   }, [onToggle])
 
   const clearBatch = useCallback(() => {
-    batchTxs.forEach((item) => deleteTx(item.txDetails.txId))
+    batchTxs.forEach((item) => deleteTx(item.id))
   }, [deleteTx, batchTxs])
 
   const onAddClick = useCallback(

--- a/src/hooks/useDraftBatch.ts
+++ b/src/hooks/useDraftBatch.ts
@@ -31,7 +31,7 @@ export const useUpdateBatch = () => {
   )
 
   const onDelete = useCallback(
-    (id: string) => {
+    (id: DraftBatchItem['id']) => {
       dispatch(
         removeTx({
           chainId,


### PR DESCRIPTION
## What it solves

When a batch is confirmed, it should be removed. It didn't work because I was passing the wrong id.

## How to test it

* Create a batch
* Confirm it
* It should be proposed to the queue (or executed)
* It should disappear from the batch sidebar