### PR TITLE
fix: nonce field styles

### DIFF
--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -14,6 +14,7 @@ import {
   ListSubheader,
   type ListSubheaderProps,
 } from '@mui/material'
+import { createFilterOptions } from '@mui/material/Autocomplete'
 import { Controller, useForm } from 'react-hook-form'
 
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
@@ -81,12 +82,21 @@ const NonceFormOption = memo(function NonceFormOption({
   )
 })
 
-const getFieldMinWidth = (value: string): string => {
+const getFieldMinWidth = (value: string, showRecommendedNonceButton = false): string => {
   const MIN_CHARS = 5
   const MAX_WIDTH = '200px'
+  const ADORNMENT_PADDING = '24px'
 
-  return `clamp(calc(${MIN_CHARS}ch + 6px), calc(${Math.max(MIN_CHARS, value.length)}ch + 6px), ${MAX_WIDTH})`
+  const clamped = `clamp(calc(${MIN_CHARS}ch + 6px), calc(${Math.max(MIN_CHARS, value.length)}ch + 6px), ${MAX_WIDTH})`
+
+  if (showRecommendedNonceButton) {
+    return `calc(${clamped} + ${ADORNMENT_PADDING})`
+  }
+
+  return clamped
 }
+
+const filter = createFilterOptions<string>()
 
 enum TxNonceFormFieldNames {
   NONCE = 'nonce',
@@ -169,6 +179,17 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
             }}
             options={[recommendedNonce, ...previousNonces]}
             getOptionLabel={(option) => option.toString()}
+            filterOptions={(options, params) => {
+              const filtered = filter(options, params)
+
+              const isExisting = options.some((option) => params.inputValue === option)
+
+              if (params.inputValue !== '' && !isExisting) {
+                filtered.push(recommendedNonce)
+              }
+
+              return filtered
+            }}
             renderOption={(props, option) => {
               const isRecommendedNonce = option === recommendedNonce
               const isInitialPreviousNonce = option === previousNonces[0]
@@ -213,7 +234,7 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
                       },
                     ])}
                     sx={{
-                      minWidth: getFieldMinWidth(field.value),
+                      minWidth: getFieldMinWidth(field.value, showRecommendedNonceButton),
                     }}
                   />
                 </Tooltip>


### PR DESCRIPTION
## What it solves

Partially resolves #2560

## How this PR fixes it

The recommended nonce is always shown and the padding applied for the reset nonce button is included in the field width.

## How to test it

Open the transaction flow and observe the recommended nonce always shown when a non-existent recommended nonce exists, as well as the value always visible.

## Screenshots

![recommended-nonce](https://github.com/safe-global/safe-wallet-web/assets/20442784/55468506-1538-4928-8c8a-b2b89fa891d9)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
