### PR TITLE
Fix: rm WalletConnect v1 and Taho; reorder wallets

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -12,7 +12,6 @@ jest.mock('@web3-onboard/keystone/dist/index', () => jest.fn())
 jest.mock('@web3-onboard/ledger/dist/index', () => jest.fn())
 jest.mock('@web3-onboard/trezor', () => jest.fn())
 jest.mock('@web3-onboard/walletconnect', () => jest.fn())
-jest.mock('@web3-onboard/taho', () => jest.fn())
 
 const mockOnboardState = {
   chains: [],

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@web3-onboard/injected-wallets": "^2.10.0",
     "@web3-onboard/keystone": "^2.3.7",
     "@web3-onboard/ledger": "2.3.2",
-    "@web3-onboard/taho": "^2.0.5",
     "@web3-onboard/trezor": "^2.4.2",
     "@web3-onboard/walletconnect": "^2.4.5",
     "classnames": "^2.3.1",

--- a/src/components/licenses/index.tsx
+++ b/src/components/licenses/index.tsx
@@ -553,14 +553,6 @@ const SafeLicenses = () => {
                 </TableCell>
               </TableRow>
               <TableRow>
-                <TableCell>@web3-onboard/taho</TableCell>
-                <TableCell>
-                  <ExternalLink href="https://github.com/blocknative/web3-onboard/blob/main/LICENSE">
-                    https://github.com/blocknative/web3-onboard/blob/main/LICENSE
-                  </ExternalLink>
-                </TableCell>
-              </TableRow>
-              <TableRow>
                 <TableCell>@web3-onboard/trezor</TableCell>
                 <TableCell>
                   <ExternalLink href="https://github.com/blocknative/web3-onboard/blob/main/LICENSE">

--- a/src/hooks/wallets/consts.ts
+++ b/src/hooks/wallets/consts.ts
@@ -1,23 +1,19 @@
 export const enum WALLET_KEYS {
-  COINBASE = 'COINBASE',
   INJECTED = 'INJECTED',
-  KEYSTONE = 'KEYSTONE',
-  LEDGER = 'LEDGER',
-  PAIRING = 'PAIRING',
-  TREZOR = 'TREZOR',
-  WALLETCONNECT = 'WALLETCONNECT',
   WALLETCONNECT_V2 = 'WALLETCONNECT_V2',
-  TAHO = 'TAHO',
+  COINBASE = 'COINBASE',
+  PAIRING = 'PAIRING',
+  LEDGER = 'LEDGER',
+  TREZOR = 'TREZOR',
+  KEYSTONE = 'KEYSTONE',
 }
 
 export const CGW_NAMES: { [key in WALLET_KEYS]: string | undefined } = {
-  [WALLET_KEYS.COINBASE]: 'coinbase',
   [WALLET_KEYS.INJECTED]: 'detectedwallet',
-  [WALLET_KEYS.KEYSTONE]: 'keystone',
-  [WALLET_KEYS.LEDGER]: 'ledger',
-  [WALLET_KEYS.PAIRING]: 'safeMobile',
-  [WALLET_KEYS.TREZOR]: 'trezor',
-  [WALLET_KEYS.WALLETCONNECT]: 'walletConnect',
   [WALLET_KEYS.WALLETCONNECT_V2]: 'walletConnect_v2',
-  [WALLET_KEYS.TAHO]: 'tally',
+  [WALLET_KEYS.COINBASE]: 'coinbase',
+  [WALLET_KEYS.PAIRING]: 'safeMobile',
+  [WALLET_KEYS.LEDGER]: 'ledger',
+  [WALLET_KEYS.TREZOR]: 'trezor',
+  [WALLET_KEYS.KEYSTONE]: 'keystone',
 }

--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -68,8 +68,7 @@ const getWalletConnectLabel = async (wallet: ConnectedWallet): Promise<string | 
   if (!isWalletConnect) return
   const { connector } = wallet.provider as unknown as any
   const peerWalletV2 = connector.session?.peer?.metadata?.name
-  const peerWalletV1 = connector.peerMeta?.name
-  return peerWalletV2 || peerWalletV1 || UNKNOWN_PEER
+  return peerWalletV2 || UNKNOWN_PEER
 }
 
 const trackWalletType = (wallet: ConnectedWallet) => {

--- a/src/hooks/wallets/wallets.ts
+++ b/src/hooks/wallets/wallets.ts
@@ -1,5 +1,5 @@
-import { CYPRESS_MNEMONIC, TREZOR_APP_URL, TREZOR_EMAIL, WC_BRIDGE, WC_PROJECT_ID } from '@/config/constants'
-import type { RecommendedInjectedWallets, WalletInit, WalletModule } from '@web3-onboard/common/dist/types.d'
+import { CYPRESS_MNEMONIC, TREZOR_APP_URL, TREZOR_EMAIL, WC_PROJECT_ID } from '@/config/constants'
+import type { RecommendedInjectedWallets, WalletInit } from '@web3-onboard/common/dist/types.d'
 import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 
 import coinbaseModule from '@web3-onboard/coinbase'
@@ -8,7 +8,6 @@ import keystoneModule from '@web3-onboard/keystone/dist/index'
 import ledgerModule from '@web3-onboard/ledger/dist/index'
 import trezorModule from '@web3-onboard/trezor'
 import walletConnect from '@web3-onboard/walletconnect'
-import tahoModule from '@web3-onboard/taho'
 
 import pairingModule from '@/services/pairing/module'
 import e2eWalletModule from '@/tests/e2e-wallet'
@@ -16,20 +15,6 @@ import { CGW_NAMES, WALLET_KEYS } from './consts'
 
 const prefersDarkMode = (): boolean => {
   return window?.matchMedia('(prefers-color-scheme: dark)')?.matches
-}
-
-// We need to modify the module name as onboard dedupes modules with the same label and the WC v1 and v2 modules have the same
-// @see https://github.com/blocknative/web3-onboard/blob/d399e0b76daf7b363d6a74b100b2c96ccb14536c/packages/core/src/store/actions.ts#L419
-// TODO: When removing this, also remove the associated CSS in `onboard.css`
-export const WALLET_CONNECT_V1_MODULE_NAME = 'WalletConnect v1'
-const walletConnectV1 = (): WalletInit => {
-  return (helpers) => {
-    const walletConnectModule = walletConnect({ version: 1, bridge: WC_BRIDGE })(helpers) as WalletModule
-
-    walletConnectModule.label = WALLET_CONNECT_V1_MODULE_NAME
-
-    return walletConnectModule
-  }
 }
 
 const walletConnectV2 = (chain: ChainInfo): WalletInit => {
@@ -54,14 +39,12 @@ const walletConnectV2 = (chain: ChainInfo): WalletInit => {
 
 const WALLET_MODULES: { [key in WALLET_KEYS]: (chain: ChainInfo) => WalletInit } = {
   [WALLET_KEYS.INJECTED]: () => injectedWalletModule(),
-  [WALLET_KEYS.PAIRING]: () => pairingModule(),
-  [WALLET_KEYS.WALLETCONNECT]: () => walletConnectV1(),
   [WALLET_KEYS.WALLETCONNECT_V2]: (chain) => walletConnectV2(chain),
+  [WALLET_KEYS.COINBASE]: () => coinbaseModule({ darkMode: prefersDarkMode() }),
+  [WALLET_KEYS.PAIRING]: () => pairingModule(),
   [WALLET_KEYS.LEDGER]: () => ledgerModule(),
   [WALLET_KEYS.TREZOR]: () => trezorModule({ appUrl: TREZOR_APP_URL, email: TREZOR_EMAIL }),
   [WALLET_KEYS.KEYSTONE]: () => keystoneModule(),
-  [WALLET_KEYS.TAHO]: () => tahoModule(),
-  [WALLET_KEYS.COINBASE]: () => coinbaseModule({ darkMode: prefersDarkMode() }),
 }
 
 export const getAllWallets = (chain: ChainInfo): WalletInit[] => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5040,15 +5040,6 @@
     buffer "^6.0.3"
     ethereumjs-util "^7.1.3"
 
-"@web3-onboard/taho@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@web3-onboard/taho/-/taho-2.0.5.tgz#899d147c234d61e1fb81045fc7339182c230c632"
-  integrity sha512-Z5n2UMumLNppOlDgYM9MhrM+YGyz8Emouaf7htH8l4B2r/meV4F3Wkgol2xYuwwu5SJyPaJH2GxNeh/EAfyBxg==
-  dependencies:
-    "@web3-onboard/common" "^2.3.3"
-    tallyho-detect-provider "^1.0.0"
-    tallyho-onboarding "^1.0.2"
-
 "@web3-onboard/trezor@^2.4.2":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@web3-onboard/trezor/-/trezor-2.4.2.tgz#49a485467d970ae872288c07eccb7adf18782622"
@@ -5860,7 +5851,7 @@ borsh@^0.7.0:
     bs58 "^4.0.0"
     text-encoding-utf-8 "^1.0.2"
 
-bowser@^2.11.0, bowser@^2.9.0:
+bowser@^2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
   integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
@@ -13409,18 +13400,6 @@ table-layout@^1.0.2:
     deep-extend "~0.6.0"
     typical "^5.2.0"
     wordwrapjs "^4.0.0"
-
-tallyho-detect-provider@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/tallyho-detect-provider/-/tallyho-detect-provider-1.0.2.tgz#6e462c34494217d39a83e22709dd855488b2d32d"
-  integrity sha512-VUGZiWUrKJUUjtnkib09tuNO7Kld4UWLs54nnNYP0tewvzmeb1VWDK0UTv88bEUcuRKx2YWGDIuOuK9v270Ewg==
-
-tallyho-onboarding@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/tallyho-onboarding/-/tallyho-onboarding-1.0.2.tgz#afc7dc4eb05b3a7861ead215e798585e1cbe2e91"
-  integrity sha512-bdFT/fNrFrq1BYVgjl/JKtwDmeS+z2u0415PoxmGmmYYRfdcKqXtEPImMoEbVwGtOeN0iFVohuS8ESrrAe+w7w==
-  dependencies:
-    bowser "^2.9.0"
 
 tapable@^2.2.0:
   version "2.2.1"


### PR DESCRIPTION
## What it solves

When MetaMask is intalled:
<img width="809" alt="Screenshot 2023-08-29 at 10 07 53" src="https://github.com/safe-global/safe-wallet-web/assets/381895/ab143864-51f9-4a91-9ae4-9a65288d0b59">

When Taho is installed:
<img width="822" alt="Screenshot 2023-08-29 at 10 09 29" src="https://github.com/safe-global/safe-wallet-web/assets/381895/80007fb9-03de-4996-9a38-071da8090e76">