### PR TITLE
fix: clear pairing URI on rejection

### DIFF
--- a/src/components/walletconnect/HeaderWidget/index.tsx
+++ b/src/components/walletconnect/HeaderWidget/index.tsx
@@ -63,6 +63,14 @@ const WalletConnectHeaderWidget = (): ReactElement => {
     return walletConnect.onSessionAdd(onSuccess)
   }, [onSuccess, walletConnect])
 
+  useEffect(() => {
+    if (!walletConnect) {
+      return
+    }
+
+    return walletConnect.onSessionReject(clearUri)
+  }, [clearUri, walletConnect])
+
   return (
     <>
       <div ref={iconRef}>

--- a/src/components/walletconnect/WcInput/index.tsx
+++ b/src/components/walletconnect/WcInput/index.tsx
@@ -4,7 +4,7 @@ import type { ReactElement } from 'react'
 
 import { WalletConnectContext } from '@/services/walletconnect/WalletConnectContext'
 import { asError } from '@/services/exceptions/utils'
-import { getClipboard } from '@/utils/clipboard'
+import { getClipboard, isFirefox } from '@/utils/clipboard'
 
 import css from '../SessionList/styles.module.css'
 
@@ -13,10 +13,6 @@ const WcInput = ({ uri }: { uri: string }): ReactElement => {
   const [value, setValue] = useState('')
   const [error, setError] = useState<Error>()
   const [connecting, setConnecting] = useState(false)
-
-  // readText is not supported by Firefox
-  // @see https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/readText#browser_compatibility
-  const isFirefox = navigator?.userAgent.includes('Firefox')
 
   const onInput = useCallback(
     async (uri: string) => {
@@ -66,7 +62,7 @@ const WcInput = ({ uri }: { uri: string }): ReactElement => {
       label={error ? error.message : 'Pairing UI'}
       placeholder="wc:"
       InputProps={{
-        endAdornment: isFirefox ? undefined : (
+        endAdornment: isFirefox() ? undefined : (
           <InputAdornment position="end">
             <Button variant="contained" onClick={onPaste} className={css.button}>
               Paste

--- a/src/components/walletconnect/WcInput/index.tsx
+++ b/src/components/walletconnect/WcInput/index.tsx
@@ -4,7 +4,7 @@ import type { ReactElement } from 'react'
 
 import { WalletConnectContext } from '@/services/walletconnect/WalletConnectContext'
 import { asError } from '@/services/exceptions/utils'
-import { getClipboard, isFirefox } from '@/utils/clipboard'
+import { getClipboard, isPastingSupported } from '@/utils/clipboard'
 
 import css from '../SessionList/styles.module.css'
 
@@ -62,7 +62,7 @@ const WcInput = ({ uri }: { uri: string }): ReactElement => {
       label={error ? error.message : 'Pairing UI'}
       placeholder="wc:"
       InputProps={{
-        endAdornment: isFirefox() ? undefined : (
+        endAdornment: isPastingSupported() ? undefined : (
           <InputAdornment position="end">
             <Button variant="contained" onClick={onPaste} className={css.button}>
               Paste

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,13 +1,13 @@
 import { logError, Errors } from '@/services/exceptions'
 
-export const isFirefox = (): boolean => {
+export const isPastingSupported = (): boolean => {
   // 'clipboard-read' and `readText` are not supported by Firefox
   // @see https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/readText#browser_compatibility
   return navigator.userAgent.includes('Firefox')
 }
 
 export const isClipboardGranted = async (): Promise<boolean> => {
-  if (isFirefox()) {
+  if (isPastingSupported()) {
     return false
   }
 
@@ -25,7 +25,7 @@ export const isClipboardGranted = async (): Promise<boolean> => {
 }
 
 export const getClipboard = async (): Promise<string> => {
-  if (isFirefox()) {
+  if (isPastingSupported()) {
     return ''
   }
 

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,6 +1,16 @@
 import { logError, Errors } from '@/services/exceptions'
 
+export const isFirefox = (): boolean => {
+  // 'clipboard-read' and `readText` are not supported by Firefox
+  // @see https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/readText#browser_compatibility
+  return navigator.userAgent.includes('Firefox')
+}
+
 export const isClipboardGranted = async (): Promise<boolean> => {
+  if (isFirefox()) {
+    return false
+  }
+
   let isGranted = false
 
   try {
@@ -15,10 +25,7 @@ export const isClipboardGranted = async (): Promise<boolean> => {
 }
 
 export const getClipboard = async (): Promise<string> => {
-  // readText is not supported by Firefox
-  // @see https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/readText#browser_compatibility
-  const isFirefox = navigator.userAgent.includes('Firefox')
-  if (isFirefox) {
+  if (isFirefox()) {
     return ''
   }
 


### PR DESCRIPTION
## What it solves

Resolves stale pairing URIs in input

## How this PR fixes it

When rejecting a session proposal, the pairing URI is cleared from the URL/clipboard (state) meaning that the input is not populated with the value.

## How to test it

Copy a pairing URI from a DApp and reject the proposal, observing no value prepopulating the input field.

## Screenshots

![rejection-clear](https://github.com/safe-global/safe-wallet-web/assets/20442784/ac3c5a94-9959-47cf-ad23-d50d4e62194d)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
