### PR TITLE
fix: Show recommended nonce when nonce is 0, fix msgSummary layout

### DIFF
--- a/src/components/safe-messages/MsgSummary/index.tsx
+++ b/src/components/safe-messages/MsgSummary/index.tsx
@@ -34,7 +34,7 @@ const MsgSummary = ({ msg }: { msg: SafeMessage }): ReactElement => {
   const isConfirmed = msg.status === SafeMessageStatus.CONFIRMED
 
   return (
-    <Box className={classNames(txSummaryCss.gridContainer, txSummaryCss.columnTemplateWithoutNonce)}>
+    <Box className={classNames(txSummaryCss.gridContainer, txSummaryCss.columnTemplate)}>
       <Box gridArea="type" className={txSummaryCss.columnWrap}>
         <MsgType msg={msg} />
       </Box>

--- a/src/components/tx/SignOrExecuteForm/hooks.ts
+++ b/src/components/tx/SignOrExecuteForm/hooks.ts
@@ -170,7 +170,7 @@ export const useRecommendedNonce = (): number | undefined => {
 
       const recommendedNonce = await getRecommendedNonce(safe.chainId, safeAddress)
 
-      return recommendedNonce ? Math.max(safe.nonce, recommendedNonce) : undefined
+      return recommendedNonce !== undefined ? Math.max(safe.nonce, recommendedNonce) : undefined
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [safeAddress, safe.chainId, safe.txQueuedTag], // update when tx queue changes


### PR DESCRIPTION
## What it solves

Fixes https://github.com/safe-global/safe-wallet-web/pull/2546#issuecomment-1738335210, https://github.com/safe-global/safe-wallet-web/pull/2546#issuecomment-1738357845

## How this PR fixes it

- Checks the `recommendedNonce` for undefined
- Adds correct css class to MsgSummary

## How to test it

1. Create a new transaction in a new safe
2. Observe the nonce form showing 0
3. Go to Messages with existing messages there
4. Observe no overlaps

## Screenshots
<img width="1256" alt="Screenshot 2023-09-28 at 09 11 26" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/efcfcd9a-23dc-45d1-ba35-df758ce36a0b">
<img width="711" alt="Screenshot 2023-09-28 at 09 12 53" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/72bd92f5-046a-4e9b-852b-c6b0e0e8eef2">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
