### PR TITLE
Update default value for Relay Service URL

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -62,7 +62,7 @@ export enum SafeAppsTag {
 
 // Safe Gelato relay service
 export const SAFE_RELAY_SERVICE_URL_PRODUCTION =
-  process.env.NEXT_PUBLIC_SAFE_RELAY_SERVICE_URL_PRODUCTION || 'https://safe-client-nest.safe.global/v1/relay'
+  process.env.NEXT_PUBLIC_SAFE_RELAY_SERVICE_URL_PRODUCTION || 'https://safe-client.safe.global/v1/relay'
 export const SAFE_RELAY_SERVICE_URL_STAGING =
   process.env.NEXT_PUBLIC_SAFE_RELAY_SERVICE_URL_STAGING || 'https://safe-client.staging.5afe.dev/v1/relay'
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -64,7 +64,7 @@ export enum SafeAppsTag {
 export const SAFE_RELAY_SERVICE_URL_PRODUCTION =
   process.env.NEXT_PUBLIC_SAFE_RELAY_SERVICE_URL_PRODUCTION || 'https://safe-client-nest.safe.global/v1/relay'
 export const SAFE_RELAY_SERVICE_URL_STAGING =
-  process.env.NEXT_PUBLIC_SAFE_RELAY_SERVICE_URL_STAGING || 'https://safe-client-nest.staging.5afe.dev/v1/relay'
+  process.env.NEXT_PUBLIC_SAFE_RELAY_SERVICE_URL_STAGING || 'https://safe-client.staging.5afe.dev/v1/relay'
 
 // Help Center
 export const HELP_CENTER_URL = 'https://help.safe.global'


### PR DESCRIPTION
## What it solves

The `-nest` name in the domain name should not be used anymore and will be removed in the future. This PR updates the respective value to use the new supported URL.

## How this PR fixes it

- Updates the default value set for `SAFE_RELAY_SERVICE_URL_STAGING` from `https://safe-client-nest.staging.5afe.dev/v1/relay` to `https://safe-client.staging.5afe.dev/v1/relay`
- Updates the default value set for `SAFE_RELAY_SERVICE_URL_PRODUCTION` from `https://safe-client-nest.safe.global/v1/relay` to `https://safe-client.safe.global/v1/relay`

## How to test it

NA

## Screenshots

NA

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
