### PR TITLE
fix: Add addOwner route and open tx flow

### DIFF
--- a/src/components/tx-flow/flows/AddOwner/index.tsx
+++ b/src/components/tx-flow/flows/AddOwner/index.tsx
@@ -16,17 +16,7 @@ export type AddOwnerFlowProps = {
   threshold: number
 }
 
-const AddOwnerFlow = () => {
-  const { safe } = useSafeInfo()
-
-  const defaultValues: AddOwnerFlowProps = {
-    newOwner: {
-      address: '',
-      name: '',
-    },
-    threshold: safe.threshold,
-  }
-
+const FlowInner = ({ defaultValues }: { defaultValues: AddOwnerFlowProps }) => {
   const { data, step, nextStep, prevStep } = useTxStepper<AddOwnerFlowProps>(defaultValues)
 
   const steps = [
@@ -50,6 +40,22 @@ const AddOwnerFlow = () => {
       {steps}
     </TxLayout>
   )
+}
+
+const AddOwnerFlow = ({ address }: { address?: string }) => {
+  const { safe, safeLoading, safeLoaded } = useSafeInfo()
+
+  const defaultValues: AddOwnerFlowProps = {
+    newOwner: {
+      address: address || '',
+      name: '',
+    },
+    threshold: safe.threshold,
+  }
+
+  if (!safeLoaded || safeLoading) return null
+
+  return <FlowInner defaultValues={defaultValues} />
 }
 
 export default AddOwnerFlow

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -9,6 +9,7 @@ export const AppRoutes = {
   home: '/home',
   cookie: '/cookie',
   addressBook: '/address-book',
+  addOwner: '/addOwner',
   _offline: '/_offline',
   apps: {
     open: '/apps/open',

--- a/src/pages/addOwner.tsx
+++ b/src/pages/addOwner.tsx
@@ -1,0 +1,32 @@
+import type { NextPage } from 'next'
+import Head from 'next/head'
+import { useRouter } from 'next/router'
+import { useContext, useEffect } from 'react'
+import { TxModalContext } from '@/components/tx-flow'
+import AddOwnerFlow from '@/components/tx-flow/flows/AddOwner'
+import { AppRoutes } from '@/config/routes'
+
+const AddOwner: NextPage = () => {
+  const router = useRouter()
+  const { address } = router.query
+  const ownerAddress = Array.isArray(address) ? address[0] : address
+  const { setTxFlow } = useContext(TxModalContext)
+
+  useEffect(() => {
+    router.push({ pathname: AppRoutes.settings.setup, query: router.query }).then(() => {
+      if (!ownerAddress) return
+
+      setTxFlow(<AddOwnerFlow address={ownerAddress} />)
+    })
+  }, [ownerAddress, router, setTxFlow])
+
+  return (
+    <>
+      <Head>
+        <title>{'Safe{Wallet} – Add Owner'}</title>
+      </Head>
+    </>
+  )
+}
+
+export default AddOwner


### PR DESCRIPTION
## What it solves

Resolves #2381 

## How this PR fixes it

- Adds a new route `/addOwner` that redirects to the `/settings/setup` page
- Opens the txFlow with pre-filled address

## How to test it

1. Open `/addOwner?safe=<your safe address>&address=<the address you want to add as an owner>`
2. Add owner txFlow opens with the address filled in
3. Open `/addOwner?safe=<your safe address>`
4. Redirected to the settings page but no txFlow opening
5. Open `/addOwner?safe=<your safe address>&address=<an invalid address>`
6. Redirected to the settings page and txFlow opens with the address value but an error for invalid value is displayed

## Screenshots

<img width="718" alt="Screenshot 2023-08-15 at 12 17 06" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/361f65e7-836c-4452-beb8-e72a90083350">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
