### PR TITLE
fix: WC details + header badges

### DIFF
--- a/src/components/batch/BatchIndicator/index.tsx
+++ b/src/components/batch/BatchIndicator/index.tsx
@@ -4,15 +4,25 @@ import { useDraftBatch } from '@/hooks/useDraftBatch'
 import Track from '@/components/common/Track'
 import { BATCH_EVENTS } from '@/services/analytics'
 import BatchTooltip from './BatchTooltip'
+import { useDarkMode } from '@/hooks/useDarkMode'
 
 const BatchIndicator = ({ onClick }: { onClick?: () => void }) => {
   const { length } = useDraftBatch()
+  const isDarkMode = useDarkMode()
 
   return (
     <BatchTooltip>
       <Track {...BATCH_EVENTS.BATCH_SIDEBAR_OPEN} label={length}>
-        <ButtonBase onClick={onClick} sx={{ p: 0.5 }} title="Batch">
-          <Badge variant="standard" color="secondary" badgeContent={length}>
+        <ButtonBase title="Batch" onClick={onClick} sx={{ p: 0.5 }}>
+          <Badge
+            variant="standard"
+            badgeContent={length}
+            color={isDarkMode ? 'primary' : 'secondary'}
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'right',
+            }}
+          >
             <SvgIcon component={BatchIcon} inheritViewBox fontSize="small" />
           </Badge>
         </ButtonBase>

--- a/src/components/walletconnect/HeaderWidget/Icon.tsx
+++ b/src/components/walletconnect/HeaderWidget/Icon.tsx
@@ -1,7 +1,9 @@
 import { Badge, ButtonBase, SvgIcon } from '@mui/material'
+import { useContext } from 'react'
 
 import WalletConnectIcon from '@/public/images/common/walletconnect.svg'
-import SafeAppIconCard from '@/components/safe-apps/SafeAppIconCard'
+import { useDarkMode } from '@/hooks/useDarkMode'
+import { WalletConnectContext } from '@/services/walletconnect/WalletConnectContext'
 
 type IconProps = {
   onClick: () => void
@@ -12,22 +14,25 @@ type IconProps = {
   }
 }
 
-const Icon = ({ sessionCount, sessionInfo, onClick }: IconProps): React.ReactElement => (
-  <ButtonBase disableRipple onClick={onClick}>
-    <Badge
-      badgeContent={
-        sessionCount > 1
-          ? sessionCount
-          : sessionInfo && <SafeAppIconCard alt={sessionInfo.name} src={sessionInfo.iconUrl} width={12} height={12} />
-      }
-      anchorOrigin={{
-        vertical: 'bottom',
-        horizontal: 'right',
-      }}
-    >
-      <SvgIcon component={WalletConnectIcon} inheritViewBox fontSize="small" />
-    </Badge>
-  </ButtonBase>
-)
+const Icon = ({ sessionCount, sessionInfo, ...props }: IconProps): React.ReactElement => {
+  const { error } = useContext(WalletConnectContext)
+  const isDarkMode = useDarkMode()
+
+  return (
+    <ButtonBase disableRipple onClick={props.onClick} title="WalletConnect">
+      <Badge
+        variant={error ? 'dot' : 'standard'}
+        badgeContent={sessionCount}
+        color={error ? 'error' : isDarkMode ? 'primary' : 'secondary'}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+      >
+        <SvgIcon component={WalletConnectIcon} inheritViewBox fontSize="small" />
+      </Badge>
+    </ButtonBase>
+  )
+}
 
 export default Icon

--- a/src/components/walletconnect/HeaderWidget/index.tsx
+++ b/src/components/walletconnect/HeaderWidget/index.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useContext, useEffect, useRef, useState } from 'react'
-import { Badge } from '@mui/material'
 import type { CoreTypes, SessionTypes } from '@walletconnect/types'
 import type { ReactElement } from 'react'
 
@@ -27,7 +26,7 @@ const usePrepopulatedUri = (): [string, () => void] => {
 }
 
 const WalletConnectHeaderWidget = (): ReactElement => {
-  const { error, walletConnect } = useContext(WalletConnectContext)
+  const { walletConnect } = useContext(WalletConnectContext)
   const [popupOpen, setPopupOpen] = useState(false)
   const iconRef = useRef<HTMLDivElement>(null)
   const sessions = useWalletConnectSessions()
@@ -74,16 +73,7 @@ const WalletConnectHeaderWidget = (): ReactElement => {
   return (
     <>
       <div ref={iconRef}>
-        <Icon
-          onClick={onOpenSessionManager}
-          sessionCount={sessions.length}
-          sessionInfo={
-            sessions[0]
-              ? { name: sessions[0].peer.metadata.name, iconUrl: sessions[0].peer.metadata.icons[0] }
-              : undefined
-          }
-        />
-        <Badge color="error" variant="dot" invisible={!error} />
+        <Icon onClick={onOpenSessionManager} sessionCount={sessions.length} />
       </div>
 
       <Popup anchorEl={iconRef.current} open={popupOpen || !!uri} onClose={onCloseSessionManager}>

--- a/src/components/walletconnect/Hints/index.tsx
+++ b/src/components/walletconnect/Hints/index.tsx
@@ -59,8 +59,9 @@ const HintAccordion = ({
 const ConnectionTitle = 'How do I connect to a dApp?'
 const ConnectionSteps = [
   'Open a WalletConnect supported dApp',
-  'Select WalletConnect as the connection method',
-  'Copy the pairing URI and paste it into the input field above',
+  'Connect a wallet',
+  'Select WalletConnect as the wallet',
+  'Copy the pairing code and paste it into the input field above',
   'Approve the session',
   'dApp is now connected to the Safe',
 ]

--- a/src/components/walletconnect/ProposalForm/ChainWarning.tsx
+++ b/src/components/walletconnect/ProposalForm/ChainWarning.tsx
@@ -6,8 +6,6 @@ import type { Web3WalletTypes } from '@walletconnect/web3wallet'
 import ChainIndicator from '@/components/common/ChainIndicator'
 import useChains from '@/hooks/useChains'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import { EIP155 } from '@/services/walletconnect/constants'
-import { getEip155ChainId } from '@/services/walletconnect/utils'
 
 import css from './styles.module.css'
 
@@ -29,18 +27,11 @@ export const ChainWarning = ({
 }: {
   proposal: Web3WalletTypes.SessionProposal
   chainIds: Array<string>
-}): ReactElement | null => {
+}): ReactElement => {
   const { configs } = useChains()
   const { safe } = useSafeInfo()
 
   const supportsCurrentChain = chainIds.includes(safe.chainId)
-
-  const requiredChains = proposal.params.requiredNamespaces[EIP155]?.chains ?? []
-  const isCorrectChain = requiredChains.includes(getEip155ChainId(safe.chainId))
-
-  if (supportsCurrentChain && isCorrectChain) {
-    return null
-  }
 
   if (supportsCurrentChain) {
     const chainName = configs.find((chain) => chain.chainId === safe.chainId)?.chainName ?? ''

--- a/src/components/walletconnect/WcInput/index.tsx
+++ b/src/components/walletconnect/WcInput/index.tsx
@@ -61,7 +61,7 @@ const WcInput = ({ uri }: { uri: string }): ReactElement => {
       autoComplete="off"
       disabled={connecting || !safeLoaded}
       error={!!error}
-      label={error ? error.message : 'Pairing UI'}
+      label={error ? error.message : 'Pairing code'}
       placeholder="wc:"
       InputProps={{
         endAdornment: isPastingSupported() ? undefined : (


### PR DESCRIPTION
## What it solves

Resolves various feedback

## How this PR fixes it

1. All references to "pairing URI" are now "pairing code".
2. An extra two steps have been added to the "How do I connect to a dApp?" section.
3. The hint dismissal checkbox has been removed, opting in favour of session proposal hiding them instead.
4. The "Ensure the dApp is connected to %%chain%%" info is now always shown if the DApp supports the Safe.
5. Session counts are now displayed numerically in a badge, and the batch indicator badge design has been alignned to match it (solving https://github.com/safe-global/safe-wallet-web/issues/2442).

## How to test it

1. No references of "pairing URI" should be present when testing the following.
2. "Connect a wallet" and "Select WalletConnect as the wallet" should be present in the "How do I connect to a dApp?" hint.
3. No dismissal checkbox should be present. The first session should instead hide hints thereafter.
4. Connect to Uniswap on Polygon with a Safe on Polygon. Observe the info displayed.
5. Connect to a DApp and observe the new badge. (The badge when batching transactions should match the same design.)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
