### PR TITLE
fix: track banner once

### DIFF
--- a/src/components/settings/PushNotifications/PushNotificationsBanner/index.tsx
+++ b/src/components/settings/PushNotifications/PushNotificationsBanner/index.tsx
@@ -1,7 +1,7 @@
 import { Button, Chip, Grid, SvgIcon, Typography, IconButton } from '@mui/material'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import type { ReactElement } from 'react'
 
 import { CustomTooltip } from '@/components/common/CustomTooltip'
@@ -89,6 +89,21 @@ const getSafesToRegister = (addedSafes: AddedSafesState, allPreferences: PushNot
   }, {})
 }
 
+const TrackBanner = (): null => {
+  const hasTracked = useRef(false)
+
+  useEffect(() => {
+    if (hasTracked.current) {
+      return
+    }
+
+    trackEvent(PUSH_NOTIFICATION_EVENTS.DISPLAY_BANNER)
+    hasTracked.current = true
+  }, [])
+
+  return null
+}
+
 export const PushNotificationsBanner = ({ children }: { children: ReactElement }): ReactElement => {
   const isNotificationsEnabled = useHasFeature(FEATURES.PUSH_NOTIFICATIONS)
   const addedSafes = useAppSelector(selectAllAddedSafes)
@@ -109,12 +124,6 @@ export const PushNotificationsBanner = ({ children }: { children: ReactElement }
     trackEvent(PUSH_NOTIFICATION_EVENTS.DISMISS_BANNER)
     dismissPushNotificationBanner(safe.chainId)
   }, [dismissPushNotificationBanner, safe.chainId])
-
-  useEffect(() => {
-    if (shouldShowBanner) {
-      trackEvent(PUSH_NOTIFICATION_EVENTS.DISPLAY_BANNER)
-    }
-  }, [dismissBanner, shouldShowBanner])
 
   const onEnableAll = async () => {
     if (!onboard) {
@@ -148,55 +157,58 @@ export const PushNotificationsBanner = ({ children }: { children: ReactElement }
   }
 
   return (
-    <CustomTooltip
-      className={css.banner}
-      title={
-        <Grid container className={css.container}>
-          <Grid item xs={3}>
-            <Chip label="New" className={css.chip} />
-            <SvgIcon component={PushNotificationIcon} inheritViewBox fontSize="inherit" className={css.icon} />
-          </Grid>
-          <Grid item xs={9}>
-            <Typography variant="subtitle2" fontWeight={700}>
-              Enable push notifications
-            </Typography>
-            <IconButton onClick={dismissBanner} className={css.close}>
-              <SvgIcon component={CloseIcon} inheritViewBox color="border" fontSize="small" />
-            </IconButton>
-            <Typography mt={0.5} mb={1.5} variant="body2">
-              Get notified about pending signatures, incoming and outgoing transactions and more when Safe{`{Wallet}`}{' '}
-              is in the background or closed.
-            </Typography>
-            <div className={css.buttons}>
-              {totalAddedSafes > 0 && (
-                <CheckWallet>
-                  {(isOk) => (
-                    <Button
-                      variant="contained"
-                      size="small"
-                      className={css.button}
-                      onClick={onEnableAll}
-                      disabled={!isOk || !onboard}
-                    >
-                      Enable all
+    <>
+      <TrackBanner />
+      <CustomTooltip
+        className={css.banner}
+        title={
+          <Grid container className={css.container}>
+            <Grid item xs={3}>
+              <Chip label="New" className={css.chip} />
+              <SvgIcon component={PushNotificationIcon} inheritViewBox fontSize="inherit" className={css.icon} />
+            </Grid>
+            <Grid item xs={9}>
+              <Typography variant="subtitle2" fontWeight={700}>
+                Enable push notifications
+              </Typography>
+              <IconButton onClick={dismissBanner} className={css.close}>
+                <SvgIcon component={CloseIcon} inheritViewBox color="border" fontSize="small" />
+              </IconButton>
+              <Typography mt={0.5} mb={1.5} variant="body2">
+                Get notified about pending signatures, incoming and outgoing transactions and more when Safe{`{Wallet}`}{' '}
+                is in the background or closed.
+              </Typography>
+              <div className={css.buttons}>
+                {totalAddedSafes > 0 && (
+                  <CheckWallet>
+                    {(isOk) => (
+                      <Button
+                        variant="contained"
+                        size="small"
+                        className={css.button}
+                        onClick={onEnableAll}
+                        disabled={!isOk || !onboard}
+                      >
+                        Enable all
+                      </Button>
+                    )}
+                  </CheckWallet>
+                )}
+                {safe && (
+                  <Link passHref href={{ pathname: AppRoutes.settings.notifications, query }} onClick={onCustomize}>
+                    <Button variant="outlined" size="small" className={css.button}>
+                      Customize
                     </Button>
-                  )}
-                </CheckWallet>
-              )}
-              {safe && (
-                <Link passHref href={{ pathname: AppRoutes.settings.notifications, query }} onClick={onCustomize}>
-                  <Button variant="outlined" size="small" className={css.button}>
-                    Customize
-                  </Button>
-                </Link>
-              )}
-            </div>
+                  </Link>
+                )}
+              </div>
+            </Grid>
           </Grid>
-        </Grid>
-      }
-      open
-    >
-      <span>{children}</span>
-    </CustomTooltip>
+        }
+        open
+      >
+        <span>{children}</span>
+      </CustomTooltip>
+    </>
   )
 }


### PR DESCRIPTION
## What it solves

Resolves over-tracking of notification banner display

## How this PR fixes it

Tracking of the notification banner now occurs whenever it is shown. It is done within a component to prevent complex caching of tracking. If the `showBanner` flag is true, the component renders and tracks.

## How to test it

Open a Safe that has not been registered for notifications and observe only one "Display notification banner" event. If the banner is not dismissed, navigating back to the Safe should dispatch the tracking again. However, dismissing the banner should prevent any future tracking.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
