### PR TITLE
feat: help centre article link placeholder

### DIFF
--- a/src/components/settings/PushNotifications/index.tsx
+++ b/src/components/settings/PushNotifications/index.tsx
@@ -21,7 +21,7 @@ import { useNotificationRegistrations } from './hooks/useNotificationRegistratio
 import { useNotificationPreferences } from './hooks/useNotificationPreferences'
 import { GlobalPushNotifications } from './GlobalPushNotifications'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
-import { IS_DEV } from '@/config/constants'
+import { HelpCenterArticle, IS_DEV } from '@/config/constants'
 import { trackEvent } from '@/services/analytics'
 import { PUSH_NOTIFICATION_EVENTS } from '@/services/analytics/events/push-notifications'
 import { AppRoutes } from '@/config/routes'
@@ -108,7 +108,7 @@ export const PushNotifications = (): ReactElement => {
               <Typography>
                 Enable push notifications for {safeLoaded ? 'this Safe Account' : 'your Safe Accounts'} in your browser
                 with your signature. You will need to enable them again if you clear your browser cache. Learn more
-                about push notifications <ExternalLink href="#">here</ExternalLink>
+                about push notifications <ExternalLink href={HelpCenterArticle.PUSH_NOTIFICATIONS}>here</ExternalLink>
               </Typography>
 
               {shouldShowMacHelper && (

--- a/src/components/settings/PushNotifications/index.tsx
+++ b/src/components/settings/PushNotifications/index.tsx
@@ -29,6 +29,7 @@ import CheckWallet from '@/components/common/CheckWallet'
 import { useIsMac } from '@/hooks/useIsMac'
 import useOnboard from '@/hooks/wallets/useOnboard'
 import { assertWalletChain } from '@/services/tx/tx-sender/sdk'
+import ExternalLink from '@/components/common/ExternalLink'
 
 import css from './styles.module.css'
 
@@ -106,7 +107,8 @@ export const PushNotifications = (): ReactElement => {
             <Grid container gap={2.5} flexDirection="column">
               <Typography>
                 Enable push notifications for {safeLoaded ? 'this Safe Account' : 'your Safe Accounts'} in your browser
-                with your signature. You will need to enable them again if you clear your browser cache.
+                with your signature. You will need to enable them again if you clear your browser cache. Learn more
+                about push notifications <ExternalLink href="#">here</ExternalLink>
               </Typography>
 
               {shouldShowMacHelper && (

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -84,6 +84,7 @@ export const HelpCenterArticle = {
   TRANSACTION_GUARD: `${HELP_CENTER_URL}/en/articles/40809-what-is-a-transaction-guard`,
   UNEXPECTED_DELEGATE_CALL: `${HELP_CENTER_URL}/en/articles/40794-why-do-i-see-an-unexpected-delegate-call-warning-in-my-transaction`,
   DELEGATES: `${HELP_CENTER_URL}/en/articles/40799-what-is-a-delegate-key`,
+  PUSH_NOTIFICATIONS: `${HELP_CENTER_URL}/en/articles/99197-how-to-start-receiving-web-push-notifications-in-the-web-wallet`,
 } as const
 
 // Social


### PR DESCRIPTION
## What it solves

Adds help center link to the push notifications settings page.

## How this PR fixes it

A new "Learn more about push notifications here" sentence has been added to the end of the description of push notifications in the per-Safe/global notifications settings.

## How to test it

Open the per-Safe/global notifications settings and observe the new sentence/working link.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/998ff1cb-ad51-4f42-9972-319c240d38bd)

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/5acc8f51-3e47-47f4-903f-f00f0cfe8699)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
