### PR TITLE
fix: don't over-poll Spending Limits data

### DIFF
--- a/src/hooks/loadables/useLoadSpendingLimits.ts
+++ b/src/hooks/loadables/useLoadSpendingLimits.ts
@@ -105,8 +105,9 @@ export const useLoadSpendingLimits = (): AsyncResult<SpendingLimitState[]> => {
     if (!provider || !safeLoaded || !safe.modules || !tokenInfoFromBalances) return
 
     return getSpendingLimits(provider, safe.modules, safeAddress, chainId, tokenInfoFromBalances)
+    // Need to check length of modules array to prevent new request every time Safe info polls
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [provider, safeLoaded, safe.modules, tokenInfoFromBalances, safeAddress, chainId, safe.txHistoryTag])
+  }, [provider, safeLoaded, safe.modules?.length, tokenInfoFromBalances, safeAddress, chainId, safe.txHistoryTag])
 
   useEffect(() => {
     if (error) {


### PR DESCRIPTION
## What it solves

Reduces `eth_call` requests

## How this PR fixes it

The `length` of the `modules` array is checked instead of the array itself when requesting spending limit details in `useLoadSpendingLimits`.

`useAsync` linting [changed the `safe.modules` `length` dependency](https://github.com/safe-global/safe-wallet-web/pull/2291/files#diff-8696548ccdc8dd843d851f0db58d34d722702c7c69eb48549a153b125b8eb640R109) in favour of `safe.modules`. This caused the increase of `eth_call` requests as a new instance of the Safe info is returned every poll [due to the `loading` flag](https://github.com/safe-global/safe-wallet-web/blob/8f92a0d9106ed89f897cae2eb5f58f6b88d4ef4b/src/hooks/useSafeInfo.ts#L24-L25) in `useSafeInfo`.

## How to test it

Open a Safe with spending limits enabled and observe a reduced number of `eth_call`s when compared to prod.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
