### PR TITLE
feat: eip-1559 fixed gas prices

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@safe-global/safe-core-sdk-utils": "^1.7.4",
     "@safe-global/safe-deployments": "^1.25.0",
     "@safe-global/safe-ethers-lib": "^1.9.4",
-    "@safe-global/safe-gateway-typescript-sdk": "^3.8.0",
+    "@safe-global/safe-gateway-typescript-sdk": "^3.9.0",
     "@safe-global/safe-modules-deployments": "^1.0.0",
     "@safe-global/safe-react-components": "^2.0.6",
     "@sentry/react": "^7.28.1",

--- a/src/hooks/__tests__/useGasPrice.test.ts
+++ b/src/hooks/__tests__/useGasPrice.test.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from 'ethers'
 import { act, renderHook } from '@/tests/test-utils'
 import useGasPrice from '@/hooks/useGasPrice'
+import { useCurrentChain } from '../useChains'
 
 // mock useWeb3Readonly
 jest.mock('../wallets/web3', () => {
@@ -8,8 +9,8 @@ jest.mock('../wallets/web3', () => {
     getFeeData: jest.fn(() =>
       Promise.resolve({
         gasPrice: undefined,
-        maxFeePerGas: BigNumber.from('0x956e'),
-        maxPriorityFeePerGas: BigNumber.from('0x136f'),
+        maxFeePerGas: BigNumber.from('0x956e'), //38254
+        maxPriorityFeePerGas: BigNumber.from('0x136f'), //4975
       }),
     ),
   }
@@ -17,32 +18,30 @@ jest.mock('../wallets/web3', () => {
     useWeb3ReadOnly: jest.fn(() => provider),
   }
 })
-
+const currentChain = {
+  chainId: '4',
+  gasPrice: [
+    {
+      type: 'oracle',
+      uri: 'https://api.etherscan.io/api?module=gastracker&action=gasoracle',
+      gasParameter: 'FastGasPrice',
+      gweiFactor: '1000000000.000000000',
+    },
+    {
+      type: 'oracle',
+      uri: 'https://ethgasstation.info/json/ethgasAPI.json',
+      gasParameter: 'fast',
+      gweiFactor: '200000000.000000000',
+    },
+    {
+      type: 'fixed',
+      weiValue: '24000000000',
+    },
+  ],
+  features: ['EIP1559'],
+}
 // Mock useCurrentChain
 jest.mock('@/hooks/useChains', () => {
-  const currentChain = {
-    chainId: '4',
-    gasPrice: [
-      {
-        type: 'ORACLE',
-        uri: 'https://api.etherscan.io/api?module=gastracker&action=gasoracle',
-        gasParameter: 'FastGasPrice',
-        gweiFactor: '1000000000.000000000',
-      },
-      {
-        type: 'ORACLE',
-        uri: 'https://ethgasstation.info/json/ethgasAPI.json',
-        gasParameter: 'fast',
-        gweiFactor: '200000000.000000000',
-      },
-      {
-        type: 'FIXED',
-        weiValue: '24000000000',
-      },
-    ],
-    features: ['EIP1559'],
-  }
-
   return {
     useCurrentChain: jest.fn(() => currentChain),
   }
@@ -52,6 +51,7 @@ describe('useGasPrice', () => {
   beforeEach(() => {
     jest.useFakeTimers()
     jest.clearAllMocks()
+    ;(useCurrentChain as jest.Mock).mockReturnValue(currentChain)
   })
 
   it('should return the fetched gas price from the first oracle', async () => {
@@ -168,6 +168,56 @@ describe('useGasPrice', () => {
 
     // assert the priority fee is correct
     expect(result.current[0]?.maxPriorityFeePerGas?.toString()).toEqual('4975')
+  })
+
+  it('should be able to set a fixed EIP 1559 gas price', async () => {
+    ;(useCurrentChain as jest.Mock).mockReturnValue({
+      chainId: '10',
+      gasPrice: [
+        {
+          type: 'fixed1559',
+          maxFeePerGas: '100000000',
+          maxPriorityFeePerGas: '100000',
+        },
+      ],
+      features: ['EIP1559'],
+    })
+
+    const { result } = renderHook(() => useGasPrice())
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    // assert the hook is not loading
+    expect(result.current[2]).toBe(false)
+
+    // assert fixed gas price as minimum of 0.1 gwei
+    expect(result.current[0]?.maxFeePerGas?.toString()).toBe('100000000')
+
+    // assert fixed priority fee
+    expect(result.current[0]?.maxPriorityFeePerGas?.toString()).toBe('100000')
+  })
+
+  it("should use the previous block's fee data if there are no oracles", async () => {
+    ;(useCurrentChain as jest.Mock).mockReturnValue({
+      chainId: '1',
+      gasPrice: [],
+      features: ['EIP1559'],
+    })
+
+    const { result } = renderHook(() => useGasPrice())
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    // assert the hook is not loading
+    expect(result.current[2]).toBe(false)
+
+    // assert gas price from provider
+    expect(result.current[0]?.maxFeePerGas?.toString()).toBe('38254')
+
+    // assert priority fee from provider
+    expect(result.current[0]?.maxPriorityFeePerGas?.toString()).toBe('4975')
   })
 
   it('should keep the previous gas price if the hook re-renders', async () => {

--- a/src/hooks/useDecodeTx.ts
+++ b/src/hooks/useDecodeTx.ts
@@ -15,8 +15,8 @@ const useDecodeTx = (tx?: SafeTransaction): AsyncResult<DecodedDataResponse> => 
 
   const [data = nativeTransfer, error, loading] = useAsync<DecodedDataResponse>(() => {
     if (!encodedData || isEmptyData) return
-    return getDecodedData(chainId, encodedData)
-  }, [chainId, encodedData, isEmptyData])
+    return getDecodedData(chainId, encodedData, tx.data.to)
+  }, [chainId, encodedData, isEmptyData, tx?.data.to])
 
   return [data, error, loading]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3295,7 +3295,18 @@
     "@safe-global/safe-gateway-typescript-sdk" "^3.5.3"
     viem "^1.0.0"
 
-"@safe-global/safe-core-sdk-types@^1.9.1", "@safe-global/safe-core-sdk-types@^1.9.2":
+"@safe-global/safe-core-sdk-types@^1.9.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-core-sdk-types/-/safe-core-sdk-types-1.10.1.tgz#94331b982671d2f2b8cc23114c58baf63d460c81"
+  integrity sha512-BKvuYTLOlY16Rq6qCXglmnL6KxInDuXMFqZMaCzwDKiEh+uoHu3xCumG5tVtWOkCgBF4XEZXMqwZUiLcon7IsA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/contracts" "^5.7.0"
+    "@safe-global/safe-deployments" "^1.20.2"
+    web3-core "^1.8.1"
+    web3-utils "^1.8.1"
+
+"@safe-global/safe-core-sdk-types@^1.9.2":
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/@safe-global/safe-core-sdk-types/-/safe-core-sdk-types-1.9.2.tgz#c8ae3500f5f16a9380f0270ab543f7f0718c9848"
   integrity sha512-TVBoCf3bry3y6vmJXACDNOaQnHWTh8Q9G8P3wZCgUBxMc676hP9HEvF1Xrvwe0wMxevMIKyBnEV4FpZUJGSefg==
@@ -3328,6 +3339,13 @@
     semver "^7.3.8"
     web3-utils "^1.8.1"
 
+"@safe-global/safe-deployments@^1.20.2":
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.26.0.tgz#b83615b3b5a66e736e08f8ecf2801ed988e9e007"
+  integrity sha512-Tw89O4/paT19ieMoiWQbqRApb0Bef/DxweS9rxodXAM5EQModkbyFXGZca+YxXE67sLvWjLr2jJUOxwze8mhGw==
+  dependencies:
+    semver "^7.3.7"
+
 "@safe-global/safe-deployments@^1.25.0":
   version "1.25.0"
   resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.25.0.tgz#882f0703cd4dd86cc19238319d77459ded09ec88"
@@ -3351,10 +3369,10 @@
   dependencies:
     cross-fetch "^3.1.5"
 
-"@safe-global/safe-gateway-typescript-sdk@^3.8.0":
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.8.0.tgz#6a71eeab0ecd447a585531ef87cf987da30b78a0"
-  integrity sha512-CiGWIHgIaOdICpDxp05Jw3OPslWTu8AnL0PhrCT1xZgIO86NlMMLzkGbeycJ4FHpTjA999O791Oxp4bZPIjgHA==
+"@safe-global/safe-gateway-typescript-sdk@^3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.9.0.tgz#5aa36c05b865f6fe754d1d460f83bc9bf3a0145e"
+  integrity sha512-DxRM/sBBQhv955dPtdo0z2Bf2fXxrzoRUnGyTa3+4Z0RAhcyiqnffRP1Bt3tyuvlyfZnFL0RsvkqDcAIKzq3RQ==
   dependencies:
     cross-fetch "^3.1.5"
 


### PR DESCRIPTION
## What it solves
This PR fixes the usage of chain gas configs in general and adds a new fixed gas config.
Resolves #2222 

## How this PR fixes it
Enabled fixed gas prices for EIP-1559

## How to test it
**Fixed 1559 gas prices**
We added Optimism with the desired gas price config to staging and enabled 1559 there.
1. Create any tx on optimism staging
2. Go to execute modal
3. Expand the gas price details
4. Observe 0.1 for maxFeePerGas and 0.0001 for maxPriorityFeePerGas
5. Execute
6. Observe same values in i.e. connected metamask

**Bug fix: Use gas price configs**
This PR also fixed our gas estimations in general which never considered the gas price configs from our config service before.
To test this try to create transactions on networks with specific gas price configs:
- Gas price oracles
  - Mainnet
  - Polygon
- Fixed
  - Görli

## Screenshots
The screenshot shows the desired fixed gas price of 0.1 maxFee and 0.0001 maxPrio on Optimism.
![Screenshot 2023-08-15 at 10 35 36](https://github.com/safe-global/safe-wallet-web/assets/2670790/47decc5c-7ab9-4b82-b7f6-22b4859c250e)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
