### PR TITLE
[Seedless Onboarding]: Show Safe list sidebar button on welcome page

### DIFF
--- a/src/components/welcome/NewSafe.tsx
+++ b/src/components/welcome/NewSafe.tsx
@@ -11,6 +11,7 @@ import { useAppSelector } from '@/store'
 import { selectTotalAdded } from '@/store/addedSafesSlice'
 
 import drawerCSS from '@/components/sidebar/Sidebar/styles.module.css'
+import useOwnedSafes from '@/hooks/useOwnedSafes'
 
 const BulletListItem = ({ text }: { text: string }) => (
   <li>
@@ -22,7 +23,10 @@ const BulletListItem = ({ text }: { text: string }) => (
 )
 
 const NewSafe = () => {
-  const addedSafes = useAppSelector(selectTotalAdded)
+  const numberOfAddedSafes = useAppSelector(selectTotalAdded)
+  const ownedSafes = useOwnedSafes()
+  const numberOfOwnedSafes = Object.values(ownedSafes).reduce((acc, curr) => acc + curr.length, 0)
+  const totalNumberOfSafes = numberOfOwnedSafes + numberOfAddedSafes
 
   const [showSidebar, setShowSidebar] = useState(false)
 
@@ -46,7 +50,7 @@ const NewSafe = () => {
         <Grid item xs={12} lg={6} flex={1}>
           <div className={css.content}>
             <Box minWidth={{ md: 480 }} className={css.sidebar}>
-              {addedSafes > 0 && (
+              {totalNumberOfSafes > 0 ? (
                 <Box display="flex" flexDirection="column">
                   <Box flex={1}>
                     <Accordion className={css.accordion} onClick={() => setShowSidebar(true)} expanded={false}>
@@ -56,14 +60,14 @@ const NewSafe = () => {
                             <ChevronRightIcon />
                           </IconButton>
                           <Typography sx={{ mr: 'auto' }} variant="h4" display="inline" fontWeight={700}>
-                            My Safe Accounts ({addedSafes})
+                            My Safe Accounts ({totalNumberOfSafes})
                           </Typography>
                         </Box>
                       </AccordionSummary>
                     </Accordion>
                   </Box>
                 </Box>
-              )}
+              ) : null}
             </Box>
 
             <Typography variant="h1" fontSize={[44, null, 52]} lineHeight={1} letterSpacing={-1.5} color="static.main">


### PR DESCRIPTION
## What it solves

Part of #2452 

## How this PR fixes it

- Displays the button to open the safe list sidebar if there are owned safes detected

## How to test it

1. Open the welcome page
2. No button should be visible when not connected and there are no added safes
3. Connect with a wallet that owns safes
4. Observe the button appears and displays the number of owned safes + added safes

## Screenshots

<img width="748" alt="Screenshot 2023-10-10 at 13 21 11" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/21112895-2ae8-4aac-a801-c8a11925a21a">
<img width="757" alt="Screenshot 2023-10-10 at 13 21 26" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/1476a05c-6ed7-449d-b30b-44c07bf9b4e4">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
