### PR TITLE
fix: SAFE token balance in header

### DIFF
--- a/src/hooks/useSafeTokenAllocation.ts
+++ b/src/hooks/useSafeTokenAllocation.ts
@@ -157,7 +157,7 @@ const useSafeTokenAllocation = (): [BigNumber | undefined, boolean] => {
     )
 
     // add balance
-    const totalAllocation = tokensInVesting.add(balance || '0')
+    const totalAllocation = tokensInVesting.add(BigNumber.from(balance))
     return totalAllocation
   }, [allocationData, balance])
 


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/safe-wallet-web/pull/2462#issuecomment-1700369218

## How this PR fixes it

The balance is first converted to a `BigNumber`. "Empty" balances were returned as `0x` which caused `add` to throw.

## How to test it

Switch from `gno:0xB8d760a90a5ed54D3c2b3EFC231277e99188642A` to `eth:0x8675B754342754A30A2AeF474D114d8460bca19b` and observe no crash. Switching the other way should not either.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
