### PR TITLE
fix: WC session list height

### DIFF
--- a/src/components/walletconnect/SessionList/styles.module.css
+++ b/src/components/walletconnect/SessionList/styles.module.css
@@ -9,7 +9,7 @@
 .sessionListItem {
   border: 1px solid var(--color-border-light);
   border-radius: 6px;
-  height: 56px;
+  min-height: 56px;
 }
 
 .sessionListAvatar {


### PR DESCRIPTION
## What it solves

Resolves overflow of DApp names

## How this PR fixes it

The `ListItem`s of `SessionList` now have a `min-height` instead of fixed `height`.

## How to test it

Connect to CoW Swap via WC and observe no overflow of the name.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/75558227-820a-49cb-9a7c-9624e664e30a)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
