### PR TITLE
fix: TxFlow close button zindex

### DIFF
--- a/src/components/common/TxModalDialog/styles.module.css
+++ b/src/components/common/TxModalDialog/styles.module.css
@@ -57,7 +57,6 @@
   .title {
     position: sticky;
     top: 0;
-    z-index: 1;
   }
 }
 


### PR DESCRIPTION
## What it solves

Resolves #2429 

## How this PR fixes it

Removes the z-index for the close button

## How to test it

1. Scroll down in the tx flow window
2. Try to press elements that are at the top of the screen e.g. nonce form
3. Observe that its possible to interact with them

## Screenshots
<img width="742" alt="Screenshot 2023-08-23 at 11 28 36" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/16a51855-86e8-447e-97d6-7411aaa731bf">

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
