### PR TITLE
fix: address WC style feedback

### DIFF
--- a/src/components/walletconnect/ConnectionForm/index.tsx
+++ b/src/components/walletconnect/ConnectionForm/index.tsx
@@ -1,7 +1,8 @@
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
 import { Grid, Typography, Divider, FormControlLabel, Checkbox, SvgIcon, IconButton, Tooltip } from '@mui/material'
-import type { SessionTypes } from '@walletconnect/types'
+import { useState } from 'react'
 import type { ReactElement } from 'react'
+import type { SessionTypes } from '@walletconnect/types'
 
 import { Hints } from '../Hints'
 import SessionList from '../SessionList'
@@ -21,8 +22,18 @@ export const ConnectionForm = ({
   sessions: SessionTypes.Struct[]
   onDisconnect: (session: SessionTypes.Struct) => Promise<void>
 }): ReactElement => {
-  const [hideHints = false, setHideHints] = useLocalStorage<boolean>(WC_HINTS_KEY)
-  const debouncedHideHints = useDebounce(hideHints, 300)
+  const [dismissedHints = false, setDismissedHints] = useLocalStorage<boolean>(WC_HINTS_KEY)
+  const debouncedHideHints = useDebounce(dismissedHints, 300)
+  const [showHints, setShowHints] = useState(dismissedHints)
+
+  const onToggle = () => {
+    setShowHints((prev) => !prev)
+  }
+
+  const onHide = () => {
+    setDismissedHints(true)
+    setShowHints(false)
+  }
 
   return (
     <Grid className={css.container}>
@@ -35,7 +46,7 @@ export const ConnectionForm = ({
           className={css.infoIcon}
         >
           <span>
-            <IconButton onClick={() => setHideHints(false)}>
+            <IconButton onClick={onToggle}>
               <SvgIcon component={InfoIcon} inheritViewBox color="border" />
             </IconButton>
           </span>
@@ -44,7 +55,7 @@ export const ConnectionForm = ({
         <WalletConnectHeader />
 
         <Typography variant="body2" color="text.secondary" mb={3}>
-          Connnect your Safe to any dApp via WalletConnect and trigger transactions
+          Paste the pairing URI below to connect to your {`Safe{Wallet}`} via WalletConnect
         </Typography>
 
         <WcInput />
@@ -56,18 +67,20 @@ export const ConnectionForm = ({
         <SessionList sessions={sessions} onDisconnect={onDisconnect} />
       </Grid>
 
-      {!debouncedHideHints && (
+      {(!debouncedHideHints || showHints) && (
         <>
           <Divider flexItem className={css.divider} />
 
           <Grid item>
             <Hints />
 
-            <FormControlLabel
-              control={<Checkbox checked={hideHints} onChange={(_, checked) => setHideHints(checked)} />}
-              label="Don't show this anymore"
-              sx={{ mt: 1 }}
-            />
+            {!debouncedHideHints && (
+              <FormControlLabel
+                control={<Checkbox checked={dismissedHints} onChange={onHide} />}
+                label="Don't show this anymore"
+                sx={{ mt: 1 }}
+              />
+            )}
           </Grid>
         </>
       )}

--- a/src/components/walletconnect/Hints/index.tsx
+++ b/src/components/walletconnect/Hints/index.tsx
@@ -12,6 +12,7 @@ import {
   ListItemAvatar,
   ListItemText,
 } from '@mui/material'
+import { useState } from 'react'
 import type { ReactElement } from 'react'
 
 import { useCurrentChain } from '@/hooks/useChains'
@@ -19,9 +20,19 @@ import Question from '@/public/images/common/question.svg'
 
 import css from './styles.module.css'
 
-const HintAccordion = ({ title, items }: { title: string; items: Array<string> }): ReactElement => {
+const HintAccordion = ({
+  title,
+  items,
+  expanded,
+  onExpand,
+}: {
+  title: string
+  items: Array<string>
+  expanded: boolean
+  onExpand: () => void
+}): ReactElement => {
   return (
-    <Accordion>
+    <Accordion onClick={onExpand} expanded={expanded}>
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
         <Typography className={css.title}>
           <SvgIcon component={Question} inheritViewBox className={css.questionIcon} />
@@ -63,7 +74,14 @@ const InteractionSteps = [
 ]
 
 export const Hints = (): ReactElement => {
+  const [expandedAccordion, setExpandedAccordion] = useState<'connection' | 'interaction' | null>(null)
   const chain = useCurrentChain()
+
+  const onExpand = (accordion: 'connection' | 'interaction') => {
+    setExpandedAccordion((prev) => {
+      return prev === accordion ? null : accordion
+    })
+  }
 
   if (chain?.chainName) {
     InteractionSteps[1] = InteractionSteps[1].replace(/%%chain%%/, chain?.chainName)
@@ -71,8 +89,18 @@ export const Hints = (): ReactElement => {
 
   return (
     <Box display="flex" flexDirection="column" gap={1}>
-      <HintAccordion title={ConnectionTitle} items={ConnectionSteps} />
-      <HintAccordion title={InteractionTitle} items={InteractionSteps} />
+      <HintAccordion
+        title={ConnectionTitle}
+        items={ConnectionSteps}
+        onExpand={() => onExpand('connection')}
+        expanded={expandedAccordion === 'connection'}
+      />
+      <HintAccordion
+        title={InteractionTitle}
+        items={InteractionSteps}
+        onExpand={() => onExpand('interaction')}
+        expanded={expandedAccordion === 'interaction'}
+      />
     </Box>
   )
 }

--- a/src/components/walletconnect/SessionList/index.tsx
+++ b/src/components/walletconnect/SessionList/index.tsx
@@ -46,7 +46,7 @@ const SessionList = ({ sessions, onDisconnect }: SesstionListProps): ReactElemen
   if (sessions.length === 0) {
     return (
       <Typography variant="body2" textAlign="center" color="text.secondary">
-        No dApps are connected
+        No dApps are connected yet
       </Typography>
     )
   }

--- a/src/components/walletconnect/SessionManager/Header.tsx
+++ b/src/components/walletconnect/SessionManager/Header.tsx
@@ -16,7 +16,7 @@ export const WalletConnectHeader = ({ error }: { error?: boolean }): ReactElemen
       />
 
       <Typography variant="h5" mt={2} mb={0.5}>
-        Safe via WalletConnect
+        Connect dApp to {`Safe{Wallet}`}
       </Typography>
     </>
   )

--- a/src/components/walletconnect/WcInput/index.tsx
+++ b/src/components/walletconnect/WcInput/index.tsx
@@ -21,27 +21,29 @@ const WcInput = (): ReactElement => {
     async (uri: string) => {
       if (!walletConnect) return
 
+      setValue(uri)
+
       if (!uri) {
         setError(undefined)
         return
       }
 
-      setValue(uri)
+      setConnecting(true)
 
       try {
         await walletConnect.connect(uri)
       } catch (e) {
         setError(asError(e))
-        return
       }
 
-      setConnecting(true)
+      setConnecting(false)
     },
     [walletConnect],
   )
 
   const onPaste = useCallback(async () => {
     let clipboard: string | null = null
+
     try {
       clipboard = await navigator.clipboard.readText()
     } catch (e) {


### PR DESCRIPTION
## What it solves

Addresses initial design implementation feedback

## How this PR fixes it

- Only one help accordion can be open at once
- Hiding the accordions is indefinite and then shown only via the info button
- URI input field is no longer disabled after URI entry
- Small text adjustments

## How to test it

Interact with the WC modal and observe the above addressed.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
