### PR TITLE
Chore: Jest CI: annotations only for failed tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:
           skip-step: install
+          annotations: failed-tests
           package-manager: yarn
           test-script: yarn test:ci
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What it solves

A follow up on #2637

Disable line coverage annotations. Too spammy.

![Screenshot 2023-10-17 at 14 15 32](https://github.com/safe-global/safe-wallet-web/assets/381895/a87d68ae-2936-419f-8055-3fcef4098ea8)
