### PR TITLE
fix: Update tx flow form when selecting a replacement nonce

### DIFF
--- a/src/components/tx-flow/SafeTxProvider.tsx
+++ b/src/components/tx-flow/SafeTxProvider.tsx
@@ -42,11 +42,12 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
   const isSigned = safeTx && safeTx.signatures.size > 0
 
   // Recommended nonce and safeTxGas
-  const recommendedNonce = Math.max(safe.nonce, useRecommendedNonce() ?? 0)
+  const recommendedNonce = useRecommendedNonce()
+  const safeRecommendedNonce = recommendedNonce ? Math.max(safe.nonce, recommendedNonce) : undefined
   const recommendedSafeTxGas = useSafeTxGas(safeTx)
 
   // Priority to external nonce, then to the recommended one
-  const finalNonce = isSigned ? safeTx?.data.nonce : nonce ?? recommendedNonce ?? safeTx?.data.nonce
+  const finalNonce = isSigned ? safeTx?.data.nonce : nonce ?? safeRecommendedNonce ?? safeTx?.data.nonce
   const finalSafeTxGas = isSigned ? safeTx?.data.safeTxGas : safeTxGas ?? recommendedSafeTxGas ?? safeTx?.data.safeTxGas
 
   // Update the tx when the nonce or safeTxGas change
@@ -77,7 +78,7 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
         setNonceNeeded,
         safeTxGas: finalSafeTxGas,
         setSafeTxGas,
-        recommendedNonce,
+        recommendedNonce: safeRecommendedNonce,
       }}
     >
       {children}

--- a/src/components/tx-flow/SafeTxProvider.tsx
+++ b/src/components/tx-flow/SafeTxProvider.tsx
@@ -4,7 +4,6 @@ import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { createTx } from '@/services/tx/tx-sender'
 import { useRecommendedNonce, useSafeTxGas } from '../tx/SignOrExecuteForm/hooks'
 import { Errors, logError } from '@/services/exceptions'
-import useSafeInfo from '@/hooks/useSafeInfo'
 
 export const SafeTxContext = createContext<{
   safeTx?: SafeTransaction
@@ -36,18 +35,16 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
   const [nonce, setNonce] = useState<number>()
   const [nonceNeeded, setNonceNeeded] = useState<boolean>(true)
   const [safeTxGas, setSafeTxGas] = useState<number>()
-  const { safe } = useSafeInfo()
 
   // Signed txs cannot be updated
   const isSigned = safeTx && safeTx.signatures.size > 0
 
   // Recommended nonce and safeTxGas
   const recommendedNonce = useRecommendedNonce()
-  const safeRecommendedNonce = recommendedNonce ? Math.max(safe.nonce, recommendedNonce) : undefined
   const recommendedSafeTxGas = useSafeTxGas(safeTx)
 
   // Priority to external nonce, then to the recommended one
-  const finalNonce = isSigned ? safeTx?.data.nonce : nonce ?? safeRecommendedNonce ?? safeTx?.data.nonce
+  const finalNonce = isSigned ? safeTx?.data.nonce : nonce ?? recommendedNonce ?? safeTx?.data.nonce
   const finalSafeTxGas = isSigned ? safeTx?.data.safeTxGas : safeTxGas ?? recommendedSafeTxGas ?? safeTx?.data.safeTxGas
 
   // Update the tx when the nonce or safeTxGas change
@@ -78,7 +75,7 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
         setNonceNeeded,
         safeTxGas: finalSafeTxGas,
         setSafeTxGas,
-        recommendedNonce: safeRecommendedNonce,
+        recommendedNonce,
       }}
     >
       {children}

--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -122,7 +122,7 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
         required: 'Nonce is required',
         // Validation must be async to allow resetting invalid values onBlur
         validate: async (value) => {
-          // Skip initial validation so that setNonce is not called without user input
+          // nonce is always valid so no need to validate if the input is the same
           if (value === nonce) return
 
           const newNonce = Number(value)

--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -1,4 +1,4 @@
-import { memo, type ReactElement, useContext, useMemo } from 'react'
+import { memo, type ReactElement, useContext, useEffect, useMemo } from 'react'
 import {
   Autocomplete,
   Box,
@@ -104,11 +104,19 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
     defaultValues: {
       [TxNonceFormFieldNames.NONCE]: nonce,
     },
-    mode: 'onTouched',
+    mode: 'all',
     values: {
       [TxNonceFormFieldNames.NONCE]: nonce,
     },
   })
+
+  // Update the nonce in the form if the user hasn't changed the value manually
+  // and the recommendedNonce updated in the background
+  useEffect(() => {
+    if (formMethods.formState.touchedFields[TxNonceFormFieldNames.NONCE]) return
+
+    formMethods.setValue(TxNonceFormFieldNames.NONCE, recommendedNonce)
+  }, [formMethods, recommendedNonce])
 
   const resetNonce = () => {
     formMethods.setValue(TxNonceFormFieldNames.NONCE, recommendedNonce)
@@ -155,10 +163,7 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
           <Autocomplete
             value={field.value}
             freeSolo
-            onChange={(_, value) => {
-              field.onChange(value)
-              field.onBlur()
-            }}
+            onChange={(_, value) => field.onChange(value)}
             onInputChange={(_, value) => field.onChange(value)}
             onBlur={() => {
               field.onBlur()

--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -1,4 +1,4 @@
-import { memo, type ReactElement, useContext, useEffect, useMemo } from 'react'
+import { memo, type ReactElement, useContext, useMemo } from 'react'
 import {
   Autocomplete,
   Box,
@@ -110,14 +110,6 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
     },
   })
 
-  // Update the nonce in the form if the user hasn't changed the value manually
-  // and the recommendedNonce updated in the background
-  useEffect(() => {
-    if (formMethods.formState.touchedFields[TxNonceFormFieldNames.NONCE]) return
-
-    formMethods.setValue(TxNonceFormFieldNames.NONCE, recommendedNonce)
-  }, [formMethods, recommendedNonce])
-
   const resetNonce = () => {
     formMethods.setValue(TxNonceFormFieldNames.NONCE, recommendedNonce)
   }
@@ -130,6 +122,9 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
         required: 'Nonce is required',
         // Validation must be async to allow resetting invalid values onBlur
         validate: async (value) => {
+          // Skip initial validation so that setNonce is not called without user input
+          if (value === nonce) return
+
           const newNonce = Number(value)
 
           if (isNaN(newNonce)) {

--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -155,7 +155,10 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
           <Autocomplete
             value={field.value}
             freeSolo
-            onChange={(_, value) => field.onChange(value)}
+            onChange={(_, value) => {
+              field.onChange(value)
+              field.onBlur()
+            }}
             onInputChange={(_, value) => field.onChange(value)}
             onBlur={() => {
               field.onBlur()

--- a/src/components/tx/SignOrExecuteForm/hooks.ts
+++ b/src/components/tx/SignOrExecuteForm/hooks.ts
@@ -165,10 +165,12 @@ export const useRecommendedNonce = (): number | undefined => {
   const { safeAddress, safe } = useSafeInfo()
 
   const [recommendedNonce] = useAsync(
-    () => {
+    async () => {
       if (!safe.chainId || !safeAddress) return
 
-      return getRecommendedNonce(safe.chainId, safeAddress)
+      const recommendedNonce = await getRecommendedNonce(safe.chainId, safeAddress)
+
+      return recommendedNonce ? Math.max(safe.nonce, recommendedNonce) : undefined
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [safeAddress, safe.chainId, safe.txQueuedTag], // update when tx queue changes


### PR DESCRIPTION
## What it solves

Part of #2383 

The form mode for the nonce form changed to `onTouched` with #2383 but selecting a nonce now doesn't update the form unless the user blurs the nonce input. This change calls `onBlur()` whenever the user selects something from the nonce replacement dropdown.

## How to test it

1. Open a safe with at least one transaction in queue
2. Create a new transaction
3. Go to the review screen
4. Observe seeing the Sign flow
5. Select the existing nonce from the nonce form
6. Observe seeing the Execute flow

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
