### PR TITLE
fix: don't track clicks on disabled elements

### DIFF
--- a/src/components/common/Track/index.tsx
+++ b/src/components/common/Track/index.tsx
@@ -10,6 +10,11 @@ type Props = {
   label?: EventLabel
 }
 
+const shouldTrack = (el: HTMLDivElement) => {
+  const disabledChildren = el.querySelectorAll('*[disabled]')
+  return disabledChildren.length === 0
+}
+
 const Track = ({ children, as: Wrapper = 'span', ...trackData }: Props): typeof children => {
   const el = useRef<HTMLDivElement>(null)
 
@@ -20,9 +25,8 @@ const Track = ({ children, as: Wrapper = 'span', ...trackData }: Props): typeof 
 
     const trackEl = el.current
 
-    const handleClick = (e: MouseEvent) => {
-      // If clicked target is disabled, event.target will be trackEl
-      if (e.target !== trackEl) {
+    const handleClick = () => {
+      if (shouldTrack(trackEl)) {
         trackEvent(trackData)
       }
     }

--- a/src/components/common/Track/index.tsx
+++ b/src/components/common/Track/index.tsx
@@ -32,7 +32,7 @@ const Track = ({ children, as: Wrapper = 'span', ...trackData }: Props): typeof 
     return () => {
       trackEl.removeEventListener('click', handleClick)
     }
-  }, [children.type, el, trackData])
+  }, [el, trackData])
 
   if (children.type === Fragment) {
     throw new Error('Fragments cannot be tracked.')

--- a/src/components/common/Track/index.tsx
+++ b/src/components/common/Track/index.tsx
@@ -20,8 +20,11 @@ const Track = ({ children, as: Wrapper = 'span', ...trackData }: Props): typeof 
 
     const trackEl = el.current
 
-    const handleClick = () => {
-      trackEvent(trackData)
+    const handleClick = (e: MouseEvent) => {
+      // If clicked target is disabled, event.target will be trackEl
+      if (e.target !== trackEl) {
+        trackEvent(trackData)
+      }
     }
 
     // We cannot use onClick as events in children do not always bubble up
@@ -29,7 +32,7 @@ const Track = ({ children, as: Wrapper = 'span', ...trackData }: Props): typeof 
     return () => {
       trackEl.removeEventListener('click', handleClick)
     }
-  }, [el, trackData])
+  }, [children.type, el, trackData])
 
   if (children.type === Fragment) {
     throw new Error('Fragments cannot be tracked.')


### PR DESCRIPTION
## What it solves

Resolves #2405

## How this PR fixes it

Elements wrapped in `Track` now check whether the `children` is targetted. If not, it means that the clicked `target` is disabled and, as such, not tracked.

## How to test it

Click the following elements whilst disabled and observe no tracking event for them:

- Adding an owner
- Removing an owner
- Replacing an owner
- Change policies
- Adding a spending limit
- Removing a spending limit
- "Send" button in the assets table
- "Send" from the address book
- "Add to batch" from a tx from
- "New transaction" from the Add to batch section that opens from the topbar
- "Add a new tx" that shows when there are already batched tx in the menu displayed from the top bar
- "Confirm batch" from that same menu

## Checklist
* [ ] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
