### PR TITLE
Fix: AddressInput identicon

### DIFF
--- a/src/components/common/AddressInput/index.tsx
+++ b/src/components/common/AddressInput/index.tsx
@@ -22,6 +22,7 @@ import SaveAddressIcon from '@/public/images/common/save-address.svg'
 import classnames from 'classnames'
 import css from './styles.module.css'
 import inputCss from '@/styles/inputs.module.css'
+import Identicon from '../Identicon'
 
 export type AddressInputProps = TextFieldProps & {
   name: string
@@ -128,8 +129,13 @@ const AddressInput = ({
 
           // Display the current short name in the adornment, unless the value contains the same prefix
           startAdornment: (
-            <InputAdornment position="end" sx={{ ml: 0 }}>
-              <Skeleton variant="circular" width={32} height={32} animation={false} sx={{ marginRight: '0.5em' }} />
+            <InputAdornment position="end" sx={{ ml: 0, gap: 1 }}>
+              {watchedValue && !fieldError ? (
+                <Identicon address={watchedValue} size={32} />
+              ) : (
+                <Skeleton variant="circular" width={32} height={32} animation={false} />
+              )}
+
               {!rawValueRef.current.startsWith(`${currentShortName}:`) && <>{currentShortName}:</>}
             </InputAdornment>
           ),


### PR DESCRIPTION
## What it solves

Resolves #2378

## How this PR fixes it
If a valid address is inputted, it should show an identicon instead of a placeholder.

## Screenshots
<img width="644" alt="Screenshot 2023-08-14 at 16 00 32" src="https://github.com/safe-global/safe-wallet-web/assets/381895/c3ff81b3-c83d-46cc-8260-3a4d125c808d">
