### PR TITLE
Fix: do not sandbox safe icon URLs

### DIFF
--- a/cypress/e2e/smoke/tx_history.cy.js
+++ b/cypress/e2e/smoke/tx_history.cy.js
@@ -31,7 +31,7 @@ describe('Transaction history', () => {
       .last()
       .within(() => {
         // Type
-        cy.get('iframe').should('have.attr', 'title', INCOMING)
+        cy.get('img').should('have.attr', 'alt', INCOMING)
         cy.contains('div', 'Received').should('exist')
 
         // Info
@@ -103,7 +103,7 @@ describe('Transaction history', () => {
       .prev()
       .within(() => {
         // Type
-        cy.get('iframe').should('have.attr', 'title', OUTGOING)
+        cy.get('img').should('have.attr', 'alt', OUTGOING)
         cy.contains('div', 'Sent').should('exist')
 
         // Info

--- a/src/components/safe-apps/SafeAppIconCard/index.test.ts
+++ b/src/components/safe-apps/SafeAppIconCard/index.test.ts
@@ -1,0 +1,14 @@
+import { _isSafeSrc } from '.'
+
+describe('SafeAppIconCard', () => {
+  it('should detect unsafe src', () => {
+    expect(_isSafeSrc('https://google.com/test.jpg')).toBe(false)
+    expect(_isSafeSrc('data:image/png;base64,')).toBe(false)
+  })
+
+  it('should detect safe src', () => {
+    expect(_isSafeSrc('https://safe-transaction-assets.safe.global/contracts/logos/0x34CfAC646f3.png')).toBe(true)
+    expect(_isSafeSrc('https://safe-transaction-assets.staging.5afe.dev/contracts/logos/0x34CfAC.png')).toBe(true)
+    expect(_isSafeSrc('/images/transactions/incoming.svg')).toBe(true)
+  })
+})

--- a/src/components/safe-apps/SafeAppIconCard/index.tsx
+++ b/src/components/safe-apps/SafeAppIconCard/index.tsx
@@ -1,3 +1,4 @@
+import ImageFallback from '@/components/common/ImageFallback'
 import { type ReactElement, memo } from 'react'
 
 const APP_LOGO_FALLBACK_IMAGE = `/images/apps/app-placeholder.svg`
@@ -16,6 +17,22 @@ const getIframeContent = (url: string, width: number, height: number, fallback: 
   `
 }
 
+export const _isSafeSrc = (src: string) => {
+  const allowedHosts = ['.safe.global', '.5afe.dev']
+  const isRelative = src.startsWith('/')
+
+  let hostname = ''
+  if (!isRelative) {
+    try {
+      hostname = new URL(src).hostname
+    } catch (e) {
+      return false
+    }
+  }
+
+  return isRelative || allowedHosts.some((host) => hostname.endsWith(host))
+}
+
 const SafeAppIconCard = ({
   src,
   alt,
@@ -29,6 +46,10 @@ const SafeAppIconCard = ({
   height?: number
   fallback?: string
 }): ReactElement => {
+  if (_isSafeSrc(src)) {
+    return <ImageFallback src={src} alt={alt} width={width} height={height} fallbackSrc={fallback} />
+  }
+
   return (
     <iframe
       title={alt}


### PR DESCRIPTION
## What it solves

Resolves #2419

## How this PR fixes it

This PR checks if an icon src is a relative path or comes from one of our own domains, and inserts it as a regular image in that case. Otherwise, it embeds it in a sandboxed iframe like before.