### PR TITLE
fix: reset nonce if outdated

### DIFF
--- a/src/components/tx-flow/SafeTxProvider.tsx
+++ b/src/components/tx-flow/SafeTxProvider.tsx
@@ -4,6 +4,7 @@ import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { createTx } from '@/services/tx/tx-sender'
 import { useRecommendedNonce, useSafeTxGas } from '../tx/SignOrExecuteForm/hooks'
 import { Errors, logError } from '@/services/exceptions'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 export const SafeTxContext = createContext<{
   safeTx?: SafeTransaction
@@ -35,15 +36,16 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
   const [nonce, setNonce] = useState<number>()
   const [nonceNeeded, setNonceNeeded] = useState<boolean>(true)
   const [safeTxGas, setSafeTxGas] = useState<number>()
+  const { safe } = useSafeInfo()
 
   // Signed txs cannot be updated
   const isSigned = safeTx && safeTx.signatures.size > 0
 
   // Recommended nonce and safeTxGas
-  const recommendedNonce = useRecommendedNonce()
+  const recommendedNonce = Math.max(safe.nonce, useRecommendedNonce() ?? 0)
   const recommendedSafeTxGas = useSafeTxGas(safeTx)
 
-  // Priority to external nonce then to the recommended one
+  // Priority to external nonce, then to the recommended one
   const finalNonce = isSigned ? safeTx?.data.nonce : nonce ?? recommendedNonce ?? safeTx?.data.nonce
   const finalSafeTxGas = isSigned ? safeTx?.data.safeTxGas : safeTxGas ?? recommendedSafeTxGas ?? safeTx?.data.safeTxGas
 

--- a/src/components/tx-flow/SafeTxProvider.tsx
+++ b/src/components/tx-flow/SafeTxProvider.tsx
@@ -47,8 +47,7 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
   const recommendedSafeTxGas = useSafeTxGas(safeTx)
 
   // Priority to external nonce if valid, then to the recommended one
-  const isNonceValid = nonce !== undefined && nonce >= safe.nonce
-  const finalNonce = isSigned ? safeTx?.data.nonce : isNonceValid ? nonce : recommendedNonce ?? safeTx?.data.nonce
+  const finalNonce = isSigned ? safeTx?.data.nonce : nonce ?? recommendedNonce ?? safeTx?.data.nonce
   const finalSafeTxGas = isSigned ? safeTx?.data.safeTxGas : safeTxGas ?? recommendedSafeTxGas ?? safeTx?.data.safeTxGas
 
   // Update the tx when the nonce or safeTxGas change

--- a/src/components/tx-flow/SafeTxProvider.tsx
+++ b/src/components/tx-flow/SafeTxProvider.tsx
@@ -4,7 +4,6 @@ import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { createTx } from '@/services/tx/tx-sender'
 import { useRecommendedNonce, useSafeTxGas } from '../tx/SignOrExecuteForm/hooks'
 import { Errors, logError } from '@/services/exceptions'
-import useSafeInfo from '@/hooks/useSafeInfo'
 
 export const SafeTxContext = createContext<{
   safeTx?: SafeTransaction
@@ -37,8 +36,6 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
   const [nonceNeeded, setNonceNeeded] = useState<boolean>(true)
   const [safeTxGas, setSafeTxGas] = useState<number>()
 
-  const { safe } = useSafeInfo()
-
   // Signed txs cannot be updated
   const isSigned = safeTx && safeTx.signatures.size > 0
 
@@ -46,7 +43,7 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
   const recommendedNonce = useRecommendedNonce()
   const recommendedSafeTxGas = useSafeTxGas(safeTx)
 
-  // Priority to external nonce if valid, then to the recommended one
+  // Priority to external nonce then to the recommended one
   const finalNonce = isSigned ? safeTx?.data.nonce : nonce ?? recommendedNonce ?? safeTx?.data.nonce
   const finalSafeTxGas = isSigned ? safeTx?.data.safeTxGas : safeTxGas ?? recommendedSafeTxGas ?? safeTx?.data.safeTxGas
 

--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -1,4 +1,4 @@
-import { memo, type ReactElement, useContext, useMemo } from 'react'
+import { memo, type ReactElement, useContext, useMemo, useEffect } from 'react'
 import {
   Autocomplete,
   Box,
@@ -108,6 +108,16 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
   const resetNonce = () => {
     formMethods.setValue(TxNonceFormFieldNames.NONCE, recommendedNonce)
   }
+
+  const currentFormNonce = formMethods.watch(TxNonceFormFieldNames.NONCE)
+  const isFormChanged = formMethods.formState.isDirty
+
+  // Update to recommended nonce if the current nonce is unchanged and invalid after update
+  useEffect(() => {
+    if (!isFormChanged && Number(currentFormNonce) < safe.nonce) {
+      formMethods.setValue(TxNonceFormFieldNames.NONCE, recommendedNonce)
+    }
+  }, [safe.nonce, recommendedNonce, currentFormNonce, isFormChanged, formMethods])
 
   return (
     <Controller

--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -115,9 +115,9 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
   // Update to recommended nonce if the current nonce is unchanged and invalid after update
   useEffect(() => {
     if (!isFormChanged && Number(currentFormNonce) < safe.nonce) {
-      formMethods.setValue(TxNonceFormFieldNames.NONCE, recommendedNonce)
+      formMethods.setValue(TxNonceFormFieldNames.NONCE, safe.nonce.toString())
     }
-  }, [safe.nonce, recommendedNonce, currentFormNonce, isFormChanged, formMethods])
+  }, [safe.nonce, currentFormNonce, isFormChanged, formMethods])
 
   return (
     <Controller

--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -109,15 +109,10 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
     formMethods.setValue(TxNonceFormFieldNames.NONCE, recommendedNonce)
   }
 
-  const currentFormNonce = formMethods.watch(TxNonceFormFieldNames.NONCE)
-  const isFormChanged = formMethods.formState.isDirty
-
-  // Update to recommended nonce if the current nonce is unchanged and invalid after update
+  // keep the formdata up-to-date when the actually used nonce updates
   useEffect(() => {
-    if (!isFormChanged && Number(currentFormNonce) < safe.nonce) {
-      formMethods.setValue(TxNonceFormFieldNames.NONCE, safe.nonce.toString())
-    }
-  }, [safe.nonce, currentFormNonce, isFormChanged, formMethods])
+    formMethods.setValue(TxNonceFormFieldNames.NONCE, nonce)
+  }, [nonce, formMethods])
 
   return (
     <Controller

--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -1,4 +1,4 @@
-import { memo, type ReactElement, useContext, useMemo, useEffect } from 'react'
+import { memo, type ReactElement, useContext, useMemo } from 'react'
 import {
   Autocomplete,
   Box,
@@ -102,17 +102,15 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
     defaultValues: {
       [TxNonceFormFieldNames.NONCE]: nonce,
     },
-    mode: 'all',
+    mode: 'onChange',
+    values: {
+      [TxNonceFormFieldNames.NONCE]: nonce,
+    },
   })
 
   const resetNonce = () => {
     formMethods.setValue(TxNonceFormFieldNames.NONCE, recommendedNonce)
   }
-
-  // keep the formdata up-to-date when the actually used nonce updates
-  useEffect(() => {
-    formMethods.setValue(TxNonceFormFieldNames.NONCE, nonce)
-  }, [nonce, formMethods])
 
   return (
     <Controller

--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -102,7 +102,7 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
     defaultValues: {
       [TxNonceFormFieldNames.NONCE]: nonce,
     },
-    mode: 'onChange',
+    mode: 'onTouched',
     values: {
       [TxNonceFormFieldNames.NONCE]: nonce,
     },

--- a/src/components/tx/SignOrExecuteForm/hooks.ts
+++ b/src/components/tx/SignOrExecuteForm/hooks.ts
@@ -164,7 +164,7 @@ export const useRecommendedNonce = (): number | undefined => {
       return getRecommendedNonce(safe.chainId, safeAddress)
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [safeAddress, safe.chainId, safe.txQueuedTag], // update when tx queue changes
+    [safeAddress, safe.chainId, safe.txQueuedTag, safe.nonce], // update when tx queue or safe nonce changes
     false, // keep old recommended nonce while refreshing to avoid skeleton
   )
 

--- a/src/components/tx/SignOrExecuteForm/hooks.ts
+++ b/src/components/tx/SignOrExecuteForm/hooks.ts
@@ -164,7 +164,7 @@ export const useRecommendedNonce = (): number | undefined => {
       return getRecommendedNonce(safe.chainId, safeAddress)
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [safeAddress, safe.chainId, safe.txQueuedTag],
+    [safeAddress, safe.chainId, safe.txQueuedTag], // update when tx queue changes
     false, // keep old recommended nonce while refreshing to avoid skeleton
   )
 

--- a/src/components/tx/SignOrExecuteForm/hooks.ts
+++ b/src/components/tx/SignOrExecuteForm/hooks.ts
@@ -164,7 +164,7 @@ export const useRecommendedNonce = (): number | undefined => {
       return getRecommendedNonce(safe.chainId, safeAddress)
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [safeAddress, safe.chainId, safe.txQueuedTag, safe.nonce], // update when tx queue or safe nonce changes
+    [safeAddress, safe.chainId, safe.txQueuedTag],
     false, // keep old recommended nonce while refreshing to avoid skeleton
   )
 


### PR DESCRIPTION
## What it solves
If the recommended nonce and safe nonce updates while the transaction modal is open, the current nonce is not updated and transactions with too low nonces are created which lead to validation errors when proposed.

## How this PR fixes it
Resets nonce to recommended nonce if the currently selected nonce is lower than the Safe nonce.

## How to test it
1. Open a 1/n Safe with nothing in the queue
2. Initiate any transaction, note the used nonce and immediately execute it (without signing it first)
3. While the transaction is executing, initiate another transaction
4. Observe that this new transaction can initially not be executed and the nonce being the same as the pending transaction
5. Do nothing and wait in the transaction modal until the first transaction got executed and indexed.
6. Observe that the new transaction's nonce gets updated to the next nonce and that the execute button is now available for this transaction.

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
