### PR TITLE
Strip 0x from safe address when sending to GTM

### DIFF
--- a/src/services/analytics/gtm.ts
+++ b/src/services/analytics/gtm.ts
@@ -55,7 +55,7 @@ export const gtmSetDeviceType = (type: DeviceType): void => {
 }
 
 export const gtmSetSafeAddress = (safeAddress: string): void => {
-  commonEventParams.safeAddress = safeAddress
+  commonEventParams.safeAddress = safeAddress.slice(2)
 }
 
 export const gtmInit = (): void => {


### PR DESCRIPTION
## What it solves

Strips 0x from addresses so that they are not interpreted as numbers in GA

## Screenshots
<img width="381" alt="Screenshot 2023-09-20 at 10 01 00" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/142a63bd-aa55-4a46-83ee-bc601652261c">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
