### PR TITLE
Takehome assignment: wrap and unwrap ETH

### DIFF
--- a/src/components/dashboard/WrappedEth/index.test.tsx
+++ b/src/components/dashboard/WrappedEth/index.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+import { render } from '@/tests/test-utils'
+import WrappedEth from '.'
+
+it('renders without errors', () => {
+  render(<WrappedEth />)
+})

--- a/src/components/dashboard/WrappedEth/index.tsx
+++ b/src/components/dashboard/WrappedEth/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Box, Button, TextField, Typography } from '@mui/material'
 import { ethers } from 'ethers'
 import { Card, WidgetBody, WidgetContainer } from '../styled'
@@ -24,20 +24,24 @@ const WrappedEth = () => {
   const wethABI = JSON.parse(wethABIString)
   const wethAddress = '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6'
 
-  const getWethContract = () => {
+  const getWethContract = useCallback(() => {
     if (!wallet) return null
     const provider = createWeb3(wallet.provider)
     const signer = provider.getSigner()
     return new ethers.Contract(wethAddress, wethABI, signer)
-  }
+  }, [wallet, wethABI])
 
   useEffect(() => {
     const getWethBalance = async () => {
       const wethContract = getWethContract()
       if (!safeAddress || !wethContract) return null
-      const weiBalance = await wethContract.balanceOf(safeAddress)
-      const balance = Number(ethers.utils.formatEther(weiBalance))
-      setWethBalance(`${balance}`)
+      try {
+        const weiBalance = await wethContract.balanceOf(safeAddress)
+        const balance = Number(ethers.utils.formatEther(weiBalance))
+        setWethBalance(`${balance}`)
+      } catch (error) {
+        console.log(error)
+      }
     }
     getWethBalance()
   }, [wallet, wethABI, safeAddress, getWethContract])

--- a/src/components/dashboard/WrappedEth/index.tsx
+++ b/src/components/dashboard/WrappedEth/index.tsx
@@ -54,6 +54,8 @@ const WrappedEth = () => {
     if (!wethContract) return null
 
     const amount = isWrap ? wrapAmount : unwrapAmount
+    if (!amount) return null
+
     const amountInWei = ethers.utils.parseEther(amount)
 
     const encodedFunctionData = isWrap

--- a/src/components/dashboard/WrappedEth/index.tsx
+++ b/src/components/dashboard/WrappedEth/index.tsx
@@ -1,79 +1,77 @@
 import { useEffect, useState } from 'react'
 import { Box, Button, TextField, Typography } from '@mui/material'
+import { ethers } from 'ethers'
 import { Card, WidgetBody, WidgetContainer } from '../styled'
-import useSafeTransactionFlow from './useSafeTransactionFlow'
 import useBalances from '@/hooks/useBalances'
 import useWallet from '@/hooks/wallets/useWallet'
 import { createWeb3 } from '@/hooks/wallets/web3'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import { ethers } from 'ethers'
+import useSafeTransactionFlow from './useSafeTransactionFlow'
 
 const WrappedEth = () => {
   const onTxSubmit = useSafeTransactionFlow()
-  const [wethBalance, setWethBalance] = useState(0)
-  const [wrapAmount, setWrapAmount] = useState('')
-  const [unwrapAmount, setUnwrapAmount] = useState('')
+
   const { balances } = useBalances()
   const { safeAddress } = useSafeInfo()
+  const wallet = useWallet()
+
+  const [wethBalance, setWethBalance] = useState('')
+  const [wrapAmount, setWrapAmount] = useState('')
+  const [unwrapAmount, setUnwrapAmount] = useState('')
 
   const wethABIString =
     '[{"constant":true,"inputs":[],"name":"name","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"guy","type":"address"},{"name":"wad","type":"uint256"}],"name":"approve","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"totalSupply","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"src","type":"address"},{"name":"dst","type":"address"},{"name":"wad","type":"uint256"}],"name":"transferFrom","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"name":"wad","type":"uint256"}],"name":"withdraw","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"decimals","outputs":[{"name":"","type":"uint8"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"","type":"address"}],"name":"balanceOf","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"symbol","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"dst","type":"address"},{"name":"wad","type":"uint256"}],"name":"transfer","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[],"name":"deposit","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"constant":true,"inputs":[{"name":"","type":"address"},{"name":"","type":"address"}],"name":"allowance","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"payable":true,"stateMutability":"payable","type":"fallback"},{"anonymous":false,"inputs":[{"indexed":true,"name":"src","type":"address"},{"indexed":true,"name":"guy","type":"address"},{"indexed":false,"name":"wad","type":"uint256"}],"name":"Approval","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"src","type":"address"},{"indexed":true,"name":"dst","type":"address"},{"indexed":false,"name":"wad","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"dst","type":"address"},{"indexed":false,"name":"wad","type":"uint256"}],"name":"Deposit","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"src","type":"address"},{"indexed":false,"name":"wad","type":"uint256"}],"name":"Withdrawal","type":"event"}]'
   const wethABI = JSON.parse(wethABIString)
   const wethAddress = '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6'
-  const wallet = useWallet()
 
-  const wrapEth = () => {
-    if (!wallet) return
+  const getWethContract = () => {
+    if (!wallet) return null
     const provider = createWeb3(wallet.provider)
     const signer = provider.getSigner()
-    const wethContract = new ethers.Contract(wethAddress, wethABI, signer)
-    let amountInWei = ethers.utils.parseEther(wrapAmount)
-
-    const encodedFunctionData = wethContract.interface.encodeFunctionData('deposit')
-
-    const tx = {
-      to: wethAddress,
-      value: amountInWei.toString(),
-      data: encodedFunctionData,
-    }
-
-    onTxSubmit(tx)
-    setWrapAmount('')
-  }
-
-  const unwrapEth = () => {
-    if (!wallet) return
-    const provider = createWeb3(wallet.provider)
-    const signer = provider.getSigner()
-    const wethContract = new ethers.Contract(wethAddress, wethABI, signer)
-    let amountInWei = ethers.utils.parseEther(unwrapAmount)
-
-    const encodedFunctionData = wethContract.interface.encodeFunctionData('withdraw', [amountInWei])
-
-    const tx = {
-      to: wethAddress,
-      value: ethers.utils.parseEther('0').toString(),
-      data: encodedFunctionData,
-    }
-
-    onTxSubmit(tx)
-    setUnwrapAmount('')
+    return new ethers.Contract(wethAddress, wethABI, signer)
   }
 
   useEffect(() => {
     const getWethBalance = async () => {
-      if (!wallet) return
-      const provider = createWeb3(wallet.provider)
-      const wethContract = new ethers.Contract(wethAddress, wethABI, provider)
+      const wethContract = getWethContract()
+      if (!safeAddress || !wethContract) return null
       const weiBalance = await wethContract.balanceOf(safeAddress)
       const balance = Number(ethers.utils.formatEther(weiBalance))
-      setWethBalance(balance)
+      setWethBalance(`${balance}`)
     }
     getWethBalance()
-  }, [wallet, wethABI, safeAddress])
+  }, [wallet, wethABI, safeAddress, getWethContract])
 
-  const item = (balances.items || [])[0]
-  const bal = Number(item?.balance) / 10 ** item?.tokenInfo.decimals
+  const getEthBalance = () => {
+    const item = balances.items.find((item) => item.tokenInfo.symbol === 'GOR')
+    if (!item) return
+    const balance = Number(item.balance) / 10 ** item.tokenInfo.decimals
+    return balance
+  }
+
+  const submitWethTx = (isWrap: boolean) => {
+    const wethContract = getWethContract()
+    if (!wethContract) return null
+
+    const amount = isWrap ? wrapAmount : unwrapAmount
+    const amountInWei = ethers.utils.parseEther(amount)
+
+    const encodedFunctionData = isWrap
+      ? wethContract.interface.encodeFunctionData('deposit')
+      : wethContract.interface.encodeFunctionData('withdraw', [amountInWei])
+
+    const txValue = isWrap ? amountInWei.toString() : ethers.utils.parseEther('0').toString()
+
+    const tx = {
+      to: wethAddress,
+      value: txValue,
+      data: encodedFunctionData,
+    }
+
+    onTxSubmit(tx)
+    // Clear the input field
+    isWrap ? setWrapAmount('') : setUnwrapAmount('')
+  }
 
   return (
     <WidgetContainer>
@@ -84,27 +82,27 @@ const WrappedEth = () => {
       <WidgetBody>
         <Card>
           <Typography component="h3" variant="subtitle1" fontWeight={700} mb={1}>
-            Your ETH balance is {bal}
+            Your ETH balance is {getEthBalance() || '...'}
           </Typography>
 
           {/* Wrap ETH */}
           <Box display="flex" mb={3} gap={2}>
             <TextField label="Amount" value={wrapAmount} onChange={(event) => setWrapAmount(event.target.value)} />
 
-            <Button onClick={wrapEth} variant="contained">
+            <Button onClick={() => submitWethTx(true)} variant="contained">
               Wrap
             </Button>
           </Box>
 
           <Typography component="h3" variant="subtitle1" fontWeight={700} mb={1}>
-            Your WETH balance is {wethBalance}
+            Your WETH balance is {wethBalance || '...'}
           </Typography>
 
           {/* Unwrap ETH */}
           <Box display="flex" gap={2}>
             <TextField label="Amount" value={unwrapAmount} onChange={(event) => setUnwrapAmount(event.target.value)} />
 
-            <Button onClick={unwrapEth} variant="contained">
+            <Button onClick={() => submitWethTx(false)} variant="contained">
               Unwrap
             </Button>
           </Box>

--- a/src/components/dashboard/WrappedEth/index.tsx
+++ b/src/components/dashboard/WrappedEth/index.tsx
@@ -1,9 +1,61 @@
+import { useEffect, useState } from 'react'
 import { Box, Button, TextField, Typography } from '@mui/material'
 import { Card, WidgetBody, WidgetContainer } from '../styled'
 import useSafeTransactionFlow from './useSafeTransactionFlow'
+import useBalances from '@/hooks/useBalances'
+import useWallet from '@/hooks/wallets/useWallet'
+import { createWeb3 } from '@/hooks/wallets/web3'
+import { ethers } from 'ethers'
 
 const WrappedEth = () => {
   const onTxSubmit = useSafeTransactionFlow()
+  const [wethBalance, setWethBalance] = useState(0)
+  const { balances } = useBalances()
+
+  const wethABIString =
+    '[{"constant":true,"inputs":[],"name":"name","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"guy","type":"address"},{"name":"wad","type":"uint256"}],"name":"approve","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"totalSupply","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"src","type":"address"},{"name":"dst","type":"address"},{"name":"wad","type":"uint256"}],"name":"transferFrom","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"name":"wad","type":"uint256"}],"name":"withdraw","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"decimals","outputs":[{"name":"","type":"uint8"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"","type":"address"}],"name":"balanceOf","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"symbol","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"dst","type":"address"},{"name":"wad","type":"uint256"}],"name":"transfer","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[],"name":"deposit","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"constant":true,"inputs":[{"name":"","type":"address"},{"name":"","type":"address"}],"name":"allowance","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"payable":true,"stateMutability":"payable","type":"fallback"},{"anonymous":false,"inputs":[{"indexed":true,"name":"src","type":"address"},{"indexed":true,"name":"guy","type":"address"},{"indexed":false,"name":"wad","type":"uint256"}],"name":"Approval","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"src","type":"address"},{"indexed":true,"name":"dst","type":"address"},{"indexed":false,"name":"wad","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"dst","type":"address"},{"indexed":false,"name":"wad","type":"uint256"}],"name":"Deposit","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"src","type":"address"},{"indexed":false,"name":"wad","type":"uint256"}],"name":"Withdrawal","type":"event"}]'
+  const wethABI = JSON.parse(wethABIString)
+  const wethAddress = '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6'
+  const wallet = useWallet()
+
+  // const wrapEth = async (value: number) => {
+  //   if (!wallet) return
+  //   const provider = createWeb3(wallet.provider)
+  //   const signer = provider.getSigner()
+  //   const wethContract = new ethers.Contract(wethAddress, wethABI, signer);
+  //   let amountInWei = ethers.utils.parseEther('0.0000001');
+  //   const tx = await wethContract.deposit({
+  //     value: amountInWei,
+  //   });
+
+  //   const res = await tx.wait();
+  //   console.log(res);
+  // }
+
+  // const unwrapEth = async (value: number) => {
+
+  // }
+
+  useEffect(() => {
+    const getWethBalance = async () => {
+      if (!wallet) return
+      const provider = createWeb3(wallet.provider)
+      const wethContract = new ethers.Contract(wethAddress, wethABI, provider)
+      const { _hex: hexBalance } = await wethContract.balanceOf(wallet.address)
+      const balance = parseInt(hexBalance, 16) / 10 ** 18
+      setWethBalance(balance)
+    }
+    getWethBalance()
+  }, [wallet, wethABI])
+
+  const item = (balances.items || [])[0]
+  const bal = Number(item?.balance) / 10 ** item?.tokenInfo.decimals
+
+  const transaction = {
+    to: '',
+    value: '',
+    data: '',
+  }
 
   return (
     <WidgetContainer>
@@ -14,7 +66,7 @@ const WrappedEth = () => {
       <WidgetBody>
         <Card>
           <Typography component="h3" variant="subtitle1" fontWeight={700} mb={1}>
-            Your ETH balance is ...
+            Your ETH balance is {bal}
           </Typography>
 
           {/* Wrap ETH */}
@@ -25,7 +77,7 @@ const WrappedEth = () => {
           </Box>
 
           <Typography component="h3" variant="subtitle1" fontWeight={700} mb={1}>
-            Your WETH balance is ...
+            Your WETH balance is {wethBalance}
           </Typography>
 
           {/* Unwrap ETH */}

--- a/src/components/dashboard/WrappedEth/index.tsx
+++ b/src/components/dashboard/WrappedEth/index.tsx
@@ -5,12 +5,16 @@ import useSafeTransactionFlow from './useSafeTransactionFlow'
 import useBalances from '@/hooks/useBalances'
 import useWallet from '@/hooks/wallets/useWallet'
 import { createWeb3 } from '@/hooks/wallets/web3'
+import useSafeInfo from '@/hooks/useSafeInfo'
 import { ethers } from 'ethers'
 
 const WrappedEth = () => {
   const onTxSubmit = useSafeTransactionFlow()
   const [wethBalance, setWethBalance] = useState(0)
+  const [wrapAmount, setWrapAmount] = useState('')
+  const [unwrapAmount, setUnwrapAmount] = useState('')
   const { balances } = useBalances()
+  const { safeAddress } = useSafeInfo()
 
   const wethABIString =
     '[{"constant":true,"inputs":[],"name":"name","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"guy","type":"address"},{"name":"wad","type":"uint256"}],"name":"approve","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"totalSupply","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"src","type":"address"},{"name":"dst","type":"address"},{"name":"wad","type":"uint256"}],"name":"transferFrom","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"name":"wad","type":"uint256"}],"name":"withdraw","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"decimals","outputs":[{"name":"","type":"uint8"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[{"name":"","type":"address"}],"name":"balanceOf","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"symbol","outputs":[{"name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"name":"dst","type":"address"},{"name":"wad","type":"uint256"}],"name":"transfer","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[],"name":"deposit","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"constant":true,"inputs":[{"name":"","type":"address"},{"name":"","type":"address"}],"name":"allowance","outputs":[{"name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"payable":true,"stateMutability":"payable","type":"fallback"},{"anonymous":false,"inputs":[{"indexed":true,"name":"src","type":"address"},{"indexed":true,"name":"guy","type":"address"},{"indexed":false,"name":"wad","type":"uint256"}],"name":"Approval","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"src","type":"address"},{"indexed":true,"name":"dst","type":"address"},{"indexed":false,"name":"wad","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"dst","type":"address"},{"indexed":false,"name":"wad","type":"uint256"}],"name":"Deposit","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"src","type":"address"},{"indexed":false,"name":"wad","type":"uint256"}],"name":"Withdrawal","type":"event"}]'
@@ -18,44 +22,58 @@ const WrappedEth = () => {
   const wethAddress = '0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6'
   const wallet = useWallet()
 
-  // const wrapEth = async (value: number) => {
-  //   if (!wallet) return
-  //   const provider = createWeb3(wallet.provider)
-  //   const signer = provider.getSigner()
-  //   const wethContract = new ethers.Contract(wethAddress, wethABI, signer);
-  //   let amountInWei = ethers.utils.parseEther('0.0000001');
-  //   const tx = await wethContract.deposit({
-  //     value: amountInWei,
-  //   });
+  const wrapEth = () => {
+    if (!wallet) return
+    const provider = createWeb3(wallet.provider)
+    const signer = provider.getSigner()
+    const wethContract = new ethers.Contract(wethAddress, wethABI, signer)
+    let amountInWei = ethers.utils.parseEther(wrapAmount)
 
-  //   const res = await tx.wait();
-  //   console.log(res);
-  // }
+    const encodedFunctionData = wethContract.interface.encodeFunctionData('deposit')
 
-  // const unwrapEth = async (value: number) => {
+    const tx = {
+      to: wethAddress,
+      value: amountInWei.toString(),
+      data: encodedFunctionData,
+    }
 
-  // }
+    onTxSubmit(tx)
+    setWrapAmount('')
+  }
+
+  const unwrapEth = () => {
+    if (!wallet) return
+    const provider = createWeb3(wallet.provider)
+    const signer = provider.getSigner()
+    const wethContract = new ethers.Contract(wethAddress, wethABI, signer)
+    let amountInWei = ethers.utils.parseEther(unwrapAmount)
+
+    const encodedFunctionData = wethContract.interface.encodeFunctionData('withdraw', [amountInWei])
+
+    const tx = {
+      to: wethAddress,
+      value: ethers.utils.parseEther('0').toString(),
+      data: encodedFunctionData,
+    }
+
+    onTxSubmit(tx)
+    setUnwrapAmount('')
+  }
 
   useEffect(() => {
     const getWethBalance = async () => {
       if (!wallet) return
       const provider = createWeb3(wallet.provider)
       const wethContract = new ethers.Contract(wethAddress, wethABI, provider)
-      const { _hex: hexBalance } = await wethContract.balanceOf(wallet.address)
-      const balance = parseInt(hexBalance, 16) / 10 ** 18
+      const weiBalance = await wethContract.balanceOf(safeAddress)
+      const balance = Number(ethers.utils.formatEther(weiBalance))
       setWethBalance(balance)
     }
     getWethBalance()
-  }, [wallet, wethABI])
+  }, [wallet, wethABI, safeAddress])
 
   const item = (balances.items || [])[0]
   const bal = Number(item?.balance) / 10 ** item?.tokenInfo.decimals
-
-  const transaction = {
-    to: '',
-    value: '',
-    data: '',
-  }
 
   return (
     <WidgetContainer>
@@ -71,9 +89,11 @@ const WrappedEth = () => {
 
           {/* Wrap ETH */}
           <Box display="flex" mb={3} gap={2}>
-            <TextField label="Amount" />
+            <TextField label="Amount" value={wrapAmount} onChange={(event) => setWrapAmount(event.target.value)} />
 
-            <Button variant="contained">Wrap</Button>
+            <Button onClick={wrapEth} variant="contained">
+              Wrap
+            </Button>
           </Box>
 
           <Typography component="h3" variant="subtitle1" fontWeight={700} mb={1}>
@@ -82,9 +102,11 @@ const WrappedEth = () => {
 
           {/* Unwrap ETH */}
           <Box display="flex" gap={2}>
-            <TextField label="Amount" />
+            <TextField label="Amount" value={unwrapAmount} onChange={(event) => setUnwrapAmount(event.target.value)} />
 
-            <Button variant="contained">Unwrap</Button>
+            <Button onClick={unwrapEth} variant="contained">
+              Unwrap
+            </Button>
           </Box>
         </Card>
       </WidgetBody>


### PR DESCRIPTION
## What it solves
This PR is to complete the functionality of the WrappedEth component as part of a take home interview.

Caveats:
- It only works with Goerli testnet
- I did not add tests because I had already spent more than the recommended time on it.

## How this PR fixes it
My changes do the following
- Display the balance of ETH and WETH a user has in their safe. This is done using the `balanceOf` function of the WETH smart contract.
- Allow a user to wrap a specified amount of ETH. This uses the `deposit` function of the WETH contract.
- Allows a user to unwrap a specified amount of WETH using the `withdraw` function of the WETH contract.

The smart contract used is the Goerli version of the WETH contract:
https://goerli.etherscan.io/address/0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6


## How to test it
- Set up a safe using Goerli.
- Get some GOR from a faucet.
- Navigate to `/home`
- You should see the amount of GOR in your safe displayed [1]
- Enter an amount of ETH to wrap and click the `Wrap`  button. Go through the safe transaction flow.
- When you return to the home screen the specified amount of ETH should be converted to WETH [2].
- Do the same using the unwrap box to convert WETH back to ETH.

## Screenshots
[1] ![Screenshot from 2023-10-12 09-10-43 (1)](https://github.com/safe-global/safe-wallet-web/assets/17801424/6ee74389-e288-4b51-ac31-0899d62872d2)
[2] ![Screenshot from 2023-10-12 09-25-30](https://github.com/safe-global/safe-wallet-web/assets/17801424/c75540be-0c04-44a0-9b8d-f7a7ed44f573)