### PR TITLE
fix: Remove ENS lookup from address book e2e test

### DIFF
--- a/cypress/e2e/smoke/address_book.cy.js
+++ b/cypress/e2e/smoke/address_book.cy.js
@@ -4,8 +4,7 @@ import { format } from 'date-fns'
 
 const NAME = 'Owner1'
 const EDITED_NAME = 'Edited Owner1'
-const ENS_NAME = 'diogo.eth'
-const ENS_ADDRESS = '0x6a5602335a878ADDCa4BF63a050E34946B56B5bC'
+const ADDRESS = '0x6a5602335a878ADDCa4BF63a050E34946B56B5bC'
 const GOERLI_TEST_SAFE = 'gor:0x97d314157727D517A706B5D08507A1f9B44AaaE9'
 const GNO_TEST_SAFE = 'gno:0xB8d760a90a5ed54D3c2b3EFC231277e99188642A'
 const GOERLI_CSV_ENTRY = {
@@ -30,13 +29,14 @@ describe('Address book', () => {
       // Add a new entry manually
       cy.contains('Create entry').click()
       cy.get('input[name="name"]').type(NAME)
-      cy.get('input[name="address"]').type(ENS_NAME)
-      // Name was translated
-      cy.get(ENS_NAME).should('not.exist')
+      cy.get('input[name="address"]').type(ADDRESS)
+
+      // Save the entry
       cy.contains('button', 'Save').click()
 
+      // The new entry is visible
       cy.contains(NAME).should('exist')
-      cy.contains(ENS_ADDRESS).should('exist')
+      cy.contains(ADDRESS).should('exist')
     })
 
     it('should save an edited entry name', () => {

--- a/cypress/e2e/smoke/batch_tx.cy.js
+++ b/cypress/e2e/smoke/batch_tx.cy.js
@@ -13,6 +13,8 @@ describe('Create batch transaction', () => {
   before(() => {
     cy.visit(`/home?safe=${SAFE}`)
     cy.contains('Accept selection').click()
+
+    cy.contains(/E2E Wallet @ G(ö|oe)rli/)
   })
 
   it('Should open an empty batch list', () => {


### PR DESCRIPTION
## What it solves

The address-book e2e test often fails if the provider call to resolve ENS takes too long. The ENS lookup is already covered by tests for the `AddressInput` and it is not possible to intercept the call via cypress so we can remove it there.

## How this PR fixes it

- Removes the ENS lookup from the address book e2e test