### PR TITLE
Fix: wallet icons in dark mode

### DIFF
--- a/src/components/common/WalletInfo/styles.module.css
+++ b/src/components/common/WalletInfo/styles.module.css
@@ -10,7 +10,6 @@
   justify-content: center;
 }
 
-[data-theme='dark'] .imageContainer img[alt*='Trezor'],
 [data-theme='dark'] .imageContainer img[alt*='Ledger'] {
   filter: invert(100%);
 }

--- a/src/styles/onboard.css
+++ b/src/styles/onboard.css
@@ -58,8 +58,7 @@
   --onboard-link-color: var(--color-primary-main);
 
   --onboard-wallet-app-icon-border-color: var(--color-border-light);
-  --onboard-wallet-app-icon-background-white: #fff;
-  --onboard-wallet-app-icon-background-transparent: #fff;
+  --onboard-wallet-app-icon-background-transparent: rgba(255, 255, 255, 0.05);
   --onboard-wallet-app-icon-background-light-gray: rgba(255, 255, 255, 0.5);
 
   --onboard-wallet-button-border-radius: var(--w3o-border-radius);

--- a/src/styles/onboard.css
+++ b/src/styles/onboard.css
@@ -58,7 +58,7 @@
   --onboard-link-color: var(--color-primary-main);
 
   --onboard-wallet-app-icon-border-color: var(--color-border-light);
-  --onboard-wallet-app-icon-background-transparent: rgba(255, 255, 255, 0.05);
+  --onboard-wallet-app-icon-background-transparent: rgba(255, 255, 255, 0.2);
   --onboard-wallet-app-icon-background-light-gray: rgba(255, 255, 255, 0.5);
 
   --onboard-wallet-button-border-radius: var(--w3o-border-radius);


### PR DESCRIPTION
## What it solves

Resolves #2374

## How this PR fixes it

I've replaced our custom white background on wallet buttons with a semi-transparent white, so that it works for both dark and light icons.

## Screenshots

<img width="798" alt="Screenshot 2023-08-14 at 15 45 18" src="https://github.com/safe-global/safe-wallet-web/assets/381895/a5aae8d9-9680-4597-9497-f0a5ee536e98">

<img width="815" alt="Screenshot 2023-08-14 at 15 45 43" src="https://github.com/safe-global/safe-wallet-web/assets/381895/08605133-726d-4038-844f-9d66bbd6a46c">