### PR TITLE
fix: update session after approval

### DIFF
--- a/src/services/walletconnect/WalletConnectWallet.ts
+++ b/src/services/walletconnect/WalletConnectWallet.ts
@@ -118,10 +118,13 @@ class WalletConnectWallet {
       namespaces: getNamespaces(chains, proposal.params.requiredNamespaces[EIP155]?.methods ?? SAFE_COMPATIBLE_METHODS),
     })
 
+    await this.updateSession(session, currentChainId, safeAddress)
+
     // Workaround: WalletConnect doesn't have a session_add event
     this.web3Wallet?.events.emit(SESSION_ADD_EVENT)
 
-    return session
+    // Return updated session as it may have changed
+    return this.getActiveSessions().find(({ topic }) => topic === session.topic) ?? session
   }
 
   private async updateSession(session: SessionTypes.Struct, chainId: string, safeAddress: string) {

--- a/src/services/walletconnect/__tests__/WalletConnectContext.test.tsx
+++ b/src/services/walletconnect/__tests__/WalletConnectContext.test.tsx
@@ -320,8 +320,14 @@ describe('WalletConnectProvider', () => {
         },
       } as unknown as Web3WalletTypes.SessionRequest)
 
-      expect(mockRequest).not.toHaveBeenCalled()
-      expect(sendSessionResponseSpy).not.toHaveBeenCalled()
+      await waitFor(() => {
+        expect(sendSessionResponseSpy).toHaveBeenCalledWith('topic', {
+          error: { code: 5100, message: 'Unsupported chains.' },
+          id: 1,
+          jsonrpc: '2.0',
+        })
+        expect(mockRequest).not.toHaveBeenCalled()
+      })
     })
 
     it('does not continue with the request if there is no matching chainId', async () => {
@@ -376,8 +382,14 @@ describe('WalletConnectProvider', () => {
         },
       } as unknown as Web3WalletTypes.SessionRequest)
 
-      expect(mockRequest).not.toHaveBeenCalled()
-      expect(sendSessionResponseSpy).not.toHaveBeenCalled()
+      await waitFor(() => {
+        expect(sendSessionResponseSpy).toHaveBeenCalledWith('topic', {
+          error: { code: 5100, message: 'Unsupported chains.' },
+          id: 1,
+          jsonrpc: '2.0',
+        })
+        expect(mockRequest).not.toHaveBeenCalled()
+      })
     })
 
     it('passes the request onto the Safe Wallet Provider and sends the response to WalletConnect', async () => {


### PR DESCRIPTION
## What it solves

DApp on wrong chain

## How this PR fixes it

1. The session is now updated after approval with the chain of the Safe, and updated session returned accordingly.
2. As a precaution, if no active session or matching `chainId` exists, an error is now returned upon "wrong" request.

## How to test it

1. Connect to Uniswap via native WC with a Safe on Gnosis Chain. Observe it immediately requesting chain switch.
2. Connect via native WC to a DApp that doesn't support the current Safe and try to transact, observing the "Unsupported chains." error.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
