### PR TITLE
Fix: notifications popup: don't hide just one item

### DIFF
--- a/src/components/notification-center/NotificationCenter/index.tsx
+++ b/src/components/notification-center/NotificationCenter/index.tsx
@@ -37,7 +37,7 @@ const NotificationCenter = (): ReactElement => {
     return notifications.slice().sort((a, b) => b.timestamp - a.timestamp)
   }, [notifications])
 
-  const canExpand = notifications.length > NOTIFICATION_CENTER_LIMIT
+  const canExpand = notifications.length > NOTIFICATION_CENTER_LIMIT + 1
 
   const notificationsToShow =
     canExpand && showAll ? chronologicalNotifications : chronologicalNotifications.slice(0, NOTIFICATION_CENTER_LIMIT)

--- a/src/components/transactions/TxType/styles.module.css
+++ b/src/components/transactions/TxType/styles.module.css
@@ -1,7 +1,7 @@
 .txType {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: var(--space-1);
   color: var(--color-text-primary);
 }


### PR DESCRIPTION
Avoid hiding a single notification behind a collapsible box. It occupies exactly the same space.
Plus, the wording "1 other notification<b>s</b>" is wrong.

## How to test
1.
* Trigger 5 notitications
* Before: the 5th one was hidden, and it said "1 other notifications"
* After: all 5 are shown

2.
* Trigger 6 or more notitications
* Only 4 are shown and it says "2 other notifications"