### PR TITLE
Fix: prevent Safe Apps tracking on non-Safe App pages

### DIFF
--- a/src/services/analytics/gtm.ts
+++ b/src/services/analytics/gtm.ts
@@ -21,6 +21,7 @@ import { EventType, DeviceType } from './types'
 import { SAFE_APPS_SDK_CATEGORY } from './events'
 import { getAbTest } from '../tracking/abTesting'
 import type { AbTest } from '../tracking/abTesting'
+import { AppRoutes } from '@/config/routes'
 
 type GTMEnvironment = 'LIVE' | 'LATEST' | 'DEVELOPMENT'
 type GTMEnvironmentArgs = Required<Pick<TagManagerArgs, 'auth' | 'preview'>>
@@ -155,6 +156,10 @@ export const normalizeAppName = (appName?: string): string => {
 }
 
 export const gtmTrackSafeApp = (eventData: AnalyticsEvent, appName?: string, sdkEventData?: SafeAppSDKEvent): void => {
+  if (!location.pathname.startsWith(AppRoutes.apps.index)) {
+    return
+  }
+
   const safeAppGtmEvent: SafeAppGtmEvent = {
     ...commonEventParams,
     event: EventType.SAFE_APP,


### PR DESCRIPTION
Safe Apps track all RPC requests a lot of which are triggered from the Governance App on the Dashboard. Since this doesn't reflect actual Safe App usage, it should be disabled.

## How to test

* Safe Apps tracking events should not be triggered on the dashboard anymore
* Events on the /apps page, as well as individual Safe App pages should be still emitted like before.