### PR TITLE
style: welcome screen re-ordering enhancement for mobile view

### DIFF
--- a/src/components/welcome/NewSafe.tsx
+++ b/src/components/welcome/NewSafe.tsx
@@ -42,8 +42,8 @@ const NewSafe = () => {
   }
 
   return (
-    <Grid container spacing={3} p={3} pb={0} flex={1} direction={'row-reverse'}>
-      <Grid item xs={12} md={4} lg={3.5} minWidth={{ md: 480 }} className={css.sidebar} order={2}>
+    <Grid container spacing={3} p={3} pb={0} flex={1}>
+      <Grid item xs={12} md={4} lg={3.5} minWidth={{ md: 480 }} className={css.sidebar}>
         <Box display="flex" flexDirection="column" height="100%">
           <Box flex={1}>
             <Accordion className={css.accordion} onClick={toggleSafeList} expanded={expanded} defaultExpanded={true}>
@@ -59,13 +59,27 @@ const NewSafe = () => {
             </Accordion>
           </Box>
 
-          <Box mt={2}>
+          <Box mt={2} display={{ xs: 'none', md: 'block' }}>
             <DataWidget />
           </Box>
         </Box>
       </Grid>
+      <Grid
+        item
+        xs={12}
+        md={4}
+        lg={3.5}
+        minWidth={{ md: 480 }}
+        className={css.sidebar}
+        display={{ md: 'none' }}
+        order={3}
+      >
+        <Box>
+          <DataWidget />
+        </Box>
+      </Grid>
 
-      <Grid item flex={1} order={1}>
+      <Grid item flex={1}>
         <div className={css.content}>
           <Typography
             variant="h1"

--- a/src/components/welcome/NewSafe.tsx
+++ b/src/components/welcome/NewSafe.tsx
@@ -42,8 +42,8 @@ const NewSafe = () => {
   }
 
   return (
-    <Grid container spacing={3} p={3} pb={0} flex={1}>
-      <Grid item xs={12} md={4} lg={3.5} minWidth={{ md: 480 }} className={css.sidebar}>
+    <Grid container spacing={3} p={3} pb={0} flex={1} direction={'row-reverse'}>
+      <Grid item xs={12} md={4} lg={3.5} minWidth={{ md: 480 }} className={css.sidebar} order={2}>
         <Box display="flex" flexDirection="column" height="100%">
           <Box flex={1}>
             <Accordion className={css.accordion} onClick={toggleSafeList} expanded={expanded} defaultExpanded={true}>
@@ -65,7 +65,7 @@ const NewSafe = () => {
         </Box>
       </Grid>
 
-      <Grid item flex={1}>
+      <Grid item flex={1} order={1}>
         <div className={css.content}>
           <Typography
             variant="h1"


### PR DESCRIPTION
## What it solves
It changes the order of "welcome to safe{wallet}" component in the welcome screen in mobile view

Resolves #2473 

## How this PR fixes it
Using the Row-reverse property of grid, it changes the order of the components on mobile view

## How to test it
In desktop view, The import component will be in left and the welcome component will be in right
In mobile view, The welcome component will be in top and the import component will be in bottom

## Screenshots
Desktop:
<img width="1978" alt="CleanShot 2023-08-31 at 09 07 46@2x" src="https://github.com/safe-global/safe-wallet-web/assets/24606613/cb6ac51f-5009-4c78-9bb0-6d4e520be305">
Mobile:
<img width="872" alt="CleanShot 2023-08-31 at 09 08 36@2x" src="https://github.com/safe-global/safe-wallet-web/assets/24606613/28363bbc-8ee0-4cbf-ac9e-7cdd9e62c118">


## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
