### PR TITLE
fix: don't cut off DApp icon

### DIFF
--- a/src/components/safe-apps/SafeAppIconCard/index.tsx
+++ b/src/components/safe-apps/SafeAppIconCard/index.tsx
@@ -5,7 +5,7 @@ const APP_LOGO_FALLBACK_IMAGE = `/images/apps/app-placeholder.svg`
 
 const getIframeContent = (url: string, width: number, height: number, fallback: string): string => {
   return `
-     <body style="margin: 0; overflow: hidden;">
+     <body style="margin: 0; overflow: hidden; display: flex;">
        <img src="${encodeURI(url)}" alt="Safe App logo" width="${width}" height="${height}" />
        <script>
           document.querySelector('img').onerror = (e) => {


### PR DESCRIPTION
## What it solves

Resolves cut off logo

## How this PR fixes it

The full logo is now shown in the header when connected to a DApp.

## How to test it

Connect to a DApp via native WC and observe no cut off logo.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
