### PR TITLE
Feat: show contract names in multisend summary

### DIFF
--- a/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
@@ -61,7 +61,9 @@ export const SingleTxDecoded = ({
           <CodeIcon color="border" fontSize="small" />
           <Typography>{actionTitle}</Typography>
           <Typography ml="8px">
-            <b>{method || 'native transfer'}</b>
+            <b>
+              {name ? name + ': ' : ''} {method || 'native transfer'}
+            </b>
           </Typography>
         </div>
       </AccordionSummary>

--- a/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
@@ -61,9 +61,8 @@ export const SingleTxDecoded = ({
           <CodeIcon color="border" fontSize="small" />
           <Typography>{actionTitle}</Typography>
           <Typography ml="8px">
-            <b>
-              {name ? name + ': ' : ''} {method || 'native transfer'}
-            </b>
+            {name ? name + ': ' : ''}
+            <b>{method || 'native transfer'}</b>
           </Typography>
         </div>
       </AccordionSummary>


### PR DESCRIPTION
## What it solves

A follow-up on #2423

In multisend actions, in addition to displaying the contract method, show the contract name if it comes from the backend.

Before:
<img width="814" alt="Screenshot 2023-08-25 at 12 15 36" src="https://github.com/safe-global/safe-wallet-web/assets/381895/f86517e4-87db-40d4-8b4d-521a93f1b1d3">

After:
<img width="822" alt="Screenshot 2023-08-25 at 12 14 07" src="https://github.com/safe-global/safe-wallet-web/assets/381895/a6437d27-029c-472c-846c-b4302b109bd3">
