### PR TITLE
fix: only delete all preferences per chain

### DIFF
--- a/src/components/settings/PushNotifications/GlobalPushNotifications.tsx
+++ b/src/components/settings/PushNotifications/GlobalPushNotifications.tsx
@@ -11,6 +11,7 @@ import {
   ListItemButton,
   ListItemIcon,
   ListItemText,
+  CircularProgress,
 } from '@mui/material'
 import { Fragment, useEffect, useMemo, useState } from 'react'
 import type { ReactElement } from 'react'
@@ -192,6 +193,7 @@ const shouldUnregisterDevice = (
 export const GlobalPushNotifications = (): ReactElement | null => {
   const chains = useChains()
   const addedSafes = useAppSelector(selectAllAddedSafes)
+  const [isLoading, setIsLoading] = useState(false)
 
   const { dismissPushNotificationBanner } = useDismissPushNotificationsBanner()
   const { getAllPreferences } = useNotificationPreferences()
@@ -264,11 +266,14 @@ export const GlobalPushNotifications = (): ReactElement | null => {
       return
     }
 
+    setIsLoading(true)
+
     // Although the (un-)registration functions will request permission in getToken we manually
     // check beforehand to prevent multiple promises in registrationPromises from throwing
     const isGranted = await requestNotificationPermission()
 
     if (!isGranted) {
+      setIsLoading(false)
       return
     }
 
@@ -299,6 +304,8 @@ export const GlobalPushNotifications = (): ReactElement | null => {
     await Promise.all(registrationPromises)
 
     trackEvent(PUSH_NOTIFICATION_EVENTS.SAVE_SETTINGS)
+
+    setIsLoading(false)
   }
 
   if (totalNotifiableSafes === 0) {
@@ -322,8 +329,8 @@ export const GlobalPushNotifications = (): ReactElement | null => {
 
           <CheckWallet allowNonOwner>
             {(isOk) => (
-              <Button variant="contained" disabled={!canSave || !isOk} onClick={onSave}>
-                Save
+              <Button variant="contained" disabled={!canSave || !isOk || isLoading} onClick={onSave}>
+                {isLoading ? <CircularProgress size={20} /> : 'Save'}
               </Button>
             )}
           </CheckWallet>

--- a/src/components/settings/PushNotifications/__tests__/GlobalPushNotifications.test.ts
+++ b/src/components/settings/PushNotifications/__tests__/GlobalPushNotifications.test.ts
@@ -1,0 +1,505 @@
+import {
+  transformAddedSafes,
+  _mergeNotifiableSafes,
+  _transformCurrentSubscribedSafes,
+  _getTotalNotifiableSafes,
+  _areAllSafesSelected,
+  _getTotalSignaturesRequired,
+  _shouldRegisterSelectedSafes,
+  _shouldUnregsiterSelectedSafes,
+  _getSafesToRegister,
+  _getSafesToUnregister,
+  _shouldUnregisterDevice,
+} from '../GlobalPushNotifications'
+import type { AddedSafesState } from '@/store/addedSafesSlice'
+
+describe('GlobalPushNotifications', () => {
+  describe('transformAddedSafes', () => {
+    it('should transform added safes into notifiable safes', () => {
+      const addedSafes = {
+        '1': {
+          '0x123': {},
+          '0x456': {},
+        },
+        '4': {
+          '0x789': {},
+        },
+      } as unknown as AddedSafesState
+
+      const expectedNotifiableSafes = {
+        '1': ['0x123', '0x456'],
+        '4': ['0x789'],
+      }
+
+      expect(transformAddedSafes(addedSafes)).toEqual(expectedNotifiableSafes)
+    })
+  })
+
+  describe('mergeNotifiableSafes', () => {
+    it('should merge added safes and current subscriptions', () => {
+      const addedSafes = {
+        '1': {
+          '0x123': {},
+          '0x456': {},
+        },
+        '4': {
+          '0x789': {},
+        },
+      } as unknown as AddedSafesState
+
+      const currentSubscriptions = {
+        '1': ['0x123', '0x789'],
+        '4': ['0x789'],
+      }
+
+      const expectedNotifiableSafes = {
+        '1': ['0x123', '0x456', '0x789'],
+        '4': ['0x789'],
+      }
+
+      expect(_mergeNotifiableSafes(addedSafes, currentSubscriptions)).toEqual(expectedNotifiableSafes)
+    })
+
+    it('should return added safes if there are no current subscriptions', () => {
+      const addedSafes = {
+        '1': {
+          '0x123': {},
+          '0x456': {},
+        },
+        '4': {
+          '0x789': {},
+        },
+      } as unknown as AddedSafesState
+
+      expect(_mergeNotifiableSafes(addedSafes)).toEqual(transformAddedSafes(addedSafes))
+    })
+  })
+
+  describe('transformCurrentSubscribedSafes', () => {
+    it('should transform current subscriptions into notifiable safes', () => {
+      const currentSubscriptions = {
+        '0x123': {
+          chainId: '1',
+          safeAddress: '0x123',
+        },
+        '0x456': {
+          chainId: '1',
+          safeAddress: '0x456',
+        },
+        '0x789': {
+          chainId: '4',
+          safeAddress: '0x789',
+        },
+      }
+
+      const expectedNotifiableSafes = {
+        '1': ['0x123', '0x456'],
+        '4': ['0x789'],
+      }
+
+      expect(_transformCurrentSubscribedSafes(currentSubscriptions)).toEqual(expectedNotifiableSafes)
+    })
+
+    it('should return undefined if there are no current subscriptions', () => {
+      expect(_transformCurrentSubscribedSafes()).toBeUndefined()
+    })
+  })
+
+  describe('getTotalNotifiableSafes', () => {
+    it('should return the total number of notifiable safes', () => {
+      const notifiableSafes = {
+        '1': ['0x123', '0x456'],
+        '4': ['0x789'],
+      }
+
+      expect(_getTotalNotifiableSafes(notifiableSafes)).toEqual(3)
+    })
+
+    it('should return 0 if there are no notifiable safes', () => {
+      expect(_getTotalNotifiableSafes({})).toEqual(0)
+    })
+  })
+
+  describe('areAllSafesSelected', () => {
+    it('should return true if all notifiable safes are selected', () => {
+      const notifiableSafes = {
+        '1': ['0x123', '0x456'],
+        '4': ['0x789'],
+      }
+
+      const selectedSafes = {
+        '1': ['0x123', '0x456'],
+        '4': ['0x789'],
+      }
+
+      expect(_areAllSafesSelected(notifiableSafes, selectedSafes)).toEqual(true)
+    })
+
+    it('should return false if not all notifiable safes are selected', () => {
+      const notifiableSafes = {
+        '1': ['0x123', '0x456'],
+        '4': ['0x789'],
+      }
+
+      const selectedSafes = {
+        '1': ['0x123', '0x456'],
+        '4': ['0x123'],
+      }
+
+      expect(_areAllSafesSelected(notifiableSafes, selectedSafes)).toEqual(false)
+    })
+
+    it('should return false if there are no notifiable safes', () => {
+      const notifiableSafes = {}
+
+      const selectedSafes = {
+        '1': ['0x123', '0x456'],
+        '4': ['0x789'],
+      }
+
+      expect(_areAllSafesSelected(notifiableSafes, selectedSafes)).toEqual(false)
+    })
+  })
+
+  describe('getTotalSignaturesRequired', () => {
+    it('should return the total number of signatures required to register a new chain', () => {
+      const currentNotifiedSafes = {
+        '1': ['0x123', '0x456'],
+        '4': ['0x789'],
+      }
+
+      const selectedSafes = {
+        ...currentNotifiedSafes,
+        '5': ['0xabc'],
+      }
+
+      expect(_getTotalSignaturesRequired(selectedSafes, currentNotifiedSafes)).toEqual(1)
+    })
+
+    it('should return the total number of signatures required to register a new Safe', () => {
+      const currentNotifiedSafes = {
+        '1': ['0x123'],
+        '4': ['0x789'],
+      }
+
+      const selectedSafes = {
+        '1': ['0x123'],
+        '4': [...currentNotifiedSafes['4'], '0xabc'],
+      }
+
+      expect(_getTotalSignaturesRequired(selectedSafes, currentNotifiedSafes)).toEqual(1)
+    })
+
+    it('should return the total number of signatures required to register new chains/Safes', () => {
+      const currentNotifiedSafes = {}
+
+      const selectedSafes = {
+        '1': ['0x123'],
+        '4': ['0x789', '0xabc'],
+      }
+
+      expect(_getTotalSignaturesRequired(selectedSafes, currentNotifiedSafes)).toEqual(2)
+    })
+
+    it('should not increase the count if a new chain is empty', () => {
+      const currentNotifiedSafes = {
+        '1': ['0x123', '0x456'],
+      }
+
+      const selectedSafes = {
+        '1': currentNotifiedSafes['1'],
+        '5': [],
+      }
+
+      expect(_getTotalSignaturesRequired(selectedSafes, currentNotifiedSafes)).toEqual(0)
+    })
+
+    it('should not increase the count if a chain was removed', () => {
+      const currentNotifiedSafes = {
+        '1': ['0x123', '0x456'],
+        '4': ['0x789'],
+      }
+
+      const selectedSafes = {
+        '1': currentNotifiedSafes['1'],
+      }
+
+      expect(_getTotalSignaturesRequired(selectedSafes, currentNotifiedSafes)).toEqual(0)
+    })
+
+    it('should not increase the count if a Safe was removed', () => {
+      const currentNotifiedSafes = {
+        '1': ['0x123', '0x456'],
+        '4': ['0x789'],
+      }
+
+      const selectedSafes = {
+        '1': currentNotifiedSafes['1'].slice(0, 1),
+        '4': ['0x789'],
+      }
+
+      expect(_getTotalSignaturesRequired(selectedSafes, currentNotifiedSafes)).toEqual(0)
+    })
+
+    it('should not increase the count if a chain/Safe was removed', () => {
+      const currentNotifiedSafes = {
+        '1': ['0x123'],
+        '4': ['0x789', '0xabc'],
+      }
+
+      const selectedSafes = {}
+
+      expect(_getTotalSignaturesRequired(selectedSafes, currentNotifiedSafes)).toEqual(0)
+    })
+
+    it('should return 0 if there are no selected safes', () => {
+      const currentNotifiedSafes = {
+        '1': ['0x123'],
+        '4': ['0x789'],
+      }
+
+      const selectedSafes = {}
+
+      expect(_getTotalSignaturesRequired(selectedSafes, currentNotifiedSafes)).toEqual(0)
+    })
+  })
+
+  describe('shouldRegisterSelectedSafes', () => {
+    it('should return true if there are safes to register', () => {
+      const currentNotifiedSafes = {
+        '1': ['0x123'],
+        '4': ['0x789'],
+      }
+
+      const selectedSafes = {
+        '1': ['0x123', '0x456'],
+        '4': ['0x789'],
+      }
+
+      const result = _shouldRegisterSelectedSafes(selectedSafes, currentNotifiedSafes)
+      expect(result).toBe(true)
+    })
+
+    it('should return true if there are chains to register', () => {
+      const currentNotifiedSafes = {
+        '1': ['0x123', '0x456'],
+      }
+
+      const selectedSafes = {
+        '1': ['0x123', '0x456'],
+        '4': ['0x789'],
+      }
+
+      const result = _shouldRegisterSelectedSafes(selectedSafes, currentNotifiedSafes)
+      expect(result).toBe(true)
+    })
+
+    it('should return true if there are safes/chains to register', () => {
+      const currentNotifiedSafes = {
+        '1': ['0x123', '0x456'],
+        '4': ['0x789'],
+      }
+
+      const selectedSafes = {
+        '1': ['0x123', '0x456', '0x789'],
+        '4': ['0x789'],
+      }
+
+      const result = _shouldRegisterSelectedSafes(selectedSafes, currentNotifiedSafes)
+      expect(result).toBe(true)
+    })
+
+    it('should return false if there are no safes to register', () => {
+      const selectedSafes = {
+        '1': ['0x123'],
+        '4': ['0x789'],
+      }
+
+      const currentNotifiedSafes = {
+        '1': ['0x123'],
+        '4': ['0x789'],
+      }
+
+      const result = _shouldRegisterSelectedSafes(selectedSafes, currentNotifiedSafes)
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('shouldUnregisterSelectedSafes', () => {
+    it('should return true if there are safes to unregister', () => {
+      const currentNotifiedSafes = {
+        '1': ['0x123', '0x456'],
+        '4': ['0x789'],
+      }
+
+      const selectedSafes = {
+        '1': ['0x123'],
+        '4': ['0x789'],
+      }
+
+      const result = _shouldUnregsiterSelectedSafes(selectedSafes, currentNotifiedSafes)
+      expect(result).toBe(true)
+    })
+
+    it('should return true if there are chains to unregister', () => {
+      const currentNotifiedSafes = {
+        '1': ['0x123', '0x456'],
+        '4': ['0x789', '0xabc'],
+      }
+
+      const selectedSafes = {
+        '1': ['0x123', '0x456'],
+      }
+
+      const result = _shouldUnregsiterSelectedSafes(selectedSafes, currentNotifiedSafes)
+      expect(result).toBe(true)
+    })
+
+    it('should return true if there are safes/chains to unregister', () => {
+      const currentNotifiedSafes = {
+        '1': ['0x123', '0x456'],
+        '4': ['0x789', '0xabc'],
+      }
+
+      const selectedSafes = {
+        '1': ['0x123'],
+      }
+
+      const result = _shouldUnregsiterSelectedSafes(selectedSafes, currentNotifiedSafes)
+      expect(result).toBe(true)
+    })
+
+    it('should return false if there are no safes to unregister', () => {
+      const currentNotifiedSafes = {
+        '1': ['0x123'],
+        '4': ['0x789'],
+      }
+
+      const selectedSafes = {
+        '1': ['0x123'],
+        '4': ['0x789'],
+      }
+
+      const result = _shouldUnregsiterSelectedSafes(selectedSafes, currentNotifiedSafes)
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('getSafesToRegister', () => {
+    it('returns the safes to register', () => {
+      const currentNotifiedSafes = {
+        1: ['0x123'],
+        2: ['0xabc'],
+        4: ['0x789', '0xdef'],
+      }
+      const selectedSafes = {
+        1: ['0x123', '0x456'],
+        4: ['0x789'],
+      }
+
+      const result = _getSafesToRegister(selectedSafes, currentNotifiedSafes)
+
+      expect(result).toEqual({
+        1: ['0x456'],
+      })
+    })
+
+    it('returns undefined if there are no safes to register', () => {
+      const currentNotifiedSafes = {
+        1: ['0x123'],
+        2: ['0xabc'],
+        4: ['0x789', '0xdef'],
+      }
+      const selectedSafes = {
+        1: ['0x123'],
+        2: ['0xabc'],
+        4: ['0x789', '0xdef'],
+      }
+
+      const result = _getSafesToRegister(selectedSafes, currentNotifiedSafes)
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('getSafesToUnregister', () => {
+    it('returns undefined if there are no current notified safes', () => {
+      const currentNotifiedSafes = undefined
+      const selectedSafes = {
+        1: ['0x123', '0x456'],
+        4: ['0x789'],
+      }
+
+      const result = _getSafesToUnregister(selectedSafes, currentNotifiedSafes)
+
+      expect(result).toBeUndefined()
+    })
+
+    it('returns the safes to unregister', () => {
+      const currentNotifiedSafes = {
+        1: ['0x123'],
+        2: ['0xabc'],
+        4: ['0x789', '0xdef'],
+      }
+      const selectedSafes = {
+        1: ['0x123', '0x456'],
+        4: ['0x789'],
+      }
+
+      const result = _getSafesToUnregister(selectedSafes, currentNotifiedSafes)
+
+      expect(result).toEqual({
+        2: ['0xabc'],
+        4: ['0xdef'],
+      })
+    })
+
+    it('returns undefined if there are no safes to unregister', () => {
+      const currentNotifiedSafes = {
+        1: ['0x123'],
+        2: ['0xabc'],
+        4: ['0x789', '0xdef'],
+      }
+      const selectedSafes = {
+        1: ['0x123'],
+        2: ['0xabc'],
+        4: ['0x789', '0xdef'],
+      }
+
+      const result = _getSafesToUnregister(selectedSafes, currentNotifiedSafes)
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('shouldUnregisterDevice', () => {
+    const chainId = '1'
+    const safeAddresses = ['0x123', '0x456']
+    const currentNotifiedSafes = {
+      '1': ['0x123', '0x456'],
+      '4': ['0x789'],
+    }
+
+    it('returns true if all safe addresses are included in currentNotifiedSafes', () => {
+      const result = _shouldUnregisterDevice(chainId, safeAddresses, currentNotifiedSafes)
+      expect(result).toBe(true)
+    })
+
+    it('returns false if not all safe addresses are included in currentNotifiedSafes', () => {
+      const invalidSafeAddresses = ['0x123', '0x789']
+      const result = _shouldUnregisterDevice(chainId, invalidSafeAddresses, currentNotifiedSafes)
+      expect(result).toBe(false)
+    })
+
+    it('returns false if currentNotifiedSafes is undefined', () => {
+      const result = _shouldUnregisterDevice(chainId, safeAddresses)
+      expect(result).toBe(false)
+    })
+
+    it('returns false if the length of safeAddresses is different from the length of currentNotifiedSafes', () => {
+      const invalidSafeAddresses = ['0x123']
+      const result = _shouldUnregisterDevice(chainId, invalidSafeAddresses, currentNotifiedSafes)
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/src/components/settings/PushNotifications/__tests__/logic.test.ts
+++ b/src/components/settings/PushNotifications/__tests__/logic.test.ts
@@ -4,9 +4,9 @@ import { hexZeroPad } from 'ethers/lib/utils'
 import { Web3Provider } from '@ethersproject/providers'
 import type { JsonRpcSigner } from '@ethersproject/providers'
 
-import * as logic from './logic'
+import * as logic from '../logic'
 import * as web3 from '@/hooks/wallets/web3'
-import packageJson from '../../../../package.json'
+import packageJson from '../../../../../package.json'
 import type { ConnectedWallet } from '@/services/onboard'
 
 jest.mock('firebase/messaging')

--- a/src/components/settings/PushNotifications/hooks/__tests__/useNotificationPreferences.test.ts
+++ b/src/components/settings/PushNotifications/hooks/__tests__/useNotificationPreferences.test.ts
@@ -58,66 +58,15 @@ describe('useNotificationPreferences', () => {
       _setPreferences(undefined)
     })
 
-    it('should return all existing preferences', async () => {
-      const chainId = '1'
-      const safeAddress = hexZeroPad('0x1', 20)
+    describe('_getAllPreferenceEntries', () => {
+      it('should get all preference entries', async () => {
+        const chainId1 = '1'
+        const safeAddress1 = hexZeroPad('0x1', 20)
+        const safeAddress2 = hexZeroPad('0x1', 20)
 
-      const preferences = {
-        [`${chainId}:${safeAddress}`]: {
-          chainId,
-          safeAddress,
-          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
-        },
-      }
+        const chainId2 = '2'
 
-      await setMany(Object.entries(preferences), createPushNotificationPrefsIndexedDb())
-
-      const { result } = renderHook(() => useNotificationPreferences())
-
-      await waitFor(() => {
-        expect(result.current.getAllPreferences()).toEqual(preferences)
-      })
-    })
-
-    it('should return existing Safe preferences', async () => {
-      const chainId = '1'
-      const safeAddress = hexZeroPad('0x1', 20)
-
-      const preferences = {
-        [`${chainId}:${safeAddress}`]: {
-          chainId,
-          safeAddress,
-          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
-        },
-      }
-
-      await setMany(Object.entries(preferences), createPushNotificationPrefsIndexedDb())
-
-      const { result } = renderHook(() => useNotificationPreferences())
-
-      await waitFor(() => {
-        expect(result.current.getPreferences(chainId, safeAddress)).toEqual(
-          preferences[`${chainId}:${safeAddress}`].preferences,
-        )
-      })
-    })
-
-    it('should create preferences, then hydrate the preferences state', async () => {
-      const { result } = renderHook(() => useNotificationPreferences())
-
-      const chainId1 = '1'
-      const safeAddress1 = hexZeroPad('0x1', 20)
-      const safeAddress2 = hexZeroPad('0x1', 20)
-
-      const chainId2 = '2'
-
-      result.current._createPreferences({
-        [chainId1]: [safeAddress1, safeAddress2],
-        [chainId2]: [safeAddress1],
-      })
-
-      await waitFor(() => {
-        expect(result.current.getAllPreferences()).toEqual({
+        const preferences = {
           [`${chainId1}:${safeAddress1}`]: {
             chainId: chainId1,
             safeAddress: safeAddress1,
@@ -133,182 +82,374 @@ describe('useNotificationPreferences', () => {
             safeAddress: safeAddress1,
             preferences: DEFAULT_NOTIFICATION_PREFERENCES,
           },
+        }
+
+        await setMany(Object.entries(preferences), createPushNotificationPrefsIndexedDb())
+
+        const { result } = renderHook(() => useNotificationPreferences())
+
+        await waitFor(async () => {
+          const _preferences = await result.current._getAllPreferenceEntries()
+          expect(_preferences).toEqual(Object.entries(preferences))
         })
       })
     })
 
-    it('should not create preferences when passed an empty object', async () => {
-      const { result } = renderHook(() => useNotificationPreferences())
+    describe('_deleteManyPreferenceKeys', () => {
+      it('should delete many preference keys', async () => {
+        const chainId1 = '1'
+        const safeAddress1 = hexZeroPad('0x1', 20)
+        const safeAddress2 = hexZeroPad('0x1', 20)
 
-      result.current._createPreferences({})
+        const chainId2 = '2'
 
-      await waitFor(() => {
-        expect(result.current.getAllPreferences()).toEqual({})
-      })
-    })
-
-    it('should not create preferences when passed an empty array of Safes', async () => {
-      const { result } = renderHook(() => useNotificationPreferences())
-
-      result.current._createPreferences({ ['1']: [] })
-
-      await waitFor(() => {
-        expect(result.current.getAllPreferences()).toEqual({})
-      })
-    })
-
-    it('should update preferences, then hydrate the preferences state', async () => {
-      const chainId = '1'
-      const safeAddress = hexZeroPad('0x1', 20)
-
-      const preferences = {
-        [`${chainId}:${safeAddress}`]: {
-          chainId: chainId,
-          safeAddress: safeAddress,
-          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
-        },
-      }
-
-      await setMany(Object.entries(preferences), createPushNotificationPrefsIndexedDb())
-
-      const { result } = renderHook(() => useNotificationPreferences())
-
-      result.current.updatePreferences(chainId, safeAddress, {
-        ...DEFAULT_NOTIFICATION_PREFERENCES,
-        [WebhookType.CONFIRMATION_REQUEST]: false,
-      })
-
-      await waitFor(() => {
-        expect(result.current.getAllPreferences()).toEqual({
-          [`${chainId}:${safeAddress}`]: {
-            chainId: chainId,
-            safeAddress: safeAddress,
-            preferences: {
-              ...DEFAULT_NOTIFICATION_PREFERENCES,
-              [WebhookType.CONFIRMATION_REQUEST]: false,
-            },
+        const preferences = {
+          [`${chainId1}:${safeAddress1}`]: {
+            chainId: chainId1,
+            safeAddress: safeAddress1,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
           },
-        })
-      })
-    })
-
-    it('should delete preferences, then hydrate the preferences state', async () => {
-      const chainId1 = '1'
-      const safeAddress1 = hexZeroPad('0x1', 20)
-      const safeAddress2 = hexZeroPad('0x1', 20)
-
-      const chainId2 = '2'
-
-      const preferences = {
-        [`${chainId1}:${safeAddress1}`]: {
-          chainId: chainId1,
-          safeAddress: safeAddress1,
-          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
-        },
-        [`${chainId1}:${safeAddress2}`]: {
-          chainId: chainId1,
-          safeAddress: safeAddress2,
-          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
-        },
-        [`${chainId2}:${safeAddress1}`]: {
-          chainId: chainId2,
-          safeAddress: safeAddress1,
-          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
-        },
-      }
-
-      await setMany(Object.entries(preferences), createPushNotificationPrefsIndexedDb())
-
-      const { result } = renderHook(() => useNotificationPreferences())
-
-      result.current._deletePreferences({
-        [chainId1]: [safeAddress1, safeAddress2],
-      })
-
-      await waitFor(() => {
-        expect(result.current.getAllPreferences()).toEqual({
+          [`${chainId1}:${safeAddress2}`]: {
+            chainId: chainId1,
+            safeAddress: safeAddress2,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+          },
           [`${chainId2}:${safeAddress1}`]: {
             chainId: chainId2,
             safeAddress: safeAddress1,
             preferences: DEFAULT_NOTIFICATION_PREFERENCES,
           },
+        }
+
+        await setMany(Object.entries(preferences), createPushNotificationPrefsIndexedDb())
+
+        const { result } = renderHook(() => useNotificationPreferences())
+
+        await waitFor(() => {
+          expect(result.current.getAllPreferences()).toEqual(preferences)
+        })
+
+        const keysToDelete = Object.entries(preferences).map(([key]) => key)
+
+        result.current._deleteManyPreferenceKeys(keysToDelete as `${string}:${string}`[])
+
+        await waitFor(() => {
+          expect(result.current.getAllPreferences()).toEqual({})
         })
       })
     })
 
-    it('should delete all preferences, then hydrate the preferences state', async () => {
-      const chainId1 = '1'
-      const safeAddress1 = hexZeroPad('0x1', 20)
-      const safeAddress2 = hexZeroPad('0x1', 20)
+    describe('getAllPreferences', () => {
+      it('should return all existing preferences', async () => {
+        const chainId = '1'
+        const safeAddress = hexZeroPad('0x1', 20)
 
-      const chainId2 = '2'
+        const preferences = {
+          [`${chainId}:${safeAddress}`]: {
+            chainId,
+            safeAddress,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+          },
+        }
 
-      const preferences = {
-        [`${chainId1}:${safeAddress1}`]: {
-          chainId: chainId1,
-          safeAddress: safeAddress1,
-          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
-        },
-        [`${chainId1}:${safeAddress2}`]: {
-          chainId: chainId1,
-          safeAddress: safeAddress2,
-          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
-        },
-        [`${chainId2}:${safeAddress1}`]: {
-          chainId: chainId2,
-          safeAddress: safeAddress1,
-          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
-        },
-      }
+        await setMany(Object.entries(preferences), createPushNotificationPrefsIndexedDb())
 
-      await setMany(Object.entries(preferences), createPushNotificationPrefsIndexedDb())
+        const { result } = renderHook(() => useNotificationPreferences())
 
-      const { result } = renderHook(() => useNotificationPreferences())
-
-      result.current._deletePreferences({
-        [chainId1]: [safeAddress1, safeAddress2],
-      })
-
-      await waitFor(() => {
-        expect(result.current.getAllPreferences()).toEqual(undefined)
+        await waitFor(() => {
+          expect(result.current.getAllPreferences()).toEqual(preferences)
+        })
       })
     })
 
-    it('should hydrate accross instances', async () => {
-      const chainId1 = '1'
-      const safeAddress1 = hexZeroPad('0x1', 20)
-      const safeAddress2 = hexZeroPad('0x1', 20)
+    describe('getPreferences', () => {
+      it('should return existing Safe preferences', async () => {
+        const chainId = '1'
+        const safeAddress = hexZeroPad('0x1', 20)
 
-      const chainId2 = '2'
-      const { result: instance1 } = renderHook(() => useNotificationPreferences())
-      const { result: instance2 } = renderHook(() => useNotificationPreferences())
+        const preferences = {
+          [`${chainId}:${safeAddress}`]: {
+            chainId,
+            safeAddress,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+          },
+        }
 
-      instance1.current._createPreferences({
-        [chainId1]: [safeAddress1, safeAddress2],
-        [chainId2]: [safeAddress1],
+        await setMany(Object.entries(preferences), createPushNotificationPrefsIndexedDb())
+
+        const { result } = renderHook(() => useNotificationPreferences())
+
+        await waitFor(() => {
+          expect(result.current.getPreferences(chainId, safeAddress)).toEqual(
+            preferences[`${chainId}:${safeAddress}`].preferences,
+          )
+        })
+      })
+    })
+
+    describe('createPreferences', () => {
+      it('should create preferences, then hydrate the preferences state', async () => {
+        const { result } = renderHook(() => useNotificationPreferences())
+
+        const chainId1 = '1'
+        const safeAddress1 = hexZeroPad('0x1', 20)
+        const safeAddress2 = hexZeroPad('0x1', 20)
+
+        const chainId2 = '2'
+
+        result.current.createPreferences({
+          [chainId1]: [safeAddress1, safeAddress2],
+          [chainId2]: [safeAddress1],
+        })
+
+        await waitFor(() => {
+          expect(result.current.getAllPreferences()).toEqual({
+            [`${chainId1}:${safeAddress1}`]: {
+              chainId: chainId1,
+              safeAddress: safeAddress1,
+              preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+            },
+            [`${chainId1}:${safeAddress2}`]: {
+              chainId: chainId1,
+              safeAddress: safeAddress2,
+              preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+            },
+            [`${chainId2}:${safeAddress1}`]: {
+              chainId: chainId2,
+              safeAddress: safeAddress1,
+              preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+            },
+          })
+        })
       })
 
-      const expectedPreferences = {
-        [`${chainId1}:${safeAddress1}`]: {
-          chainId: chainId1,
-          safeAddress: safeAddress1,
-          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
-        },
-        [`${chainId1}:${safeAddress2}`]: {
-          chainId: chainId1,
-          safeAddress: safeAddress2,
-          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
-        },
-        [`${chainId2}:${safeAddress1}`]: {
-          chainId: chainId2,
-          safeAddress: safeAddress1,
-          preferences: DEFAULT_NOTIFICATION_PREFERENCES,
-        },
-      }
+      it('should not create preferences when passed an empty object', async () => {
+        const { result } = renderHook(() => useNotificationPreferences())
 
-      await waitFor(() => {
-        expect(instance1.current.getAllPreferences()).toEqual(expectedPreferences)
-        expect(instance2.current.getAllPreferences()).toEqual(expectedPreferences)
+        result.current.createPreferences({})
+
+        await waitFor(() => {
+          expect(result.current.getAllPreferences()).toEqual({})
+        })
+      })
+
+      it('should not create preferences when passed an empty array of Safes', async () => {
+        const { result } = renderHook(() => useNotificationPreferences())
+
+        result.current.createPreferences({ ['1']: [] })
+
+        await waitFor(() => {
+          expect(result.current.getAllPreferences()).toEqual({})
+        })
+      })
+
+      it('should hydrate accross instances', async () => {
+        const chainId1 = '1'
+        const safeAddress1 = hexZeroPad('0x1', 20)
+        const safeAddress2 = hexZeroPad('0x1', 20)
+
+        const chainId2 = '2'
+        const { result: instance1 } = renderHook(() => useNotificationPreferences())
+        const { result: instance2 } = renderHook(() => useNotificationPreferences())
+
+        instance1.current.createPreferences({
+          [chainId1]: [safeAddress1, safeAddress2],
+          [chainId2]: [safeAddress1],
+        })
+
+        const expectedPreferences = {
+          [`${chainId1}:${safeAddress1}`]: {
+            chainId: chainId1,
+            safeAddress: safeAddress1,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+          },
+          [`${chainId1}:${safeAddress2}`]: {
+            chainId: chainId1,
+            safeAddress: safeAddress2,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+          },
+          [`${chainId2}:${safeAddress1}`]: {
+            chainId: chainId2,
+            safeAddress: safeAddress1,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+          },
+        }
+
+        await waitFor(() => {
+          expect(instance1.current.getAllPreferences()).toEqual(expectedPreferences)
+          expect(instance2.current.getAllPreferences()).toEqual(expectedPreferences)
+        })
+      })
+    })
+
+    describe('updatePreferences', () => {
+      it('should update preferences, then hydrate the preferences state', async () => {
+        const chainId = '1'
+        const safeAddress = hexZeroPad('0x1', 20)
+
+        const preferences = {
+          [`${chainId}:${safeAddress}`]: {
+            chainId: chainId,
+            safeAddress: safeAddress,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+          },
+        }
+
+        await setMany(Object.entries(preferences), createPushNotificationPrefsIndexedDb())
+
+        const { result } = renderHook(() => useNotificationPreferences())
+
+        result.current.updatePreferences(chainId, safeAddress, {
+          ...DEFAULT_NOTIFICATION_PREFERENCES,
+          [WebhookType.CONFIRMATION_REQUEST]: false,
+        })
+
+        await waitFor(() => {
+          expect(result.current.getAllPreferences()).toEqual({
+            [`${chainId}:${safeAddress}`]: {
+              chainId: chainId,
+              safeAddress: safeAddress,
+              preferences: {
+                ...DEFAULT_NOTIFICATION_PREFERENCES,
+                [WebhookType.CONFIRMATION_REQUEST]: false,
+              },
+            },
+          })
+        })
+      })
+    })
+
+    describe('deletePreferences', () => {
+      it('should delete preferences, then hydrate the preferences state', async () => {
+        const chainId1 = '1'
+        const safeAddress1 = hexZeroPad('0x1', 20)
+        const safeAddress2 = hexZeroPad('0x1', 20)
+
+        const chainId2 = '2'
+
+        const preferences = {
+          [`${chainId1}:${safeAddress1}`]: {
+            chainId: chainId1,
+            safeAddress: safeAddress1,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+          },
+          [`${chainId1}:${safeAddress2}`]: {
+            chainId: chainId1,
+            safeAddress: safeAddress2,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+          },
+          [`${chainId2}:${safeAddress1}`]: {
+            chainId: chainId2,
+            safeAddress: safeAddress1,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+          },
+        }
+
+        await setMany(Object.entries(preferences), createPushNotificationPrefsIndexedDb())
+
+        const { result } = renderHook(() => useNotificationPreferences())
+
+        result.current.deletePreferences({
+          [chainId1]: [safeAddress1, safeAddress2],
+        })
+
+        await waitFor(() => {
+          expect(result.current.getAllPreferences()).toEqual({
+            [`${chainId2}:${safeAddress1}`]: {
+              chainId: chainId2,
+              safeAddress: safeAddress1,
+              preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+            },
+          })
+        })
+      })
+
+      it('should delete preferences, then hydrate the preferences state', async () => {
+        const chainId1 = '1'
+        const safeAddress1 = hexZeroPad('0x1', 20)
+        const safeAddress2 = hexZeroPad('0x1', 20)
+
+        const chainId2 = '2'
+
+        const preferences = {
+          [`${chainId1}:${safeAddress1}`]: {
+            chainId: chainId1,
+            safeAddress: safeAddress1,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+          },
+          [`${chainId1}:${safeAddress2}`]: {
+            chainId: chainId1,
+            safeAddress: safeAddress2,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+          },
+          [`${chainId2}:${safeAddress1}`]: {
+            chainId: chainId2,
+            safeAddress: safeAddress1,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+          },
+        }
+
+        await setMany(Object.entries(preferences), createPushNotificationPrefsIndexedDb())
+
+        const { result } = renderHook(() => useNotificationPreferences())
+
+        result.current.deletePreferences({
+          [chainId1]: [safeAddress1, safeAddress2],
+        })
+
+        await waitFor(() => {
+          expect(result.current.getAllPreferences()).toEqual({
+            [`${chainId2}:${safeAddress1}`]: {
+              chainId: chainId2,
+              safeAddress: safeAddress1,
+              preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+            },
+          })
+        })
+      })
+    })
+
+    describe('deleteAllChainPreferences', () => {
+      it('should delete per chain, then hydrate the preferences state', async () => {
+        const chainId1 = '1'
+        const safeAddress1 = hexZeroPad('0x1', 20)
+        const safeAddress2 = hexZeroPad('0x1', 20)
+
+        const chainId2 = '2'
+
+        const preferences = {
+          [`${chainId1}:${safeAddress1}`]: {
+            chainId: chainId1,
+            safeAddress: safeAddress1,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+          },
+          [`${chainId1}:${safeAddress2}`]: {
+            chainId: chainId1,
+            safeAddress: safeAddress2,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+          },
+          [`${chainId2}:${safeAddress1}`]: {
+            chainId: chainId2,
+            safeAddress: safeAddress1,
+            preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+          },
+        }
+
+        await setMany(Object.entries(preferences), createPushNotificationPrefsIndexedDb())
+
+        const { result } = renderHook(() => useNotificationPreferences())
+
+        result.current.deleteAllChainPreferences(chainId1)
+
+        await waitFor(() => {
+          expect(result.current.getAllPreferences()).toEqual({
+            [`${chainId2}:${safeAddress1}`]: {
+              chainId: chainId2,
+              safeAddress: safeAddress1,
+              preferences: DEFAULT_NOTIFICATION_PREFERENCES,
+            },
+          })
+        })
       })
     })
   })

--- a/src/components/settings/PushNotifications/hooks/__tests__/useNotificationRegistrations.test.ts
+++ b/src/components/settings/PushNotifications/hooks/__tests__/useNotificationRegistrations.test.ts
@@ -104,7 +104,7 @@ describe('useNotificationRegistrations', () => {
         () =>
           ({
             uuid: self.crypto.randomUUID(),
-            _createPreferences: createPreferencesMock,
+            createPreferences: createPreferencesMock,
           } as unknown as ReturnType<typeof preferences.useNotificationPreferences>),
       )
 
@@ -136,7 +136,7 @@ describe('useNotificationRegistrations', () => {
         () =>
           ({
             uuid: self.crypto.randomUUID(),
-            _createPreferences: createPreferencesMock,
+            createPreferences: createPreferencesMock,
           } as unknown as ReturnType<typeof preferences.useNotificationPreferences>),
       )
 
@@ -167,7 +167,7 @@ describe('useNotificationRegistrations', () => {
         () =>
           ({
             uuid: self.crypto.randomUUID(),
-            _createPreferences: createPreferencesMock,
+            createPreferences: createPreferencesMock,
           } as unknown as ReturnType<typeof preferences.useNotificationPreferences>),
       )
 
@@ -218,7 +218,7 @@ describe('useNotificationRegistrations', () => {
         () =>
           ({
             uuid,
-            _deletePreferences: deletePreferencesMock,
+            deletePreferences: deletePreferencesMock,
           } as unknown as ReturnType<typeof preferences.useNotificationPreferences>),
       )
 
@@ -244,7 +244,7 @@ describe('useNotificationRegistrations', () => {
         () =>
           ({
             uuid,
-            _deletePreferences: deletePreferencesMock,
+            deletePreferences: deletePreferencesMock,
           } as unknown as ReturnType<typeof preferences.useNotificationPreferences>),
       )
 
@@ -270,7 +270,7 @@ describe('useNotificationRegistrations', () => {
         () =>
           ({
             uuid,
-            _deletePreferences: deletePreferencesMock,
+            deletePreferences: deletePreferencesMock,
           } as unknown as ReturnType<typeof preferences.useNotificationPreferences>),
       )
 
@@ -310,13 +310,13 @@ describe('useNotificationRegistrations', () => {
       unregisterDeviceSpy.mockImplementation(() => Promise.resolve('Unregistration could not be completed.'))
 
       const uuid = self.crypto.randomUUID()
-      const deleteAllPreferencesMock = jest.fn()
+      const deleteAllChainPreferencesMock = jest.fn()
 
       ;(preferences.useNotificationPreferences as jest.Mock).mockImplementation(
         () =>
           ({
             uuid,
-            _deleteAllPreferences: deleteAllPreferencesMock,
+            deleteAllChainPreferences: deleteAllChainPreferencesMock,
           } as unknown as ReturnType<typeof preferences.useNotificationPreferences>),
       )
 
@@ -326,20 +326,20 @@ describe('useNotificationRegistrations', () => {
 
       expect(unregisterDeviceSpy).toHaveBeenCalledWith('1', uuid)
 
-      expect(deleteAllPreferencesMock).not.toHaveBeenCalled()
+      expect(deleteAllChainPreferencesMock).not.toHaveBeenCalled()
     })
 
     it('does not clear preferences if unregistration throws', async () => {
       unregisterDeviceSpy.mockImplementation(() => Promise.reject())
 
       const uuid = self.crypto.randomUUID()
-      const deleteAllPreferencesMock = jest.fn()
+      const deleteAllChainPreferencesMock = jest.fn()
 
       ;(preferences.useNotificationPreferences as jest.Mock).mockImplementation(
         () =>
           ({
             uuid,
-            _deleteAllPreferences: deleteAllPreferencesMock,
+            deleteAllChainPreferences: deleteAllChainPreferencesMock,
           } as unknown as ReturnType<typeof preferences.useNotificationPreferences>),
       )
 
@@ -349,20 +349,20 @@ describe('useNotificationRegistrations', () => {
 
       expect(unregisterDeviceSpy).toHaveBeenCalledWith('1', uuid)
 
-      expect(deleteAllPreferencesMock).not.toHaveBeenCalledWith()
+      expect(deleteAllChainPreferencesMock).not.toHaveBeenCalledWith()
     })
 
-    it('clears preferences if unregistration succeeds', async () => {
+    it('clears chain preferences if unregistration succeeds', async () => {
       unregisterDeviceSpy.mockImplementation(() => Promise.resolve())
 
       const uuid = self.crypto.randomUUID()
-      const deleteAllPreferencesMock = jest.fn()
+      const deleteAllChainPreferencesMock = jest.fn()
 
       ;(preferences.useNotificationPreferences as jest.Mock).mockImplementation(
         () =>
           ({
             uuid,
-            _deleteAllPreferences: deleteAllPreferencesMock,
+            deleteAllChainPreferences: deleteAllChainPreferencesMock,
           } as unknown as ReturnType<typeof preferences.useNotificationPreferences>),
       )
 
@@ -372,7 +372,7 @@ describe('useNotificationRegistrations', () => {
 
       expect(unregisterDeviceSpy).toHaveBeenCalledWith('1', uuid)
 
-      expect(deleteAllPreferencesMock).toHaveBeenCalled()
+      expect(deleteAllChainPreferencesMock).toHaveBeenCalledWith('1')
     })
   })
 })

--- a/src/components/settings/PushNotifications/hooks/useNotificationRegistrations.ts
+++ b/src/components/settings/PushNotifications/hooks/useNotificationRegistrations.ts
@@ -39,7 +39,7 @@ export const useNotificationRegistrations = (): {
   const dispatch = useAppDispatch()
   const wallet = useWallet()
 
-  const { uuid, _createPreferences, _deletePreferences, _deleteAllPreferences } = useNotificationPreferences()
+  const { uuid, createPreferences, deletePreferences, deleteAllChainPreferences } = useNotificationPreferences()
 
   const registerNotifications = async (safesToRegister: NotifiableSafes) => {
     if (!uuid || !wallet) {
@@ -57,7 +57,7 @@ export const useNotificationRegistrations = (): {
     }
 
     return registrationFlow(register(), () => {
-      _createPreferences(safesToRegister)
+      createPreferences(safesToRegister)
 
       const totalRegistered = Object.values(safesToRegister).reduce(
         (acc, safeAddresses) => acc + safeAddresses.length,
@@ -84,7 +84,7 @@ export const useNotificationRegistrations = (): {
   const unregisterSafeNotifications = async (chainId: string, safeAddress: string) => {
     if (uuid) {
       return registrationFlow(unregisterSafe(chainId, safeAddress, uuid), () => {
-        _deletePreferences({ [chainId]: [safeAddress] })
+        deletePreferences({ [chainId]: [safeAddress] })
         trackEvent(PUSH_NOTIFICATION_EVENTS.UNREGISTER_SAFE)
       })
     }
@@ -93,7 +93,7 @@ export const useNotificationRegistrations = (): {
   const unregisterDeviceNotifications = async (chainId: string) => {
     if (uuid) {
       return registrationFlow(unregisterDevice(chainId, uuid), () => {
-        _deleteAllPreferences()
+        deleteAllChainPreferences(chainId)
         trackEvent(PUSH_NOTIFICATION_EVENTS.UNREGISTER_DEVICE)
       })
     }

--- a/src/services/exceptions/ErrorCodes.ts
+++ b/src/services/exceptions/ErrorCodes.ts
@@ -45,8 +45,8 @@ enum ErrorCodes {
   _702 = '702: Failed to remove from local/session storage',
   _703 = '703: Error importing an address book',
   _704 = '704: Error importing global data',
-  _705 = '704: Failed to read from IndexedDB',
-  _706 = '704: Failed to write to IndexedDB',
+  _705 = '705: Failed to read from IndexedDB',
+  _706 = '706: Failed to write to IndexedDB',
 
   _800 = '800: Safe creation tx failed',
   _801 = '801: Failed to send a tx with a spending limit',


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/safe-wallet-web/pull/2546#issuecomment-1736499323

## How this PR fixes it

`deleteAllPreferences` is has been replaced with `deleteAllChainPreferences`, which clears preferences according to a provided `chainId` according to the device unregistration (also per `chainId`).

A loading indicator has also been added to the global preferences "Save" button.

## How to test it

During the following registrations, a loading indicator should appear in the "Save" button:

1. Ensure multiple Safes are registered across differing chains.
2. Navigate to the global notification preferences.
3. Unregister a Safe.
4. Observe _only_ the preferences from that Safe removed.
---

1. Ensure multiple Safes are registered across differing chains.
2. Navigate to the global notification preferences.
3. Unregister _all_ Safes on one network.
6. Observe the Safes on other chain(s) retain their preferences.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
