### PR TITLE
fix: Hide txInfo when displaying human description in batch tx

### DIFF
--- a/src/components/batch/BatchSidebar/BatchTxItem.tsx
+++ b/src/components/batch/BatchSidebar/BatchTxItem.tsx
@@ -12,6 +12,9 @@ import { MethodDetails } from '@/components/transactions/TxDetails/TxData/Decode
 import { TxDataRow } from '@/components/transactions/TxDetails/Summary/TxDataRow'
 import { dateString } from '@/utils/formatters'
 import { BATCH_EVENTS, trackEvent } from '@/services/analytics'
+import { TransactionInfoType } from '@safe-global/safe-gateway-typescript-sdk'
+import useABTesting from '@/services/tracking/useAbTesting'
+import { AbTest } from '@/services/tracking/abTesting'
 
 type BatchTxItemProps = DraftBatchItem & {
   id: string
@@ -30,6 +33,8 @@ const BatchTxItem = ({
   dragging = false,
   draggable = false,
 }: BatchTxItemProps) => {
+  const shouldDisplayHumanDescription = useABTesting(AbTest.HUMAN_DESCRIPTION)
+
   const txSummary = useMemo(
     () => ({
       timestamp,
@@ -55,6 +60,9 @@ const BatchTxItem = ({
   const handleExpand = () => {
     trackEvent(BATCH_EVENTS.BATCH_EXPAND_TX)
   }
+  const displayInfo =
+    (!txDetails.txInfo.richDecodedInfo && txDetails.txInfo.type !== TransactionInfoType.TRANSFER) ||
+    !shouldDisplayHumanDescription
 
   return (
     <ListItem disablePadding sx={{ gap: 2, alignItems: 'flex-start' }}>
@@ -75,9 +83,7 @@ const BatchTxItem = ({
 
             <TxType tx={txSummary} />
 
-            <Box flex={1}>
-              <TxInfo info={txDetails.txInfo} />
-            </Box>
+            <Box flex={1}>{displayInfo && <TxInfo info={txDetails.txInfo} />}</Box>
 
             {onDelete && (
               <>


### PR DESCRIPTION
## What it solves

Part of #2011 

## How this PR fixes it

- Hides the `TxInfo` in the batch view when human-readable descriptions are displayed

## How to test it

1. Open a Safe and create a batch (e.g. with transfers)
2. Observe that if human-readable descriptions are visible, there is no second column

## Screenshots
<img width="706" alt="Screenshot 2023-09-26 at 14 07 10" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/99c5ef0f-66ec-4289-8be4-070e92422a0d">
<img width="708" alt="Screenshot 2023-09-26 at 14 07 33" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/9db87d36-d055-4662-9e97-298766e8f026">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
