### PR TITLE
fix: notification preferences, post-switch registration + sequential signatures

### DIFF
--- a/src/components/settings/PushNotifications/PushNotificationsBanner/index.tsx
+++ b/src/components/settings/PushNotifications/PushNotificationsBanner/index.tsx
@@ -126,7 +126,11 @@ export const PushNotificationsBanner = ({ children }: { children: ReactElement }
     const allPreferences = getAllPreferences()
     const safesToRegister = getSafesToRegister(addedSafes, allPreferences)
 
-    await assertWalletChain(onboard, safe.chainId)
+    try {
+      await assertWalletChain(onboard, safe.chainId)
+    } catch {
+      return
+    }
 
     await registerNotifications(safesToRegister)
 

--- a/src/components/settings/PushNotifications/hooks/__tests__/useNotificationRegistrations.test.ts
+++ b/src/components/settings/PushNotifications/hooks/__tests__/useNotificationRegistrations.test.ts
@@ -30,12 +30,12 @@ describe('useNotificationRegistrations', () => {
   describe('registerNotifications', () => {
     beforeEach(() => {
       const mockProvider = new Web3Provider(jest.fn())
-      jest.spyOn(web3, 'useWeb3').mockImplementation(() => mockProvider)
+      jest.spyOn(web3, 'createWeb3').mockImplementation(() => mockProvider)
       jest.spyOn(wallet, 'default').mockImplementation(
         () =>
           ({
             label: 'MetaMask',
-          } as unknown as ConnectedWallet),
+          } as ConnectedWallet),
       )
     })
 

--- a/src/components/settings/PushNotifications/hooks/useNotificationPreferences.ts
+++ b/src/components/settings/PushNotifications/hooks/useNotificationPreferences.ts
@@ -25,7 +25,7 @@ export const DEFAULT_NOTIFICATION_PREFERENCES: PushNotificationPreferences[PushN
   [WebhookType.INCOMING_ETHER]: true,
   [WebhookType.INCOMING_TOKEN]: true,
   [WebhookType.MODULE_TRANSACTION]: true,
-  [WebhookType.CONFIRMATION_REQUEST]: false, // Requires signature
+  [WebhookType.CONFIRMATION_REQUEST]: true, // Requires signature
   [WebhookType.SAFE_CREATED]: false, // We do not preemptively subscribe to Safes before they are created
   // Disabled on the Transaction Service but kept here for completeness
   [WebhookType._PENDING_MULTISIG_TRANSACTION]: true,

--- a/src/components/settings/PushNotifications/hooks/useNotificationPreferences.ts
+++ b/src/components/settings/PushNotifications/hooks/useNotificationPreferences.ts
@@ -17,7 +17,6 @@ import {
 } from '@/services/push-notifications/preferences'
 import { logError } from '@/services/exceptions'
 import ErrorCodes from '@/services/exceptions/ErrorCodes'
-import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import type { PushNotificationPreferences, PushNotificationPrefsKey } from '@/services/push-notifications/preferences'
 import type { NotifiableSafes } from '../logic'
 
@@ -59,7 +58,6 @@ export const useNotificationPreferences = (): {
   // State
   const uuid = useUuid()
   const preferences = usePreferences()
-  const isOwner = useIsSafeOwner()
 
   // Getters
   const getPreferences = (chainId: string, safeAddress: string) => {
@@ -152,10 +150,7 @@ export const useNotificationPreferences = (): {
           const defaultPreferences: PushNotificationPreferences[PushNotificationPrefsKey] = {
             chainId,
             safeAddress,
-            preferences: {
-              ...DEFAULT_NOTIFICATION_PREFERENCES,
-              [WebhookType.CONFIRMATION_REQUEST]: isOwner,
-            },
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
           }
 
           return [key, defaultPreferences]

--- a/src/components/settings/PushNotifications/hooks/useNotificationRegistrations.ts
+++ b/src/components/settings/PushNotifications/hooks/useNotificationRegistrations.ts
@@ -1,6 +1,5 @@
 import { registerDevice, unregisterDevice, unregisterSafe } from '@safe-global/safe-gateway-typescript-sdk'
 
-import { useWeb3 } from '@/hooks/wallets/web3'
 import { useAppDispatch } from '@/store'
 import { showNotification } from '@/store/notificationsSlice'
 import { useNotificationPreferences } from './useNotificationPreferences'
@@ -10,7 +9,6 @@ import { getRegisterDevicePayload } from '../logic'
 import { logError } from '@/services/exceptions'
 import ErrorCodes from '@/services/exceptions/ErrorCodes'
 import useWallet from '@/hooks/wallets/useWallet'
-import { isLedger } from '@/utils/wallets'
 import type { NotifiableSafes } from '../logic'
 
 const registrationFlow = async (registrationFn: Promise<unknown>, callback: () => void): Promise<boolean> => {
@@ -39,13 +37,12 @@ export const useNotificationRegistrations = (): {
   unregisterDeviceNotifications: (chainId: string) => Promise<boolean | undefined>
 } => {
   const dispatch = useAppDispatch()
-  const web3 = useWeb3()
   const wallet = useWallet()
 
   const { uuid, _createPreferences, _deletePreferences, _deleteAllPreferences } = useNotificationPreferences()
 
   const registerNotifications = async (safesToRegister: NotifiableSafes) => {
-    if (!uuid || !web3 || !wallet) {
+    if (!uuid || !wallet) {
       return
     }
 
@@ -53,8 +50,7 @@ export const useNotificationRegistrations = (): {
       const payload = await getRegisterDevicePayload({
         uuid,
         safesToRegister,
-        web3,
-        isLedger: isLedger(wallet),
+        wallet,
       })
 
       return registerDevice(payload)

--- a/src/components/settings/PushNotifications/index.tsx
+++ b/src/components/settings/PushNotifications/index.tsx
@@ -63,7 +63,11 @@ export const PushNotifications = (): ReactElement => {
 
     setIsRegistering(true)
 
-    await assertWalletChain(onboard, safe.chainId)
+    try {
+      await assertWalletChain(onboard, safe.chainId)
+    } catch {
+      return
+    }
 
     if (!preferences) {
       await registerNotifications({ [safe.chainId]: [safe.address.value] })

--- a/src/components/settings/PushNotifications/logic.test.ts
+++ b/src/components/settings/PushNotifications/logic.test.ts
@@ -5,7 +5,9 @@ import { Web3Provider } from '@ethersproject/providers'
 import type { JsonRpcSigner } from '@ethersproject/providers'
 
 import * as logic from './logic'
+import * as web3 from '@/hooks/wallets/web3'
 import packageJson from '../../../../package.json'
+import type { ConnectedWallet } from '@/services/onboard'
 
 jest.mock('firebase/messaging')
 
@@ -128,6 +130,7 @@ describe('Notifications', () => {
             signMessage: jest.fn().mockResolvedValueOnce(MM_SIGNATURE),
           } as unknown as JsonRpcSigner),
       )
+      jest.spyOn(web3, 'createWeb3').mockImplementation(() => mockProvider)
 
       const uuid = crypto.randomUUID()
 
@@ -137,8 +140,9 @@ describe('Notifications', () => {
           ['2']: [hexZeroPad('0x1', 20)],
         },
         uuid,
-        web3: mockProvider,
-        isLedger: false,
+        wallet: {
+          label: 'MetaMask',
+        } as ConnectedWallet,
       })
 
       expect(payload).toStrictEqual({
@@ -176,6 +180,7 @@ describe('Notifications', () => {
             signMessage: jest.fn().mockResolvedValueOnce(LEDGER_SIGNATURE),
           } as unknown as JsonRpcSigner),
       )
+      jest.spyOn(web3, 'createWeb3').mockImplementation(() => mockProvider)
 
       const uuid = crypto.randomUUID()
 
@@ -185,8 +190,9 @@ describe('Notifications', () => {
           ['2']: [hexZeroPad('0x1', 20)],
         },
         uuid,
-        web3: mockProvider,
-        isLedger: true,
+        wallet: {
+          label: 'Ledger',
+        } as ConnectedWallet,
       })
 
       expect(payload).toStrictEqual({

--- a/src/components/settings/PushNotifications/logic.ts
+++ b/src/components/settings/PushNotifications/logic.ts
@@ -9,6 +9,9 @@ import packageJson from '../../../../package.json'
 import { logError } from '@/services/exceptions'
 import ErrorCodes from '@/services/exceptions/ErrorCodes'
 import { checksumAddress } from '@/utils/addresses'
+import { isLedger } from '@/utils/wallets'
+import { createWeb3 } from '@/hooks/wallets/web3'
+import type { ConnectedWallet } from '@/services/onboard'
 
 type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] }
 
@@ -85,13 +88,11 @@ export type NotifiableSafes = { [chainId: string]: Array<string> }
 export const getRegisterDevicePayload = async ({
   safesToRegister,
   uuid,
-  web3,
-  isLedger,
+  wallet,
 }: {
   safesToRegister: NotifiableSafes
   uuid: string
-  web3: Web3Provider
-  isLedger: boolean
+  wallet: ConnectedWallet
 }): Promise<RegisterNotificationsRequest> => {
   const BUILD_NUMBER = '0' // Required value, but does not exist on web
   const BUNDLE = 'safe'
@@ -106,6 +107,9 @@ export const getRegisterDevicePayload = async ({
     vapidKey: FIREBASE_VAPID_KEY,
     serviceWorkerRegistration,
   })
+
+  const web3 = createWeb3(wallet.provider)
+  const isLedgerWallet = isLedger(wallet)
 
   // If uuid is not provided a new device will be created.
   // If a uuid for an existing Safe is provided the FirebaseDevice will be updated with all the new data provided.
@@ -125,7 +129,7 @@ export const getRegisterDevicePayload = async ({
         uuid,
         timestamp,
         token,
-        isLedger,
+        isLedger: isLedgerWallet,
       })
 
       return {


### PR DESCRIPTION
## What it solves

### Resolves

1. https://github.com/safe-global/safe-wallet-web/pull/2546#issuecomment-1735593295
2. "Global registration" not enabling "Confirmation requests" checkbox in notification preferences
3. Signing for added Safes across different chains doesn't work on Ledger/Trezor

## How this PR fixes it

### 1. Enable all via banner

The `wallet` is now directly used to create a `Web3Provider` within `getRegisterDevicePayload`. (The chain assertion that happens when clicking "Enable all" causes `useWeb3` to return `undefined` for a short period of time.)

### 2. Confirmation request preference

Ownership of the Safes being registered is no longer references `useIsSafeOwner`. The registrant is inherently registered and the checkbox should therefore be checked. (If they are not an owner or delegate they won't receive notifications, however.)

### 3. Hardware wallet registration

Multiple signatures are now requested sequentially instead of using `Promise.all`.

## How to test it

### 1. Enable all via banner

1. Ensure Safes are added.
4. Ensure owner wallet of aforementioned Safes is connected, and on the wrong network.
5. Navigate to an added Safe and click "Enable all".
6. Observe chain switch request, then respective signature requests.

### 2. Confirmation request preference

1. Ensure Safes are added.
2. Navigate to "global" notifications settings.
3. Enable notifications for n Safes.
4. Navigate to the respective Safe notification settings.
7. Observe the "Confirmation requests" notification type preference checked.

### 3. Hardware wallet registration

1. Ensure Safes are added on >1 chain.
2. Navigate to "global" notifications settings.
3. Enable notifications for all Safes via a Ledger/Trezor.
4. Observe successful registration.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
