### PR TITLE
fix: do not fetch safe version on-chain

### DIFF
--- a/src/components/tx/SignOrExecuteForm/hooks.ts
+++ b/src/components/tx/SignOrExecuteForm/hooks.ts
@@ -187,10 +187,10 @@ export const useSafeTxGas = (safeTx: SafeTransaction | undefined): number | unde
   }, [safeTx?.data.to, safeTx?.data.value, safeTx?.data.data, safeTx?.data.operation])
 
   const [safeTxGas] = useAsync(() => {
-    if (!safe.chainId || !safeAddress || !safeTxParams) return
+    if (!safe.chainId || !safeAddress || !safeTxParams || !safe.version) return
 
-    return getSafeTxGas(safe.chainId, safeAddress, safeTxParams)
-  }, [safeAddress, safe.chainId, safeTxParams])
+    return getSafeTxGas(safe.chainId, safeAddress, safe.version, safeTxParams)
+  }, [safeAddress, safe.chainId, safe.version, safeTxParams])
 
   return safeTxGas
 }

--- a/src/services/tx/tx-sender/recommendedNonce.ts
+++ b/src/services/tx/tx-sender/recommendedNonce.ts
@@ -3,7 +3,6 @@ import { Operation, postSafeGasEstimation } from '@safe-global/safe-gateway-type
 import type { MetaTransactionData, SafeTransactionDataPartial } from '@safe-global/safe-core-sdk-types'
 import { isLegacyVersion } from '@/hooks/coreSDK/safeCoreSDK'
 import { Errors, logError } from '@/services/exceptions'
-import { getAndValidateSafeSDK } from './sdk'
 import { EMPTY_DATA } from '@safe-global/safe-core-sdk/dist/src/utils/constants'
 
 const fetchRecommendedParams = async (
@@ -22,11 +21,10 @@ const fetchRecommendedParams = async (
 export const getSafeTxGas = async (
   chainId: string,
   safeAddress: string,
+  safeVersion: string,
   safeTxData: SafeTransactionDataPartial,
 ): Promise<number | undefined> => {
-  const safeSDK = getAndValidateSafeSDK()
-  const contractVersion = await safeSDK.getContractVersion()
-  const isSafeTxGasRequired = isLegacyVersion(contractVersion)
+  const isSafeTxGasRequired = isLegacyVersion(safeVersion)
 
   // For 1.3.0+ Safes safeTxGas is not required
   if (!isSafeTxGasRequired) return 0


### PR DESCRIPTION
## What it solves

Reduces RPC calls during tx creation

## How this PR fixes it
Pass the safe version from the SafeInfo instead of fetching it on-chain

## How to test it
1. Create any transaction. 
2. Witness no more Infura calls coming from `recommendedNonce.ts`

## Screenshots

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
