### PR TITLE
fix: selector reference warnings

### DIFF
--- a/src/store/batchSlice.ts
+++ b/src/store/batchSlice.ts
@@ -74,7 +74,7 @@ export const batchSlice = createSlice({
 export const { setBatch, addTx, removeTx } = batchSlice.actions
 
 const selectAllBatches = (state: RootState): BatchTxsState => {
-  return state[batchSlice.name] || {}
+  return state[batchSlice.name] || initialState
 }
 
 export const selectBatchBySafe = createSelector(

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -151,9 +151,12 @@ export const selectTokenList = (state: RootState): SettingsState['tokenList'] =>
   return state[settingsSlice.name].tokenList || initialState.tokenList
 }
 
-export const selectHiddenTokensPerChain = (state: RootState, chainId: string): string[] => {
-  return state[settingsSlice.name].hiddenTokens?.[chainId] || []
-}
+export const selectHiddenTokensPerChain = createSelector(
+  [selectSettings, (_, chainId) => chainId],
+  (settings, chainId) => {
+    return settings.hiddenTokens?.[chainId] || []
+  },
+)
 
 export const selectRpc = createSelector(selectSettings, (settings) => settings.env.rpc)
 


### PR DESCRIPTION
## What it solves

Resolves console warning/unnecessary re-renders

## How this PR fixes it

If a selector returns a new reference, it should be memoised either manually or inside `createSelector`, etc. The following changes solved the console warning:

- `selectAllBatches` no longer returns an empty array but the `initialState`.
- `selectHiddenTokensPerChain` now leverages `createSelector` as it can return an empty array.

## How to test it

- Run the project locally and observe no console warnings.
- Batching should work as expected.
- Hiding/showing spam tokens should work as expected.

## Screenshots

Console warning in question:

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/f48a41a4-a3e1-4c57-aea3-cbbfc3e2c674)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
