### PR TITLE
Chore: track tx errors on Sentry

### DIFF
--- a/src/components/new-safe/create/logic/index.ts
+++ b/src/components/new-safe/create/logic/index.ts
@@ -9,7 +9,7 @@ import type { ConnectedWallet } from '@/services/onboard'
 import { BigNumber } from '@ethersproject/bignumber'
 import { SafeCreationStatus } from '@/components/new-safe/create/steps/StatusStep/useSafeCreation'
 import { didRevert, type EthersError } from '@/utils/ethers-utils'
-import { Errors, logError } from '@/services/exceptions'
+import { Errors, trackError } from '@/services/exceptions'
 import { ErrorCode } from '@ethersproject/logger'
 import { isWalletRejection } from '@/utils/wallets'
 import type { PendingSafeTx } from '@/components/new-safe/create/types'
@@ -167,7 +167,7 @@ export const pollSafeInfo = async (chainId: string, safeAddress: string): Promis
 }
 
 export const handleSafeCreationError = (error: EthersError) => {
-  logError(Errors._800, error.message)
+  trackError(Errors._800, error.message)
 
   if (isWalletRejection(error)) {
     return SafeCreationStatus.WALLET_REJECTED

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -3,7 +3,7 @@ import { Box, Button, CardActions, Divider } from '@mui/material'
 import classNames from 'classnames'
 
 import ErrorMessage from '@/components/tx/ErrorMessage'
-import { logError, Errors } from '@/services/exceptions'
+import { trackError, Errors } from '@/services/exceptions'
 import { useCurrentChain } from '@/hooks/useChains'
 import { getTxOptions } from '@/utils/transactions'
 import useIsValidExecution from '@/hooks/useIsValidExecution'
@@ -93,7 +93,7 @@ const ExecuteForm = ({
       setTxFlow(<SuccessScreen txId={executedTxId} />, undefined, false)
     } catch (_err) {
       const err = asError(_err)
-      logError(Errors._804, err)
+      trackError(Errors._804, err)
       setIsSubmittable(true)
       setSubmitError(err)
       return

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -2,7 +2,7 @@ import { type ReactElement, type SyntheticEvent, useContext, useState } from 're
 import { Box, Button, CardActions, Divider } from '@mui/material'
 
 import ErrorMessage from '@/components/tx/ErrorMessage'
-import { logError, Errors } from '@/services/exceptions'
+import { trackError, Errors } from '@/services/exceptions'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import CheckWallet from '@/components/common/CheckWallet'
 import { useAlreadySigned, useTxActions } from './hooks'
@@ -60,7 +60,7 @@ const SignForm = ({
       await (isAddingToBatch ? addToBatch(safeTx, origin) : signTx(safeTx, txId, origin, tx))
     } catch (_err) {
       const err = asError(_err)
-      logError(Errors._804, err)
+      trackError(Errors._804, err)
       setIsSubmittable(true)
       setSubmitError(err)
       return

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -60,7 +60,7 @@ const SignForm = ({
       await (isAddingToBatch ? addToBatch(safeTx, origin) : signTx(safeTx, txId, origin, tx))
     } catch (_err) {
       const err = asError(_err)
-      trackError(Errors._804, err)
+      trackError(Errors._805, err)
       setIsSubmittable(true)
       setSubmitError(err)
       return

--- a/src/services/exceptions/ErrorCodes.ts
+++ b/src/services/exceptions/ErrorCodes.ts
@@ -44,7 +44,8 @@ enum ErrorCodes {
 
   _800 = '800: Safe creation tx failed',
   _801 = '801: Failed to send a tx with a spending limit',
-  _804 = '804: Error processing a transaction',
+  _804 = '804: Error executing a transaction',
+  _805 = '805: Error proposing or confirming a transaction',
   _806 = '806: Failed to remove module',
   _807 = '807: Failed to remove guard',
   _808 = '808: Failed to get transaction origin',


### PR DESCRIPTION
## What it solves

We now have almost no uncaught exceptions on Sentry, so we can track more stuff.
Like failed executions, signatures and Safe creations. This might help when debugging support requests.