### PR TITLE
feat: add claim button to header

### DIFF
--- a/src/components/common/SafeTokenWidget/__tests__/SafeTokenWidget.test.tsx
+++ b/src/components/common/SafeTokenWidget/__tests__/SafeTokenWidget.test.tsx
@@ -6,7 +6,7 @@ import { BigNumber } from 'ethers'
 import SafeTokenWidget from '..'
 import { hexZeroPad } from 'ethers/lib/utils'
 import { AppRoutes } from '@/config/routes'
-import useSafeTokenAllocation from '@/hooks/useSafeTokenAllocation'
+import useSafeTokenAllocation, { useSafeTokenBalance } from '@/hooks/useSafeTokenAllocation'
 
 const MOCK_GOVERNANCE_APP_URL = 'https://mock.governance.safe.global'
 
@@ -52,21 +52,24 @@ describe('SafeTokenWidget', () => {
 
   it('Should render nothing for unsupported chains', () => {
     ;(useChainId as jest.Mock).mockImplementationOnce(jest.fn(() => '100'))
-    ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => [BigNumber.from(0), false])
+    ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => [[], , false])
+    ;(useSafeTokenBalance as jest.Mock).mockImplementation(() => [BigNumber.from(0), , false])
 
     const result = render(<SafeTokenWidget />)
     expect(result.baseElement).toContainHTML('<body><div /></body>')
   })
 
   it('Should display 0 if Safe has no SAFE token', async () => {
-    ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => [BigNumber.from(0), false])
+    ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => [[], , false])
+    ;(useSafeTokenBalance as jest.Mock).mockImplementation(() => [BigNumber.from(0), , false])
 
     const result = render(<SafeTokenWidget />)
     await waitFor(() => expect(result.baseElement).toHaveTextContent('0'))
   })
 
   it('Should display the value formatted correctly', async () => {
-    ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => [BigNumber.from('472238796133701648384'), false])
+    ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => [[], , false])
+    ;(useSafeTokenBalance as jest.Mock).mockImplementation(() => [BigNumber.from('472238796133701648384'), , false])
 
     // to avoid failing tests in some environments
     const NumberFormat = Intl.NumberFormat
@@ -82,13 +85,24 @@ describe('SafeTokenWidget', () => {
   })
 
   it('Should render a link to the governance app', async () => {
-    ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => [BigNumber.from(420000), false])
+    ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => [[], , false])
+    ;(useSafeTokenBalance as jest.Mock).mockImplementation(() => [BigNumber.from(420000), , false])
 
     const result = render(<SafeTokenWidget />)
     await waitFor(() => {
       expect(result.baseElement).toContainHTML(
         `href="${AppRoutes.apps.open}?safe=${fakeSafeAddress}&appUrl=${encodeURIComponent(MOCK_GOVERNANCE_APP_URL)}"`,
       )
+    })
+  })
+
+  it('Should render a claim button for SEP5 qualification', async () => {
+    ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => [[{ tag: 'user_v2' }], , false])
+    ;(useSafeTokenBalance as jest.Mock).mockImplementation(() => [BigNumber.from(420000), , false])
+
+    const result = render(<SafeTokenWidget />)
+    await waitFor(() => {
+      expect(result.baseElement).toContainHTML('New allocation')
     })
   })
 })

--- a/src/components/common/SafeTokenWidget/__tests__/SafeTokenWidget.test.tsx
+++ b/src/components/common/SafeTokenWidget/__tests__/SafeTokenWidget.test.tsx
@@ -6,7 +6,7 @@ import { BigNumber } from 'ethers'
 import SafeTokenWidget from '..'
 import { hexZeroPad } from 'ethers/lib/utils'
 import { AppRoutes } from '@/config/routes'
-import useSafeTokenAllocation, { useSafeTokenBalance } from '@/hooks/useSafeTokenAllocation'
+import useSafeTokenAllocation, { useSafeVotingPower } from '@/hooks/useSafeTokenAllocation'
 
 const MOCK_GOVERNANCE_APP_URL = 'https://mock.governance.safe.global'
 
@@ -53,7 +53,7 @@ describe('SafeTokenWidget', () => {
   it('Should render nothing for unsupported chains', () => {
     ;(useChainId as jest.Mock).mockImplementationOnce(jest.fn(() => '100'))
     ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => [[], , false])
-    ;(useSafeTokenBalance as jest.Mock).mockImplementation(() => [BigNumber.from(0), , false])
+    ;(useSafeVotingPower as jest.Mock).mockImplementation(() => [BigNumber.from(0), , false])
 
     const result = render(<SafeTokenWidget />)
     expect(result.baseElement).toContainHTML('<body><div /></body>')
@@ -61,7 +61,7 @@ describe('SafeTokenWidget', () => {
 
   it('Should display 0 if Safe has no SAFE token', async () => {
     ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => [[], , false])
-    ;(useSafeTokenBalance as jest.Mock).mockImplementation(() => [BigNumber.from(0), , false])
+    ;(useSafeVotingPower as jest.Mock).mockImplementation(() => [BigNumber.from(0), , false])
 
     const result = render(<SafeTokenWidget />)
     await waitFor(() => expect(result.baseElement).toHaveTextContent('0'))
@@ -69,7 +69,7 @@ describe('SafeTokenWidget', () => {
 
   it('Should display the value formatted correctly', async () => {
     ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => [[], , false])
-    ;(useSafeTokenBalance as jest.Mock).mockImplementation(() => [BigNumber.from('472238796133701648384'), , false])
+    ;(useSafeVotingPower as jest.Mock).mockImplementation(() => [BigNumber.from('472238796133701648384'), , false])
 
     // to avoid failing tests in some environments
     const NumberFormat = Intl.NumberFormat
@@ -86,7 +86,7 @@ describe('SafeTokenWidget', () => {
 
   it('Should render a link to the governance app', async () => {
     ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => [[], , false])
-    ;(useSafeTokenBalance as jest.Mock).mockImplementation(() => [BigNumber.from(420000), , false])
+    ;(useSafeVotingPower as jest.Mock).mockImplementation(() => [BigNumber.from(420000), , false])
 
     const result = render(<SafeTokenWidget />)
     await waitFor(() => {
@@ -98,7 +98,7 @@ describe('SafeTokenWidget', () => {
 
   it('Should render a claim button for SEP5 qualification', async () => {
     ;(useSafeTokenAllocation as jest.Mock).mockImplementation(() => [[{ tag: 'user_v2' }], , false])
-    ;(useSafeTokenBalance as jest.Mock).mockImplementation(() => [BigNumber.from(420000), , false])
+    ;(useSafeVotingPower as jest.Mock).mockImplementation(() => [BigNumber.from(420000), , false])
 
     const result = render(<SafeTokenWidget />)
     await waitFor(() => {

--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -2,7 +2,7 @@ import { SafeAppsTag, SAFE_TOKEN_ADDRESSES } from '@/config/constants'
 import { AppRoutes } from '@/config/routes'
 import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
 import useChainId from '@/hooks/useChainId'
-import useSafeTokenAllocation, { useSafeTokenBalance, type Vesting } from '@/hooks/useSafeTokenAllocation'
+import useSafeTokenAllocation, { useSafeVotingPower, type Vesting } from '@/hooks/useSafeTokenAllocation'
 import { OVERVIEW_EVENTS } from '@/services/analytics'
 import { formatVisualAmount } from '@/utils/formatters'
 import { Box, Button, ButtonBase, Skeleton, Tooltip, Typography } from '@mui/material'
@@ -28,7 +28,7 @@ const canRedeemSep5Airdrop = (allocation?: Vesting[]): boolean => {
     return false
   }
 
-  return !sep5Allocation.isRedeemed
+  return !sep5Allocation.isRedeemed && !sep5Allocation.isExpired
 }
 
 const SafeTokenWidget = () => {
@@ -38,7 +38,7 @@ const SafeTokenWidget = () => {
   const governanceApp = apps?.[0]
 
   const [allocationData, , allocationDataLoading] = useSafeTokenAllocation()
-  const [allocation, , allocationLoading] = useSafeTokenBalance(allocationData)
+  const [allocation, , allocationLoading] = useSafeVotingPower(allocationData)
 
   const tokenAddress = getSafeTokenAddress(chainId)
   if (!tokenAddress) {

--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -32,6 +32,8 @@ const canRedeemSep5Airdrop = (allocation?: Vesting[]): boolean => {
   return !sep5Allocation.isRedeemed && !sep5Allocation.isExpired
 }
 
+const SEP5_DEADLINE = '27.10.2023 10:00 UTC'
+
 const SafeTokenWidget = () => {
   const chainId = useChainId()
   const router = useRouter()
@@ -58,7 +60,9 @@ const SafeTokenWidget = () => {
 
   return (
     <Box className={css.buttonContainer}>
-      <Tooltip title={url ? `Open ${governanceApp?.name}` : ''}>
+      <Tooltip
+        title={url ? (canRedeemSep5 ? `New airdrop until ${SEP5_DEADLINE}` : `Open ${governanceApp?.name}`) : ''}
+      >
         <span>
           <Track {...OVERVIEW_EVENTS.SAFE_TOKEN_WIDGET}>
             <Link href={url || ''} passHref legacyBehavior>
@@ -90,9 +94,11 @@ const SafeTokenWidget = () => {
                   </UnreadBadge>
                 </Typography>
                 {canRedeemSep5 && (
-                  <Button variant="contained" className={css.redeemButton}>
-                    New allocation
-                  </Button>
+                  <Track {...OVERVIEW_EVENTS.SEP5_ALLOCATION_BUTTON}>
+                    <Button variant="contained" className={css.redeemButton}>
+                      New allocation
+                    </Button>
+                  </Track>
                 )}
               </ButtonBase>
             </Link>

--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -32,7 +32,7 @@ const canRedeemSep5Airdrop = (allocation?: Vesting[]): boolean => {
   return !sep5Allocation.isRedeemed && !sep5Allocation.isExpired
 }
 
-const SEP5_DEADLINE = '27.10.2023 10:00 UTC'
+const SEP5_DEADLINE = '27.10'
 
 const SafeTokenWidget = () => {
   const chainId = useChainId()
@@ -61,7 +61,13 @@ const SafeTokenWidget = () => {
   return (
     <Box className={css.buttonContainer}>
       <Tooltip
-        title={url ? (canRedeemSep5 ? `New airdrop until ${SEP5_DEADLINE}` : `Open ${governanceApp?.name}`) : ''}
+        title={
+          url
+            ? canRedeemSep5
+              ? `Claim any amount until ${SEP5_DEADLINE} to be eligible!`
+              : `Open ${governanceApp?.name}`
+            : ''
+        }
       >
         <span>
           <Track {...OVERVIEW_EVENTS.SAFE_TOKEN_WIDGET}>

--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -14,6 +14,7 @@ import Track from '../Track'
 import SafeTokenIcon from '@/public/images/common/safe-token.svg'
 import css from './styles.module.css'
 import UnreadBadge from '../UnreadBadge'
+import classnames from 'classnames'
 
 const TOKEN_DECIMALS = 18
 
@@ -63,8 +64,7 @@ const SafeTokenWidget = () => {
             <Link href={url || ''} passHref legacyBehavior>
               <ButtonBase
                 aria-describedby="safe-token-widget"
-                sx={canRedeemSep5 ? { height: '42px !important' } : undefined}
-                className={css.tokenButton}
+                className={classnames(css.tokenButton, { [css.sep5]: canRedeemSep5 })}
                 disabled={url === undefined}
               >
                 <SafeTokenIcon width={24} height={24} />

--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -2,10 +2,10 @@ import { SafeAppsTag, SAFE_TOKEN_ADDRESSES } from '@/config/constants'
 import { AppRoutes } from '@/config/routes'
 import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
 import useChainId from '@/hooks/useChainId'
-import useSafeTokenAllocation from '@/hooks/useSafeTokenAllocation'
+import useSafeTokenAllocation, { useSafeTokenBalance, type Vesting } from '@/hooks/useSafeTokenAllocation'
 import { OVERVIEW_EVENTS } from '@/services/analytics'
 import { formatVisualAmount } from '@/utils/formatters'
-import { Box, ButtonBase, Skeleton, Tooltip, Typography } from '@mui/material'
+import { Box, Button, ButtonBase, Skeleton, Tooltip, Typography } from '@mui/material'
 import { BigNumber } from 'ethers'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -13,11 +13,22 @@ import type { UrlObject } from 'url'
 import Track from '../Track'
 import SafeTokenIcon from '@/public/images/common/safe-token.svg'
 import css from './styles.module.css'
+import UnreadBadge from '../UnreadBadge'
 
 const TOKEN_DECIMALS = 18
 
 export const getSafeTokenAddress = (chainId: string): string => {
   return SAFE_TOKEN_ADDRESSES[chainId]
+}
+
+const canRedeemSep5Airdrop = (allocation?: Vesting[]): boolean => {
+  const sep5Allocation = allocation?.find(({ tag }) => tag === 'user_v2')
+
+  if (!sep5Allocation) {
+    return false
+  }
+
+  return !sep5Allocation.isRedeemed
 }
 
 const SafeTokenWidget = () => {
@@ -26,7 +37,8 @@ const SafeTokenWidget = () => {
   const [apps] = useRemoteSafeApps(SafeAppsTag.SAFE_GOVERNANCE_APP)
   const governanceApp = apps?.[0]
 
-  const [allocation, allocationLoading] = useSafeTokenAllocation()
+  const [allocationData, , allocationDataLoading] = useSafeTokenAllocation()
+  const [allocation, , allocationLoading] = useSafeTokenBalance(allocationData)
 
   const tokenAddress = getSafeTokenAddress(chainId)
   if (!tokenAddress) {
@@ -40,6 +52,7 @@ const SafeTokenWidget = () => {
       }
     : undefined
 
+  const canRedeemSep5 = canRedeemSep5Airdrop(allocationData)
   const flooredSafeBalance = formatVisualAmount(allocation || BigNumber.from(0), TOKEN_DECIMALS, 2)
 
   return (
@@ -50,14 +63,37 @@ const SafeTokenWidget = () => {
             <Link href={url || ''} passHref legacyBehavior>
               <ButtonBase
                 aria-describedby="safe-token-widget"
-                sx={{ alignSelf: 'stretch' }}
+                sx={canRedeemSep5 ? { height: '42px !important' } : undefined}
                 className={css.tokenButton}
                 disabled={url === undefined}
               >
                 <SafeTokenIcon width={24} height={24} />
-                <Typography component="div" lineHeight="16px" fontWeight={700}>
-                  {allocationLoading ? <Skeleton width="16px" animation="wave" /> : flooredSafeBalance}
+                <Typography
+                  component="div"
+                  lineHeight="16px"
+                  fontWeight={700}
+                  // Badge does not accept className so must be here
+                  className={css.allocationBadge}
+                >
+                  <UnreadBadge
+                    invisible={!canRedeemSep5}
+                    anchorOrigin={{
+                      vertical: 'bottom',
+                      horizontal: 'right',
+                    }}
+                  >
+                    {allocationDataLoading || allocationLoading ? (
+                      <Skeleton width="16px" animation="wave" />
+                    ) : (
+                      flooredSafeBalance
+                    )}
+                  </UnreadBadge>
                 </Typography>
+                {canRedeemSep5 && (
+                  <Button variant="contained" className={css.redeemButton}>
+                    New allocation
+                  </Button>
+                )}
               </ButtonBase>
             </Link>
           </Track>

--- a/src/components/common/SafeTokenWidget/styles.module.css
+++ b/src/components/common/SafeTokenWidget/styles.module.css
@@ -22,6 +22,10 @@
   align-self: stretch;
 }
 
+.sep5 {
+  height: 42px;
+}
+
 [data-theme='dark'] .allocationBadge :global .MuiBadge-dot {
   background-color: var(--color-primary-main);
 }

--- a/src/components/common/SafeTokenWidget/styles.module.css
+++ b/src/components/common/SafeTokenWidget/styles.module.css
@@ -19,4 +19,14 @@
   gap: var(--space-1);
   margin-left: 0;
   margin-right: 0;
+  align-self: stretch;
+}
+
+[data-theme='dark'] .allocationBadge :global .MuiBadge-dot {
+  background-color: var(--color-primary-main);
+}
+
+.redeemButton {
+  margin-left: var(--space-1);
+  padding: calc(var(--space-1) / 2) var(--space-1);
 }

--- a/src/hooks/__tests__/useSafeTokenAllocation.test.ts
+++ b/src/hooks/__tests__/useSafeTokenAllocation.test.ts
@@ -1,6 +1,11 @@
 import { renderHook, waitFor } from '@/tests/test-utils'
 import { defaultAbiCoder, hexZeroPad, keccak256, parseEther, toUtf8Bytes } from 'ethers/lib/utils'
-import useSafeTokenAllocation, { type VestingData, _getRedeemDeadline } from '../useSafeTokenAllocation'
+import useSafeTokenAllocation, {
+  type VestingData,
+  _getRedeemDeadline,
+  useSafeTokenBalance,
+  type Vesting,
+} from '../useSafeTokenAllocation'
 import * as web3 from '../wallets/web3'
 import * as useSafeInfoHook from '@/hooks/useSafeInfo'
 import { ZERO_ADDRESS } from '@safe-global/safe-core-sdk/dist/src/utils/constants'
@@ -55,8 +60,7 @@ describe('_getRedeemDeadline', () => {
   })
 })
 
-// TODO: use mockWeb3Provider()
-describe('useSafeTokenAllocation', () => {
+describe('Allocations', () => {
   afterEach(() => {
     //@ts-ignore
     global.fetch?.mockClear?.()
@@ -84,361 +88,302 @@ describe('useSafeTokenAllocation', () => {
     )
   })
 
-  test('return undefined without safe address', async () => {
-    jest.spyOn(useSafeInfoHook, 'default').mockImplementation(
-      () =>
-        ({
-          safeAddress: undefined,
-          safe: {
-            address: undefined,
-            chainId: '1',
+  describe('useSafeTokenAllocation', () => {
+    it('should return undefined without safe address', async () => {
+      jest.spyOn(useSafeInfoHook, 'default').mockImplementation(
+        () =>
+          ({
+            safeAddress: undefined,
+            safe: {
+              address: undefined,
+              chainId: '1',
+            },
+          } as any),
+      )
+
+      const { result } = renderHook(() => useSafeTokenAllocation())
+
+      await waitFor(() => {
+        expect(result.current[1]).toBeFalsy()
+        expect(result.current[0]).toBeUndefined()
+      })
+    })
+
+    it('should return an empty array without web3Provider', async () => {
+      global.fetch = jest.fn().mockImplementation(setupFetchStub('', 404))
+      const { result } = renderHook(() => useSafeTokenAllocation())
+
+      await waitFor(() => {
+        expect(result.current[1]).toBeFalsy()
+        expect(result.current[0]).toStrictEqual([])
+      })
+    })
+
+    it('should return an empty array if no allocations exist', async () => {
+      global.fetch = jest.fn().mockImplementation(setupFetchStub('', 404))
+      const mockFetch = jest.spyOn(global, 'fetch')
+
+      const { result } = renderHook(() => useSafeTokenAllocation())
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalled()
+        expect(result.current[0]).toStrictEqual([])
+        expect(result.current[1]).toBeFalsy()
+      })
+    })
+
+    it('should calculate expiration', async () => {
+      const mockAllocations = [
+        {
+          tag: 'user',
+          account: hexZeroPad('0x2', 20),
+          chainId: 1,
+          contract: hexZeroPad('0xabc', 20),
+          vestingId: hexZeroPad('0x4110', 32),
+          durationWeeks: 208,
+          startDate: 1657231200,
+          amount: '2000',
+          curve: 0,
+          proof: [],
+        },
+      ]
+
+      global.fetch = jest.fn().mockImplementation(setupFetchStub(mockAllocations, 200))
+      const mockFetch = jest.spyOn(global, 'fetch')
+
+      jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
+        () =>
+          ({
+            call: (transaction: any) => {
+              const vestingsSigHash = keccak256(toUtf8Bytes('vestings(bytes32)')).slice(0, 10)
+              const redeemDeadlineSigHash = keccak256(toUtf8Bytes('redeemDeadline()')).slice(0, 10)
+
+              if (transaction.data?.startsWith(vestingsSigHash)) {
+                return Promise.resolve(
+                  defaultAbiCoder.encode(
+                    ['address', 'uint8', 'bool', 'uint16', 'uint64', 'uint128', 'uint128', 'uint64', 'bool'],
+                    [ZERO_ADDRESS, '0x1', false, 208, 1657231200, 2000, 0, 0, false],
+                  ),
+                )
+              }
+              if (transaction.data?.startsWith(redeemDeadlineSigHash)) {
+                // 30th Nov 2022
+                return Promise.resolve(defaultAbiCoder.encode(['uint64'], [1669766400]))
+              }
+              return Promise.resolve('0x')
+            },
+          } as any),
+      )
+
+      const { result } = renderHook(() => useSafeTokenAllocation())
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalled()
+        expect(result.current[0]).toEqual([
+          {
+            ...mockAllocations[0],
+            amountClaimed: '0',
+            isExpired: true,
+            isRedeemed: false,
           },
-        } as any),
-    )
+        ])
+        expect(result.current[1]).toBeFalsy()
+      })
+    })
 
-    const { result } = renderHook(() => useSafeTokenAllocation())
+    it('should calculate redemption', async () => {
+      const mockAllocation = [
+        {
+          tag: 'user',
+          account: hexZeroPad('0x2', 20),
+          chainId: 1,
+          contract: hexZeroPad('0xabc', 20),
+          vestingId: hexZeroPad('0x4110', 32),
+          durationWeeks: 208,
+          startDate: 1657231200,
+          amount: '2000',
+          curve: 0,
+          proof: [],
+        },
+      ]
 
-    await waitFor(() => {
-      expect(result.current[1]).toBeFalsy()
-      expect(result.current[0]).toBeUndefined()
+      global.fetch = jest.fn().mockImplementation(setupFetchStub(mockAllocation, 200))
+      const mockFetch = jest.spyOn(global, 'fetch')
+
+      jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
+        () =>
+          ({
+            call: (transaction: any) => {
+              const vestingsSigHash = keccak256(toUtf8Bytes('vestings(bytes32)')).slice(0, 10)
+              const redeemDeadlineSigHash = keccak256(toUtf8Bytes('redeemDeadline()')).slice(0, 10)
+
+              if (transaction.data?.startsWith(vestingsSigHash)) {
+                return Promise.resolve(
+                  defaultAbiCoder.encode(
+                    ['address', 'uint8', 'bool', 'uint16', 'uint64', 'uint128', 'uint128', 'uint64', 'bool'],
+                    [hexZeroPad('0x2', 20), '0x1', false, 208, 1657231200, 2000, 0, 0, false],
+                  ),
+                )
+              }
+              if (transaction.data?.startsWith(redeemDeadlineSigHash)) {
+                // 08.Dec 2200
+                return Promise.resolve(defaultAbiCoder.encode(['uint64'], [7287610110]))
+              }
+              return Promise.resolve('0x')
+            },
+          } as any),
+      )
+
+      const { result } = renderHook(() => useSafeTokenAllocation())
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalled()
+        expect(result.current[0]).toEqual([
+          {
+            ...mockAllocation[0],
+            amountClaimed: BigNumber.from(0),
+            isExpired: false,
+            isRedeemed: true,
+          },
+        ])
+        expect(result.current[1]).toBeFalsy()
+      })
     })
   })
 
-  test('return 0 without web3Provider', async () => {
-    global.fetch = jest.fn().mockImplementation(setupFetchStub('', 404))
-    const { result } = renderHook(() => useSafeTokenAllocation())
+  describe('useSafeTokenBalance', () => {
+    it('should return undefined without allocation data', async () => {
+      const { result } = renderHook(() => useSafeTokenBalance())
 
-    await waitFor(() => {
-      expect(result.current[1]).toBeFalsy()
-      expect(result.current[0]?.toNumber()).toEqual(0)
+      await waitFor(() => {
+        expect(result.current[1]).toBeFalsy()
+        expect(result.current[0]).toBeUndefined()
+      })
     })
-  })
 
-  test('return 0 if no allocations / balances exist', async () => {
-    global.fetch = jest.fn().mockImplementation(setupFetchStub('', 404))
-    const mockFetch = jest.spyOn(global, 'fetch')
-    jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
-      () =>
-        ({
-          call: (transaction: any, blockTag?: any) => {
-            const sigHash = keccak256(toUtf8Bytes('balanceOf(address)')).slice(0, 10)
-            if (transaction.data?.startsWith(sigHash)) {
-              return Promise.resolve('0x0')
-            }
-            return Promise.resolve('0x')
-          },
-        } as any),
-    )
+    it('should return undefined without safe address', async () => {
+      jest.spyOn(useSafeInfoHook, 'default').mockImplementation(
+        () =>
+          ({
+            safeAddress: undefined,
+            safe: {
+              address: undefined,
+              chainId: '1',
+            },
+          } as any),
+      )
 
-    const { result } = renderHook(() => useSafeTokenAllocation())
+      const { result } = renderHook(() => useSafeTokenBalance([{} as Vesting]))
 
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalled()
-      expect(result.current[0]?.toNumber()).toEqual(0)
-      expect(result.current[1]).toBeFalsy()
+      await waitFor(() => {
+        expect(result.current[1]).toBeFalsy()
+        expect(result.current[0]).toBeUndefined()
+      })
     })
-  })
 
-  test('return balance if no allocation exists', async () => {
-    global.fetch = jest.fn().mockImplementation(setupFetchStub('', 404))
-    const mockFetch = jest.spyOn(global, 'fetch')
+    it('should return balance if no allocation exists', async () => {
+      jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
+        () =>
+          ({
+            call: (transaction: any) => {
+              const sigHash = keccak256(toUtf8Bytes('balanceOf(address)')).slice(0, 10)
 
-    jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
-      () =>
-        ({
-          call: (transaction: any, blockTag?: any) => {
-            const sigHash = keccak256(toUtf8Bytes('balanceOf(address)')).slice(0, 10)
-            if (transaction.data?.startsWith(sigHash)) {
-              return Promise.resolve(parseEther('100').toHexString())
-            }
-            return Promise.resolve('0x')
-          },
-        } as any),
-    )
+              if (transaction.data?.startsWith(sigHash)) {
+                return Promise.resolve(parseEther('100').toHexString())
+              }
+              return Promise.resolve('0x')
+            },
+          } as any),
+      )
 
-    const { result } = renderHook(() => useSafeTokenAllocation())
+      const { result } = renderHook(() => useSafeTokenBalance())
 
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalled()
-      expect(result.current[0]?.eq(parseEther('100'))).toBeTruthy()
-      expect(result.current[1]).toBeFalsy()
+      await waitFor(() => {
+        expect(result.current[0]?.eq(parseEther('100'))).toBeTruthy()
+        expect(result.current[1]).toBeFalsy()
+      })
     })
-  })
 
-  test('always return allocation if it is rededeemed', async () => {
-    const mockAllocation = [
-      {
-        tag: 'user',
-        account: hexZeroPad('0x2', 20),
-        chainId: 1,
-        contract: hexZeroPad('0xabc', 20),
-        vestingId: hexZeroPad('0x4110', 32),
-        durationWeeks: 208,
-        startDate: 1657231200,
-        amount: '2000',
-        curve: 0,
-        proof: [],
-      },
-    ]
+    test('formula: allocation - claimed + balance', async () => {
+      jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
+        () =>
+          ({
+            call: (transaction: any) => {
+              const balanceOfSigHash = keccak256(toUtf8Bytes('balanceOf(address)')).slice(0, 10)
 
-    global.fetch = jest.fn().mockImplementation(setupFetchStub(mockAllocation, 200))
-    const mockFetch = jest.spyOn(global, 'fetch')
+              if (transaction.data?.startsWith(balanceOfSigHash)) {
+                return Promise.resolve(BigNumber.from('400').toHexString())
+              }
+              return Promise.resolve('0x')
+            },
+          } as any),
+      )
 
-    jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
-      () =>
-        ({
-          call: (transaction: any, blockTag?: any) => {
-            const balanceOfSigHash = keccak256(toUtf8Bytes('balanceOf(address)')).slice(0, 10)
-            const vestingsSigHash = keccak256(toUtf8Bytes('vestings(bytes32)')).slice(0, 10)
+      const mockAllocation: Vesting[] = [
+        {
+          tag: 'user',
+          account: hexZeroPad('0x2', 20),
+          chainId: 1,
+          contract: hexZeroPad('0xabc', 20),
+          vestingId: hexZeroPad('0x4110', 32),
+          durationWeeks: 208,
+          startDate: 1657231200,
+          amount: '2000',
+          curve: 0,
+          proof: [],
+          isExpired: false,
+          isRedeemed: false,
+          amountClaimed: '1000',
+        },
+      ]
 
-            if (transaction.data?.startsWith(balanceOfSigHash)) {
-              return Promise.resolve(parseEther('0').toHexString())
-            }
-            if (transaction.data?.startsWith(vestingsSigHash)) {
-              return Promise.resolve(
-                defaultAbiCoder.encode(
-                  ['address', 'uint8', 'bool', 'uint16', 'uint64', 'uint128', 'uint128', 'uint64', 'bool'],
-                  [hexZeroPad('0x2', 20), '0x1', false, 208, 1657231200, 2000, 0, 0, false],
-                ),
-              )
-            }
-            return Promise.resolve('0x')
-          },
-        } as any),
-    )
+      const { result } = renderHook(() => useSafeTokenBalance(mockAllocation))
 
-    const { result } = renderHook(() => useSafeTokenAllocation())
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalled()
-      expect(result.current[0]?.toNumber()).toEqual(2000)
-      expect(result.current[1]).toBeFalsy()
+      await waitFor(() => {
+        expect(result.current[0]?.toNumber()).toEqual(2000 - 1000 + 400)
+        expect(result.current[1]).toBeFalsy()
+      })
     })
-  })
 
-  test('ignore not redeemed allocations if deadline has passed', async () => {
-    const mockAllocation = [
-      {
-        tag: 'user',
-        account: hexZeroPad('0x2', 20),
-        chainId: 1,
-        contract: hexZeroPad('0xabc', 20),
-        vestingId: hexZeroPad('0x4110', 32),
-        durationWeeks: 208,
-        startDate: 1657231200,
-        amount: '2000',
-        curve: 0,
-        proof: [],
-      },
-    ]
+    test('formula: allocation - claimed + balance, everything claimed and no balance', async () => {
+      jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
+        () =>
+          ({
+            call: (transaction: any) => {
+              const balanceOfSigHash = keccak256(toUtf8Bytes('balanceOf(address)')).slice(0, 10)
 
-    global.fetch = jest.fn().mockImplementation(setupFetchStub(mockAllocation, 200))
-    const mockFetch = jest.spyOn(global, 'fetch')
+              if (transaction.data?.startsWith(balanceOfSigHash)) {
+                return Promise.resolve(BigNumber.from('0').toHexString())
+              }
+              return Promise.resolve('0x')
+            },
+          } as any),
+      )
 
-    jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
-      () =>
-        ({
-          call: (transaction: any, blockTag?: any) => {
-            const balanceOfSigHash = keccak256(toUtf8Bytes('balanceOf(address)')).slice(0, 10)
-            const vestingsSigHash = keccak256(toUtf8Bytes('vestings(bytes32)')).slice(0, 10)
-            const redeemDeadlineSigHash = keccak256(toUtf8Bytes('redeemDeadline()')).slice(0, 10)
+      const mockAllocation: Vesting[] = [
+        {
+          tag: 'user',
+          account: hexZeroPad('0x2', 20),
+          chainId: 1,
+          contract: hexZeroPad('0xabc', 20),
+          vestingId: hexZeroPad('0x4110', 32),
+          durationWeeks: 208,
+          startDate: 1657231200,
+          amount: '2000',
+          curve: 0,
+          proof: [],
+          isExpired: false,
+          isRedeemed: false,
+          amountClaimed: '2000',
+        },
+      ]
 
-            if (transaction.data?.startsWith(balanceOfSigHash)) {
-              return Promise.resolve(parseEther('0').toHexString())
-            }
-            if (transaction.data?.startsWith(vestingsSigHash)) {
-              return Promise.resolve(
-                defaultAbiCoder.encode(
-                  ['address', 'uint8', 'bool', 'uint16', 'uint64', 'uint128', 'uint128', 'uint64', 'bool'],
-                  [ZERO_ADDRESS, 0, false, 0, 0, 0, 0, 0, false],
-                ),
-              )
-            }
-            if (transaction.data?.startsWith(redeemDeadlineSigHash)) {
-              // 30th Nov 2022
-              return Promise.resolve(defaultAbiCoder.encode(['uint64'], [1669766400]))
-            }
-            return Promise.resolve('0x')
-          },
-        } as any),
-    )
+      const { result } = renderHook(() => useSafeTokenBalance(mockAllocation))
 
-    const { result } = renderHook(() => useSafeTokenAllocation())
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalled()
-      expect(result.current[0]?.toNumber()).toEqual(0)
-      expect(result.current[1]).toBeFalsy()
-    })
-  })
-
-  test('add not redeemed allocations if deadline has not passed', async () => {
-    const mockAllocation = [
-      {
-        tag: 'user',
-        account: hexZeroPad('0x2', 20),
-        chainId: 1,
-        contract: hexZeroPad('0xabc', 20),
-        vestingId: hexZeroPad('0x4110', 32),
-        durationWeeks: 208,
-        startDate: 1657231200,
-        amount: '2000',
-        curve: 0,
-        proof: [],
-      },
-    ]
-
-    global.fetch = jest.fn().mockImplementation(setupFetchStub(mockAllocation, 200))
-    const mockFetch = jest.spyOn(global, 'fetch')
-
-    jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
-      () =>
-        ({
-          call: (transaction: any, blockTag?: any) => {
-            const balanceOfSigHash = keccak256(toUtf8Bytes('balanceOf(address)')).slice(0, 10)
-            const vestingsSigHash = keccak256(toUtf8Bytes('vestings(bytes32)')).slice(0, 10)
-            const redeemDeadlineSigHash = keccak256(toUtf8Bytes('redeemDeadline()')).slice(0, 10)
-
-            if (transaction.data?.startsWith(balanceOfSigHash)) {
-              return Promise.resolve(parseEther('0').toHexString())
-            }
-            if (transaction.data?.startsWith(vestingsSigHash)) {
-              return Promise.resolve(
-                defaultAbiCoder.encode(
-                  ['address', 'uint8', 'bool', 'uint16', 'uint64', 'uint128', 'uint128', 'uint64', 'bool'],
-                  [ZERO_ADDRESS, 0, false, 0, 0, 0, 0, 0, false],
-                ),
-              )
-            }
-            if (transaction.data?.startsWith(redeemDeadlineSigHash)) {
-              // 08.Dec 2200
-              return Promise.resolve(defaultAbiCoder.encode(['uint64'], [7287610110]))
-            }
-            return Promise.resolve('0x')
-          },
-        } as any),
-    )
-
-    const { result } = renderHook(() => useSafeTokenAllocation())
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalled()
-      expect(result.current[0]?.toNumber()).toEqual(2000)
-      expect(result.current[1]).toBeFalsy()
-    })
-  })
-
-  test('test formula: allocation - claimed + balance', async () => {
-    const mockAllocation = [
-      {
-        tag: 'user',
-        account: hexZeroPad('0x2', 20),
-        chainId: 1,
-        contract: hexZeroPad('0xabc', 20),
-        vestingId: hexZeroPad('0x4110', 32),
-        durationWeeks: 208,
-        startDate: 1657231200,
-        amount: '2000',
-        curve: 0,
-        proof: [],
-      },
-    ]
-
-    global.fetch = jest.fn().mockImplementation(setupFetchStub(mockAllocation, 200))
-    const mockFetch = jest.spyOn(global, 'fetch')
-
-    jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
-      () =>
-        ({
-          call: (transaction: any, blockTag?: any) => {
-            const balanceOfSigHash = keccak256(toUtf8Bytes('balanceOf(address)')).slice(0, 10)
-            const vestingsSigHash = keccak256(toUtf8Bytes('vestings(bytes32)')).slice(0, 10)
-            const redeemDeadlineSigHash = keccak256(toUtf8Bytes('redeemDeadline()')).slice(0, 10)
-
-            if (transaction.data?.startsWith(balanceOfSigHash)) {
-              return Promise.resolve(BigNumber.from('400').toHexString())
-            }
-            if (transaction.data?.startsWith(vestingsSigHash)) {
-              return Promise.resolve(
-                defaultAbiCoder.encode(
-                  ['address', 'uint8', 'bool', 'uint16', 'uint64', 'uint128', 'uint128', 'uint64', 'bool'],
-                  // 1000 of 2000 tokens are claimed
-                  [hexZeroPad('0x2', 20), '0x1', false, 208, 1657231200, 2000, 1000, 0, false],
-                ),
-              )
-            }
-            if (transaction.data?.startsWith(redeemDeadlineSigHash)) {
-              // 08.Dec 2200
-              return Promise.resolve(defaultAbiCoder.encode(['uint64'], [7287610110]))
-            }
-            return Promise.resolve('0x')
-          },
-        } as any),
-    )
-
-    const { result } = renderHook(() => useSafeTokenAllocation())
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalled()
-      expect(result.current[0]?.toNumber()).toEqual(2000 - 1000 + 400)
-      expect(result.current[1]).toBeFalsy()
-    })
-  })
-
-  test('test formula: allocation - claimed + balance, everything claimed and no balance', async () => {
-    const mockAllocation = [
-      {
-        tag: 'user',
-        account: hexZeroPad('0x2', 20),
-        chainId: 1,
-        contract: hexZeroPad('0xabc', 20),
-        vestingId: hexZeroPad('0x4110', 32),
-        durationWeeks: 208,
-        startDate: 1657231200,
-        amount: '2000',
-        curve: 0,
-        proof: [],
-      },
-    ]
-
-    global.fetch = jest.fn().mockImplementation(setupFetchStub(mockAllocation, 200))
-    const mockFetch = jest.spyOn(global, 'fetch')
-
-    jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
-      () =>
-        ({
-          call: (transaction: any, blockTag?: any) => {
-            const balanceOfSigHash = keccak256(toUtf8Bytes('balanceOf(address)')).slice(0, 10)
-            const vestingsSigHash = keccak256(toUtf8Bytes('vestings(bytes32)')).slice(0, 10)
-            const redeemDeadlineSigHash = keccak256(toUtf8Bytes('redeemDeadline()')).slice(0, 10)
-
-            if (transaction.data?.startsWith(balanceOfSigHash)) {
-              return Promise.resolve(BigNumber.from('0').toHexString())
-            }
-            if (transaction.data?.startsWith(vestingsSigHash)) {
-              return Promise.resolve(
-                defaultAbiCoder.encode(
-                  ['address', 'uint8', 'bool', 'uint16', 'uint64', 'uint128', 'uint128', 'uint64', 'bool'],
-                  // 1000 of 2000 tokens are claimed
-                  [hexZeroPad('0x2', 20), '0x1', false, 208, 1657231200, 2000, 2000, 0, false],
-                ),
-              )
-            }
-            if (transaction.data?.startsWith(redeemDeadlineSigHash)) {
-              // 08.Dec 2200
-              return Promise.resolve(defaultAbiCoder.encode(['uint64'], [7287610110]))
-            }
-            return Promise.resolve('0x')
-          },
-        } as any),
-    )
-
-    const { result } = renderHook(() => useSafeTokenAllocation())
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalled()
-      expect(result.current[0]?.toNumber()).toEqual(0)
-      expect(result.current[1]).toBeFalsy()
+      await waitFor(() => {
+        expect(result.current[0]?.toNumber()).toEqual(0)
+        expect(result.current[1]).toBeFalsy()
+      })
     })
   })
 })

--- a/src/hooks/__tests__/useSafeTokenAllocation.test.ts
+++ b/src/hooks/__tests__/useSafeTokenAllocation.test.ts
@@ -3,7 +3,7 @@ import { defaultAbiCoder, hexZeroPad, keccak256, parseEther, toUtf8Bytes } from 
 import useSafeTokenAllocation, {
   type VestingData,
   _getRedeemDeadline,
-  useSafeTokenBalance,
+  useSafeVotingPower,
   type Vesting,
 } from '../useSafeTokenAllocation'
 import * as web3 from '../wallets/web3'
@@ -253,7 +253,7 @@ describe('Allocations', () => {
 
   describe('useSafeTokenBalance', () => {
     it('should return undefined without allocation data', async () => {
-      const { result } = renderHook(() => useSafeTokenBalance())
+      const { result } = renderHook(() => useSafeVotingPower())
 
       await waitFor(() => {
         expect(result.current[1]).toBeFalsy()
@@ -273,7 +273,7 @@ describe('Allocations', () => {
           } as any),
       )
 
-      const { result } = renderHook(() => useSafeTokenBalance([{} as Vesting]))
+      const { result } = renderHook(() => useSafeVotingPower([{} as Vesting]))
 
       await waitFor(() => {
         expect(result.current[1]).toBeFalsy()
@@ -296,7 +296,7 @@ describe('Allocations', () => {
           } as any),
       )
 
-      const { result } = renderHook(() => useSafeTokenBalance())
+      const { result } = renderHook(() => useSafeVotingPower())
 
       await waitFor(() => {
         expect(result.current[0]?.eq(parseEther('100'))).toBeTruthy()
@@ -337,7 +337,7 @@ describe('Allocations', () => {
         },
       ]
 
-      const { result } = renderHook(() => useSafeTokenBalance(mockAllocation))
+      const { result } = renderHook(() => useSafeVotingPower(mockAllocation))
 
       await waitFor(() => {
         expect(result.current[0]?.toNumber()).toEqual(2000 - 1000 + 400)
@@ -378,7 +378,7 @@ describe('Allocations', () => {
         },
       ]
 
-      const { result } = renderHook(() => useSafeTokenBalance(mockAllocation))
+      const { result } = renderHook(() => useSafeVotingPower(mockAllocation))
 
       await waitFor(() => {
         expect(result.current[0]?.toNumber()).toEqual(0)

--- a/src/hooks/useSafeTokenAllocation.ts
+++ b/src/hooks/useSafeTokenAllocation.ts
@@ -142,7 +142,7 @@ const fetchTokenBalance = async (chainId: string, safeAddress: string): Promise<
  * The Safe token allocation is equal to the voting power.
  * It is computed by adding all vested tokens - claimed tokens + token balance
  */
-export const useSafeTokenBalance = (allocationData?: Vesting[]): AsyncResult<BigNumber> => {
+export const useSafeVotingPower = (allocationData?: Vesting[]): AsyncResult<BigNumber> => {
   const { safe, safeAddress } = useSafeInfo()
   const chainId = safe.chainId
 

--- a/src/hooks/useSafeTokenAllocation.ts
+++ b/src/hooks/useSafeTokenAllocation.ts
@@ -6,7 +6,7 @@ import { isPast } from 'date-fns'
 import { BigNumber } from 'ethers'
 import { defaultAbiCoder, Interface } from 'ethers/lib/utils'
 import { useMemo } from 'react'
-import useAsync from './useAsync'
+import useAsync, { type AsyncResult } from './useAsync'
 import useSafeInfo from './useSafeInfo'
 import { getWeb3ReadOnly } from './wallets/web3'
 import { memoize } from 'lodash'
@@ -30,7 +30,7 @@ export type VestingData = {
   proof: string[]
 }
 
-type Vesting = VestingData & {
+export type Vesting = VestingData & {
   isExpired: boolean
   isRedeemed: boolean
   amountClaimed: string
@@ -107,6 +107,22 @@ const fetchAllocation = async (chainId: string, safeAddress: string): Promise<Ve
   }
 }
 
+const useSafeTokenAllocation = (): AsyncResult<Vesting[]> => {
+  const { safe, safeAddress } = useSafeInfo()
+  const chainId = safe.chainId
+
+  return useAsync<Vesting[] | undefined>(async () => {
+    if (!safeAddress) return
+    return Promise.all(
+      await fetchAllocation(chainId, safeAddress).then((allocations) =>
+        allocations.map((allocation) => completeAllocation(allocation)),
+      ),
+    )
+    // If the history tag changes we could have claimed / redeemed tokens
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chainId, safeAddress, safe.txHistoryTag])
+}
+
 const fetchTokenBalance = async (chainId: string, safeAddress: string): Promise<string> => {
   try {
     const web3ReadOnly = getWeb3ReadOnly()
@@ -126,22 +142,11 @@ const fetchTokenBalance = async (chainId: string, safeAddress: string): Promise<
  * The Safe token allocation is equal to the voting power.
  * It is computed by adding all vested tokens - claimed tokens + token balance
  */
-const useSafeTokenAllocation = (): [BigNumber | undefined, boolean] => {
+export const useSafeTokenBalance = (allocationData?: Vesting[]): AsyncResult<BigNumber> => {
   const { safe, safeAddress } = useSafeInfo()
   const chainId = safe.chainId
 
-  const [allocationData, _, allocationLoading] = useAsync<Vesting[] | undefined>(async () => {
-    if (!safeAddress) return
-    return Promise.all(
-      await fetchAllocation(chainId, safeAddress).then((allocations) =>
-        allocations.map((allocation) => completeAllocation(allocation)),
-      ),
-    )
-    // If the history tag changes we could have claimed / redeemed tokens
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chainId, safeAddress, safe.txHistoryTag])
-
-  const [balance, _error, balanceLoading] = useAsync<string>(() => {
+  const [balance, balanceError, balanceLoading] = useAsync<string>(() => {
     if (!safeAddress) return
     return fetchTokenBalance(chainId, safeAddress)
     // If the history tag changes we could have claimed / redeemed tokens
@@ -149,7 +154,14 @@ const useSafeTokenAllocation = (): [BigNumber | undefined, boolean] => {
   }, [chainId, safeAddress, safe.txHistoryTag])
 
   const allocation = useMemo(() => {
-    if (!allocationData || !balance) return
+    if (!balance) {
+      return
+    }
+
+    // Return current balance if no allocation exists
+    if (!allocationData) {
+      return BigNumber.from(balance)
+    }
 
     const tokensInVesting = allocationData.reduce(
       (acc, data) => (data.isExpired ? acc : acc.add(data.amount).sub(data.amountClaimed)),
@@ -161,7 +173,7 @@ const useSafeTokenAllocation = (): [BigNumber | undefined, boolean] => {
     return totalAllocation
   }, [allocationData, balance])
 
-  return [allocation, allocationLoading || balanceLoading]
+  return [allocation, balanceError, balanceLoading]
 }
 
 export default useSafeTokenAllocation

--- a/src/services/analytics/events/overview.ts
+++ b/src/services/analytics/events/overview.ts
@@ -88,4 +88,8 @@ export const OVERVIEW_EVENTS = {
     action: 'Open relaying help article',
     category: OVERVIEW_CATEGORY,
   },
+  SEP5_ALLOCATION_BUTTON: {
+    action: 'Click on SEP5 allocation button',
+    category: OVERVIEW_CATEGORY,
+  },
 }


### PR DESCRIPTION
## What it solves

Implements claim button in header

## How this PR fixes it

The token allocation element in the header now includes a "New allocation" button according to [the designs](https://www.figma.com/file/ptTs6lDBeUuLNySroJ5PiF/Web-Master-File?type=design&node-id=7969-133988&mode=design&t=6FeK1GEhF8jSaoo7-0). Clicking it will take you to the claiming app and, providing there is nothing to claim, it should not appear.

## How to test it

Open a Safe with an allocation and observe the new button. Claiming should make it dissappear and opening a Safe _without_ an allocation should not show it at all.

Clicking on the button should the following event: "Click on SEP5 allocation button".

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/e4fb216d-936c-455e-b07e-0f62a07fbe2d)

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/2d977a6d-28ed-42b3-b17b-4b4518813f56)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
