### PR TITLE
fix: only request new notification signatures

### DIFF
--- a/src/components/settings/PushNotifications/PushNotificationsBanner/PushNotificationsBanner.test.ts
+++ b/src/components/settings/PushNotifications/PushNotificationsBanner/PushNotificationsBanner.test.ts
@@ -1,0 +1,84 @@
+import { _getSafesToRegister } from '.'
+import type { AddedSafesState } from '@/store/addedSafesSlice'
+import type { PushNotificationPreferences } from '@/services/push-notifications/preferences'
+
+describe('PushNotificationsBanner', () => {
+  describe('getSafesToRegister', () => {
+    it('should return all added safes if no preferences exist', () => {
+      const addedSafes = {
+        '1': {
+          '0x123': {},
+          '0x456': {},
+        },
+        '4': {
+          '0x789': {},
+        },
+      } as unknown as AddedSafesState
+      const allPreferences = undefined
+
+      const result = _getSafesToRegister(addedSafes, allPreferences)
+
+      expect(result).toEqual({
+        '1': ['0x123', '0x456'],
+        '4': ['0x789'],
+      })
+    })
+
+    it('should return only newly added safes if preferences exist', () => {
+      const addedSafes = {
+        '1': {
+          '0x123': {},
+          '0x456': {},
+        },
+        '4': {
+          '0x789': {},
+        },
+      } as unknown as AddedSafesState
+      const allPreferences = {
+        '1:0x123': {
+          safeAddress: '0x123',
+          chainId: '1',
+        },
+        '4:0x789': {
+          safeAddress: '0x789',
+          chainId: '4',
+        },
+      } as unknown as PushNotificationPreferences
+
+      const result = _getSafesToRegister(addedSafes, allPreferences)
+
+      expect(result).toEqual({
+        '1': ['0x456'],
+      })
+    })
+
+    it('should return all added safes if no preferences match', () => {
+      const addedSafes = {
+        '1': {
+          '0x123': {},
+          '0x456': {},
+        },
+        '4': {
+          '0x789': {},
+        },
+      } as unknown as AddedSafesState
+      const allPreferences = {
+        '1:0x111': {
+          safeAddress: '0x111',
+          chainId: '1',
+        },
+        '4:0x222': {
+          safeAddress: '0x222',
+          chainId: '4',
+        },
+      } as unknown as PushNotificationPreferences
+
+      const result = _getSafesToRegister(addedSafes, allPreferences)
+
+      expect(result).toEqual({
+        '1': ['0x123', '0x456'],
+        '4': ['0x789'],
+      })
+    })
+  })
+})

--- a/src/components/settings/PushNotifications/PushNotificationsBanner/index.tsx
+++ b/src/components/settings/PushNotifications/PushNotificationsBanner/index.tsx
@@ -65,7 +65,10 @@ export const useDismissPushNotificationsBanner = () => {
   }
 }
 
-const getSafesToRegister = (addedSafes: AddedSafesState, allPreferences: PushNotificationPreferences | undefined) => {
+export const _getSafesToRegister = (
+  addedSafes: AddedSafesState,
+  allPreferences: PushNotificationPreferences | undefined,
+) => {
   // Regiser all added Safes
   if (!allPreferences) {
     return transformAddedSafes(addedSafes)
@@ -77,13 +80,14 @@ const getSafesToRegister = (addedSafes: AddedSafesState, allPreferences: PushNot
     const notificationRegistrations = Object.values(allPreferences)
 
     const newlyAddedSafes = addedSafeAddressesOnChain.filter((safeAddress) => {
-      return (
-        notificationRegistrations.length === 0 ||
-        notificationRegistrations.some((registration) => !sameAddress(registration.safeAddress, safeAddress))
+      return !notificationRegistrations.some(
+        (registration) => chainId === registration.chainId && sameAddress(registration.safeAddress, safeAddress),
       )
     })
 
-    acc[chainId] = newlyAddedSafes
+    if (newlyAddedSafes.length > 0) {
+      acc[chainId] = newlyAddedSafes
+    }
 
     return acc
   }, {})
@@ -124,7 +128,7 @@ export const PushNotificationsBanner = ({ children }: { children: ReactElement }
     trackEvent(PUSH_NOTIFICATION_EVENTS.ENABLE_ALL)
 
     const allPreferences = getAllPreferences()
-    const safesToRegister = getSafesToRegister(addedSafes, allPreferences)
+    const safesToRegister = _getSafesToRegister(addedSafes, allPreferences)
 
     try {
       await assertWalletChain(onboard, safe.chainId)


### PR DESCRIPTION
## What it solves

Resolves signature requests for Safes that are already registered for notifications.

## How this PR fixes it

The logic within the banner has been fixed, as well as more unit test coverage added.

## How to test it

1. Add a Safe on chain A and register for notifications with it.
2. Add a Safe on chain B and register for notifications with it.
3. Observe only one signature request.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
