### PR TITLE
fix: populate address from URL in load Safe flow

### DIFF
--- a/src/components/new-safe/load/index.tsx
+++ b/src/components/new-safe/load/index.tsx
@@ -20,8 +20,8 @@ export const LoadSafeSteps: TxStepperProps<LoadSafeFormData>['steps'] = [
   {
     title: 'Name, address & network',
     subtitle: 'Paste the address of the Safe Account you want to add, select the network and choose a name.',
-    render: (_, onSubmit, onBack, setStep) => (
-      <SetAddressStep onSubmit={onSubmit} onBack={onBack} data={_} setStep={setStep} />
+    render: (data, onSubmit, onBack, setStep) => (
+      <SetAddressStep onSubmit={onSubmit} onBack={onBack} data={data} setStep={setStep} />
     ),
   },
   {
@@ -61,6 +61,8 @@ const LoadSafe = ({ initialData }: { initialData?: TxStepperProps<LoadSafeFormDa
         </Grid>
         <Grid item xs={12} md={10} lg={8} order={[1, null, 0]}>
           <CardStepper
+            // Populate initial data
+            key={initialSafe.address}
             initialData={initialSafe}
             onClose={onClose}
             steps={LoadSafeSteps}


### PR DESCRIPTION
## What it solves

Resolves #2438

## How this PR fixes it

The `CardStepper` now has the `address` assigned as a `key` to trigger a re-render if an `address` parameter is in the URL as the `query` is not initially available.

## How to test it

Open the load Safe flow with an `address` search parameter and observe the field populated. Changing the address and navigating forwards/backwards should *not* result in the URL `address` repopulating the field.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻