### PR TITLE
feat: show Beamer NPS on tx success screen

### DIFF
--- a/src/components/tx-flow/flows/SuccessScreen/index.tsx
+++ b/src/components/tx-flow/flows/SuccessScreen/index.tsx
@@ -30,6 +30,12 @@ export const SuccessScreen = ({ txId }: { txId: string }) => {
   }, [txHash])
 
   useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.Beamer?.forceShowNPS()
+    }
+  }, [])
+
+  useEffect(() => {
     const unsubFns: Array<() => void> = ([TxEvent.FAILED, TxEvent.REVERTED] as const).map((event) =>
       txSubscribe(event, (detail) => {
         if (detail.txId === txId) setError(detail.error)


### PR DESCRIPTION
## What it solves

Resolves #2432

## How this PR fixes it

Beamer's NPS is now shown on the transaction success screen.

## How to test it

Create and execute a transaction, observing the NPS opening when the success screen is shown.

## Screenshots

tbd

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
