### PR TITLE
fix: chain names overflow menu on small resolutions

### DIFF
--- a/src/components/common/NetworkSelector/index.tsx
+++ b/src/components/common/NetworkSelector/index.tsx
@@ -65,6 +65,7 @@ const NetworkSelector = (): ReactElement => {
         sx: {
           '& .MuiPaper-root': {
             mt: 2,
+            overflow: 'auto',
           },
         },
       }}


### PR DESCRIPTION
## What it solves

Resolves #2412

(same as #2433 but this time with updated git config so I can actually sign the CLA 🙂 )

## How this PR fixes it

The `<Paper>` component surrounding the `<NetworkSelector>` had `overflow: visible`, which led to network names potentially being displayed outside the network selector box on small resolutions.

Overriding this specific style with `overflow: auto` fixes the issue and makes the network selector scrollable when vertical screen space is insufficient.

## How to test it

1. Open this branch on dev
2. Open the network selector on a normal desktop resolution and see that it still works as before
3. Open the network selector on a small resolution with low vertical pixel size so that the list of chain names is longer than the screen is able to show
4. See that there's now a scrollbar, and the chain names no longer overflow the surrounding menu box

## Screenshots

<img width="192" alt="Screenshot 2023-08-23 at 17 03 00" src="https://github.com/safe-global/safe-wallet-web/assets/117495/4923f73a-aa9b-400c-be4a-cce6c6706b84">

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
