### PR TITLE
fix: console warnings in owner list

### DIFF
--- a/cypress/e2e/pages/create_wallet.pages.js
+++ b/cypress/e2e/pages/create_wallet.pages.js
@@ -5,7 +5,7 @@ const selectNetworkBtn = '[data-cy="create-safe-select-network"]'
 const ownerInput = 'input[name^="owners"][name$="name"]'
 const ownerAddress = 'input[name^="owners"][name$="address"]'
 const thresholdInput = 'input[name="threshold"]'
-export const removeOwnerBtn = 'button[aria-label="Remove owner"]'
+export const removeOwnerBtn = 'span[aria-label="Remove owner"]'
 const connectingContainer = 'div[class*="connecting-container"]'
 const createNewSafeBtn = 'span[data-track="create-safe: Open stepper"]'
 

--- a/cypress/e2e/pages/create_wallet.pages.js
+++ b/cypress/e2e/pages/create_wallet.pages.js
@@ -5,7 +5,7 @@ const selectNetworkBtn = '[data-cy="create-safe-select-network"]'
 const ownerInput = 'input[name^="owners"][name$="name"]'
 const ownerAddress = 'input[name^="owners"][name$="address"]'
 const thresholdInput = 'input[name="threshold"]'
-export const removeOwnerBtn = 'span[aria-label="Remove owner"]'
+export const removeOwnerBtn = 'button[aria-label="Remove owner"]'
 const connectingContainer = 'div[class*="connecting-container"]'
 const createNewSafeBtn = 'span[data-track="create-safe: Open stepper"]'
 

--- a/cypress/e2e/pages/owners.pages.js
+++ b/cypress/e2e/pages/owners.pages.js
@@ -3,9 +3,9 @@ import * as main from '../pages/main.page'
 
 const copyToClipboardBtn = 'button[aria-label="Copy to clipboard"]'
 const tooltipLabel = (label) => `span[aria-label="${label}"]`
-const removeOwnerBtn = 'span[aria-label="Remove owner"]'
-const replaceOwnerBtn = 'span[aria-label="Replace owner"]'
-const addOwnerBtn = 'span[data-track="settings: Add owner"]'
+const removeOwnerBtn = 'span[data-track="settings: Remove owner"] > span > button'
+const replaceOwnerBtn = 'span[data-track="settings: Replace owner"] > span > button'
+const addOwnerBtn = 'span[data-track="settings: Add owner"] > span > button'
 const tooltip = 'div[role="tooltip"]'
 const expandMoreIcon = 'svg[data-testid="ExpandMoreIcon"]'
 const sentinelStart = 'div[data-testid="sentinelStart"]'

--- a/cypress/e2e/pages/owners.pages.js
+++ b/cypress/e2e/pages/owners.pages.js
@@ -5,7 +5,7 @@ const copyToClipboardBtn = 'button[aria-label="Copy to clipboard"]'
 const tooltipLabel = (label) => `span[aria-label="${label}"]`
 const removeOwnerBtn = 'span[data-track="settings: Remove owner"] > span > button'
 const replaceOwnerBtn = 'span[data-track="settings: Replace owner"] > span > button'
-const addOwnerBtn = 'span[data-track="settings: Add owner"] > span > button'
+const addOwnerBtn = 'span[data-track="settings: Add owner"]'
 const tooltip = 'div[role="tooltip"]'
 const expandMoreIcon = 'svg[data-testid="ExpandMoreIcon"]'
 const sentinelStart = 'div[data-testid="sentinelStart"]'

--- a/cypress/e2e/pages/owners.pages.js
+++ b/cypress/e2e/pages/owners.pages.js
@@ -3,8 +3,8 @@ import * as main from '../pages/main.page'
 
 const copyToClipboardBtn = 'button[aria-label="Copy to clipboard"]'
 const tooltipLabel = (label) => `span[aria-label="${label}"]`
-const removeOwnerBtn = 'button[aria-label="Remove owner"]'
-const replaceOwnerBtn = 'button[aria-label="Replace owner"]'
+const removeOwnerBtn = 'span[aria-label="Remove owner"]'
+const replaceOwnerBtn = 'span[aria-label="Replace owner"]'
 const addOwnerBtn = 'span[data-track="settings: Add owner"]'
 const tooltip = 'div[role="tooltip"]'
 const expandMoreIcon = 'svg[data-testid="ExpandMoreIcon"]'

--- a/src/components/settings/owner/EditOwnerDialog/index.tsx
+++ b/src/components/settings/owner/EditOwnerDialog/index.tsx
@@ -51,9 +51,11 @@ export const EditOwnerDialog = ({ chainId, address, name }: { chainId: string; a
     <>
       <Track {...SETTINGS_EVENTS.SETUP.EDIT_OWNER}>
         <Tooltip title="Edit owner">
-          <IconButton onClick={() => setOpen(true)} size="small">
-            <SvgIcon component={EditIcon} inheritViewBox color="border" fontSize="small" />
-          </IconButton>
+          <span>
+            <IconButton onClick={() => setOpen(true)} size="small">
+              <SvgIcon component={EditIcon} inheritViewBox color="border" fontSize="small" />
+            </IconButton>
+          </span>
         </Tooltip>
       </Track>
 

--- a/src/components/settings/owner/OwnerList/index.tsx
+++ b/src/components/settings/owner/OwnerList/index.tsx
@@ -49,7 +49,7 @@ export const OwnerList = () => {
                 <CheckWallet>
                   {(isOk) => (
                     <Track {...SETTINGS_EVENTS.SETUP.REPLACE_OWNER}>
-                      <Tooltip title="Replace owner">
+                      <Tooltip title={isOk ? 'Replace owner' : undefined}>
                         <span>
                           <IconButton
                             onClick={() => setTxFlow(<ReplaceOwnerFlow address={address} />)}
@@ -70,7 +70,7 @@ export const OwnerList = () => {
                   <CheckWallet>
                     {(isOk) => (
                       <Track {...SETTINGS_EVENTS.SETUP.REMOVE_OWNER}>
-                        <Tooltip title="Remove owner">
+                        <Tooltip title={isOk ? 'Remove owner' : undefined}>
                           <span>
                             <IconButton
                               onClick={() => setTxFlow(<RemoveOwnerFlow name={name} address={address} />)}

--- a/src/components/settings/owner/OwnerList/index.tsx
+++ b/src/components/settings/owner/OwnerList/index.tsx
@@ -50,13 +50,15 @@ export const OwnerList = () => {
                   {(isOk) => (
                     <Track {...SETTINGS_EVENTS.SETUP.REPLACE_OWNER}>
                       <Tooltip title="Replace owner">
-                        <IconButton
-                          onClick={() => setTxFlow(<ReplaceOwnerFlow address={address} />)}
-                          size="small"
-                          disabled={!isOk}
-                        >
-                          <SvgIcon component={ReplaceOwnerIcon} inheritViewBox color="border" fontSize="small" />
-                        </IconButton>
+                        <span>
+                          <IconButton
+                            onClick={() => setTxFlow(<ReplaceOwnerFlow address={address} />)}
+                            size="small"
+                            disabled={!isOk}
+                          >
+                            <SvgIcon component={ReplaceOwnerIcon} inheritViewBox color="border" fontSize="small" />
+                          </IconButton>
+                        </span>
                       </Tooltip>
                     </Track>
                   )}
@@ -69,13 +71,15 @@ export const OwnerList = () => {
                     {(isOk) => (
                       <Track {...SETTINGS_EVENTS.SETUP.REMOVE_OWNER}>
                         <Tooltip title="Remove owner">
-                          <IconButton
-                            onClick={() => setTxFlow(<RemoveOwnerFlow name={name} address={address} />)}
-                            size="small"
-                            disabled={!isOk}
-                          >
-                            <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />
-                          </IconButton>
+                          <span>
+                            <IconButton
+                              onClick={() => setTxFlow(<RemoveOwnerFlow name={name} address={address} />)}
+                              size="small"
+                              disabled={!isOk}
+                            >
+                              <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />
+                            </IconButton>
+                          </span>
                         </Tooltip>
                       </Track>
                     )}


### PR DESCRIPTION
## What it solves

Resolves console warnings in owner list.

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/b9aeaa76-e417-427e-9171-4accf364c2d5)

## How this PR fixes it

All `Tooltip` children within the owner list have been wrapped in `span` elements.

## How to test it

Open the project locally and navigate to the owner list within the settings:
- Observe working tooltips for replacing, editing and removing owners.
- When clicking each, observe the transaction flow opening as well as correct tracking.

## Screenshots

![274208285-754faf72-dea9-4bbd-9796-d6ed3d6ce0a0](https://github.com/safe-global/safe-wallet-web/assets/20442784/f30f5a57-e8f1-4d83-a370-35345a1e2902)

![connected-tooltips](https://github.com/safe-global/safe-wallet-web/assets/20442784/98f5cbab-a3a7-4748-8353-c868199d6aaf)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
