### PR TITLE
fix: enable notifications per chain

### DIFF
--- a/src/components/settings/PushNotifications/PushNotificationsBanner/PushNotificationsBanner.test.ts
+++ b/src/components/settings/PushNotifications/PushNotificationsBanner/PushNotificationsBanner.test.ts
@@ -1,39 +1,28 @@
 import { _getSafesToRegister } from '.'
-import type { AddedSafesState } from '@/store/addedSafesSlice'
+import type { AddedSafesOnChain } from '@/store/addedSafesSlice'
 import type { PushNotificationPreferences } from '@/services/push-notifications/preferences'
 
 describe('PushNotificationsBanner', () => {
   describe('getSafesToRegister', () => {
     it('should return all added safes if no preferences exist', () => {
-      const addedSafes = {
-        '1': {
-          '0x123': {},
-          '0x456': {},
-        },
-        '4': {
-          '0x789': {},
-        },
-      } as unknown as AddedSafesState
+      const addedSafesOnChain = {
+        '0x123': {},
+        '0x456': {},
+      } as unknown as AddedSafesOnChain
       const allPreferences = undefined
 
-      const result = _getSafesToRegister(addedSafes, allPreferences)
+      const result = _getSafesToRegister('1', addedSafesOnChain, allPreferences)
 
       expect(result).toEqual({
         '1': ['0x123', '0x456'],
-        '4': ['0x789'],
       })
     })
 
     it('should return only newly added safes if preferences exist', () => {
-      const addedSafes = {
-        '1': {
-          '0x123': {},
-          '0x456': {},
-        },
-        '4': {
-          '0x789': {},
-        },
-      } as unknown as AddedSafesState
+      const addedSafesOnChain = {
+        '0x123': {},
+        '0x456': {},
+      } as unknown as AddedSafesOnChain
       const allPreferences = {
         '1:0x123': {
           safeAddress: '0x123',
@@ -45,7 +34,7 @@ describe('PushNotificationsBanner', () => {
         },
       } as unknown as PushNotificationPreferences
 
-      const result = _getSafesToRegister(addedSafes, allPreferences)
+      const result = _getSafesToRegister('1', addedSafesOnChain, allPreferences)
 
       expect(result).toEqual({
         '1': ['0x456'],
@@ -53,15 +42,10 @@ describe('PushNotificationsBanner', () => {
     })
 
     it('should return all added safes if no preferences match', () => {
-      const addedSafes = {
-        '1': {
-          '0x123': {},
-          '0x456': {},
-        },
-        '4': {
-          '0x789': {},
-        },
-      } as unknown as AddedSafesState
+      const addedSafesOnChain = {
+        '0x123': {},
+        '0x456': {},
+      } as unknown as AddedSafesOnChain
       const allPreferences = {
         '1:0x111': {
           safeAddress: '0x111',
@@ -73,11 +57,10 @@ describe('PushNotificationsBanner', () => {
         },
       } as unknown as PushNotificationPreferences
 
-      const result = _getSafesToRegister(addedSafes, allPreferences)
+      const result = _getSafesToRegister('1', addedSafesOnChain, allPreferences)
 
       expect(result).toEqual({
         '1': ['0x123', '0x456'],
-        '4': ['0x789'],
       })
     })
   })

--- a/src/components/settings/PushNotifications/PushNotificationsBanner/index.tsx
+++ b/src/components/settings/PushNotifications/PushNotificationsBanner/index.tsx
@@ -162,8 +162,9 @@ export const PushNotificationsBanner = ({ children }: { children: ReactElement }
               <SvgIcon component={CloseIcon} inheritViewBox color="border" fontSize="small" />
             </IconButton>
             <Typography mt={0.5} mb={1.5} variant="body2">
-              Get notified about pending signatures, incoming and outgoing transactions and more when Safe{`{Wallet}`}{' '}
-              is in the background or closed.
+              Get notified about pending signatures, incoming and outgoing transactions for all Safes on{' '}
+              {chain?.chainName} when Safe
+              {`{Wallet}`} is in the background or closed.
             </Typography>
             {/* Cannot wrap singular button as it causes style inconsistencies */}
             <CheckWallet>
@@ -177,7 +178,7 @@ export const PushNotificationsBanner = ({ children }: { children: ReactElement }
                       onClick={onEnableAll}
                       disabled={!isOk || !onboard}
                     >
-                      Enable on {chain?.chainName}
+                      Enable all
                     </Button>
                   )}
                   {safe && (

--- a/src/components/settings/PushNotifications/PushNotificationsBanner/index.tsx
+++ b/src/components/settings/PushNotifications/PushNotificationsBanner/index.tsx
@@ -162,7 +162,7 @@ export const PushNotificationsBanner = ({ children }: { children: ReactElement }
               <SvgIcon component={CloseIcon} inheritViewBox color="border" fontSize="small" />
             </IconButton>
             <Typography mt={0.5} mb={1.5} variant="body2">
-              Get notified about pending signatures, incoming and outgoing transactions for all Safes on{' '}
+              Get notified about pending signatures, incoming and outgoing transactions for all Safe Accounts on{' '}
               {chain?.chainName} when Safe
               {`{Wallet}`} is in the background or closed.
             </Typography>

--- a/src/components/settings/PushNotifications/__tests__/GlobalPushNotifications.test.ts
+++ b/src/components/settings/PushNotifications/__tests__/GlobalPushNotifications.test.ts
@@ -1,5 +1,7 @@
+import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
+
 import {
-  transformAddedSafes,
+  _transformAddedSafes,
   _mergeNotifiableSafes,
   _transformCurrentSubscribedSafes,
   _getTotalNotifiableSafes,
@@ -10,6 +12,7 @@ import {
   _getSafesToRegister,
   _getSafesToUnregister,
   _shouldUnregisterDevice,
+  _sanitizeNotifiableSafes,
 } from '../GlobalPushNotifications'
 import type { AddedSafesState } from '@/store/addedSafesSlice'
 
@@ -31,7 +34,7 @@ describe('GlobalPushNotifications', () => {
         '4': ['0x789'],
       }
 
-      expect(transformAddedSafes(addedSafes)).toEqual(expectedNotifiableSafes)
+      expect(_transformAddedSafes(addedSafes)).toEqual(expectedNotifiableSafes)
     })
   })
 
@@ -71,7 +74,24 @@ describe('GlobalPushNotifications', () => {
         },
       } as unknown as AddedSafesState
 
-      expect(_mergeNotifiableSafes(addedSafes)).toEqual(transformAddedSafes(addedSafes))
+      expect(_mergeNotifiableSafes(addedSafes)).toEqual(_transformAddedSafes(addedSafes))
+    })
+  })
+
+  describe('sanitizeNotifiableSafes', () => {
+    it('should remove Safes that are not on a supported chain', () => {
+      const chains = [{ chainId: '1', name: 'Mainnet' }] as unknown as Array<ChainInfo>
+
+      const notifiableSafes = {
+        '1': ['0x123', '0x456'],
+        '4': ['0xabc'],
+      }
+
+      const expected = {
+        '1': ['0x123', '0x456'],
+      }
+
+      expect(_sanitizeNotifiableSafes(chains, notifiableSafes)).toEqual(expected)
     })
   })
 

--- a/src/services/analytics/events/push-notifications.ts
+++ b/src/services/analytics/events/push-notifications.ts
@@ -38,7 +38,7 @@ export const PUSH_NOTIFICATION_EVENTS = {
   },
   // User enabled all notifications from banner
   ENABLE_ALL: {
-    action: 'Enable all notifications',
+    action: 'Enable all notifications on chain',
     category,
   },
   // User opened Safe notification settings from banner

--- a/src/services/analytics/events/push-notifications.ts
+++ b/src/services/analytics/events/push-notifications.ts
@@ -38,7 +38,7 @@ export const PUSH_NOTIFICATION_EVENTS = {
   },
   // User enabled all notifications from banner
   ENABLE_ALL: {
-    action: 'Enable all notifications on chain',
+    action: 'Enable all notifications',
     category,
   },
   // User opened Safe notification settings from banner


### PR DESCRIPTION
## What it solves

Multiple signing windows and unsupported added Safes breaking registration.

## How this PR fixes it

Enabling "all" notifications via the banner is now per chain. Only one signing window will appear and Safes on that chain will be registered for notifications.

On the global notifications settings page, the notifiable Safes are filtered according to the chains of the config service.

## How to test it

### Enabling per chain

1. Ensure there are added Safes on differing networks and that no notification banner has been previously dismissed.
2. Open a network with added Safes and enable the notifications via the banner.
3. Observe only one signing window appear.
4. Switch to another network with added Safes and repeat.

### Enabling globally

1. Add an unsupported chain with Safes to the `SAFE_v2__addedSafes` key in the `localStorage`.
2. Navigate to the global notification settings.
3. Select all Safes or the supported Safes.
4. Click "Save" and observe a successful registration.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/89f623b8-7276-4429-99d7-8c530d378089)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
