### PR TITLE
Feat: actionable pending txs on the Dashboard

### DIFF
--- a/cypress/e2e/pages/dashboard.pages.js
+++ b/cypress/e2e/pages/dashboard.pages.js
@@ -1,7 +1,7 @@
 import * as constants from '../../support/constants'
 
 const connectAndTransactStr = 'Connect & transact'
-const transactionQueueStr = 'Transaction queue'
+const transactionQueueStr = 'Pending transactions'
 const noTransactionStr = 'This Safe has no queued transactions'
 const overviewStr = 'Overview'
 const viewAssetsStr = 'View assets'

--- a/src/components/dashboard/PendingTxs/PendingTxListItem.tsx
+++ b/src/components/dashboard/PendingTxs/PendingTxListItem.tsx
@@ -5,12 +5,16 @@ import { useMemo } from 'react'
 import ChevronRight from '@mui/icons-material/ChevronRight'
 import type { TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import { Box, SvgIcon, Typography } from '@mui/material'
-import { isMultisigExecutionInfo } from '@/utils/transaction-guards'
+import { isExecutable, isMultisigExecutionInfo, isSignableBy } from '@/utils/transaction-guards'
 import TxInfo from '@/components/transactions/TxInfo'
 import TxType from '@/components/transactions/TxType'
 import css from './styles.module.css'
 import OwnersIcon from '@/public/images/common/owners.svg'
 import { AppRoutes } from '@/config/routes'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import useWallet from '@/hooks/wallets/useWallet'
+import SignTxButton from '@/components/transactions/SignTxButton'
+import ExecuteTxButton from '@/components/transactions/ExecuteTxButton'
 
 type PendingTxType = {
   transaction: TransactionSummary
@@ -19,6 +23,10 @@ type PendingTxType = {
 const PendingTx = ({ transaction }: PendingTxType): ReactElement => {
   const router = useRouter()
   const { id } = transaction
+  const { safe } = useSafeInfo()
+  const wallet = useWallet()
+  const signable = wallet ? isSignableBy(transaction, wallet.address) : false
+  const executable = wallet ? isExecutable(transaction, wallet?.address, safe) : false
 
   const url = useMemo(
     () => ({
@@ -55,7 +63,13 @@ const PendingTx = ({ transaction }: PendingTxType): ReactElement => {
           <Box flexGrow={1} />
         )}
 
-        <ChevronRight color="border" />
+        {executable ? (
+          <ExecuteTxButton txSummary={transaction} compact />
+        ) : signable ? (
+          <SignTxButton txSummary={transaction} compact />
+        ) : (
+          <ChevronRight color="border" />
+        )}
       </Box>
     </NextLink>
   )

--- a/src/components/dashboard/PendingTxs/PendingTxListItem.tsx
+++ b/src/components/dashboard/PendingTxs/PendingTxListItem.tsx
@@ -25,8 +25,8 @@ const PendingTx = ({ transaction }: PendingTxType): ReactElement => {
   const { id } = transaction
   const { safe } = useSafeInfo()
   const wallet = useWallet()
-  const signable = wallet ? isSignableBy(transaction, wallet.address) : false
-  const executable = wallet ? isExecutable(transaction, wallet?.address, safe) : false
+  const canSign = wallet ? isSignableBy(transaction, wallet.address) : false
+  const canExecute = wallet ? isExecutable(transaction, wallet?.address, safe) : false
 
   const url = useMemo(
     () => ({
@@ -63,9 +63,9 @@ const PendingTx = ({ transaction }: PendingTxType): ReactElement => {
           <Box flexGrow={1} />
         )}
 
-        {executable ? (
+        {canExecute ? (
           <ExecuteTxButton txSummary={transaction} compact />
-        ) : signable ? (
+        ) : canSign ? (
           <SignTxButton txSummary={transaction} compact />
         ) : (
           <ChevronRight color="border" />

--- a/src/components/dashboard/PendingTxs/PendingTxsList.tsx
+++ b/src/components/dashboard/PendingTxs/PendingTxsList.tsx
@@ -44,7 +44,7 @@ const PendingTxsList = (): ReactElement | null => {
   const wallet = useWallet()
   const queuedTxns = useMemo(() => getLatestTransactions(page?.results), [page?.results])
 
-  const actionable = useMemo(() => {
+  const actionableTxs = useMemo(() => {
     return wallet
       ? queuedTxns.filter(
           (tx) => isSignableBy(tx.transaction, wallet.address) || isExecutable(tx.transaction, wallet.address, safe),
@@ -52,7 +52,7 @@ const PendingTxsList = (): ReactElement | null => {
       : queuedTxns
   }, [wallet, queuedTxns, safe])
 
-  const txs = actionable.length ? actionable : queuedTxns
+  const txs = actionableTxs.length ? actionableTxs : queuedTxns
   const txsToDisplay = txs.slice(0, MAX_TXS)
 
   const queueUrl = useMemo(

--- a/src/components/dashboard/PendingTxs/PendingTxsList.tsx
+++ b/src/components/dashboard/PendingTxs/PendingTxsList.tsx
@@ -38,6 +38,7 @@ const LoadingState = () => (
 )
 
 const PendingTxsList = (): ReactElement | null => {
+  const router = useRouter()
   const { page, loading } = useTxQueue()
   const { safe } = useSafeInfo()
   const wallet = useWallet()
@@ -53,25 +54,23 @@ const PendingTxsList = (): ReactElement | null => {
 
   const txs = actionable.length ? actionable : queuedTxns
   const txsToDisplay = txs.slice(0, MAX_TXS)
-  const txsCount = txs.length
-  const router = useRouter()
 
   const queueUrl = useMemo(
     () => ({
       pathname: AppRoutes.transactions.queue,
       query: { safe: router.query.safe },
     }),
-    [router],
+    [router.query.safe],
   )
 
   return (
     <WidgetContainer>
       <div className={css.title}>
         <Typography component="h2" variant="subtitle1" fontWeight={700} mb={2}>
-          Pending transaction{txsCount > 1 ? 's' : ''}
+          Pending transactions
         </Typography>
 
-        {queuedTxns.length > 0 && <ViewAllLink url={queueUrl} text="View queue" />}
+        {queuedTxns.length > 0 && <ViewAllLink url={queueUrl} />}
       </div>
 
       <WidgetBody>

--- a/src/components/dashboard/PendingTxs/PendingTxsList.tsx
+++ b/src/components/dashboard/PendingTxs/PendingTxsList.tsx
@@ -2,31 +2,18 @@ import type { ReactElement } from 'react'
 import { useMemo } from 'react'
 import { useRouter } from 'next/router'
 import { getLatestTransactions } from '@/utils/tx-list'
-import styled from '@emotion/styled'
 import { Box, Skeleton, Typography } from '@mui/material'
 import { Card, ViewAllLink, WidgetBody, WidgetContainer } from '../styled'
 import PendingTxListItem from './PendingTxListItem'
 import useTxQueue from '@/hooks/useTxQueue'
 import { AppRoutes } from '@/config/routes'
 import NoTransactionsIcon from '@/public/images/transactions/no-transactions.svg'
-import { getQueuedTransactionCount } from '@/utils/transactions'
+import css from './styles.module.css'
+import { isSignableBy, isExecutable } from '@/utils/transaction-guards'
+import useWallet from '@/hooks/wallets/useWallet'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
-const SkeletonWrapper = styled.div`
-  border-radius: 8px;
-  overflow: hidden;
-`
-
-const StyledList = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-  width: 100%;
-`
-
-const StyledWidgetTitle = styled.div`
-  display: flex;
-  justify-content: space-between;
-`
+const MAX_TXS = 4
 
 const EmptyState = () => {
   return (
@@ -42,11 +29,31 @@ const EmptyState = () => {
   )
 }
 
-const PendingTxsList = ({ size = 4 }: { size?: number }): ReactElement | null => {
+const LoadingState = () => (
+  <div className={css.list}>
+    {Array.from(Array(MAX_TXS).keys()).map((key) => (
+      <Skeleton key={key} variant="rectangular" height={52} />
+    ))}
+  </div>
+)
+
+const PendingTxsList = (): ReactElement | null => {
   const { page, loading } = useTxQueue()
+  const { safe } = useSafeInfo()
+  const wallet = useWallet()
   const queuedTxns = useMemo(() => getLatestTransactions(page?.results), [page?.results])
-  const queuedTxsToDisplay = queuedTxns.slice(0, size)
-  const totalQueuedTxs = getQueuedTransactionCount(page)
+
+  const actionable = useMemo(() => {
+    return wallet
+      ? queuedTxns.filter(
+          (tx) => isSignableBy(tx.transaction, wallet.address) || isExecutable(tx.transaction, wallet.address, safe),
+        )
+      : queuedTxns
+  }, [wallet, queuedTxns, safe])
+
+  const txs = actionable.length ? actionable : queuedTxns
+  const txsToDisplay = txs.slice(0, MAX_TXS)
+  const txsCount = txs.length
   const router = useRouter()
 
   const queueUrl = useMemo(
@@ -57,45 +64,29 @@ const PendingTxsList = ({ size = 4 }: { size?: number }): ReactElement | null =>
     [router],
   )
 
-  const LoadingState = useMemo(
-    () => (
-      <StyledList>
-        {Array.from(Array(size).keys()).map((key) => (
-          <SkeletonWrapper key={key}>
-            <Skeleton variant="rectangular" height={52} />
-          </SkeletonWrapper>
-        ))}
-      </StyledList>
-    ),
-    [size],
-  )
-
-  const ResultState = useMemo(
-    () => (
-      <StyledList>
-        {queuedTxsToDisplay.map((transaction) => (
-          <PendingTxListItem transaction={transaction.transaction} key={transaction.transaction.id} />
-        ))}
-      </StyledList>
-    ),
-    [queuedTxsToDisplay],
-  )
-
-  const getWidgetBody = () => {
-    if (loading) return LoadingState
-    if (!queuedTxsToDisplay.length) return <EmptyState />
-    return ResultState
-  }
-
   return (
     <WidgetContainer>
-      <StyledWidgetTitle>
+      <div className={css.title}>
         <Typography component="h2" variant="subtitle1" fontWeight={700} mb={2}>
-          Transaction queue {totalQueuedTxs ? ` (${totalQueuedTxs})` : ''}
+          Pending transaction{txsCount > 1 ? 's' : ''}
         </Typography>
-        {queuedTxns.length > 0 && <ViewAllLink url={queueUrl} />}
-      </StyledWidgetTitle>
-      <WidgetBody>{getWidgetBody()}</WidgetBody>
+
+        {queuedTxns.length > 0 && <ViewAllLink url={queueUrl} text="View queue" />}
+      </div>
+
+      <WidgetBody>
+        {loading ? (
+          <LoadingState />
+        ) : queuedTxns.length ? (
+          <div className={css.list}>
+            {txsToDisplay.map((tx) => (
+              <PendingTxListItem transaction={tx.transaction} key={tx.transaction.id} />
+            ))}
+          </div>
+        ) : (
+          <EmptyState />
+        )}
+      </WidgetBody>
     </WidgetContainer>
   )
 }

--- a/src/components/dashboard/PendingTxs/styles.module.css
+++ b/src/components/dashboard/PendingTxs/styles.module.css
@@ -15,6 +15,23 @@
   border-color: var(--color-secondary-light);
 }
 
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  width: 100%;
+}
+
+.skeleton {
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.title {
+  display: flex;
+  justify-content: space-between;
+}
+
 .confirmationsCount {
   display: flex;
   align-items: center;

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -25,7 +25,7 @@ const Dashboard = (): ReactElement => {
         </Grid>
 
         <Grid item xs={12} lg={6}>
-          <PendingTxsList size={4} />
+          <PendingTxsList />
         </Grid>
 
         <Grid item xs={12} lg={supportsRelaying ? 6 : undefined}>

--- a/src/components/transactions/BatchExecuteButton/index.tsx
+++ b/src/components/transactions/BatchExecuteButton/index.tsx
@@ -60,7 +60,7 @@ const BatchExecuteButton = () => {
             disabled={isDisabled}
             onClick={handleOpenModal}
           >
-            Bulk execute{isBatchable && ` ${batchableTransactions.length} txs`}
+            Bulk execute{isBatchable && ` ${batchableTransactions.length} transactions`}
           </Button>
         </span>
       </Tooltip>

--- a/src/components/transactions/ExecuteTxButton/index.tsx
+++ b/src/components/transactions/ExecuteTxButton/index.tsx
@@ -38,6 +38,7 @@ const ExecuteTxButton = ({
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()
+    e.preventDefault()
     setTxFlow(<ConfirmTxFlow txSummary={txSummary} />, undefined, false)
   }
 

--- a/src/components/transactions/SignTxButton/index.tsx
+++ b/src/components/transactions/SignTxButton/index.tsx
@@ -35,6 +35,7 @@ const SignTxButton = ({
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()
+    e.preventDefault()
     setTxFlow(<ConfirmTxFlow txSummary={txSummary} />, undefined, false)
   }
 


### PR DESCRIPTION
## What it solves

Part of #2510

## How this PR fixes it

Shows only signable and executable queued txs, not just any queued txs. Also displays a ✔️ or 🚀 button if a tx can be executed or signed.

<img width="647" alt="Screenshot 2023-09-18 at 17 25 00" src="https://github.com/safe-global/safe-wallet-web/assets/381895/d7a11844-4acb-444d-baf5-72f238da20ee">