### PR TITLE
fix: Track transaction item open events

### DIFF
--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -29,7 +29,6 @@ import { DelegateCallWarning, UnsignedWarning } from '@/components/transactions/
 import Multisend from '@/components/transactions/TxDetails/TxData/DecodedData/Multisend'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import useIsPending from '@/hooks/useIsPending'
-import { trackEvent, TX_LIST_EVENTS } from '@/services/analytics'
 
 export const NOT_AVAILABLE = 'n/a'
 
@@ -126,10 +125,6 @@ const TxDetails = ({
 
   const [txDetailsData, error, loading] = useAsync<TransactionDetails>(
     async () => {
-      if (!txDetails) {
-        trackEvent(TX_LIST_EVENTS.FETCH_DETAILS)
-      }
-
       return txDetails || getTransactionDetails(chainId, txSummary.id)
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -126,7 +126,9 @@ const TxDetails = ({
 
   const [txDetailsData, error, loading] = useAsync<TransactionDetails>(
     async () => {
-      trackEvent(TX_LIST_EVENTS.FETCH_DETAILS)
+      if (!txDetails) {
+        trackEvent(TX_LIST_EVENTS.FETCH_DETAILS)
+      }
 
       return txDetails || getTransactionDetails(chainId, txSummary.id)
     },

--- a/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
+++ b/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
@@ -5,7 +5,7 @@ import TxSummary from '@/components/transactions/TxSummary'
 import TxDetails from '@/components/transactions/TxDetails'
 import CreateTxInfo from '@/components/transactions/SafeCreationTx'
 import { isCreationTxInfo } from '@/utils/transaction-guards'
-import { useContext, useRef } from 'react'
+import { useContext } from 'react'
 import { BatchExecuteHoverContext } from '@/components/transactions/BatchExecuteButton/BatchExecuteHoverProvider'
 import css from './styles.module.css'
 import classNames from 'classnames'
@@ -23,7 +23,6 @@ export const ExpandableTransactionItem = ({
   txDetails,
   testId,
 }: ExpandableTransactionItemProps & { testId?: string }) => {
-  const wasOpened = useRef<boolean>(false)
   const hoverContext = useContext(BatchExecuteHoverContext)
 
   const isBatched = hoverContext.activeHover.includes(item.transaction.id)
@@ -39,10 +38,9 @@ export const ExpandableTransactionItem = ({
       defaultExpanded={!!txDetails}
       className={classNames({ [css.batched]: isBatched })}
       data-testid={testId}
-      onChange={() => {
-        if (!wasOpened.current) {
+      onChange={(_, expanded) => {
+        if (expanded) {
           trackEvent(TX_LIST_EVENTS.EXPAND_TRANSACTION)
-          wasOpened.current = true
         }
       }}
     >

--- a/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
+++ b/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
@@ -5,10 +5,11 @@ import TxSummary from '@/components/transactions/TxSummary'
 import TxDetails from '@/components/transactions/TxDetails'
 import CreateTxInfo from '@/components/transactions/SafeCreationTx'
 import { isCreationTxInfo } from '@/utils/transaction-guards'
-import { useContext } from 'react'
+import { useContext, useRef } from 'react'
 import { BatchExecuteHoverContext } from '@/components/transactions/BatchExecuteButton/BatchExecuteHoverProvider'
 import css from './styles.module.css'
 import classNames from 'classnames'
+import { trackEvent, TX_LIST_EVENTS } from '@/services/analytics'
 
 type ExpandableTransactionItemProps = {
   isGrouped?: boolean
@@ -22,6 +23,7 @@ export const ExpandableTransactionItem = ({
   txDetails,
   testId,
 }: ExpandableTransactionItemProps & { testId?: string }) => {
+  const wasOpened = useRef<boolean>(false)
   const hoverContext = useContext(BatchExecuteHoverContext)
 
   const isBatched = hoverContext.activeHover.includes(item.transaction.id)
@@ -37,6 +39,12 @@ export const ExpandableTransactionItem = ({
       defaultExpanded={!!txDetails}
       className={classNames({ [css.batched]: isBatched })}
       data-testid={testId}
+      onChange={() => {
+        if (!wasOpened.current) {
+          trackEvent(TX_LIST_EVENTS.EXPAND_TRANSACTION)
+          wasOpened.current = true
+        }
+      }}
     >
       <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ justifyContent: 'flex-start', overflowX: 'auto' }}>
         <TxSummary item={item} isGrouped={isGrouped} />

--- a/src/services/analytics/events/txList.ts
+++ b/src/services/analytics/events/txList.ts
@@ -40,8 +40,8 @@ export const TX_LIST_EVENTS = {
     action: 'Batch Execute',
     category: TX_LIST_CATEGORY,
   },
-  FETCH_DETAILS: {
-    action: 'Fetch transaction details',
+  EXPAND_TRANSACTION: {
+    action: 'Expand transaction item',
     category: TX_LIST_CATEGORY,
   },
 }


### PR DESCRIPTION
## What it solves

Fix for #2543 

This will significantly reduce the number of events that are tracked due to users opening a single transaction view (which is already tracked by a page view event).

## How this PR fixes it

- Removes `Fetch transaction details` event
- Tracks `Expand transaction item` event whenever the user expands a transaction item

## How to test it

1. Open a transaction history
2. Click on a transaction to expand
3. Observe that the event is tracked
4. Close the transaction and open it again
5. Observe that the event is tracked again
6. Open a single transaction view
7. Observe that no event for fetch tx details is tracked

