### PR TITLE
fix: close batch flow when removing last draft

### DIFF
--- a/src/components/batch/BatchSidebar/index.tsx
+++ b/src/components/batch/BatchSidebar/index.tsx
@@ -27,23 +27,20 @@ const BatchSidebar = ({ isOpen, onToggle }: { isOpen: boolean; onToggle: (open: 
     batchTxs.forEach((item) => deleteTx(item.id))
   }, [deleteTx, batchTxs])
 
+  // Close confirmation flow when batch is empty
+  const shouldExitFlow = !!txFlow && batchTxs.length === 0
+  useEffect(() => {
+    if (shouldExitFlow) {
+      setTxFlow(undefined)
+    }
+  }, [setTxFlow, shouldExitFlow])
+
   const onAddClick = useCallback(
     (e: SyntheticEvent) => {
       e.preventDefault()
       setTxFlow(<NewTxMenu />, undefined, false)
     },
     [setTxFlow],
-  )
-
-  const onDelete = useCallback(
-    (id: string) => {
-      const shouldCloseFlow = batchTxs.length === 1
-      deleteTx(id)
-      if (shouldCloseFlow) {
-        setTxFlow(undefined)
-      }
-    },
-    [deleteTx, batchTxs, setTxFlow],
   )
 
   const onConfirmClick = useCallback(
@@ -73,7 +70,7 @@ const BatchSidebar = ({ isOpen, onToggle }: { isOpen: boolean; onToggle: (open: 
         {batchTxs.length ? (
           <>
             <div className={css.txs}>
-              <BatchReorder txItems={batchTxs} onDelete={onDelete} onReorder={onReorder} />
+              <BatchReorder txItems={batchTxs} onDelete={deleteTx} onReorder={onReorder} />
             </div>
 
             <Track {...BATCH_EVENTS.BATCH_NEW_TX}>

--- a/src/components/batch/BatchSidebar/index.tsx
+++ b/src/components/batch/BatchSidebar/index.tsx
@@ -35,6 +35,17 @@ const BatchSidebar = ({ isOpen, onToggle }: { isOpen: boolean; onToggle: (open: 
     [setTxFlow],
   )
 
+  const onDelete = useCallback(
+    (id: string) => {
+      const shouldCloseFlow = batchTxs.length === 1
+      deleteTx(id)
+      if (shouldCloseFlow) {
+        setTxFlow(undefined)
+      }
+    },
+    [deleteTx, batchTxs, setTxFlow],
+  )
+
   const onConfirmClick = useCallback(
     async (e: SyntheticEvent) => {
       e.preventDefault()
@@ -62,7 +73,7 @@ const BatchSidebar = ({ isOpen, onToggle }: { isOpen: boolean; onToggle: (open: 
         {batchTxs.length ? (
           <>
             <div className={css.txs}>
-              <BatchReorder txItems={batchTxs} onDelete={deleteTx} onReorder={onReorder} />
+              <BatchReorder txItems={batchTxs} onDelete={onDelete} onReorder={onReorder} />
             </div>
 
             <Track {...BATCH_EVENTS.BATCH_NEW_TX}>

--- a/src/components/batch/BatchSidebar/index.tsx
+++ b/src/components/batch/BatchSidebar/index.tsx
@@ -28,7 +28,8 @@ const BatchSidebar = ({ isOpen, onToggle }: { isOpen: boolean; onToggle: (open: 
   }, [deleteTx, batchTxs])
 
   // Close confirmation flow when batch is empty
-  const shouldExitFlow = !!txFlow && batchTxs.length === 0
+  const isConfirmationFlow = txFlow?.type === ConfirmBatchFlow
+  const shouldExitFlow = isConfirmationFlow && batchTxs.length === 0
   useEffect(() => {
     if (shouldExitFlow) {
       setTxFlow(undefined)


### PR DESCRIPTION
## What it solves

Resolves #2428

## How this PR fixes it

If the batch confirmation flow is open, it is now closed when the last draft is removed via the sidebar.

## How to test it

Batch transaction(s) and enter the confirmation flow. Whilst in the flow, remove the last draft from the sidebar and observe the confirmation flow close. It should _not_ close other flows that may be open under the sidebar.

## Screenshots

![close-batch](https://github.com/safe-global/safe-wallet-web/assets/20442784/eb7a3aa1-80de-471f-9dc5-9d376f8daf1a)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
