### PR TITLE
Feat: attach safe address to analytics events

### DIFF
--- a/src/services/analytics/gtm.ts
+++ b/src/services/analytics/gtm.ts
@@ -43,6 +43,7 @@ const GTM_ENV_AUTH: Record<GTMEnvironment, GTMEnvironmentArgs> = {
 const commonEventParams = {
   chainId: '',
   deviceType: DeviceType.DESKTOP,
+  safeAddress: '',
 }
 
 export const gtmSetChainId = (chainId: string): void => {
@@ -51,6 +52,10 @@ export const gtmSetChainId = (chainId: string): void => {
 
 export const gtmSetDeviceType = (type: DeviceType): void => {
   commonEventParams.deviceType = type
+}
+
+export const gtmSetSafeAddress = (safeAddress: string): void => {
+  commonEventParams.safeAddress = safeAddress
 }
 
 export const gtmInit = (): void => {

--- a/src/services/analytics/useGtm.ts
+++ b/src/services/analytics/useGtm.ts
@@ -12,6 +12,7 @@ import {
   gtmEnableCookies,
   gtmDisableCookies,
   gtmSetDeviceType,
+  gtmSetSafeAddress,
 } from '@/services/analytics/gtm'
 import { useAppSelector } from '@/store'
 import { CookieType, selectCookies } from '@/store/cookiesSlice'
@@ -21,6 +22,7 @@ import { AppRoutes } from '@/config/routes'
 import useMetaEvents from './useMetaEvents'
 import { useMediaQuery } from '@mui/material'
 import { DeviceType } from './types'
+import useSafeAddress from '@/hooks/useSafeAddress'
 
 const useGtm = () => {
   const chainId = useChainId()
@@ -32,6 +34,7 @@ const useGtm = () => {
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
   const isTablet = useMediaQuery(theme.breakpoints.down('md'))
   const deviceType = isMobile ? DeviceType.MOBILE : isTablet ? DeviceType.TABLET : DeviceType.DESKTOP
+  const safeAddress = useSafeAddress()
 
   // Initialize GTM
   useEffect(() => {
@@ -62,6 +65,11 @@ const useGtm = () => {
   useEffect(() => {
     gtmSetDeviceType(deviceType)
   }, [deviceType])
+
+  // Set safe address for all GTM events
+  useEffect(() => {
+    gtmSetSafeAddress(safeAddress)
+  }, [safeAddress])
 
   // Track page views – anononimized by default.
   // Sensitive info, like the safe address or tx id, is always in the query string, which we DO NOT track.


### PR DESCRIPTION
## What it solves

Sends `safeAddress` to GTM

## How to test

- Safe address should be set when opening the app
- Safe address should be updated when switching safes within the same network
- Safe address should be updated when switching safes to a different network