### PR TITLE
fix: track safeAddress on Safe creation

### DIFF
--- a/src/components/new-safe/create/steps/StatusStep/useSafeCreationEffects.ts
+++ b/src/components/new-safe/create/steps/StatusStep/useSafeCreationEffects.ts
@@ -7,6 +7,7 @@ import { updateAddressBook } from '@/components/new-safe/create/logic/address-bo
 import { useAppDispatch } from '@/store'
 import useChainId from '@/hooks/useChainId'
 import { usePendingSafe } from './usePendingSafe'
+import { gtmSetSafeAddress } from '@/services/analytics/gtm'
 
 const useSafeCreationEffects = ({
   status,
@@ -74,6 +75,7 @@ const useSafeCreationEffects = ({
   // Tracking
   useEffect(() => {
     if (status === SafeCreationStatus.SUCCESS) {
+      pendingSafe?.safeAddress && gtmSetSafeAddress(pendingSafe.safeAddress)
       trackEvent(CREATE_SAFE_EVENTS.CREATED_SAFE)
       return
     }
@@ -82,7 +84,7 @@ const useSafeCreationEffects = ({
       trackEvent(CREATE_SAFE_EVENTS.REJECT_CREATE_SAFE)
       return
     }
-  }, [status])
+  }, [pendingSafe?.safeAddress, status])
 }
 
 export default useSafeCreationEffects


### PR DESCRIPTION
## What it solves

Adds safeAddress to safe creation event

## How to test it

1. Create a new safe
2. Observe that the safe address exists in GTM on the Created Safe event
3. Navigate to that safe
4. Observe that the safe address is still there
