### PR TITLE
fix: WC popup, checkbox, session alignment

### DIFF
--- a/src/components/common/ConnectWallet/AccountCenter.tsx
+++ b/src/components/common/ConnectWallet/AccountCenter.tsx
@@ -75,7 +75,7 @@ const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
           horizontal: 'center',
         }}
         sx={{
-          '& .MuiPaper-root': {
+          '& > .MuiPaper-root': {
             top: 'var(--header-height) !important',
           },
         }}

--- a/src/components/notification-center/NotificationCenter/index.tsx
+++ b/src/components/notification-center/NotificationCenter/index.tsx
@@ -115,7 +115,7 @@ const NotificationCenter = (): ReactElement => {
           horizontal: 'left',
         }}
         sx={{
-          '& .MuiPaper-root': {
+          '& > .MuiPaper-root': {
             top: 'var(--header-height) !important',
           },
         }}

--- a/src/components/walletconnect/Popup/index.tsx
+++ b/src/components/walletconnect/Popup/index.tsx
@@ -14,7 +14,7 @@ const Popup = ({ children, ...props }: PopoverProps): ReactElement => {
         horizontal: 'center',
       }}
       sx={{
-        '& .MuiPaper-root': {
+        '& > .MuiPaper-root': {
           top: 'var(--header-height) !important',
         },
       }}

--- a/src/components/walletconnect/SessionList/index.tsx
+++ b/src/components/walletconnect/SessionList/index.tsx
@@ -4,6 +4,7 @@ import {
   List,
   ListItem,
   ListItemAvatar,
+  ListItemIcon,
   ListItemSecondaryAction,
   ListItemText,
   Typography,
@@ -28,16 +29,16 @@ const SessionListItem = ({
   return (
     <ListItem className={css.sessionListItem}>
       {session.peer.metadata.icons[0] && (
-        <ListItemAvatar>
+        <ListItemAvatar className={css.sessionListAvatar}>
           <SafeAppIconCard src={session.peer.metadata.icons[0]} alt="icon" width={20} height={20} />
         </ListItemAvatar>
       )}
       <ListItemText primary={session.peer.metadata.name} />
-      <ListItemSecondaryAction className={css.sessionListSecondaryAction}>
+      <ListItemIcon className={css.sessionListSecondaryAction}>
         <Button variant="danger" onClick={onDisconnect} className={css.button}>
           Disconnect
         </Button>
-      </ListItemSecondaryAction>
+      </ListItemIcon>
     </ListItem>
   )
 }

--- a/src/components/walletconnect/SessionList/index.tsx
+++ b/src/components/walletconnect/SessionList/index.tsx
@@ -1,14 +1,5 @@
 import SafeAppIconCard from '@/components/safe-apps/SafeAppIconCard'
-import {
-  Button,
-  List,
-  ListItem,
-  ListItemAvatar,
-  ListItemIcon,
-  ListItemSecondaryAction,
-  ListItemText,
-  Typography,
-} from '@mui/material'
+import { Button, List, ListItem, ListItemAvatar, ListItemIcon, ListItemText, Typography } from '@mui/material'
 import type { SessionTypes } from '@walletconnect/types'
 import type { ReactElement } from 'react'
 

--- a/src/components/walletconnect/SessionList/styles.module.css
+++ b/src/components/walletconnect/SessionList/styles.module.css
@@ -9,6 +9,12 @@
   height: 56px;
 }
 
+.sessionListAvatar {
+  display: flex;
+  min-width: unset;
+  padding-right: var(--space-1);
+}
+
 .sessionListSecondaryAction {
   /* InputAdornment */
   right: 14px;

--- a/src/components/walletconnect/SessionList/styles.module.css
+++ b/src/components/walletconnect/SessionList/styles.module.css
@@ -1,6 +1,9 @@
 .sessionList {
   width: 100%;
   padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
 }
 
 .sessionListItem {

--- a/src/components/walletconnect/SessionManager/ErrorMessage.tsx
+++ b/src/components/walletconnect/SessionManager/ErrorMessage.tsx
@@ -1,0 +1,15 @@
+import { Typography } from '@mui/material'
+import type { ReactElement } from 'react'
+
+import { WalletConnectHeader } from './Header'
+
+import css from './styles.module.css'
+
+export const WalletConnectErrorMessage = ({ error }: { error: Error }): ReactElement => {
+  return (
+    <div className={css.errorMessage}>
+      <WalletConnectHeader error />
+      <Typography>{error?.message}</Typography>
+    </div>
+  )
+}

--- a/src/components/walletconnect/SessionManager/index.tsx
+++ b/src/components/walletconnect/SessionManager/index.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useContext, useEffect, useState } from 'react'
-import { Typography } from '@mui/material'
 import type { Web3WalletTypes } from '@walletconnect/web3wallet'
 import type { SessionTypes } from '@walletconnect/types'
 import type { ReactElement } from 'react'
@@ -9,7 +8,7 @@ import { WalletConnectContext } from '@/services/walletconnect/WalletConnectCont
 import { asError } from '@/services/exceptions/utils'
 import ProposalForm from '../ProposalForm'
 import { ConnectionForm } from '../ConnectionForm'
-import { WalletConnectHeader } from './Header'
+import { WalletConnectErrorMessage } from './ErrorMessage'
 
 const SessionManager = ({ sessions }: { sessions: SessionTypes.Struct[] }): ReactElement => {
   const { safe, safeAddress } = useSafeInfo()
@@ -62,13 +61,9 @@ const SessionManager = ({ sessions }: { sessions: SessionTypes.Struct[] }): Reac
     return walletConnect.onSessionPropose(setProposal)
   }, [walletConnect])
 
-  if (walletConnectError || error) {
-    return (
-      <>
-        <WalletConnectHeader error />
-        <Typography>{walletConnectError?.message ?? error?.message}</Typography>
-      </>
-    )
+  const _error = walletConnectError || error
+  if (_error) {
+    return <WalletConnectErrorMessage error={_error} />
   }
 
   if (!proposal) {

--- a/src/components/walletconnect/SessionManager/styles.module.css
+++ b/src/components/walletconnect/SessionManager/styles.module.css
@@ -3,6 +3,13 @@
   width: 40px;
 }
 
+.errorMessage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
 .errorBadge {
   color: var(--color-error-main);
   margin-left: -16px;


### PR DESCRIPTION
## What it solves

Resolves alignment issues

## How this PR fixes it

- All popups now only adjust the first `Paper` top spacing.
- The disconnect button in the `SessionManager` no longer overlaps DApp names.
- Adds `gap` between sessions.
- Centralise error message.

## How to test it

1. Open the WC popup _without_ having dismissed the hints. Observe no accordion/checkbox overlap.
2. Dismiss the hints and open them via the icon. Observe no alignment issues above the accordions.
3. Approve a session with a DApp that has a long name, e.g. Aave. Observe no overlap with the disconnect button.
4. Add a second session. Observe spacing between sessions.
5. Connect to an unsupported network. Observe error, centralised.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/3d1de1d4-0cba-4ea9-84de-063b7289072c)

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/cb2e4dd6-eeba-4f34-995b-57c89825cde2)

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/2edd7de0-b543-4735-82b1-74eaa1d1f33b)

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/9a94803f-72af-4ce7-ac85-eeea115a0511)

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/4ce3c8c3-894e-480c-bd0f-9f15c7a5ad5e)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
