### PR TITLE
feat: add push notification tracking

### DIFF
--- a/src/components/settings/PushNotifications/hooks/__tests__/useNotificationPreferences.test.ts
+++ b/src/components/settings/PushNotifications/hooks/__tests__/useNotificationPreferences.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@/services/push-notifications/preferences'
 import {
   useNotificationPreferences,
-  _DEFAULT_NOTIFICATION_PREFERENCES,
+  DEFAULT_NOTIFICATION_PREFERENCES,
   _setPreferences,
   _setUuid,
 } from '../useNotificationPreferences'
@@ -66,7 +66,7 @@ describe('useNotificationPreferences', () => {
         [`${chainId}:${safeAddress}`]: {
           chainId,
           safeAddress,
-          preferences: _DEFAULT_NOTIFICATION_PREFERENCES,
+          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
         },
       }
 
@@ -87,7 +87,7 @@ describe('useNotificationPreferences', () => {
         [`${chainId}:${safeAddress}`]: {
           chainId,
           safeAddress,
-          preferences: _DEFAULT_NOTIFICATION_PREFERENCES,
+          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
         },
       }
 
@@ -121,17 +121,17 @@ describe('useNotificationPreferences', () => {
           [`${chainId1}:${safeAddress1}`]: {
             chainId: chainId1,
             safeAddress: safeAddress1,
-            preferences: _DEFAULT_NOTIFICATION_PREFERENCES,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
           },
           [`${chainId1}:${safeAddress2}`]: {
             chainId: chainId1,
             safeAddress: safeAddress2,
-            preferences: _DEFAULT_NOTIFICATION_PREFERENCES,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
           },
           [`${chainId2}:${safeAddress1}`]: {
             chainId: chainId2,
             safeAddress: safeAddress1,
-            preferences: _DEFAULT_NOTIFICATION_PREFERENCES,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
           },
         })
       })
@@ -145,7 +145,7 @@ describe('useNotificationPreferences', () => {
         [`${chainId}:${safeAddress}`]: {
           chainId: chainId,
           safeAddress: safeAddress,
-          preferences: _DEFAULT_NOTIFICATION_PREFERENCES,
+          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
         },
       }
 
@@ -154,7 +154,7 @@ describe('useNotificationPreferences', () => {
       const { result } = renderHook(() => useNotificationPreferences())
 
       result.current.updatePreferences(chainId, safeAddress, {
-        ..._DEFAULT_NOTIFICATION_PREFERENCES,
+        ...DEFAULT_NOTIFICATION_PREFERENCES,
         [WebhookType.NEW_CONFIRMATION]: false,
       })
 
@@ -164,7 +164,7 @@ describe('useNotificationPreferences', () => {
             chainId: chainId,
             safeAddress: safeAddress,
             preferences: {
-              ..._DEFAULT_NOTIFICATION_PREFERENCES,
+              ...DEFAULT_NOTIFICATION_PREFERENCES,
               [WebhookType.NEW_CONFIRMATION]: false,
             },
           },
@@ -183,17 +183,17 @@ describe('useNotificationPreferences', () => {
         [`${chainId1}:${safeAddress1}`]: {
           chainId: chainId1,
           safeAddress: safeAddress1,
-          preferences: _DEFAULT_NOTIFICATION_PREFERENCES,
+          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
         },
         [`${chainId1}:${safeAddress2}`]: {
           chainId: chainId1,
           safeAddress: safeAddress2,
-          preferences: _DEFAULT_NOTIFICATION_PREFERENCES,
+          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
         },
         [`${chainId2}:${safeAddress1}`]: {
           chainId: chainId2,
           safeAddress: safeAddress1,
-          preferences: _DEFAULT_NOTIFICATION_PREFERENCES,
+          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
         },
       }
 
@@ -210,7 +210,7 @@ describe('useNotificationPreferences', () => {
           [`${chainId2}:${safeAddress1}`]: {
             chainId: chainId2,
             safeAddress: safeAddress1,
-            preferences: _DEFAULT_NOTIFICATION_PREFERENCES,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
           },
         })
       })
@@ -227,17 +227,17 @@ describe('useNotificationPreferences', () => {
         [`${chainId1}:${safeAddress1}`]: {
           chainId: chainId1,
           safeAddress: safeAddress1,
-          preferences: _DEFAULT_NOTIFICATION_PREFERENCES,
+          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
         },
         [`${chainId1}:${safeAddress2}`]: {
           chainId: chainId1,
           safeAddress: safeAddress2,
-          preferences: _DEFAULT_NOTIFICATION_PREFERENCES,
+          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
         },
         [`${chainId2}:${safeAddress1}`]: {
           chainId: chainId2,
           safeAddress: safeAddress1,
-          preferences: _DEFAULT_NOTIFICATION_PREFERENCES,
+          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
         },
       }
 
@@ -272,17 +272,17 @@ describe('useNotificationPreferences', () => {
         [`${chainId1}:${safeAddress1}`]: {
           chainId: chainId1,
           safeAddress: safeAddress1,
-          preferences: _DEFAULT_NOTIFICATION_PREFERENCES,
+          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
         },
         [`${chainId1}:${safeAddress2}`]: {
           chainId: chainId1,
           safeAddress: safeAddress2,
-          preferences: _DEFAULT_NOTIFICATION_PREFERENCES,
+          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
         },
         [`${chainId2}:${safeAddress1}`]: {
           chainId: chainId2,
           safeAddress: safeAddress1,
-          preferences: _DEFAULT_NOTIFICATION_PREFERENCES,
+          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
         },
       }
 

--- a/src/components/settings/PushNotifications/hooks/__tests__/useNotificationTracking.test.ts
+++ b/src/components/settings/PushNotifications/hooks/__tests__/useNotificationTracking.test.ts
@@ -1,0 +1,106 @@
+import 'fake-indexeddb/auto'
+import { entries, setMany } from 'idb-keyval'
+
+import * as tracking from '@/services/analytics'
+import { PUSH_NOTIFICATION_EVENTS } from '@/services/analytics/events/push-notifications'
+import { createNotificationTrackingIndexedDb } from '@/services/push-notifications/tracking'
+import { WebhookType } from '@/service-workers/firebase-messaging/webhook-types'
+import { renderHook, waitFor } from '@/tests/test-utils'
+import { useNotificationTracking } from '../useNotificationTracking'
+
+jest.mock('@/services/analytics', () => ({
+  trackEvent: jest.fn(),
+}))
+
+describe('useNotificationTracking', () => {
+  beforeEach(() => {
+    // Reset indexedDB
+    indexedDB = new IDBFactory()
+    jest.clearAllMocks()
+  })
+
+  it('should track all cached events and clear the cache', async () => {
+    jest.spyOn(tracking, 'trackEvent')
+
+    const cache = {
+      [`1:${WebhookType.INCOMING_ETHER}`]: {
+        shown: 1,
+        opened: 0,
+      },
+      [`2:${WebhookType.OUTGOING_ETHER}`]: {
+        shown: 0,
+        opened: 1,
+      },
+      [`3:${WebhookType.INCOMING_TOKEN}`]: {
+        shown: 1,
+        opened: 1,
+      },
+      [`137:${WebhookType.OUTGOING_TOKEN}`]: {
+        shown: 0,
+        opened: 0,
+      },
+    }
+
+    await setMany(Object.entries(cache), createNotificationTrackingIndexedDb())
+
+    renderHook(() => useNotificationTracking())
+
+    await waitFor(() => {
+      expect(tracking.trackEvent).toHaveBeenCalledTimes(4)
+
+      expect(tracking.trackEvent).toHaveBeenCalledWith({
+        ...PUSH_NOTIFICATION_EVENTS.SHOW_NOTIFICATION,
+        label: WebhookType.INCOMING_ETHER,
+        chainId: '1',
+      })
+
+      expect(tracking.trackEvent).toHaveBeenCalledWith({
+        ...PUSH_NOTIFICATION_EVENTS.OPEN_NOTIFICATION,
+        label: WebhookType.OUTGOING_ETHER,
+        chainId: '2',
+      })
+
+      expect(tracking.trackEvent).toHaveBeenCalledWith({
+        ...PUSH_NOTIFICATION_EVENTS.SHOW_NOTIFICATION,
+        label: WebhookType.INCOMING_TOKEN,
+        chainId: '3',
+      })
+      expect(tracking.trackEvent).toHaveBeenCalledWith({
+        ...PUSH_NOTIFICATION_EVENTS.OPEN_NOTIFICATION,
+        label: WebhookType.INCOMING_TOKEN,
+        chainId: '3',
+      })
+    })
+
+    const _entries = await entries(createNotificationTrackingIndexedDb())
+    expect(Object.fromEntries(_entries)).toStrictEqual({
+      [`1:${WebhookType.INCOMING_ETHER}`]: {
+        shown: 0,
+        opened: 0,
+      },
+      [`2:${WebhookType.OUTGOING_ETHER}`]: {
+        shown: 0,
+        opened: 0,
+      },
+      [`3:${WebhookType.INCOMING_TOKEN}`]: {
+        shown: 0,
+        opened: 0,
+      },
+      [`137:${WebhookType.OUTGOING_TOKEN}`]: {
+        shown: 0,
+        opened: 0,
+      },
+    })
+  })
+
+  it('should not track if no cache exists', async () => {
+    jest.spyOn(tracking, 'trackEvent')
+
+    const _entries = await entries(createNotificationTrackingIndexedDb())
+    expect(_entries).toStrictEqual([])
+
+    renderHook(() => useNotificationTracking())
+
+    expect(tracking.trackEvent).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/settings/PushNotifications/hooks/useNotificationPreferences.ts
+++ b/src/components/settings/PushNotifications/hooks/useNotificationPreferences.ts
@@ -18,7 +18,7 @@ import {
 import type { PushNotificationPreferences, PushNotificationPrefsKey } from '@/services/push-notifications/preferences'
 import type { NotifiableSafes } from '../logic'
 
-export const _DEFAULT_NOTIFICATION_PREFERENCES: PushNotificationPreferences[PushNotificationPrefsKey]['preferences'] = {
+export const DEFAULT_NOTIFICATION_PREFERENCES: PushNotificationPreferences[PushNotificationPrefsKey]['preferences'] = {
   [WebhookType.NEW_CONFIRMATION]: true,
   [WebhookType.EXECUTED_MULTISIG_TRANSACTION]: true,
   [WebhookType.PENDING_MULTISIG_TRANSACTION]: true,
@@ -42,7 +42,7 @@ export const _setPreferences = setPreferences
 export const useNotificationPreferences = (): {
   uuid: string | undefined
   getAllPreferences: () => PushNotificationPreferences | undefined
-  getPreferences: (chainId: string, safeAddress: string) => typeof _DEFAULT_NOTIFICATION_PREFERENCES | undefined
+  getPreferences: (chainId: string, safeAddress: string) => typeof DEFAULT_NOTIFICATION_PREFERENCES | undefined
   updatePreferences: (
     chainId: string,
     safeAddress: string,
@@ -143,7 +143,7 @@ export const useNotificationPreferences = (): {
           const defaultPreferences: PushNotificationPreferences[PushNotificationPrefsKey] = {
             chainId,
             safeAddress,
-            preferences: _DEFAULT_NOTIFICATION_PREFERENCES,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
           }
 
           return [key, defaultPreferences]

--- a/src/components/settings/PushNotifications/hooks/useNotificationTracking.ts
+++ b/src/components/settings/PushNotifications/hooks/useNotificationTracking.ts
@@ -1,0 +1,82 @@
+import { keys as keysFromIndexedDb, update as updateIndexedDb } from 'idb-keyval'
+import { useEffect, useMemo } from 'react'
+
+import {
+  _DEFAULT_WEBHOOK_TRACKING,
+  createNotificationTrackingIndexedDb,
+  parseNotificationTrackingKey,
+} from '@/services/push-notifications/tracking'
+import { trackEvent } from '@/services/analytics'
+import { PUSH_NOTIFICATION_EVENTS } from '@/services/analytics/events/push-notifications'
+import type { NotificationTracking, NotificationTrackingKey } from '@/services/push-notifications/tracking'
+import type { WebhookType } from '@/service-workers/firebase-messaging/webhook-types'
+
+const trackNotificationEvents = (
+  chainId: string,
+  type: WebhookType,
+  tracking: NotificationTracking[NotificationTrackingKey],
+) => {
+  // Shown notifications
+  Array.from({ length: tracking.shown }).forEach(() => {
+    trackEvent({
+      ...PUSH_NOTIFICATION_EVENTS.SHOW_NOTIFICATION,
+      label: type,
+      chainId,
+    })
+  })
+
+  // Opened notifications
+  Array.from({ length: tracking.opened }).forEach(() => {
+    trackEvent({
+      ...PUSH_NOTIFICATION_EVENTS.OPEN_NOTIFICATION,
+      label: type,
+      chainId,
+    })
+  })
+}
+
+const handleTrackCachedNotificationEvents = async (
+  trackingStore: ReturnType<typeof createNotificationTrackingIndexedDb>,
+) => {
+  try {
+    // Get all tracked webhook events by chainId, e.g. "1:NEW_CONFIRMATION"
+    const trackedNotificationKeys = await keysFromIndexedDb<NotificationTrackingKey>(trackingStore)
+
+    // Get the number of notifications shown/opened and track then clear the cache
+    const promises = trackedNotificationKeys.map((key) => {
+      return updateIndexedDb<NotificationTracking[NotificationTrackingKey]>(
+        key,
+        (tracking) => {
+          if (tracking) {
+            // If tracking occurred, track the events
+            const { chainId, type } = parseNotificationTrackingKey(key)
+            trackNotificationEvents(chainId, type, tracking)
+          }
+
+          // Return the default cache with 0 shown/opened events
+          return _DEFAULT_WEBHOOK_TRACKING
+        },
+        trackingStore,
+      )
+    })
+
+    await Promise.all(promises)
+  } catch {
+    // Swallow error
+  }
+}
+
+export const useNotificationTracking = (): void => {
+  // idb-keyval stores
+  const trackingStore = useMemo(() => {
+    if (typeof indexedDB !== 'undefined') {
+      return createNotificationTrackingIndexedDb()
+    }
+  }, [])
+
+  useEffect(() => {
+    if (trackingStore) {
+      handleTrackCachedNotificationEvents(trackingStore)
+    }
+  }, [trackingStore])
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -37,6 +37,7 @@ import useSafeMessageNotifications from '@/hooks/messages/useSafeMessageNotifica
 import useSafeMessagePendingStatuses from '@/hooks/messages/useSafeMessagePendingStatuses'
 import useChangedValue from '@/hooks/useChangedValue'
 import { TxModalProvider } from '@/components/tx-flow'
+import { useNotificationTracking } from '@/components/settings/PushNotifications/hooks/useNotificationTracking'
 
 const GATEWAY_URL = IS_PRODUCTION || cgwDebugStorage.get() ? GATEWAY_URL_PRODUCTION : GATEWAY_URL_STAGING
 
@@ -44,6 +45,7 @@ const InitApp = (): null => {
   setGatewayBaseUrl(GATEWAY_URL)
   useAdjustUrl()
   useGtm()
+  useNotificationTracking()
   useInitSession()
   useLoadableStores()
   useInitOnboard()

--- a/src/services/analytics/events/push-notifications.ts
+++ b/src/services/analytics/events/push-notifications.ts
@@ -6,9 +6,9 @@ export const PUSH_NOTIFICATION_EVENTS = {
     action: 'Show notification',
     category,
   },
-  // User clicked on notification
-  CLICK_NOTIFICATION: {
-    action: 'Click notification',
+  // User opened on notification
+  OPEN_NOTIFICATION: {
+    action: 'Open notification',
     category,
   },
   // User granted notification permissions

--- a/src/services/analytics/gtm.ts
+++ b/src/services/analytics/gtm.ts
@@ -104,6 +104,7 @@ export const gtmTrack = (eventData: AnalyticsEvent): void => {
     event: eventData.event || EventType.CLICK,
     eventCategory: eventData.category,
     eventAction: eventData.action,
+    chainId: eventData.chainId || commonEventParams.chainId,
   }
 
   if (eventData.event) {

--- a/src/services/analytics/types.ts
+++ b/src/services/analytics/types.ts
@@ -15,6 +15,7 @@ export type AnalyticsEvent = {
   category: string
   action: string
   label?: EventLabel
+  chainId?: string
 }
 
 export type SafeAppSDKEvent = {

--- a/src/services/exceptions/ErrorCodes.ts
+++ b/src/services/exceptions/ErrorCodes.ts
@@ -18,6 +18,7 @@ enum ErrorCodes {
   _303 = '303: Error creating pairing session',
 
   _400 = '400: Error requesting browser notification permissions',
+  _401 = '401: Error tracking to push notifications',
 
   _600 = '600: Error fetching Safe info',
   _601 = '601: Error fetching balances',

--- a/src/services/exceptions/ErrorCodes.ts
+++ b/src/services/exceptions/ErrorCodes.ts
@@ -18,7 +18,7 @@ enum ErrorCodes {
   _303 = '303: Error creating pairing session',
 
   _400 = '400: Error requesting browser notification permissions',
-  _401 = '401: Error tracking to push notifications',
+  _401 = '401: Error tracking push notifications',
 
   _600 = '600: Error fetching Safe info',
   _601 = '601: Error fetching balances',

--- a/src/services/push-notifications/tracking.ts
+++ b/src/services/push-notifications/tracking.ts
@@ -38,7 +38,7 @@ export const createNotificationTrackingIndexedDb = () => {
   return createIndexedDb(DB_NAME, STORE_NAME)
 }
 
-export const _DEFAULT_WEBHOOK_TRACKING: NotificationTracking[NotificationTrackingKey] = {
+export const DEFAULT_WEBHOOK_TRACKING: NotificationTracking[NotificationTrackingKey] = {
   shown: 0,
   opened: 0,
 }
@@ -56,15 +56,15 @@ export const cacheServiceWorkerPushNotificationTrackingEvent = (
 
   updateIndexedDb<NotificationTracking[NotificationTrackingKey] | undefined>(
     key,
-    (tracking) => {
-      if (tracking) {
+    (notificationCount) => {
+      if (notificationCount) {
         return {
-          ...tracking,
-          [property]: (tracking[property] ?? 0) + 1,
+          ...notificationCount,
+          [property]: (notificationCount[property] ?? 0) + 1,
         }
       }
 
-      return _DEFAULT_WEBHOOK_TRACKING
+      return DEFAULT_WEBHOOK_TRACKING
     },
     store,
   ).catch(() => null)

--- a/src/services/push-notifications/tracking.ts
+++ b/src/services/push-notifications/tracking.ts
@@ -1,0 +1,71 @@
+// Be careful what you import here as it will increase the service worker bundle size
+
+import { createStore as createIndexedDb, update as updateIndexedDb } from 'idb-keyval'
+import type { MessagePayload } from 'firebase/messaging/sw'
+
+import { isWebhookEvent, WebhookType } from '@/service-workers/firebase-messaging/webhook-types'
+
+export type NotificationTrackingKey = `${string}:${WebhookType}`
+
+export type NotificationTracking = {
+  [chainKey: NotificationTrackingKey]: {
+    shown: number
+    opened: number
+  }
+}
+
+export const getNotificationTrackingKey = (chainId: string, type: WebhookType): NotificationTrackingKey => {
+  return `${chainId}:${type}`
+}
+
+export const parseNotificationTrackingKey = (key: string): { chainId: string; type: WebhookType } => {
+  const [chainId, type] = key.split(':')
+
+  if (!Object.keys(WebhookType).includes(type)) {
+    throw new Error(`Invalid notification tracking key: ${key}`)
+  }
+
+  return {
+    chainId,
+    type: type as WebhookType,
+  }
+}
+
+export const createNotificationTrackingIndexedDb = () => {
+  const DB_NAME = 'notifications-tracking-database'
+  const STORE_NAME = 'notifications-tracking-store'
+
+  return createIndexedDb(DB_NAME, STORE_NAME)
+}
+
+export const _DEFAULT_WEBHOOK_TRACKING: NotificationTracking[NotificationTrackingKey] = {
+  shown: 0,
+  opened: 0,
+}
+
+export const cacheServiceWorkerPushNotificationTrackingEvent = (
+  property: keyof NotificationTracking[NotificationTrackingKey],
+  data: MessagePayload['data'],
+) => {
+  if (!isWebhookEvent(data)) {
+    return
+  }
+
+  const key = getNotificationTrackingKey(data.chainId, data.type)
+  const store = createNotificationTrackingIndexedDb()
+
+  updateIndexedDb<NotificationTracking[NotificationTrackingKey] | undefined>(
+    key,
+    (tracking) => {
+      if (tracking) {
+        return {
+          ...tracking,
+          [property]: (tracking[property] ?? 0) + 1,
+        }
+      }
+
+      return _DEFAULT_WEBHOOK_TRACKING
+    },
+    store,
+  ).catch(() => null)
+}


### PR DESCRIPTION
## What it solves

Adds cached tracking to push notifications

## How this PR fixes it

Due to technical limitations and a desire to keep the service worker small, every notification that is shown/clicked increments a counter in a new `notifications-tracking-database` IndexedDB database. A tracking event is then dispatched for every count when the UI is next shown.

## How to test it

1. Ensure notifications are subscribed to and trigger one when the Safe is closed.
2. Open the Safe UI and observe a tracking event, labelled correcty.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
