### PR TITLE
refactor: get addresses/ABIs from deployments

### DIFF
--- a/src/components/new-safe/create/__tests__/useEstimateSafeCreationGas.test.ts
+++ b/src/components/new-safe/create/__tests__/useEstimateSafeCreationGas.test.ts
@@ -4,12 +4,10 @@ import * as chainIdModule from '@/hooks/useChainId'
 import { type ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import * as wallet from '@/hooks/wallets/useWallet'
 import * as web3 from '@/hooks/wallets/web3'
-import * as safeContracts from '@/services/contracts/safeContracts'
 import * as store from '@/store'
 import { renderHook } from '@/tests/test-utils'
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { EMPTY_DATA, ZERO_ADDRESS } from '@safe-global/safe-core-sdk/dist/src/utils/constants'
-import type GnosisSafeProxyFactoryEthersContract from '@safe-global/safe-ethers-lib/dist/src/contracts/GnosisSafeProxyFactory/GnosisSafeProxyFactoryEthersContract'
 import { waitFor } from '@testing-library/react'
 import { type EIP1193Provider } from '@web3-onboard/core'
 import { BigNumber } from 'ethers'
@@ -26,9 +24,6 @@ describe('useEstimateSafeCreationGas', () => {
 
     jest.spyOn(store, 'useAppSelector').mockReturnValue({})
     jest.spyOn(chainIdModule, 'useChainId').mockReturnValue('4')
-    jest
-      .spyOn(safeContracts, 'getProxyFactoryContract')
-      .mockReturnValue({ getAddress: () => ZERO_ADDRESS } as GnosisSafeProxyFactoryEthersContract)
     jest.spyOn(sender, 'encodeSafeCreationTx').mockReturnValue(EMPTY_DATA)
     jest.spyOn(wallet, 'default').mockReturnValue({} as ConnectedWallet)
   })

--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -11,7 +11,7 @@ import type { StepRenderProps } from '@/components/new-safe/CardStepper/useCardS
 import type { NewSafeFormData } from '@/components/new-safe/create'
 import css from '@/components/new-safe/create/steps/ReviewStep/styles.module.css'
 import layoutCss from '@/components/new-safe/create/styles.module.css'
-import { getFallbackHandlerContract } from '@/services/contracts/safeContracts'
+import { getFallbackHandlerContractDeployment } from '@/services/contracts/safeContracts'
 import { computeNewSafeAddress } from '@/components/new-safe/create/logic'
 import useWallet from '@/hooks/wallets/useWallet'
 import { isWeb3ReadOnly, useWeb3 } from '@/hooks/wallets/web3'
@@ -78,13 +78,17 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
   const createSafe = async () => {
     if (!wallet || !provider || isWeb3ReadOnly(provider) || !chain) return
 
-    const fallbackHandlerContract = getFallbackHandlerContract(chain.chainId, provider)
+    const fallbackHandlerContract = getFallbackHandlerContractDeployment(chain.chainId)
+
+    if (!fallbackHandlerContract) {
+      throw new Error('No FallbackHandler deployment found')
+    }
 
     const props = {
       safeAccountConfig: {
         threshold: data.threshold,
         owners: data.owners.map((owner) => owner.address),
-        fallbackHandler: fallbackHandlerContract.getAddress(),
+        fallbackHandler: fallbackHandlerContract.networkAddresses[chain.chainId],
       },
       safeDeploymentConfig: {
         saltNonce: saltNonce.toString(),

--- a/src/components/new-safe/create/steps/StatusStep/__tests__/useSafeCreation.test.ts
+++ b/src/components/new-safe/create/steps/StatusStep/__tests__/useSafeCreation.test.ts
@@ -4,7 +4,6 @@ import * as web3 from '@/hooks/wallets/web3'
 import * as chain from '@/hooks/useChains'
 import * as wallet from '@/hooks/wallets/useWallet'
 import * as logic from '@/components/new-safe/create/logic'
-import * as contracts from '@/services/contracts/safeContracts'
 import * as txMonitor from '@/services/tx/txMonitor'
 import { Web3Provider } from '@ethersproject/providers'
 import * as usePendingSafe from '@/components/new-safe/create/steps/StatusStep/usePendingSafe'
@@ -13,8 +12,6 @@ import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { BigNumber } from '@ethersproject/bignumber'
 import { waitFor } from '@testing-library/react'
 import type Safe from '@safe-global/safe-core-sdk'
-import { hexZeroPad } from 'ethers/lib/utils'
-import type CompatibilityFallbackHandlerEthersContract from '@safe-global/safe-ethers-lib/dist/src/contracts/CompatibilityFallbackHandler/CompatibilityFallbackHandlerEthersContract'
 import { FEATURES } from '@/utils/chains'
 import * as gasPrice from '@/hooks/useGasPrice'
 
@@ -53,9 +50,6 @@ describe('useSafeCreation', () => {
     jest.spyOn(chain, 'useCurrentChain').mockImplementation(() => mockChain)
     jest.spyOn(wallet, 'default').mockReturnValue({} as ConnectedWallet)
     jest.spyOn(logic, 'getSafeCreationTxInfo').mockReturnValue(Promise.resolve(mockSafeInfo))
-    jest
-      .spyOn(contracts, 'getFallbackHandlerContract')
-      .mockReturnValue({ getAddress: () => hexZeroPad('0x123', 20) } as CompatibilityFallbackHandlerEthersContract)
     jest
       .spyOn(gasPrice, 'default')
       .mockReturnValue([{ maxFeePerGas: BigNumber.from(123), maxPriorityFeePerGas: undefined }, undefined, false])

--- a/src/components/new-safe/create/steps/StatusStep/useSafeCreation.ts
+++ b/src/components/new-safe/create/steps/StatusStep/useSafeCreation.ts
@@ -79,7 +79,7 @@ export const useSafeCreation = (
 
     try {
       if (willRelay) {
-        const taskId = await relaySafeCreation(chain, ownersAddresses, threshold, saltNonce, provider)
+        const taskId = await relaySafeCreation(chain, ownersAddresses, threshold, saltNonce)
 
         setPendingSafe(pendingSafe ? { ...pendingSafe, taskId } : undefined)
         setStatus(SafeCreationStatus.PROCESSING)
@@ -95,7 +95,6 @@ export const useSafeCreation = (
           },
           (txHash) => createSafeCallback(txHash, tx),
           chain.chainId,
-          provider,
         )
 
         const options: DeploySafeProps['options'] = isEIP1559

--- a/src/components/tx-flow/flows/ExecuteBatch/ReviewBatch.tsx
+++ b/src/components/tx-flow/flows/ExecuteBatch/ReviewBatch.tsx
@@ -65,9 +65,9 @@ export const ReviewBatch = ({ params }: { params: ExecuteBatchFlowProps }) => {
   }, [chain?.chainId, safe.version, web3])
 
   const multiSendTxs = useMemo(() => {
-    if (!txsWithDetails || !chain || !safe.version || !web3) return
-    return getMultiSendTxs(txsWithDetails, chain, safe.address.value, web3, safe.version)
-  }, [chain, safe.address.value, safe.version, txsWithDetails, web3])
+    if (!txsWithDetails || !chain || !safe.version) return
+    return getMultiSendTxs(txsWithDetails, chain, safe.address.value, safe.version)
+  }, [chain, safe.address.value, safe.version, txsWithDetails])
 
   const multiSendTxData = useMemo(() => {
     if (!txsWithDetails || !multiSendTxs) return
@@ -93,15 +93,9 @@ export const ReviewBatch = ({ params }: { params: ExecuteBatchFlowProps }) => {
   }
 
   const onRelay = async () => {
-    if (!multiSendTxData || !multiSendContract || !txsWithDetails) return
+    if (!multiSendTxData || !txsWithDetails) return
 
-    await dispatchBatchExecutionRelay(
-      txsWithDetails,
-      multiSendContract,
-      multiSendTxData,
-      safe.chainId,
-      safe.address.value,
-    )
+    await dispatchBatchExecutionRelay(txsWithDetails, multiSendTxData, safe.chainId, safe.address.value)
   }
 
   const handleSubmit = async (e: SyntheticEvent) => {

--- a/src/components/tx-flow/flows/UpdateSafe/UpdateSafeReview.tsx
+++ b/src/components/tx-flow/flows/UpdateSafe/UpdateSafeReview.tsx
@@ -9,22 +9,20 @@ import { createUpdateSafeTxs } from '@/services/tx/safeUpdateParams'
 import { createMultiSendCallOnlyTx } from '@/services/tx/tx-sender'
 import { SafeTxContext } from '../../SafeTxProvider'
 import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
-import { useWeb3 } from '@/hooks/wallets/web3'
 
 export const UpdateSafeReview = () => {
   const { safe, safeLoaded } = useSafeInfo()
   const chain = useCurrentChain()
-  const web3 = useWeb3()
   const { setSafeTx, setSafeTxError, setNonce } = useContext(SafeTxContext)
 
   useEffect(() => {
-    if (!chain || !safeLoaded || !web3) {
+    if (!chain || !safeLoaded) {
       return
     }
 
-    const txs = createUpdateSafeTxs(safe, chain, web3)
+    const txs = createUpdateSafeTxs(safe, chain)
     createMultiSendCallOnlyTx(txs).then(setSafeTx).catch(setSafeTxError)
-  }, [chain, safe, safeLoaded, setNonce, setSafeTx, setSafeTxError, web3])
+  }, [chain, safe, safeLoaded, setNonce, setSafeTx, setSafeTxError])
 
   return (
     <SignOrExecuteForm onSubmit={() => null}>

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -26,7 +26,6 @@ import commonCss from '@/components/tx-flow/common/styles.module.css'
 import { TxSecurityContext } from '../security/shared/TxSecurityContext'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import NonOwnerError from '@/components/tx/SignOrExecuteForm/NonOwnerError'
-import { useWeb3 } from '@/hooks/wallets/web3'
 
 const ExecuteForm = ({
   safeTx,
@@ -45,7 +44,6 @@ const ExecuteForm = ({
 
   // Hooks
   const isOwner = useIsSafeOwner()
-  const web3 = useWeb3()
   const currentChain = useCurrentChain()
   const { executeTx } = useTxActions()
   const [relays] = useRelaysBySafe()
@@ -76,10 +74,6 @@ const ExecuteForm = ({
   const handleSubmit = async (e: SyntheticEvent) => {
     e.preventDefault()
 
-    if (!web3) {
-      return
-    }
-
     if (needsRiskConfirmation && !isRiskConfirmed) {
       setIsRiskIgnored(true)
       return
@@ -91,7 +85,7 @@ const ExecuteForm = ({
     const txOptions = getTxOptions(advancedParams, currentChain)
 
     try {
-      const executedTxId = await executeTx(txOptions, web3, safeTx, txId, origin, willRelay)
+      const executedTxId = await executeTx(txOptions, safeTx, txId, origin, willRelay)
       setTxFlow(<SuccessScreen txId={executedTxId} />, undefined, false)
     } catch (_err) {
       const err = asError(_err)

--- a/src/components/tx/security/tenderly/__tests__/useSimulation.test.ts
+++ b/src/components/tx/security/tenderly/__tests__/useSimulation.test.ts
@@ -1,5 +1,4 @@
-import { Web3Provider } from '@ethersproject/providers'
-import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import type { ChainInfo, SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 
 import { act, renderHook, waitFor } from '@/tests/test-utils'
 import { useSimulation } from '@/components/tx/security/tenderly/useSimulation'
@@ -28,8 +27,6 @@ describe('useSimulation()', () => {
   beforeEach(() => {
     jest.resetAllMocks()
   })
-
-  const mockProvider = new Web3Provider(jest.fn())
 
   it('should have the correct initial values', () => {
     const { result } = renderHook(() => useSimulation())
@@ -83,7 +80,7 @@ describe('useSimulation()', () => {
           chainId,
         } as SafeInfo,
         executionOwner: safeAddress,
-        provider: mockProvider,
+        chain: { chainId, l2: false } as ChainInfo,
       }),
     )
 
@@ -153,7 +150,7 @@ describe('useSimulation()', () => {
           chainId,
         } as SafeInfo,
         executionOwner: safeAddress,
-        provider: mockProvider,
+        chain: { chainId, l2: false } as ChainInfo,
       }),
     )
 
@@ -224,7 +221,7 @@ describe('useSimulation()', () => {
           chainId,
         } as SafeInfo,
         executionOwner: safeAddress,
-        provider: mockProvider,
+        chain: { chainId, l2: false } as ChainInfo,
       }),
     )
 

--- a/src/components/tx/security/tenderly/index.tsx
+++ b/src/components/tx/security/tenderly/index.tsx
@@ -18,7 +18,6 @@ import sharedCss from '@/components/tx/security/shared/styles.module.css'
 import { TxInfoContext } from '@/components/tx-flow/TxInfoProvider'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import InfoIcon from '@/public/images/notifications/info.svg'
-import { useWeb3 } from '@/hooks/wallets/web3'
 
 export type TxSimulationProps = {
   transactions?: SimulationTxParams['transactions']
@@ -32,7 +31,7 @@ export type TxSimulationProps = {
 const TxSimulationBlock = ({ transactions, disabled, gasLimit }: TxSimulationProps): ReactElement => {
   const { safe } = useSafeInfo()
   const wallet = useWallet()
-  const web3 = useWeb3()
+  const chain = useCurrentChain()
   const isDarkMode = useDarkMode()
   const { safeTx } = useContext(SafeTxContext)
   const {
@@ -41,7 +40,7 @@ const TxSimulationBlock = ({ transactions, disabled, gasLimit }: TxSimulationPro
   } = useContext(TxInfoContext)
 
   const handleSimulation = async () => {
-    if (!wallet || !web3) {
+    if (!wallet || !chain || !transactions) {
       return
     }
 
@@ -50,7 +49,7 @@ const TxSimulationBlock = ({ transactions, disabled, gasLimit }: TxSimulationPro
       executionOwner: wallet.address,
       transactions,
       gasLimit,
-      provider: web3,
+      chain,
     } as SimulationTxParams)
   }
 

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -14,7 +14,6 @@ import { ImplementationVersionState } from '@safe-global/safe-gateway-typescript
 import type { ChainInfo, SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import type { GetContractProps, SafeVersion } from '@safe-global/safe-core-sdk-types'
 import { assertValidSafeVersion, createEthersAdapter } from '@/hooks/coreSDK/safeCoreSDK'
-import type SignMessageLibEthersContract from '@safe-global/safe-ethers-lib/dist/src/contracts/SignMessageLib/SignMessageLibEthersContract'
 import type { JsonRpcProvider, Web3Provider } from '@ethersproject/providers'
 import type GnosisSafeContractEthers from '@safe-global/safe-ethers-lib/dist/src/contracts/GnosisSafe/GnosisSafeContractEthers'
 import type EthersAdapter from '@safe-global/safe-ethers-lib'
@@ -63,7 +62,7 @@ const isOldestVersion = (safeVersion: string): boolean => {
   return semverSatisfies(safeVersion, '<=1.0.0')
 }
 
-const getSafeContractDeployment = (chain: ChainInfo, safeVersion: string): SingletonDeployment | undefined => {
+export const getSafeContractDeployment = (chain: ChainInfo, safeVersion: string): SingletonDeployment | undefined => {
   // We check if version is prior to v1.0.0 as they are not supported but still we want to keep a minimum compatibility
   const useOldestContractVersion = isOldestVersion(safeVersion)
 
@@ -88,41 +87,16 @@ const getSafeContractDeployment = (chain: ChainInfo, safeVersion: string): Singl
   )
 }
 
-export const getGnosisSafeContract = (
-  chain: ChainInfo,
-  provider: JsonRpcProvider | Web3Provider,
-  safeVersion: string = LATEST_SAFE_VERSION,
-) => {
-  const ethAdapter = createEthersAdapter(provider)
-
-  return ethAdapter.getSafeContract({
-    singletonDeployment: getSafeContractDeployment(chain, safeVersion),
-    ..._getValidatedGetContractProps(chain.chainId, safeVersion),
-  })
-}
-
 // MultiSend
 
-const getMultiSendContractDeployment = (chainId: string) => {
+export const getMultiSendContractDeployment = (chainId: string) => {
   return getMultiSendDeployment({ network: chainId }) || getMultiSendDeployment()
-}
-
-export const getMultiSendContractAddress = (chainId: string): string | undefined => {
-  const deployment = getMultiSendContractDeployment(chainId)
-
-  return deployment?.networkAddresses[chainId]
 }
 
 // MultiSendCallOnly
 
-const getMultiSendCallOnlyContractDeployment = (chainId: string) => {
+export const getMultiSendCallOnlyContractDeployment = (chainId: string) => {
   return getMultiSendCallOnlyDeployment({ network: chainId }) || getMultiSendCallOnlyDeployment()
-}
-
-export const getMultiSendCallOnlyContractAddress = (chainId: string): string | undefined => {
-  const deployment = getMultiSendCallOnlyContractDeployment(chainId)
-
-  return deployment?.networkAddresses[chainId]
 }
 
 export const getMultiSendCallOnlyContract = (
@@ -152,22 +126,9 @@ export const getProxyFactoryContractDeployment = (chainId: string) => {
   )
 }
 
-export const getProxyFactoryContract = (
-  chainId: string,
-  provider: JsonRpcProvider | Web3Provider,
-  safeVersion: string = LATEST_SAFE_VERSION,
-) => {
-  const ethAdapter = createEthersAdapter(provider)
-
-  return ethAdapter.getSafeProxyFactoryContract({
-    singletonDeployment: getProxyFactoryContractDeployment(chainId),
-    ..._getValidatedGetContractProps(chainId, safeVersion),
-  })
-}
-
 // Fallback handler
 
-const getFallbackHandlerContractDeployment = (chainId: string) => {
+export const getFallbackHandlerContractDeployment = (chainId: string) => {
   return (
     getFallbackHandlerDeployment({
       version: LATEST_SAFE_VERSION,
@@ -179,33 +140,7 @@ const getFallbackHandlerContractDeployment = (chainId: string) => {
   )
 }
 
-export const getFallbackHandlerContract = (
-  chainId: string,
-  provider: JsonRpcProvider | Web3Provider,
-  safeVersion: string = LATEST_SAFE_VERSION,
-) => {
-  const ethAdapter = createEthersAdapter(provider)
-
-  return ethAdapter.getCompatibilityFallbackHandlerContract({
-    singletonDeployment: getFallbackHandlerContractDeployment(chainId),
-    ..._getValidatedGetContractProps(chainId, safeVersion),
-  })
-}
-
 // Sign messages deployment
-const getSignMessageLibContractDeployment = (chainId: string) => {
+export const getSignMessageLibContractDeployment = (chainId: string) => {
   return getSignMessageLibDeployment({ network: chainId }) || getSignMessageLibDeployment()
-}
-
-export const getSignMessageLibContract = (
-  chainId: string,
-  provider: JsonRpcProvider | Web3Provider,
-  safeVersion: string = LATEST_SAFE_VERSION,
-): SignMessageLibEthersContract => {
-  const ethAdapter = createEthersAdapter(provider)
-
-  return ethAdapter.getSignMessageLibContract({
-    singletonDeployment: getSignMessageLibContractDeployment(chainId),
-    ..._getValidatedGetContractProps(chainId, safeVersion),
-  })
 }

--- a/src/services/tx/__tests__/safeUpdateParams.test.ts
+++ b/src/services/tx/__tests__/safeUpdateParams.test.ts
@@ -8,13 +8,10 @@ import type { ChainInfo, SafeInfo } from '@safe-global/safe-gateway-typescript-s
 import { ethers } from 'ethers'
 import { createUpdateSafeTxs } from '../safeUpdateParams'
 import { LATEST_SAFE_VERSION } from '@/config/constants'
-import { Web3Provider } from '@ethersproject/providers'
 
 const MOCK_SAFE_ADDRESS = '0x0000000000000000000000000000000000005AFE'
 
 describe('safeUpgradeParams', () => {
-  const mockProvider = new Web3Provider(jest.fn())
-
   it('Should add empty setFallbackHandler transaction data for older Safes', () => {
     const mockSafe = {
       address: {
@@ -22,7 +19,7 @@ describe('safeUpgradeParams', () => {
       },
       version: '1.0.0',
     } as SafeInfo
-    const txs = createUpdateSafeTxs(mockSafe, { chainId: '4', l2: false } as ChainInfo, mockProvider)
+    const txs = createUpdateSafeTxs(mockSafe, { chainId: '4', l2: false } as ChainInfo)
     const [masterCopyTx, fallbackHandlerTx] = txs
     // Safe upgrades mastercopy and fallbackhandler
     expect(txs).toHaveLength(2)
@@ -49,7 +46,7 @@ describe('safeUpgradeParams', () => {
       },
       version: '1.1.1',
     } as SafeInfo
-    const txs = createUpdateSafeTxs(mockSafe, { chainId: '4', l2: false } as ChainInfo, mockProvider)
+    const txs = createUpdateSafeTxs(mockSafe, { chainId: '4', l2: false } as ChainInfo)
     const [masterCopyTx, fallbackHandlerTx] = txs
     // Safe upgrades mastercopy and fallbackhandler
     expect(txs).toHaveLength(2)
@@ -81,7 +78,7 @@ describe('safeUpgradeParams', () => {
       },
       version: '1.1.1',
     } as SafeInfo
-    const txs = createUpdateSafeTxs(mockSafe, { chainId: '100', l2: true } as ChainInfo, mockProvider)
+    const txs = createUpdateSafeTxs(mockSafe, { chainId: '100', l2: true } as ChainInfo)
     const [masterCopyTx, fallbackHandlerTx] = txs
     // Safe upgrades mastercopy and fallbackhandler
     expect(txs).toHaveLength(2)

--- a/src/services/tx/tx-sender/__tests__/ts-sender.test.ts
+++ b/src/services/tx/tx-sender/__tests__/ts-sender.test.ts
@@ -596,7 +596,7 @@ describe('txSender', () => {
       }
       global.fetch = jest.fn().mockImplementationOnce(setupFetchStub(mockData))
 
-      await dispatchBatchExecutionRelay(txs, multisendContractMock, '0x1234', '5', safeAddress)
+      await dispatchBatchExecutionRelay(txs, '0x1234', '5', safeAddress)
 
       expect(txEvents.txDispatch).toHaveBeenCalledWith('RELAYING', {
         txId: 'multisig_0x01',

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -35,7 +35,10 @@ import {
 } from '@safe-global/safe-gateway-typescript-sdk'
 import { getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimitContracts'
 import { sameAddress } from '@/utils/addresses'
-import { getMultiSendCallOnlyContractAddress, getMultiSendContractAddress } from '@/services/contracts/safeContracts'
+import {
+  getMultiSendCallOnlyContractDeployment,
+  getMultiSendContractDeployment,
+} from '@/services/contracts/safeContracts'
 import type { NamedAddress } from '@/components/new-safe/create/types'
 
 export const isTxQueued = (value: TransactionStatus): boolean => {
@@ -80,8 +83,12 @@ export const isCustomTxInfo = (value: TransactionInfo): value is Custom => {
 
 export const isSupportedMultiSendAddress = (txInfo: TransactionInfo, chainId: string): boolean => {
   const toAddress = isCustomTxInfo(txInfo) ? txInfo.to.value : ''
-  const multiSendAddress = getMultiSendContractAddress(chainId)
-  const multiSendCallOnlyAddress = getMultiSendCallOnlyContractAddress(chainId)
+
+  const multiSend = getMultiSendContractDeployment(chainId)
+  const multiSendCallOnly = getMultiSendCallOnlyContractDeployment(chainId)
+
+  const multiSendAddress = multiSend?.networkAddresses[chainId]
+  const multiSendCallOnlyAddress = multiSendCallOnly?.networkAddresses[chainId]
 
   return sameAddress(multiSendAddress, toAddress) || sameAddress(multiSendCallOnlyAddress, toAddress)
 }

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -19,7 +19,7 @@ import {
 } from './transaction-guards'
 import type { MetaTransactionData } from '@safe-global/safe-core-sdk-types/dist/src/types'
 import { OperationType } from '@safe-global/safe-core-sdk-types/dist/src/types'
-import { getGnosisSafeContract } from '@/services/contracts/safeContracts'
+import { getSafeContractDeployment } from '@/services/contracts/safeContracts'
 import extractTxInfo from '@/services/tx/extractTxInfo'
 import type { AdvancedParameters } from '@/components/tx/AdvancedParams'
 import type { SafeTransaction, TransactionOptions } from '@safe-global/safe-core-sdk-types'
@@ -28,9 +28,8 @@ import uniqBy from 'lodash/uniqBy'
 import { Errors, logError } from '@/services/exceptions'
 import { Multi_send__factory } from '@/types/contracts'
 import { ethers } from 'ethers'
-import type { JsonRpcProvider, Web3Provider } from '@ethersproject/providers'
 import { type BaseTransaction } from '@safe-global/safe-apps-sdk'
-import { id } from 'ethers/lib/utils'
+import { id, Interface } from 'ethers/lib/utils'
 import { isEmptyHexData } from '@/utils/hex'
 
 export const makeTxFromDetails = (txDetails: TransactionDetails): Transaction => {
@@ -102,10 +101,15 @@ export const getMultiSendTxs = (
   txs: TransactionDetails[],
   chain: ChainInfo,
   safeAddress: string,
-  provider: JsonRpcProvider | Web3Provider,
   safeVersion: string,
 ): MetaTransactionData[] => {
-  const safeContract = getGnosisSafeContract(chain, provider, safeVersion)
+  const safeContract = getSafeContractDeployment(chain, safeVersion)
+
+  if (!safeContract) {
+    throw new Error('No Safe found')
+  }
+
+  const safeContractInterface = new Interface(safeContract.abi)
 
   return txs
     .map((tx) => {
@@ -114,7 +118,7 @@ export const getMultiSendTxs = (
       const args = extractTxInfo(tx, safeAddress)
       const sigs = getSignatures(args.signatures)
 
-      const data = safeContract.encode('execTransaction', [
+      const data = safeContractInterface.encodeFunctionData('execTransaction', [
         args.txParams.to,
         args.txParams.value,
         args.txParams.data,


### PR DESCRIPTION
## What it solves

Resolves unnecessary usage of provider for getting contract addresses/encoding calldata.

## How this PR fixes it

Note: this branches off https://github.com/safe-global/safe-wallet-web/pull/2276.

As per [suggestion](https://github.com/safe-global/safe-wallet-web/pull/2276#discussion_r1288060030), this removes reliance on the excessive contract instances that require the provider to retrieve contract addresses/calldata encoding. We now use our `safe-deployments` instead.

## How to test it
This refactor removes a lot of "middleman" code and shouldn't affect anything. The specific areas to confirm working are as follows:

- [ ] Safe creation
  - [ ] Should estimate gas
  - [ ] Should create
  - [ ] Should relay
  - [ ] Should add an official FallbackHandler (can be checked in the settings of a newly created Safe)
- [ ] Tenderly
  - [ ] Should simulate standard transactions
  - [ ] Should simulate MultiSend transactions
- [ ] Transactions
  - [ ] Should relay
  - [ ] Success screen should work
- [ ] Queue batching
  - [ ] Should display MultiSend transactions
  - [ ] Should relay
- [ ] On-chain signing
  - [ ] Should display the official address of the SignMessageLib contract (can be verified in `safe-deployments`)
  - [ ] Should sign message correctly on-chain
- [ ] Safe update
  - [ ] Should update Safes < 1.3.0
- [ ] Transaction details
  - [ ] Should display MultiSend transaction info in transaction confirmation screen
  - [ ] Should display MultiSend (call only) details/actions in transaction list

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
