### PR TITLE
Fix: don't show push notifications banner if wallet not conencted

### DIFF
--- a/src/components/settings/PushNotifications/PushNotificationsBanner/PushNotificationsBanner.test.tsx
+++ b/src/components/settings/PushNotifications/PushNotificationsBanner/PushNotificationsBanner.test.tsx
@@ -10,12 +10,22 @@ import { createPushNotificationPrefsIndexedDb } from '@/services/push-notificati
 import { render } from '@/tests/test-utils'
 import type { AddedSafesOnChain } from '@/store/addedSafesSlice'
 import type { PushNotificationPreferences } from '@/services/push-notifications/preferences'
+import * as useWallet from '@/hooks/wallets/useWallet'
+import type { EIP1193Provider } from '@web3-onboard/core'
 
 Object.defineProperty(globalThis, 'crypto', {
   value: {
     randomUUID: () => Math.random().toString(),
   },
 })
+
+jest.spyOn(useWallet, 'default').mockImplementation(() => ({
+  ens: '',
+  address: '0x1230000000000000000000000000000000000000',
+  provider: jest.fn() as unknown as EIP1193Provider,
+  label: 'Metamask',
+  chainId: '4',
+}))
 
 describe('PushNotificationsBanner', () => {
   describe('getSafesToRegister', () => {

--- a/src/components/settings/PushNotifications/PushNotificationsBanner/index.tsx
+++ b/src/components/settings/PushNotifications/PushNotificationsBanner/index.tsx
@@ -27,6 +27,7 @@ import type { PushNotificationPreferences } from '@/services/push-notifications/
 import type { NotifiableSafes } from '../logic'
 
 import css from './styles.module.css'
+import useWallet from '@/hooks/wallets/useWallet'
 
 const DISMISS_PUSH_NOTIFICATIONS_KEY = 'dismissPushNotifications'
 
@@ -109,6 +110,7 @@ export const PushNotificationsBanner = ({ children }: { children: ReactElement }
   const addedSafesOnChain = useAppSelector((state) => selectAddedSafes(state, safe.chainId))
   const { query } = useRouter()
   const onboard = useOnboard()
+  const wallet = useWallet()
 
   const { getPreferences, getAllPreferences } = useNotificationPreferences()
   const { dismissPushNotificationBanner, isPushNotificationBannerDismissed } = useDismissPushNotificationsBanner()
@@ -116,14 +118,18 @@ export const PushNotificationsBanner = ({ children }: { children: ReactElement }
   const isSafeAdded = !!addedSafesOnChain?.[safeAddress]
   const isSafeRegistered = getPreferences(safe.chainId, safeAddress)
   const shouldShowBanner =
-    isNotificationFeatureEnabled && !isPushNotificationBannerDismissed && isSafeAdded && !isSafeRegistered
+    isNotificationFeatureEnabled && !isPushNotificationBannerDismissed && isSafeAdded && !isSafeRegistered && !!wallet
 
   const { registerNotifications } = useNotificationRegistrations()
 
   const dismissBanner = useCallback(() => {
-    trackEvent(PUSH_NOTIFICATION_EVENTS.DISMISS_BANNER)
     dismissPushNotificationBanner(safe.chainId)
   }, [dismissPushNotificationBanner, safe.chainId])
+
+  const onDismiss = () => {
+    trackEvent(PUSH_NOTIFICATION_EVENTS.DISMISS_BANNER)
+    dismissBanner()
+  }
 
   const onEnableAll = async () => {
     if (!onboard || !addedSafesOnChain) {
@@ -171,7 +177,7 @@ export const PushNotificationsBanner = ({ children }: { children: ReactElement }
               <Typography variant="subtitle2" fontWeight={700}>
                 Enable push notifications
               </Typography>
-              <IconButton onClick={dismissBanner} className={css.close}>
+              <IconButton onClick={onDismiss} className={css.close}>
                 <SvgIcon component={CloseIcon} inheritViewBox color="border" fontSize="small" />
               </IconButton>
               <Typography mt={0.5} mb={1.5} variant="body2">

--- a/src/components/settings/PushNotifications/PushNotificationsBanner/index.tsx
+++ b/src/components/settings/PushNotifications/PushNotificationsBanner/index.tsx
@@ -25,9 +25,9 @@ import { FEATURES } from '@/utils/chains'
 import type { AddedSafesOnChain } from '@/store/addedSafesSlice'
 import type { PushNotificationPreferences } from '@/services/push-notifications/preferences'
 import type { NotifiableSafes } from '../logic'
+import useWallet from '@/hooks/wallets/useWallet'
 
 import css from './styles.module.css'
-import useWallet from '@/hooks/wallets/useWallet'
 
 const DISMISS_PUSH_NOTIFICATIONS_KEY = 'dismissPushNotifications'
 


### PR DESCRIPTION
+ Don't track banner dismissal on enable all/customize.

The banner was previously shown regarless of whether you're connected which clashed with the onboard popup.