### PR TITLE
Feat: gas price in header

### DIFF
--- a/src/components/common/GasStation/index.tsx
+++ b/src/components/common/GasStation/index.tsx
@@ -9,8 +9,10 @@ const GasStation = () => {
   const gasGwei = maxFeePerGas ? formatVisualAmount(maxFeePerGas, 'gwei', 0) : ''
 
   return (
-    <Box display="flex" alignItems="center">
-      <Typography sx={{ minWidth: '1.4em' }}>{gasGwei}</Typography>
+    <Box display="flex" alignItems="center" gap={0.5}>
+      <Typography minWidth={gasGwei.length * 0.75 + 'em'} fontWeight="bold">
+        {gasGwei}
+      </Typography>
       <SvgIcon component={LocalGasStationIcon} inheritViewBox fontSize="small" />
     </Box>
   )

--- a/src/components/common/GasStation/index.tsx
+++ b/src/components/common/GasStation/index.tsx
@@ -1,0 +1,19 @@
+import { Box, SvgIcon, Typography } from '@mui/material'
+import LocalGasStationIcon from '@mui/icons-material/LocalGasStation'
+import useGasPrice from '@/hooks/useGasPrice'
+import { formatVisualAmount } from '@/utils/formatters'
+
+const GasStation = () => {
+  const [gasPrice] = useGasPrice()
+  const maxFeePerGas = gasPrice?.maxFeePerGas
+  const gasGwei = maxFeePerGas ? formatVisualAmount(maxFeePerGas, 'gwei', 0) : ''
+
+  return (
+    <Box display="flex" alignItems="center">
+      <Typography sx={{ minWidth: '1.4em' }}>{gasGwei}</Typography>
+      <SvgIcon component={LocalGasStationIcon} inheritViewBox fontSize="small" />
+    </Box>
+  )
+}
+
+export default GasStation

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -15,6 +15,7 @@ import SafeLogo from '@/public/images/logo.svg'
 import Link from 'next/link'
 import useSafeAddress from '@/hooks/useSafeAddress'
 import BatchIndicator from '@/components/batch/BatchIndicator'
+import GasStation from '../GasStation'
 
 type HeaderProps = {
   onMenuToggle?: Dispatch<SetStateAction<boolean>>
@@ -74,6 +75,10 @@ const Header = ({ onMenuToggle, onBatchToggle }: HeaderProps): ReactElement => {
 
       <div className={css.element}>
         <NotificationCenter />
+      </div>
+
+      <div className={css.element}>
+        <GasStation />
       </div>
 
       <div className={classnames(css.element, css.connectWallet)}>

--- a/src/hooks/__tests__/useGasPrice.test.ts
+++ b/src/hooks/__tests__/useGasPrice.test.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from 'ethers'
 import { act, renderHook } from '@/tests/test-utils'
-import useGasPrice from '@/hooks/useGasPrice'
+import { useGasPriceAsync as useGasPrice } from '@/hooks/useGasPrice'
 import { useCurrentChain } from '../useChains'
 
 // mock useWeb3Readonly

--- a/src/hooks/useGasPrice.ts
+++ b/src/hooks/useGasPrice.ts
@@ -1,3 +1,4 @@
+import { useContext, createContext } from 'react'
 import { BigNumber } from 'ethers'
 import type { FeeData } from '@ethersproject/abstract-provider'
 import type {
@@ -124,7 +125,12 @@ const getGasParameters = (
     maxPriorityFeePerGas: undefined,
   }
 }
-const useGasPrice = (): AsyncResult<GasFeeParams> => {
+
+type AsyncGasPrice = AsyncResult<GasFeeParams>
+
+export const GasContext = createContext<AsyncGasPrice>([undefined, undefined, true])
+
+export const useGasPriceAsync = (): AsyncGasPrice => {
   const chain = useCurrentChain()
   const gasPriceConfigs = chain?.gasPrice
   const [counter] = useIntervalCounter(REFRESH_DELAY)
@@ -152,6 +158,10 @@ const useGasPrice = (): AsyncResult<GasFeeParams> => {
   const isLoading = gasPriceLoading || (!gasPrice && !gasPriceError)
 
   return [gasPrice, gasPriceError, isLoading]
+}
+
+const useGasPrice = (): AsyncResult<GasFeeParams> => {
+  return useContext(GasContext)
 }
 
 export default useGasPrice

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -37,6 +37,7 @@ import useSafeMessageNotifications from '@/hooks/messages/useSafeMessageNotifica
 import useSafeMessagePendingStatuses from '@/hooks/messages/useSafeMessagePendingStatuses'
 import useChangedValue from '@/hooks/useChangedValue'
 import { TxModalProvider } from '@/components/tx-flow'
+import { GasContext, useGasPriceAsync } from '@/hooks/useGasPrice'
 
 const GATEWAY_URL = IS_PRODUCTION || cgwDebugStorage.get() ? GATEWAY_URL_PRODUCTION : GATEWAY_URL_STAGING
 
@@ -67,13 +68,16 @@ const clientSideEmotionCache = createEmotionCache()
 export const AppProviders = ({ children }: { children: ReactNode | ReactNode[] }) => {
   const isDarkMode = useDarkMode()
   const themeMode = isDarkMode ? 'dark' : 'light'
+  const gasPrice = useGasPriceAsync()
 
   return (
     <SafeThemeProvider mode={themeMode}>
       {(safeTheme: Theme) => (
         <ThemeProvider theme={safeTheme}>
           <Sentry.ErrorBoundary showDialog fallback={ErrorBoundary}>
-            <TxModalProvider>{children}</TxModalProvider>
+            <GasContext.Provider value={gasPrice}>
+              <TxModalProvider>{children}</TxModalProvider>
+            </GasContext.Provider>
           </Sentry.ErrorBoundary>
         </ThemeProvider>
       )}


### PR DESCRIPTION
## What it solves

Allows the user to check the gas price quickly which is convenient when executing transactions.

<img width="553" alt="Screenshot 2023-08-16 at 18 40 31" src="https://github.com/safe-global/safe-wallet-web/assets/381895/df6b2605-f974-4f4b-bec4-09eff4713ec2">

## Todo

* [x] Cache the gas price between polls so that tx modals use the same value
* [ ] Don't display it for chains where we use a fixed price (?)


