### PR TITLE
Fix: multisend verification only worked for the latest contract version

### DIFF
--- a/src/components/transactions/TxDetails/TxData/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/index.tsx
@@ -1,13 +1,13 @@
 import SettingsChangeTxInfo from '@/components/transactions/TxDetails/TxData/SettingsChange'
+import type { SpendingLimitMethods } from '@/utils/transaction-guards'
 import {
-  type SpendingLimitMethods,
-  isTrustedDelegateCall,
   isCancellationTxInfo,
   isCustomTxInfo,
   isMultiSendTxInfo,
   isMultisigDetailedExecutionInfo,
   isSettingsChangeTxInfo,
   isSpendingLimitMethod,
+  isSupportedMultiSendAddress,
   isSupportedSpendingLimitAddress,
   isTransferTxInfo,
 } from '@/utils/transaction-guards'
@@ -19,9 +19,11 @@ import DecodedData from '@/components/transactions/TxDetails/TxData/DecodedData'
 import TransferTxInfo from '@/components/transactions/TxDetails/TxData/Transfer'
 import useChainId from '@/hooks/useChainId'
 import { MultiSendTxInfo } from '@/components/transactions/TxDetails/TxData/MultiSendTxInfo'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 const TxData = ({ txDetails }: { txDetails: TransactionDetails }): ReactElement => {
   const chainId = useChainId()
+  const { safe } = useSafeInfo()
   const txInfo = txDetails.txInfo
 
   if (isTransferTxInfo(txInfo)) {
@@ -36,7 +38,7 @@ const TxData = ({ txDetails }: { txDetails: TransactionDetails }): ReactElement 
     return <RejectionTxInfo nonce={txDetails.detailedExecutionInfo?.nonce} isTxExecuted={!!txDetails.executedAt} />
   }
 
-  if (isTrustedDelegateCall(txDetails) && isMultiSendTxInfo(txInfo)) {
+  if (isSupportedMultiSendAddress(txInfo, chainId, safe.version) && isMultiSendTxInfo(txInfo)) {
     return <MultiSendTxInfo txInfo={txInfo} />
   }
 

--- a/src/components/transactions/TxDetails/TxData/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/index.tsx
@@ -1,13 +1,13 @@
 import SettingsChangeTxInfo from '@/components/transactions/TxDetails/TxData/SettingsChange'
-import type { SpendingLimitMethods } from '@/utils/transaction-guards'
 import {
+  type SpendingLimitMethods,
+  isTrustedDelegateCall,
   isCancellationTxInfo,
   isCustomTxInfo,
   isMultiSendTxInfo,
   isMultisigDetailedExecutionInfo,
   isSettingsChangeTxInfo,
   isSpendingLimitMethod,
-  isSupportedMultiSendAddress,
   isSupportedSpendingLimitAddress,
   isTransferTxInfo,
 } from '@/utils/transaction-guards'
@@ -19,11 +19,9 @@ import DecodedData from '@/components/transactions/TxDetails/TxData/DecodedData'
 import TransferTxInfo from '@/components/transactions/TxDetails/TxData/Transfer'
 import useChainId from '@/hooks/useChainId'
 import { MultiSendTxInfo } from '@/components/transactions/TxDetails/TxData/MultiSendTxInfo'
-import useSafeInfo from '@/hooks/useSafeInfo'
 
 const TxData = ({ txDetails }: { txDetails: TransactionDetails }): ReactElement => {
   const chainId = useChainId()
-  const { safe } = useSafeInfo()
   const txInfo = txDetails.txInfo
 
   if (isTransferTxInfo(txInfo)) {
@@ -38,7 +36,7 @@ const TxData = ({ txDetails }: { txDetails: TransactionDetails }): ReactElement 
     return <RejectionTxInfo nonce={txDetails.detailedExecutionInfo?.nonce} isTxExecuted={!!txDetails.executedAt} />
   }
 
-  if (isSupportedMultiSendAddress(txInfo, chainId, safe.version) && isMultiSendTxInfo(txInfo)) {
+  if (isTrustedDelegateCall(txDetails) && isMultiSendTxInfo(txInfo)) {
     return <MultiSendTxInfo txInfo={txInfo} />
   }
 

--- a/src/components/transactions/TxDetails/TxData/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/index.tsx
@@ -19,9 +19,11 @@ import DecodedData from '@/components/transactions/TxDetails/TxData/DecodedData'
 import TransferTxInfo from '@/components/transactions/TxDetails/TxData/Transfer'
 import useChainId from '@/hooks/useChainId'
 import { MultiSendTxInfo } from '@/components/transactions/TxDetails/TxData/MultiSendTxInfo'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 const TxData = ({ txDetails }: { txDetails: TransactionDetails }): ReactElement => {
   const chainId = useChainId()
+  const { safe } = useSafeInfo()
   const txInfo = txDetails.txInfo
 
   if (isTransferTxInfo(txInfo)) {
@@ -36,7 +38,7 @@ const TxData = ({ txDetails }: { txDetails: TransactionDetails }): ReactElement 
     return <RejectionTxInfo nonce={txDetails.detailedExecutionInfo?.nonce} isTxExecuted={!!txDetails.executedAt} />
   }
 
-  if (isSupportedMultiSendAddress(txInfo, chainId) && isMultiSendTxInfo(txInfo)) {
+  if (isSupportedMultiSendAddress(txInfo, chainId, safe.version) && isMultiSendTxInfo(txInfo)) {
     return <MultiSendTxInfo txInfo={txInfo} />
   }
 

--- a/src/components/transactions/TxDetails/TxData/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/index.tsx
@@ -7,7 +7,6 @@ import {
   isMultisigDetailedExecutionInfo,
   isSettingsChangeTxInfo,
   isSpendingLimitMethod,
-  isSupportedMultiSendAddress,
   isSupportedSpendingLimitAddress,
   isTransferTxInfo,
 } from '@/utils/transaction-guards'
@@ -19,11 +18,9 @@ import DecodedData from '@/components/transactions/TxDetails/TxData/DecodedData'
 import TransferTxInfo from '@/components/transactions/TxDetails/TxData/Transfer'
 import useChainId from '@/hooks/useChainId'
 import { MultiSendTxInfo } from '@/components/transactions/TxDetails/TxData/MultiSendTxInfo'
-import useSafeInfo from '@/hooks/useSafeInfo'
 
 const TxData = ({ txDetails }: { txDetails: TransactionDetails }): ReactElement => {
   const chainId = useChainId()
-  const { safe } = useSafeInfo()
   const txInfo = txDetails.txInfo
 
   if (isTransferTxInfo(txInfo)) {
@@ -38,7 +35,7 @@ const TxData = ({ txDetails }: { txDetails: TransactionDetails }): ReactElement 
     return <RejectionTxInfo nonce={txDetails.detailedExecutionInfo?.nonce} isTxExecuted={!!txDetails.executedAt} />
   }
 
-  if (isSupportedMultiSendAddress(txInfo, chainId, safe.version) && isMultiSendTxInfo(txInfo)) {
+  if (isMultiSendTxInfo(txInfo)) {
     return <MultiSendTxInfo txInfo={txInfo} />
   }
 

--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -40,6 +40,7 @@ type TxDetailsProps = {
 
 const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement => {
   const chainId = useChainId()
+  const { safe } = useSafeInfo()
   const isPending = useIsPending(txSummary.id)
   const isQueue = isTxQueued(txSummary.txStatus)
   const awaitingExecution = isAwaitingExecution(txSummary.txStatus)
@@ -89,13 +90,14 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
           <Summary txDetails={txDetails} />
         </div>
 
-        {isSupportedMultiSendAddress(txDetails.txInfo, chainId) && isMultiSendTxInfo(txDetails.txInfo) && (
-          <div className={`${css.multiSend}`}>
-            <ErrorBoundary fallback={<div>Error parsing data</div>}>
-              <Multisend txData={txDetails.txData} />
-            </ErrorBoundary>
-          </div>
-        )}
+        {isSupportedMultiSendAddress(txDetails.txInfo, chainId, safe.version) &&
+          isMultiSendTxInfo(txDetails.txInfo) && (
+            <div className={`${css.multiSend}`}>
+              <ErrorBoundary fallback={<div>Error parsing data</div>}>
+                <Multisend txData={txDetails.txData} />
+              </ErrorBoundary>
+            </div>
+          )}
       </div>
 
       {/* Signers */}

--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -14,7 +14,6 @@ import {
   isMultiSendTxInfo,
   isMultisigDetailedExecutionInfo,
   isMultisigExecutionInfo,
-  isSupportedMultiSendAddress,
   isTxQueued,
 } from '@/utils/transaction-guards'
 import { InfoDetails } from '@/components/transactions/InfoDetails'
@@ -39,8 +38,6 @@ type TxDetailsProps = {
 }
 
 const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement => {
-  const chainId = useChainId()
-  const { safe } = useSafeInfo()
   const isPending = useIsPending(txSummary.id)
   const isQueue = isTxQueued(txSummary.txStatus)
   const awaitingExecution = isAwaitingExecution(txSummary.txStatus)
@@ -90,14 +87,13 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
           <Summary txDetails={txDetails} />
         </div>
 
-        {isSupportedMultiSendAddress(txDetails.txInfo, chainId, safe.version) &&
-          isMultiSendTxInfo(txDetails.txInfo) && (
-            <div className={`${css.multiSend}`}>
-              <ErrorBoundary fallback={<div>Error parsing data</div>}>
-                <Multisend txData={txDetails.txData} />
-              </ErrorBoundary>
-            </div>
-          )}
+        {isMultiSendTxInfo(txDetails.txInfo) && (
+          <div className={`${css.multiSend}`}>
+            <ErrorBoundary fallback={<div>Error parsing data</div>}>
+              <Multisend txData={txDetails.txData} />
+            </ErrorBoundary>
+          </div>
+        )}
       </div>
 
       {/* Signers */}

--- a/src/components/transactions/TxInfo/index.tsx
+++ b/src/components/transactions/TxInfo/index.tsx
@@ -23,6 +23,7 @@ import {
 import { ellipsis, shortenAddress } from '@/utils/formatters'
 import { useCurrentChain } from '@/hooks/useChains'
 import useChainId from '@/hooks/useChainId'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 export const TransferTx = ({
   info,
@@ -99,12 +100,13 @@ const SettingsChangeTx = ({ info }: { info: SettingsChange }): ReactElement => {
 
 const TxInfo = ({ info, ...rest }: { info: TransactionInfo; omitSign?: boolean; withLogo?: boolean }): ReactElement => {
   const chainId = useChainId()
+  const { safe } = useSafeInfo()
 
   if (isSettingsChangeTxInfo(info)) {
     return <SettingsChangeTx info={info} />
   }
 
-  if (isSupportedMultiSendAddress(info, chainId) && isMultiSendTxInfo(info)) {
+  if (isSupportedMultiSendAddress(info, chainId, safe.version) && isMultiSendTxInfo(info)) {
     return <MultiSendTx info={info} />
   }
 

--- a/src/components/transactions/TxInfo/index.tsx
+++ b/src/components/transactions/TxInfo/index.tsx
@@ -17,10 +17,13 @@ import {
   isMultiSendTxInfo,
   isNativeTokenTransfer,
   isSettingsChangeTxInfo,
+  isSupportedMultiSendAddress,
   isTransferTxInfo,
 } from '@/utils/transaction-guards'
 import { ellipsis, shortenAddress } from '@/utils/formatters'
 import { useCurrentChain } from '@/hooks/useChains'
+import useChainId from '@/hooks/useChainId'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 export const TransferTx = ({
   info,
@@ -96,11 +99,14 @@ const SettingsChangeTx = ({ info }: { info: SettingsChange }): ReactElement => {
 }
 
 const TxInfo = ({ info, ...rest }: { info: TransactionInfo; omitSign?: boolean; withLogo?: boolean }): ReactElement => {
+  const chainId = useChainId()
+  const { safe } = useSafeInfo()
+
   if (isSettingsChangeTxInfo(info)) {
     return <SettingsChangeTx info={info} />
   }
 
-  if (isMultiSendTxInfo(info)) {
+  if (isSupportedMultiSendAddress(info, chainId, safe.version) && isMultiSendTxInfo(info)) {
     return <MultiSendTx info={info} />
   }
 

--- a/src/components/transactions/TxInfo/index.tsx
+++ b/src/components/transactions/TxInfo/index.tsx
@@ -17,13 +17,10 @@ import {
   isMultiSendTxInfo,
   isNativeTokenTransfer,
   isSettingsChangeTxInfo,
-  isSupportedMultiSendAddress,
   isTransferTxInfo,
 } from '@/utils/transaction-guards'
 import { ellipsis, shortenAddress } from '@/utils/formatters'
 import { useCurrentChain } from '@/hooks/useChains'
-import useChainId from '@/hooks/useChainId'
-import useSafeInfo from '@/hooks/useSafeInfo'
 
 export const TransferTx = ({
   info,
@@ -99,14 +96,11 @@ const SettingsChangeTx = ({ info }: { info: SettingsChange }): ReactElement => {
 }
 
 const TxInfo = ({ info, ...rest }: { info: TransactionInfo; omitSign?: boolean; withLogo?: boolean }): ReactElement => {
-  const chainId = useChainId()
-  const { safe } = useSafeInfo()
-
   if (isSettingsChangeTxInfo(info)) {
     return <SettingsChangeTx info={info} />
   }
 
-  if (isSupportedMultiSendAddress(info, chainId, safe.version) && isMultiSendTxInfo(info)) {
+  if (isMultiSendTxInfo(info)) {
     return <MultiSendTx info={info} />
   }
 

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -102,26 +102,16 @@ export const getReadOnlyGnosisSafeContract = (chain: ChainInfo, safeVersion: str
 
 // MultiSend
 
-const getMultiSendContractDeployment = (chainId: string) => {
-  return getMultiSendDeployment({ network: chainId }) || getMultiSendDeployment()
-}
-
-export const getMultiSendContractAddress = (chainId: string): string | undefined => {
-  const deployment = getMultiSendContractDeployment(chainId)
-
-  return deployment?.networkAddresses[chainId]
+export const getMultiSendContractAddress = (network: string, version: string): string | undefined => {
+  const deployment = getMultiSendDeployment({ network, version })
+  return deployment?.networkAddresses[network]
 }
 
 // MultiSendCallOnly
 
-const getMultiSendCallOnlyContractDeployment = (chainId: string) => {
-  return getMultiSendCallOnlyDeployment({ network: chainId }) || getMultiSendCallOnlyDeployment()
-}
-
-export const getMultiSendCallOnlyContractAddress = (chainId: string): string | undefined => {
-  const deployment = getMultiSendCallOnlyContractDeployment(chainId)
-
-  return deployment?.networkAddresses[chainId]
+export const getMultiSendCallOnlyContractAddress = (network: string, version: string): string | undefined => {
+  const deployment = getMultiSendCallOnlyDeployment({ network, version })
+  return deployment?.networkAddresses[network]
 }
 
 export const getMultiSendCallOnlyContract = (
@@ -132,7 +122,7 @@ export const getMultiSendCallOnlyContract = (
   const ethAdapter = createEthersAdapter(provider)
 
   return ethAdapter.getMultiSendCallOnlyContract({
-    singletonDeployment: getMultiSendCallOnlyContractDeployment(chainId),
+    singletonDeployment: getMultiSendCallOnlyDeployment({ network: chainId, version: safeVersion || undefined }),
     ..._getValidatedGetContractProps(chainId, safeVersion),
   })
 }
@@ -144,7 +134,7 @@ export const getReadOnlyMultiSendCallOnlyContract = (
   const ethAdapter = createReadOnlyEthersAdapter()
 
   return ethAdapter.getMultiSendCallOnlyContract({
-    singletonDeployment: getMultiSendCallOnlyContractDeployment(chainId),
+    singletonDeployment: getMultiSendCallOnlyDeployment({ network: chainId, version: safeVersion || undefined }),
     ..._getValidatedGetContractProps(chainId, safeVersion),
   })
 }

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -1,7 +1,6 @@
 import {
   getFallbackHandlerDeployment,
   getMultiSendCallOnlyDeployment,
-  getMultiSendDeployment,
   getProxyFactoryDeployment,
   getSafeL2SingletonDeployment,
   getSafeSingletonDeployment,
@@ -101,18 +100,6 @@ export const getReadOnlyGnosisSafeContract = (chain: ChainInfo, safeVersion: str
 }
 
 // MultiSend
-
-export const getMultiSendContractAddress = (network: string, version: string): string | undefined => {
-  const deployment = getMultiSendDeployment({ network, version })
-  return deployment?.networkAddresses[network]
-}
-
-// MultiSendCallOnly
-
-export const getMultiSendCallOnlyContractAddress = (network: string, version: string): string | undefined => {
-  const deployment = getMultiSendCallOnlyDeployment({ network, version })
-  return deployment?.networkAddresses[network]
-}
 
 export const getMultiSendCallOnlyContract = (
   chainId: string,

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -19,6 +19,7 @@ import type {
   SafeInfo,
   SettingsChange,
   Transaction,
+  TransactionDetails,
   TransactionInfo,
   TransactionListItem,
   TransactionSummary,
@@ -35,7 +36,6 @@ import {
 } from '@safe-global/safe-gateway-typescript-sdk'
 import { getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimitContracts'
 import { sameAddress } from '@/utils/addresses'
-import { getMultiSendCallOnlyContractAddress, getMultiSendContractAddress } from '@/services/contracts/safeContracts'
 import type { NamedAddress } from '@/components/new-safe/create/types'
 
 export const isTxQueued = (value: TransactionStatus): boolean => {
@@ -57,6 +57,10 @@ export const isOwner = (safeOwners: AddressEx[] | NamedAddress[] = [], walletAdd
   return safeOwners.some((owner) => sameAddress(owner.address, walletAddress))
 }
 
+export const isTrustedDelegateCall = (txDetails: TransactionDetails): boolean => {
+  return txDetails.txData?.trustedDelegateCallTarget || false
+}
+
 export const isMultisigDetailedExecutionInfo = (value?: DetailedExecutionInfo): value is MultisigExecutionDetails => {
   return value?.type === DetailedExecutionInfoType.MULTISIG
 }
@@ -76,21 +80,6 @@ export const isSettingsChangeTxInfo = (value: TransactionInfo): value is Setting
 
 export const isCustomTxInfo = (value: TransactionInfo): value is Custom => {
   return value.type === TransactionInfoType.CUSTOM
-}
-
-export const isSupportedMultiSendAddress = (
-  txInfo: TransactionInfo,
-  chainId: string,
-  version: string | null,
-): boolean => {
-  // Safe version can be null when a Safe is being loaded
-  if (version == null) return false
-
-  const toAddress = isCustomTxInfo(txInfo) ? txInfo.to.value : ''
-  const multiSendAddress = getMultiSendContractAddress(chainId, version)
-  const multiSendCallOnlyAddress = getMultiSendCallOnlyContractAddress(chainId, version)
-
-  return sameAddress(multiSendAddress, toAddress) || sameAddress(multiSendCallOnlyAddress, toAddress)
 }
 
 export const isMultiSendTxInfo = (value: TransactionInfo): value is MultiSend => {

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -78,10 +78,10 @@ export const isCustomTxInfo = (value: TransactionInfo): value is Custom => {
   return value.type === TransactionInfoType.CUSTOM
 }
 
-export const isSupportedMultiSendAddress = (txInfo: TransactionInfo, chainId: string): boolean => {
+export const isSupportedMultiSendAddress = (txInfo: TransactionInfo, chainId: string, version: string): boolean => {
   const toAddress = isCustomTxInfo(txInfo) ? txInfo.to.value : ''
-  const multiSendAddress = getMultiSendContractAddress(chainId)
-  const multiSendCallOnlyAddress = getMultiSendCallOnlyContractAddress(chainId)
+  const multiSendAddress = getMultiSendContractAddress(chainId, version)
+  const multiSendCallOnlyAddress = getMultiSendCallOnlyContractAddress(chainId, version)
 
   return sameAddress(multiSendAddress, toAddress) || sameAddress(multiSendCallOnlyAddress, toAddress)
 }

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -83,7 +83,7 @@ export const isSupportedMultiSendAddress = (
   chainId: string,
   version: string | null,
 ): boolean => {
-  // Safe version can be null when a Safe is being loaded
+  // Safe version can be null when a Safe is an unsupported deployment
   if (version == null) return false
 
   const toAddress = isCustomTxInfo(txInfo) ? txInfo.to.value : ''

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -19,7 +19,6 @@ import type {
   SafeInfo,
   SettingsChange,
   Transaction,
-  TransactionDetails,
   TransactionInfo,
   TransactionListItem,
   TransactionSummary,
@@ -36,6 +35,7 @@ import {
 } from '@safe-global/safe-gateway-typescript-sdk'
 import { getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimitContracts'
 import { sameAddress } from '@/utils/addresses'
+import { getMultiSendCallOnlyContractAddress, getMultiSendContractAddress } from '@/services/contracts/safeContracts'
 import type { NamedAddress } from '@/components/new-safe/create/types'
 
 export const isTxQueued = (value: TransactionStatus): boolean => {
@@ -57,10 +57,6 @@ export const isOwner = (safeOwners: AddressEx[] | NamedAddress[] = [], walletAdd
   return safeOwners.some((owner) => sameAddress(owner.address, walletAddress))
 }
 
-export const isTrustedDelegateCall = (txDetails: TransactionDetails): boolean => {
-  return txDetails.txData?.trustedDelegateCallTarget || false
-}
-
 export const isMultisigDetailedExecutionInfo = (value?: DetailedExecutionInfo): value is MultisigExecutionDetails => {
   return value?.type === DetailedExecutionInfoType.MULTISIG
 }
@@ -80,6 +76,21 @@ export const isSettingsChangeTxInfo = (value: TransactionInfo): value is Setting
 
 export const isCustomTxInfo = (value: TransactionInfo): value is Custom => {
   return value.type === TransactionInfoType.CUSTOM
+}
+
+export const isSupportedMultiSendAddress = (
+  txInfo: TransactionInfo,
+  chainId: string,
+  version: string | null,
+): boolean => {
+  // Safe version can be null when a Safe is being loaded
+  if (version == null) return false
+
+  const toAddress = isCustomTxInfo(txInfo) ? txInfo.to.value : ''
+  const multiSendAddress = getMultiSendContractAddress(chainId, version)
+  const multiSendCallOnlyAddress = getMultiSendCallOnlyContractAddress(chainId, version)
+
+  return sameAddress(multiSendAddress, toAddress) || sameAddress(multiSendCallOnlyAddress, toAddress)
 }
 
 export const isMultiSendTxInfo = (value: TransactionInfo): value is MultiSend => {

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -35,7 +35,6 @@ import {
 } from '@safe-global/safe-gateway-typescript-sdk'
 import { getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimitContracts'
 import { sameAddress } from '@/utils/addresses'
-import { getMultiSendCallOnlyContractAddress, getMultiSendContractAddress } from '@/services/contracts/safeContracts'
 import type { NamedAddress } from '@/components/new-safe/create/types'
 
 export const isTxQueued = (value: TransactionStatus): boolean => {
@@ -78,23 +77,12 @@ export const isCustomTxInfo = (value: TransactionInfo): value is Custom => {
   return value.type === TransactionInfoType.CUSTOM
 }
 
-export const isSupportedMultiSendAddress = (
-  txInfo: TransactionInfo,
-  chainId: string,
-  version: string | null,
-): boolean => {
-  // Safe version can be null when a Safe is an unsupported deployment
-  if (version == null) return false
-
-  const toAddress = isCustomTxInfo(txInfo) ? txInfo.to.value : ''
-  const multiSendAddress = getMultiSendContractAddress(chainId, version)
-  const multiSendCallOnlyAddress = getMultiSendCallOnlyContractAddress(chainId, version)
-
-  return sameAddress(multiSendAddress, toAddress) || sameAddress(multiSendCallOnlyAddress, toAddress)
-}
-
 export const isMultiSendTxInfo = (value: TransactionInfo): value is MultiSend => {
-  return value.type === TransactionInfoType.CUSTOM && value.methodName === 'multiSend'
+  return (
+    value.type === TransactionInfoType.CUSTOM &&
+    value.methodName === 'multiSend' &&
+    typeof value.actionCount === 'number'
+  )
 }
 
 export const isCancellationTxInfo = (value: TransactionInfo): value is Cancellation => {

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -78,7 +78,14 @@ export const isCustomTxInfo = (value: TransactionInfo): value is Custom => {
   return value.type === TransactionInfoType.CUSTOM
 }
 
-export const isSupportedMultiSendAddress = (txInfo: TransactionInfo, chainId: string, version: string): boolean => {
+export const isSupportedMultiSendAddress = (
+  txInfo: TransactionInfo,
+  chainId: string,
+  version: string | null,
+): boolean => {
+  // Safe version can be null when a Safe is being loaded
+  if (version == null) return false
+
   const toAddress = isCustomTxInfo(txInfo) ? txInfo.to.value : ''
   const multiSendAddress = getMultiSendContractAddress(chainId, version)
   const multiSendCallOnlyAddress = getMultiSendCallOnlyContractAddress(chainId, version)


### PR DESCRIPTION
## What it solves

safe-deployments 1.2.6 made Safe 1.4.1 the default. See https://github.com/safe-global/safe-deployments/pull/248

This breaks our code because we were always retrieving multisend contract addresses w/o a version. It worked for 1.3.0 but not for any other version.

## How to test

1.
* Open a single transaction view for a multisend tx on Safe 1.3.0 on mainnet
* Open a single transaction view for a multisend tx on Safe 1.1.1 on mainnet
* Open a single transaction view for a multisend tx on Safe 1.3.0 on Polygon
* Multisend details should be displayed for all of them

2.
* Create and execute a multisend tx in a 1.3.0 Safe
* Create and execute a multisend tx in a 1.1.1 Safe