### PR TITLE
fix: Show readonly approval editor only for existing transactions

### DIFF
--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -53,9 +53,11 @@ const SignOrExecuteForm = (props: SignOrExecuteProps): ReactElement => {
       <TxCard>
         {props.children}
 
-        <ErrorBoundary fallback={<div>Error parsing data</div>}>
-          <ApprovalEditor safeTransaction={safeTx} />
-        </ErrorBoundary>
+        {!isCreation && (
+          <ErrorBoundary fallback={<div>Error parsing data</div>}>
+            <ApprovalEditor safeTransaction={safeTx} />
+          </ErrorBoundary>
+        )}
 
         <DecodedTx
           tx={safeTx}


### PR DESCRIPTION
## What it solves

Resolves #2401 

## How this PR fixes it

Previously, the readonly `ApprovalEditor` was displayed as part of `DecodedTx` only if there were txDetails/txId. This was moved out of `DecodedTx` as part of #2254. With this PR, the readonly `ApprovalEditor` is only rendered if its not a tx creation.

## How to test it

1. Open a Safe App e.g. CowSwap
2. Create a token approval
3. One ApprovalEditor field is visible in the tx flow when creating the transaction and its possible to edit the value
4. Sign the transaction
5. Go to queue
6. Click Execute
7. One ApprovalEditor field is visible in read-only mode

## Screenshots

<img width="709" alt="Screenshot 2023-08-15 at 16 46 29" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/2e518fc4-519f-422c-8c98-8b5026a4af3c">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
