### PR TITLE
fix: allow safe apps to disable off-chain signing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,7 @@ jobs:
         shell: bash
         ## Cut off "refs/heads/", only allow alphanumeric characters and convert to lower case,
         ## e.g. "refs/heads/features/hello-1.2.0" -> "features_hello_1_2_0"
-        run: echo "branch=$(echo $GITHUB_HEAD_REF | sed 's/refs\/heads\///' | sed 's/[^a-z0-9]/_/ig') | sed 's/[A-Z]/\L&/g'" >> $GITHUB_OUTPUT
+        run: echo "branch=$(echo $GITHUB_HEAD_REF | sed 's/refs\/heads\///' | sed 's/[^a-z0-9]/_/ig' | sed 's/[A-Z]/\L&/g')" >> $GITHUB_OUTPUT
         id: extract_branch
 
       # Deploy to S3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,9 +67,9 @@ jobs:
       # Extract branch name
       - name: Extract branch name
         shell: bash
-        ## Cut off "refs/heads/" and only allow alphanumeric characters,
+        ## Cut off "refs/heads/", only allow alphanumeric characters and convert to lower case,
         ## e.g. "refs/heads/features/hello-1.2.0" -> "features_hello_1_2_0"
-        run: echo "branch=$(echo $GITHUB_HEAD_REF | sed 's/refs\/heads\///' | sed 's/[^a-z0-9]/_/ig')" >> $GITHUB_OUTPUT
+        run: echo "branch=$(echo $GITHUB_HEAD_REF | sed 's/refs\/heads\///' | sed 's/[^a-z0-9]/_/ig') | sed 's/[A-Z]/\L&/g'" >> $GITHUB_OUTPUT
         id: extract_branch
 
       # Deploy to S3

--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -122,7 +122,7 @@ const AppFrame = ({ appUrl, allowedFeaturesList, safeAppFromManifest }: AppFrame
       sdkVersion: string,
     ) => {
       const isOffChainSigningSupported = isOffchainEIP1271Supported(safe, chain, sdkVersion)
-      const signOffChain = isOffChainSigningSupported && !onChainSigning
+      const signOffChain = isOffChainSigningSupported && !onChainSigning && !!settings.offChainSigning
 
       setCurrentRequestId(requestId)
 


### PR DESCRIPTION
## What it solves

Resolves #2440 

## How this PR fixes it
Considers the safe signing settings when signing a message from safe apps.

## How to test it
1. Use the eip1271 test dapp
2. disable off-chain signing
3. sign a message
4. Observe on-chain signature modal

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
