### PR TITLE
fix: align all `Popover`s to header

### DIFF
--- a/src/components/common/ConnectWallet/AccountCenter.tsx
+++ b/src/components/common/ConnectWallet/AccountCenter.tsx
@@ -74,7 +74,11 @@ const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
           vertical: 'top',
           horizontal: 'center',
         }}
-        sx={{ marginTop: 1 }}
+        sx={{
+          '& .MuiPaper-root': {
+            top: 'var(--header-height) !important',
+          },
+        }}
       >
         <Paper className={css.popoverContainer}>
           <Identicon address={wallet.address} />

--- a/src/components/common/NetworkSelector/index.tsx
+++ b/src/components/common/NetworkSelector/index.tsx
@@ -64,7 +64,6 @@ const NetworkSelector = (): ReactElement => {
       MenuProps={{
         sx: {
           '& .MuiPaper-root': {
-            mt: 2,
             overflow: 'auto',
           },
         },

--- a/src/components/notification-center/NotificationCenter/index.tsx
+++ b/src/components/notification-center/NotificationCenter/index.tsx
@@ -109,7 +109,11 @@ const NotificationCenter = (): ReactElement => {
           vertical: 'top',
           horizontal: 'left',
         }}
-        sx={{ mt: 1 }}
+        sx={{
+          '& .MuiPaper-root': {
+            top: 'var(--header-height) !important',
+          },
+        }}
       >
         <Paper className={css.popoverContainer}>
           <div className={css.popoverHeader}>

--- a/src/components/walletconnect/Popup/index.tsx
+++ b/src/components/walletconnect/Popup/index.tsx
@@ -13,6 +13,11 @@ const Popup = ({ children, ...props }: PopoverProps): ReactElement => {
         vertical: 'top',
         horizontal: 'center',
       }}
+      sx={{
+        '& .MuiPaper-root': {
+          top: 'var(--header-height) !important',
+        },
+      }}
       {...props}
     >
       <Paper sx={{ p: 4, width: '454px' }}>{children}</Paper>


### PR DESCRIPTION
## What it solves

Resolves non-uniform alignments

## How this PR fixes it

All `Popover`s in the header now aligned directly below the header.

## How to test it

Open the notification, WC, account centre and network switcher popovers and observe them aligned below the header.

## Screenshots

![popover-alignment](https://github.com/safe-global/safe-wallet-web/assets/20442784/23b6af0b-b0f9-428d-9faa-191d3cc8e8af)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
