### PR TITLE
Fix: reset body scroll after mobile pairing

### DIFF
--- a/src/services/pairing/QRModal.tsx
+++ b/src/services/pairing/QRModal.tsx
@@ -45,6 +45,7 @@ const close = () => {
   const wrapper = document.getElementById(WRAPPER_ID)
   if (wrapper) {
     document.body.removeChild(wrapper)
+    document.body.style.overflow = ''
   }
 }
 


### PR DESCRIPTION
## What it solves

Resolves #2225

## How this PR fixes it

After the mobile pairing modal is closed, we reset the body element's overflow style.