### PR TITLE
fix: close transaction flow if Safe changes

### DIFF
--- a/src/components/tx-flow/index.tsx
+++ b/src/components/tx-flow/index.tsx
@@ -67,7 +67,7 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
 
   // Close the modal when the Safe changes
   useEffect(() => {
-    setFlow(undefined)
+    handleModalClose()
     // Could have same address but different chain
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [safe.chainId, safe.address.value])

--- a/src/components/tx-flow/index.tsx
+++ b/src/components/tx-flow/index.tsx
@@ -1,6 +1,7 @@
 import { createContext, type ReactElement, type ReactNode, useState, useEffect, useCallback } from 'react'
 import TxModalDialog from '@/components/common/TxModalDialog'
 import { usePathname } from 'next/navigation'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 const noop = () => {}
 
@@ -23,6 +24,7 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
   const [fullWidth, setFullWidth] = useState<boolean>(false)
   const pathname = usePathname()
   const [, setLastPath] = useState<string>(pathname)
+  const { safe } = useSafeInfo()
 
   const handleModalClose = useCallback(() => {
     setOnClose((prevOnClose) => {
@@ -62,6 +64,13 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
       return pathname
     })
   }, [txFlow, handleShowWarning, pathname])
+
+  // Close the modal when the Safe changes
+  useEffect(() => {
+    setFlow(undefined)
+    // Could have same address but different chain
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [safe.chainId, safe.address.value])
 
   return (
     <TxModalContext.Provider value={{ txFlow, setTxFlow, setFullWidth }}>

--- a/src/components/tx-flow/index.tsx
+++ b/src/components/tx-flow/index.tsx
@@ -24,7 +24,7 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
   const [fullWidth, setFullWidth] = useState<boolean>(false)
   const pathname = usePathname()
   const [, setLastPath] = useState<string>(pathname)
-  const { safe } = useSafeInfo()
+  const { safeAddress, safe } = useSafeInfo()
 
   const handleModalClose = useCallback(() => {
     setOnClose((prevOnClose) => {
@@ -70,7 +70,7 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
     handleModalClose()
     // Could have same address but different chain
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [safe.chainId, safe.address.value])
+  }, [safe.chainId, safeAddress])
 
   return (
     <TxModalContext.Provider value={{ txFlow, setTxFlow, setFullWidth }}>


### PR DESCRIPTION
## What it solves

Resolves #2499

## How this PR fixes it

The transaction modal now closes if the Safe changes.

## How to test it

1. Ensure the transaction modal is open.
2. Change Safe.
3. Observe the modal close.

The same should also happen with the a Safe of the _same_ address, but different chain.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
