### PR TITLE
fix: disabled batch sidebar buttons when not owner

### DIFF
--- a/src/components/batch/BatchSidebar/index.tsx
+++ b/src/components/batch/BatchSidebar/index.tsx
@@ -66,7 +66,7 @@ const BatchSidebar = ({ isOpen, onToggle }: { isOpen: boolean; onToggle: (open: 
               <BatchReorder txItems={batchTxs} onDelete={deleteTx} onReorder={onReorder} />
             </div>
 
-            <CheckWallet allowSpendingLimit>
+            <CheckWallet>
               {(isOk) => (
                 <Track {...BATCH_EVENTS.BATCH_NEW_TX}>
                   <Button onClick={onAddClick} disabled={!isOk}>
@@ -79,7 +79,7 @@ const BatchSidebar = ({ isOpen, onToggle }: { isOpen: boolean; onToggle: (open: 
 
             <Divider />
 
-            <CheckWallet allowSpendingLimit>
+            <CheckWallet>
               {(isOk) => (
                 <Track {...BATCH_EVENTS.BATCH_CONFIRM} label={batchTxs.length}>
                   <Button
@@ -96,7 +96,7 @@ const BatchSidebar = ({ isOpen, onToggle }: { isOpen: boolean; onToggle: (open: 
           </>
         ) : (
           <EmptyBatch>
-            <CheckWallet allowSpendingLimit>
+            <CheckWallet>
               {(isOk) => (
                 <Track {...BATCH_EVENTS.BATCH_NEW_TX}>
                   <Button onClick={onAddClick} variant="contained" disabled={!isOk}>

--- a/src/components/batch/BatchSidebar/index.tsx
+++ b/src/components/batch/BatchSidebar/index.tsx
@@ -66,7 +66,7 @@ const BatchSidebar = ({ isOpen, onToggle }: { isOpen: boolean; onToggle: (open: 
               <BatchReorder txItems={batchTxs} onDelete={deleteTx} onReorder={onReorder} />
             </div>
 
-            <CheckWallet>
+            <CheckWallet allowSpendingLimit>
               {(isOk) => (
                 <Track {...BATCH_EVENTS.BATCH_NEW_TX}>
                   <Button onClick={onAddClick} disabled={!isOk}>
@@ -79,7 +79,7 @@ const BatchSidebar = ({ isOpen, onToggle }: { isOpen: boolean; onToggle: (open: 
 
             <Divider />
 
-            <CheckWallet>
+            <CheckWallet allowSpendingLimit>
               {(isOk) => (
                 <Track {...BATCH_EVENTS.BATCH_CONFIRM} label={batchTxs.length}>
                   <Button
@@ -96,7 +96,7 @@ const BatchSidebar = ({ isOpen, onToggle }: { isOpen: boolean; onToggle: (open: 
           </>
         ) : (
           <EmptyBatch>
-            <CheckWallet>
+            <CheckWallet allowSpendingLimit>
               {(isOk) => (
                 <Track {...BATCH_EVENTS.BATCH_NEW_TX}>
                   <Button onClick={onAddClick} variant="contained" disabled={!isOk}>

--- a/src/components/batch/BatchSidebar/index.tsx
+++ b/src/components/batch/BatchSidebar/index.tsx
@@ -10,6 +10,7 @@ import ConfirmBatchFlow from '@/components/tx-flow/flows/ConfirmBatch'
 import Track from '@/components/common/Track'
 import { BATCH_EVENTS } from '@/services/analytics'
 import { BatchReorder } from './BatchTxList'
+import CheckWallet from '@/components/common/CheckWallet'
 
 import PlusIcon from '@/public/images/common/plus.svg'
 import EmptyBatch from './EmptyBatch'
@@ -65,33 +66,45 @@ const BatchSidebar = ({ isOpen, onToggle }: { isOpen: boolean; onToggle: (open: 
               <BatchReorder txItems={batchTxs} onDelete={deleteTx} onReorder={onReorder} />
             </div>
 
-            <Track {...BATCH_EVENTS.BATCH_NEW_TX}>
-              <Button onClick={onAddClick}>
-                <SvgIcon component={PlusIcon} inheritViewBox fontSize="small" sx={{ mr: 1 }} />
-                Add new transaction
-              </Button>
-            </Track>
+            <CheckWallet>
+              {(isOk) => (
+                <Track {...BATCH_EVENTS.BATCH_NEW_TX}>
+                  <Button onClick={onAddClick} disabled={!isOk}>
+                    <SvgIcon component={PlusIcon} inheritViewBox fontSize="small" sx={{ mr: 1 }} />
+                    Add new transaction
+                  </Button>
+                </Track>
+              )}
+            </CheckWallet>
 
             <Divider />
 
-            <Track {...BATCH_EVENTS.BATCH_CONFIRM} label={batchTxs.length}>
-              <Button
-                variant="contained"
-                onClick={onConfirmClick}
-                disabled={!batchTxs.length}
-                className={css.confirmButton}
-              >
-                Confirm batch
-              </Button>
-            </Track>
+            <CheckWallet>
+              {(isOk) => (
+                <Track {...BATCH_EVENTS.BATCH_CONFIRM} label={batchTxs.length}>
+                  <Button
+                    variant="contained"
+                    onClick={onConfirmClick}
+                    disabled={!batchTxs.length || !isOk}
+                    className={css.confirmButton}
+                  >
+                    Confirm batch
+                  </Button>
+                </Track>
+              )}
+            </CheckWallet>
           </>
         ) : (
           <EmptyBatch>
-            <Track {...BATCH_EVENTS.BATCH_NEW_TX}>
-              <Button onClick={onAddClick} variant="contained">
-                New transaction
-              </Button>
-            </Track>
+            <CheckWallet>
+              {(isOk) => (
+                <Track {...BATCH_EVENTS.BATCH_NEW_TX}>
+                  <Button onClick={onAddClick} variant="contained" disabled={!isOk}>
+                    New transaction
+                  </Button>
+                </Track>
+              )}
+            </CheckWallet>
           </EmptyBatch>
         )}
 


### PR DESCRIPTION
## What it solves

Resolves #2404

## How this PR fixes it

The batch sidebar buttons are now disabled if the user is not connected or not an owner.

## How to test it

### Disabled
As a non-owner open the sidebar and observe the disabled buttons with tooltip when a batch _doesn't_ exists and when one _does_.

### Enabled
As an owner or non-owner open the sidebar and observe the enabled buttons tooltip when a batch _doesn't_ exists and when one _does_.

## Screenshots

![batch sidebar buttons](https://github.com/safe-global/safe-wallet-web/assets/20442784/78a7b479-5670-46f5-8a54-8ac4cbfc954c)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
