### PR TITLE
feat: show notifications for WC requests

### DIFF
--- a/src/services/safe-wallet-provider/useSafeWalletProvider.tsx
+++ b/src/services/safe-wallet-provider/useSafeWalletProvider.tsx
@@ -17,6 +17,41 @@ import { getAddress } from 'ethers/lib/utils'
 import { AppRoutes } from '@/config/routes'
 import useChains from '@/hooks/useChains'
 
+const showNotification = (title: string, options?: NotificationOptions) => {
+  if (Notification.permission !== 'granted' || document.hasFocus()) {
+    return
+  }
+
+  const notification = new Notification(title, {
+    icon: '/images/safe-logo-green.png',
+    ...options,
+  })
+
+  notification.onclick = () => {
+    window.focus()
+    notification.close()
+  }
+
+  setTimeout(() => {
+    notification.close()
+  }, 5_000)
+}
+
+const NotificationMessages: Record<string, (appInfo: AppInfo) => { title: string; options: NotificationOptions }> = {
+  SIGNATURE_REQUEST: (appInfo: AppInfo) => ({
+    title: 'Signature request',
+    options: {
+      body: `${appInfo.name} wants you to sign a message. Open the Safe{Wallet} to continue.`,
+    },
+  }),
+  TRANSACTION_REQUEST: (appInfo: AppInfo) => ({
+    title: 'Transaction request',
+    options: {
+      body: `${appInfo.name} wants to submit a transaction. Open the Safe{Wallet} to continue.`,
+    },
+  }),
+}
+
 export const _useTxFlowApi = (chainId: string, safeAddress: string): WalletSDK | undefined => {
   const { setTxFlow } = useContext(TxModalContext)
   const web3ReadOnly = useWeb3ReadOnly()
@@ -38,6 +73,9 @@ export const _useTxFlowApi = (chainId: string, safeAddress: string): WalletSDK |
     const signMessage = (message: string | EIP712TypedData, appInfo: AppInfo): Promise<{ signature: string }> => {
       const id = Math.random().toString(36).slice(2)
       setTxFlow(<SignMessageFlow logoUri={appInfo.iconUrl} name={appInfo.name} message={message} requestId={id} />)
+
+      const { title, options } = NotificationMessages.SIGNATURE_REQUEST(appInfo)
+      showNotification(title, options)
 
       return new Promise((resolve) => {
         const unsubscribe = safeMsgSubscribe(SafeMsgEvent.SIGNATURE_PREPARED, ({ requestId, signature }) => {
@@ -84,6 +122,9 @@ export const _useTxFlowApi = (chainId: string, safeAddress: string): WalletSDK |
             }}
           />,
         )
+
+        const { title, options } = NotificationMessages.TRANSACTION_REQUEST(appInfo)
+        showNotification(title, options)
 
         return new Promise((resolve) => {
           const unsubscribe = txSubscribe(TxEvent.SAFE_APPS_REQUEST, async ({ safeAppRequestId, safeTxHash, txId }) => {


### PR DESCRIPTION
## What it solves

Resolves unclear notifications of other tabs

## How this PR fixes it

If a signature/transaction request is received when out of focus, a push notification is shown with the relevant details.

## How to test it

Connect to a DApp and request a signature/transaction. Observe the push notifications accordingly.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/c8997a7d-df5a-484f-aec5-f453d624acc5)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
