### PR TITLE
fix: don't paste stale pairing URIs

### DIFF
--- a/src/services/walletconnect/useWalletConnectClipboardUri.ts
+++ b/src/services/walletconnect/useWalletConnectClipboardUri.ts
@@ -4,6 +4,8 @@ import type { Dispatch, SetStateAction } from 'react'
 import { getClipboard, isClipboardGranted } from '@/utils/clipboard'
 import { isPairingUri } from './utils'
 
+const stalePairingUris: Array<string> = []
+
 export const useWalletConnectClipboardUri = (): [string, Dispatch<SetStateAction<string>>] => {
   const [state, setState] = useState('')
 
@@ -21,7 +23,9 @@ export const useWalletConnectClipboardUri = (): [string, Dispatch<SetStateAction
 
       const clipboard = await getClipboard()
 
-      if (isPairingUri(clipboard)) {
+      // Ensure valid pairing URIs
+      if (isPairingUri(clipboard) && !stalePairingUris.includes(clipboard)) {
+        stalePairingUris.push(clipboard)
         setState(clipboard)
       }
     }


### PR DESCRIPTION
## What it solves

Resolves stale pairing URIs from the clipboard from being entered on focus

## How this PR fixes it

Previous pairing URIs are cached and only new ones returned from `useWalletConnectClipboardUri`.

## How to test it

Pairing with WC in Chrome via clipboard and blur then focus the window again. Observe no stale pairing URI entered/no field error.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
