### PR TITLE
Fix: [mobile] CSS for not connected state in header

### DIFF
--- a/src/components/common/ConnectWallet/ConnectionCenter.tsx
+++ b/src/components/common/ConnectWallet/ConnectionCenter.tsx
@@ -34,7 +34,7 @@ const ConnectionCenter = (): ReactElement => {
       <ButtonBase disableRipple onClick={handleClick} className={css.buttonContainer}>
         <KeyholeIcon />
 
-        <Typography variant="caption">
+        <Typography variant="caption" className={css.notConnected}>
           <b>Not connected</b>
           <br />
           <Typography variant="inherit" sx={{ color: ({ palette }) => palette.error.main }}>

--- a/src/components/common/ConnectWallet/styles.module.css
+++ b/src/components/common/ConnectWallet/styles.module.css
@@ -59,10 +59,11 @@
 }
 
 @media (max-width: 599.95px) {
-  .buttonContainer button {
-    font-size: 12px;
+  .buttonContainer {
+    transform: scale(0.8);
   }
 
+  .notConnected,
   .pairingDetails {
     display: none;
   }


### PR DESCRIPTION
## What it solves

Resolves #2380

Not connected:
<img width="323" alt="Screenshot 2023-08-11 at 12 14 58" src="https://github.com/safe-global/safe-wallet-web/assets/381895/329df8a5-b51d-4733-a898-1a714b5d1353">

Connected:
<img width="315" alt="Screenshot 2023-08-11 at 12 13 31" src="https://github.com/safe-global/safe-wallet-web/assets/381895/8799d92a-962d-4650-aa3c-41041f929f3f">
