### PR TITLE
fix: change colour of icon + add error badge

### DIFF
--- a/src/components/walletconnect/SessionManager/Header.tsx
+++ b/src/components/walletconnect/SessionManager/Header.tsx
@@ -2,18 +2,17 @@ import { SvgIcon, Typography } from '@mui/material'
 import type { ReactElement } from 'react'
 
 import WalletConnect from '@/public/images/common/walletconnect.svg'
+import Alert from '@/public/images/notifications/alert.svg'
+
+import css from './styles.module.css'
 
 export const WalletConnectHeader = ({ error }: { error?: boolean }): ReactElement => {
   return (
     <>
-      <SvgIcon
-        component={WalletConnect}
-        inheritViewBox
-        sx={{
-          color: error ? '#FF5F72' : '#3A99FB',
-          width: '40px',
-        }}
-      />
+      <div>
+        <SvgIcon component={WalletConnect} inheritViewBox className={css.icon} />
+        {error && <SvgIcon component={Alert} inheritViewBox className={css.errorBadge} fontSize="small" />}
+      </div>
 
       <Typography variant="h5" mt={2} mb={0.5}>
         Connect dApp to {`Safe{Wallet}`}

--- a/src/components/walletconnect/SessionManager/styles.module.css
+++ b/src/components/walletconnect/SessionManager/styles.module.css
@@ -1,0 +1,13 @@
+.icon {
+  color: #3a99fb;
+  width: 40px;
+}
+
+.errorBadge {
+  color: var(--color-error-main);
+  margin-left: -16px;
+  margin-bottom: -6px;
+  background-color: var(--color-background-paper);
+  border-radius: 50%;
+  border: 1px solid var(--color-background-paper);
+}


### PR DESCRIPTION
## What it solves

Resolves incorrect icon on error state

## How this PR fixes it

The icon has been changed to the correct colour (blue) and a new badge added instead for the error state.

## How to test it

Cause an errorneous session and observe the new design.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/2a7d849a-1a33-4f04-bad9-2da27498e071)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
