### PR TITLE
fix: memoize deadline + smart contract check calls

### DIFF
--- a/src/hooks/__tests__/useSafeTokenAllocation.test.ts
+++ b/src/hooks/__tests__/useSafeTokenAllocation.test.ts
@@ -1,10 +1,11 @@
 import { renderHook, waitFor } from '@/tests/test-utils'
 import { defaultAbiCoder, hexZeroPad, keccak256, parseEther, toUtf8Bytes } from 'ethers/lib/utils'
-import useSafeTokenAllocation from '../useSafeTokenAllocation'
+import useSafeTokenAllocation, { type VestingData, _getRedeemDeadline } from '../useSafeTokenAllocation'
 import * as web3 from '../wallets/web3'
 import * as useSafeInfoHook from '@/hooks/useSafeInfo'
 import { ZERO_ADDRESS } from '@safe-global/safe-core-sdk/dist/src/utils/constants'
 import { BigNumber } from 'ethers'
+import type { JsonRpcProvider } from '@ethersproject/providers'
 
 const setupFetchStub =
   (data: any, status: number = 200) =>
@@ -15,6 +16,44 @@ const setupFetchStub =
       ok: status === 200,
     })
   }
+
+describe('_getRedeemDeadline', () => {
+  const mockProvider = {
+    call: jest.fn(),
+  } as unknown as JsonRpcProvider
+
+  beforeEach(() => {
+    // Clear memoization cache
+    _getRedeemDeadline.cache.clear?.()
+
+    jest.clearAllMocks()
+  })
+
+  it('should should only call the provider once per address on a chain', async () => {
+    for await (const _ of Array.from({ length: 10 })) {
+      await _getRedeemDeadline({ chainId: 1, contract: hexZeroPad('0x1', 20) } as VestingData, mockProvider)
+    }
+
+    expect(mockProvider.call).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not memoize different addresses on the same chain', async () => {
+    const chainId = 1
+
+    await _getRedeemDeadline({ chainId, contract: hexZeroPad('0x1', 20) } as VestingData, mockProvider)
+    await _getRedeemDeadline({ chainId, contract: hexZeroPad('0x2', 20) } as VestingData, mockProvider)
+
+    expect(mockProvider.call).toHaveBeenCalledTimes(2)
+  })
+
+  it('should not memoize the same address on difference chains', async () => {
+    for await (const i of Array.from({ length: 10 }, (_, i) => i + 1)) {
+      await _getRedeemDeadline({ chainId: i, contract: hexZeroPad('0x1', 20) } as VestingData, mockProvider)
+    }
+
+    expect(mockProvider.call).toHaveBeenCalledTimes(10)
+  })
+})
 
 // TODO: use mockWeb3Provider()
 describe('useSafeTokenAllocation', () => {

--- a/src/hooks/__tests__/useSafeTokenAllocation.test.ts
+++ b/src/hooks/__tests__/useSafeTokenAllocation.test.ts
@@ -69,6 +69,9 @@ describe('useSafeTokenAllocation', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
+    // Clear memoization cache
+    _getRedeemDeadline.cache.clear?.()
+
     jest.spyOn(useSafeInfoHook, 'default').mockImplementation(
       () =>
         ({

--- a/src/utils/__tests__/wallets.test.ts
+++ b/src/utils/__tests__/wallets.test.ts
@@ -1,0 +1,50 @@
+import { hexZeroPad } from 'ethers/lib/utils'
+import type { Web3Provider } from '@ethersproject/providers'
+
+import * as web3 from '@/hooks/wallets/web3'
+import { isSmartContractWallet } from '@/utils/wallets'
+import type { ConnectedWallet } from '@/services/onboard'
+
+describe('wallets', () => {
+  describe('isSmartContractWallet', () => {
+    const getCodeMock = jest.fn()
+
+    beforeEach(() => {
+      // Clear memoization cache
+      isSmartContractWallet.cache.clear?.()
+
+      jest.clearAllMocks()
+
+      jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(() => {
+        return {
+          getCode: getCodeMock,
+        } as unknown as Web3Provider
+      })
+    })
+
+    it('should should only call the provider once per address on a chain', async () => {
+      for await (const _ of Array.from({ length: 10 })) {
+        await isSmartContractWallet({ chainId: '1', address: hexZeroPad('0x1', 20) } as ConnectedWallet)
+      }
+
+      expect(getCodeMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not memoize different addresses on the same chain', async () => {
+      const chainId = '1'
+
+      await isSmartContractWallet({ chainId, address: hexZeroPad('0x1', 20) } as ConnectedWallet)
+      await isSmartContractWallet({ chainId, address: hexZeroPad('0x2', 20) } as ConnectedWallet)
+
+      expect(getCodeMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('should not memoize the same address on difference chains', async () => {
+      for await (const i of Array.from({ length: 10 }, (_, i) => i + 1)) {
+        await isSmartContractWallet({ chainId: i.toString(), address: hexZeroPad('0x1', 20) } as ConnectedWallet)
+      }
+
+      expect(getCodeMock).toHaveBeenCalledTimes(10)
+    })
+  })
+})

--- a/src/utils/wallets.ts
+++ b/src/utils/wallets.ts
@@ -3,6 +3,7 @@ import { ErrorCode } from '@ethersproject/logger'
 import { type ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import { getWeb3ReadOnly, isSmartContract } from '@/hooks/wallets/web3'
 import { WALLET_KEYS } from '@/hooks/wallets/consts'
+import { memoize } from 'lodash'
 
 const isWCRejection = (err: Error): boolean => {
   return /rejected/.test(err?.message)
@@ -22,12 +23,15 @@ export const isHardwareWallet = (wallet: ConnectedWallet): boolean => {
   )
 }
 
-export const isSmartContractWallet = async (wallet: ConnectedWallet) => {
-  const provider = getWeb3ReadOnly()
+export const isSmartContractWallet = memoize(
+  async (wallet: ConnectedWallet) => {
+    const provider = getWeb3ReadOnly()
 
-  if (!provider) {
-    throw new Error('Provider not found')
-  }
+    if (!provider) {
+      throw new Error('Provider not found')
+    }
 
-  return isSmartContract(provider, wallet.address)
-}
+    return isSmartContract(provider, wallet.address)
+  },
+  ({ chainId, address }) => chainId + address,
+)


### PR DESCRIPTION
## What it solves

Reduces `eth_call` requests

## How this PR fixes it

The request for `redeemDeadline` in `useSafeTokenAllocation` is now memoized according to the `chainId` and `address` meaning it will only request once per specific address on a chain. `isSmartContractWallet` has been memoized in a similar fashion.

## How to test it

- Switch Mainnet/Goerli and observe one less request for getting the redemption deadline (from `useSafeTokenAllocation` in the call stack). The values should match that as on prod.
- Switch between the option of executing via relayer/wallet by going back/forward in Safe creation and observe one less request for checking the contract code (from `useWalletCanRelay` -> `isSmartContractWallet` in the call stack).

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
