### PR TITLE
fix: disabled "Enable all" button height

### DIFF
--- a/src/components/settings/PushNotifications/PushNotificationsBanner/index.tsx
+++ b/src/components/settings/PushNotifications/PushNotificationsBanner/index.tsx
@@ -143,9 +143,9 @@ export const PushNotificationsBanner = ({ children }: { children: ReactElement }
     dismissBanner()
   }
 
-  // if (!shouldShowBanner) {
-  //   return children
-  // }
+  if (!shouldShowBanner) {
+    return children
+  }
 
   return (
     <CustomTooltip

--- a/src/components/settings/PushNotifications/PushNotificationsBanner/index.tsx
+++ b/src/components/settings/PushNotifications/PushNotificationsBanner/index.tsx
@@ -143,9 +143,9 @@ export const PushNotificationsBanner = ({ children }: { children: ReactElement }
     dismissBanner()
   }
 
-  if (!shouldShowBanner) {
-    return children
-  }
+  // if (!shouldShowBanner) {
+  //   return children
+  // }
 
   return (
     <CustomTooltip
@@ -167,10 +167,11 @@ export const PushNotificationsBanner = ({ children }: { children: ReactElement }
               Get notified about pending signatures, incoming and outgoing transactions and more when Safe{`{Wallet}`}{' '}
               is in the background or closed.
             </Typography>
-            <div className={css.buttons}>
-              {totalAddedSafes > 0 && (
-                <CheckWallet>
-                  {(isOk) => (
+            {/* Cannot wrap singular button as it causes style inconsistencies */}
+            <CheckWallet>
+              {(isOk) => (
+                <div className={css.buttons}>
+                  {totalAddedSafes > 0 && (
                     <Button
                       variant="contained"
                       size="small"
@@ -181,16 +182,16 @@ export const PushNotificationsBanner = ({ children }: { children: ReactElement }
                       Enable all
                     </Button>
                   )}
-                </CheckWallet>
+                  {safe && (
+                    <Link passHref href={{ pathname: AppRoutes.settings.notifications, query }} onClick={onCustomize}>
+                      <Button variant="outlined" size="small" className={css.button}>
+                        Customize
+                      </Button>
+                    </Link>
+                  )}
+                </div>
               )}
-              {safe && (
-                <Link passHref href={{ pathname: AppRoutes.settings.notifications, query }} onClick={onCustomize}>
-                  <Button variant="outlined" size="small" className={css.button}>
-                    Customize
-                  </Button>
-                </Link>
-              )}
-            </div>
+            </CheckWallet>
           </Grid>
         </Grid>
       }


### PR DESCRIPTION
## What it solves

Resolves style inconsistency for "Enable all" button height when disabled.

## How this PR fixes it

The `CheckWallet` component now wraps the button container element instead of just the "Enable all" button.

## How to test it

Note: this seems to happen only in Chrome.

1. Ensure no wallet is connect.
2. Ensure the Safe has not previously dismissed the push notification banner.
3. Open the Safe.
4. Observe the "Enable all" button (disabled) having the same height as the "Customize" button in the notification banner.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/08c15e69-cbd5-48bd-bbc3-54389c16c864)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
