### PR TITLE
Fix: hide Batch icon if not on a Safe route

### DIFF
--- a/src/components/batch/BatchIndicator/index.tsx
+++ b/src/components/batch/BatchIndicator/index.tsx
@@ -11,7 +11,7 @@ const BatchIndicator = ({ onClick }: { onClick?: () => void }) => {
   return (
     <BatchTooltip>
       <Track {...BATCH_EVENTS.BATCH_SIDEBAR_OPEN} label={length}>
-        <ButtonBase onClick={onClick} sx={{ p: 0.5 }}>
+        <ButtonBase onClick={onClick} sx={{ p: 0.5 }} title="Batch">
           <Badge variant="standard" color="secondary" badgeContent={length}>
             <SvgIcon component={BatchIcon} inheritViewBox fontSize="small" />
           </Badge>

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -66,9 +66,11 @@ const Header = ({ onMenuToggle, onBatchToggle }: HeaderProps): ReactElement => {
         </div>
       )}
 
-      <div className={classnames(css.element, css.hideMobile)}>
-        <BatchIndicator onClick={handleBatchToggle} />
-      </div>
+      {safeAddress && (
+        <div className={classnames(css.element, css.hideMobile)}>
+          <BatchIndicator onClick={handleBatchToggle} />
+        </div>
+      )}
 
       <div className={css.element}>
         <NotificationCenter />


### PR DESCRIPTION
## What it solves

Resolves #2425

## How this PR fixes it

Hides the Batch icon if there's no Safe on that URL.

## How to test it
* Go to a page like Welcome and see that there's no Batch button in the header