### PR TITLE
feat: notification settings link

### DIFF
--- a/src/components/notification-center/NotificationCenter/index.tsx
+++ b/src/components/notification-center/NotificationCenter/index.tsx
@@ -42,7 +42,7 @@ const NotificationCenter = (): ReactElement => {
     return notifications.slice().sort((a, b) => b.timestamp - a.timestamp)
   }, [notifications])
 
-  const canExpand = notifications.length > NOTIFICATION_CENTER_LIMIT + 1
+  const canExpand = notifications.length > NOTIFICATION_CENTER_LIMIT
 
   const notificationsToShow =
     canExpand && showAll ? chronologicalNotifications : chronologicalNotifications.slice(0, NOTIFICATION_CENTER_LIMIT)

--- a/src/components/notification-center/NotificationCenter/index.tsx
+++ b/src/components/notification-center/NotificationCenter/index.tsx
@@ -164,7 +164,7 @@ const NotificationCenter = (): ReactElement => {
               passHref
               legacyBehavior
             >
-              <MuiLink className={css.settingsLink} variant="body2">
+              <MuiLink className={css.settingsLink} variant="body2" onClick={handleClose}>
                 <SvgIcon component={SettingsIcon} inheritViewBox fontSize="small" /> Settings
               </MuiLink>
             </Link>

--- a/src/components/notification-center/NotificationCenter/index.tsx
+++ b/src/components/notification-center/NotificationCenter/index.tsx
@@ -3,7 +3,6 @@ import ButtonBase from '@mui/material/ButtonBase'
 import Popover from '@mui/material/Popover'
 import Paper from '@mui/material/Paper'
 import Typography from '@mui/material/Typography'
-import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
 import MuiLink from '@mui/material/Link'
 import BellIcon from '@/public/images/notifications/bell.svg'
@@ -21,6 +20,7 @@ import UnreadBadge from '@/components/common/UnreadBadge'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { AppRoutes } from '@/config/routes'
+import SettingsIcon from '@/public/images/sidebar/settings.svg'
 
 import css from './styles.module.css'
 import { trackEvent, OVERVIEW_EVENTS } from '@/services/analytics'
@@ -129,9 +129,9 @@ const NotificationCenter = (): ReactElement => {
               )}
             </div>
             {notifications.length > 0 && (
-              <Button variant="text" size="small" onClick={handleClear}>
+              <MuiLink onClick={handleClear} variant="body2" component="button" sx={{ textDecoration: 'unset' }}>
                 Clear all
-              </Button>
+              </MuiLink>
             )}
           </div>
           <div>
@@ -164,7 +164,9 @@ const NotificationCenter = (): ReactElement => {
               passHref
               legacyBehavior
             >
-              <MuiLink className={css.settingsLink}>Notification settings</MuiLink>
+              <MuiLink className={css.settingsLink} variant="body2">
+                <SvgIcon component={SettingsIcon} inheritViewBox fontSize="small" /> Settings
+              </MuiLink>
             </Link>
           </div>
         </Paper>

--- a/src/components/notification-center/NotificationCenter/index.tsx
+++ b/src/components/notification-center/NotificationCenter/index.tsx
@@ -18,16 +18,18 @@ import {
 } from '@/store/notificationsSlice'
 import NotificationCenterList from '@/components/notification-center/NotificationCenterList'
 import UnreadBadge from '@/components/common/UnreadBadge'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { AppRoutes } from '@/config/routes'
 
 import css from './styles.module.css'
 import { trackEvent, OVERVIEW_EVENTS } from '@/services/analytics'
 import SvgIcon from '@mui/icons-material/ExpandLess'
-import { AppRoutes } from '@/config/routes'
-import Link from 'next/link'
 
 const NOTIFICATION_CENTER_LIMIT = 4
 
 const NotificationCenter = (): ReactElement => {
+  const router = useRouter()
   const [showAll, setShowAll] = useState<boolean>(false)
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
   const open = Boolean(anchorEl)
@@ -154,7 +156,14 @@ const NotificationCenter = (): ReactElement => {
                 </Typography>
               </>
             )}
-            <Link href={AppRoutes.settings.notifications} passHref legacyBehavior>
+            <Link
+              href={{
+                pathname: AppRoutes.settings.notifications,
+                query: router.query,
+              }}
+              passHref
+              legacyBehavior
+            >
               <MuiLink className={css.settingsLink}>Notification settings</MuiLink>
             </Link>
           </div>

--- a/src/components/notification-center/NotificationCenter/index.tsx
+++ b/src/components/notification-center/NotificationCenter/index.tsx
@@ -5,6 +5,7 @@ import Paper from '@mui/material/Paper'
 import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
+import MuiLink from '@mui/material/Link'
 import BellIcon from '@/public/images/notifications/bell.svg'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
@@ -21,6 +22,8 @@ import UnreadBadge from '@/components/common/UnreadBadge'
 import css from './styles.module.css'
 import { trackEvent, OVERVIEW_EVENTS } from '@/services/analytics'
 import SvgIcon from '@mui/icons-material/ExpandLess'
+import { AppRoutes } from '@/config/routes'
+import Link from 'next/link'
 
 const NOTIFICATION_CENTER_LIMIT = 4
 
@@ -37,7 +40,7 @@ const NotificationCenter = (): ReactElement => {
     return notifications.slice().sort((a, b) => b.timestamp - a.timestamp)
   }, [notifications])
 
-  const canExpand = notifications.length > NOTIFICATION_CENTER_LIMIT
+  const canExpand = notifications.length > NOTIFICATION_CENTER_LIMIT + 1
 
   const notificationsToShow =
     canExpand && showAll ? chronologicalNotifications : chronologicalNotifications.slice(0, NOTIFICATION_CENTER_LIMIT)
@@ -132,24 +135,29 @@ const NotificationCenter = (): ReactElement => {
           <div>
             <NotificationCenterList notifications={notificationsToShow} handleClose={handleClose} />
           </div>
-          {canExpand && (
-            <div className={css.popoverFooter}>
-              <IconButton onClick={() => setShowAll((prev) => !prev)} disableRipple className={css.expandButton}>
-                <UnreadBadge
-                  invisible={showAll || unreadCount <= NOTIFICATION_CENTER_LIMIT}
-                  anchorOrigin={{
-                    vertical: 'top',
-                    horizontal: 'left',
-                  }}
-                >
-                  <ExpandIcon color="border" />
-                </UnreadBadge>
-              </IconButton>
-              <Typography sx={{ color: ({ palette }) => palette.border.main }}>
-                {showAll ? 'Hide' : `${notifications.length - NOTIFICATION_CENTER_LIMIT} other notifications`}
-              </Typography>
-            </div>
-          )}
+          <div className={css.popoverFooter}>
+            {canExpand && (
+              <>
+                <IconButton onClick={() => setShowAll((prev) => !prev)} disableRipple className={css.expandButton}>
+                  <UnreadBadge
+                    invisible={showAll || unreadCount <= NOTIFICATION_CENTER_LIMIT}
+                    anchorOrigin={{
+                      vertical: 'top',
+                      horizontal: 'left',
+                    }}
+                  >
+                    <ExpandIcon color="border" />
+                  </UnreadBadge>
+                </IconButton>
+                <Typography sx={{ color: ({ palette }) => palette.border.main }}>
+                  {showAll ? 'Hide' : `${notifications.length - NOTIFICATION_CENTER_LIMIT} other notifications`}
+                </Typography>
+              </>
+            )}
+            <Link href={AppRoutes.settings.notifications} passHref legacyBehavior>
+              <MuiLink className={css.settingsLink}>Notification settings</MuiLink>
+            </Link>
+          </div>
         </Paper>
       </Popover>
     </>

--- a/src/components/notification-center/NotificationCenter/styles.module.css
+++ b/src/components/notification-center/NotificationCenter/styles.module.css
@@ -28,7 +28,7 @@
 }
 
 .popoverFooter {
-  padding: var(--space-2);
+  padding: var(--space-3);
   display: flex;
   align-items: center;
 }
@@ -60,5 +60,8 @@
 
 .settingsLink {
   margin-left: auto;
+  display: flex;
+  align-items: center;
   text-decoration: unset;
+  gap: var(--space-1);
 }

--- a/src/components/notification-center/NotificationCenter/styles.module.css
+++ b/src/components/notification-center/NotificationCenter/styles.module.css
@@ -57,3 +57,8 @@
   width: 18px;
   height: 18px;
 }
+
+.settingsLink {
+  margin-left: auto;
+  text-decoration: unset;
+}

--- a/src/components/notification-center/NotificationCenter/styles.module.css
+++ b/src/components/notification-center/NotificationCenter/styles.module.css
@@ -28,7 +28,7 @@
 }
 
 .popoverFooter {
-  padding: var(--space-3);
+  padding: var(--space-2) var(--space-3);
   display: flex;
   align-items: center;
 }


### PR DESCRIPTION
## What it solves

Resolves unclear notification settings navigation

## How this PR fixes it

A "Notifications settings" link has been added to the notification centre footer.

## How to test it

Open the notification centre and observe the new, working link in the footer.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/e9379f70-d407-4ee1-af63-2f501be20f9a)

Older screenshots showcasing the presence:

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/5b2b725f-021c-4a5c-816d-04e6a037c424)

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/07dfde96-0d23-4e7b-b66e-60eb3ed1bef0)

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/0a643b81-965d-4eb0-94f1-b78523542328)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
