### PR TITLE
fix: WC signatures + subsequent transactions

### DIFF
--- a/src/hooks/useTxPendingStatuses.ts
+++ b/src/hooks/useTxPendingStatuses.ts
@@ -76,6 +76,10 @@ const useTxPendingStatuses = (): void => {
   useEffect(() => {
     const unsubFns = Object.entries(pendingStatuses).map(([event, status]) =>
       txSubscribe(event as TxEvent, (detail) => {
+        if (!detail) {
+          return
+        }
+
         // All pending txns should have a txId
         const txId = 'txId' in detail && detail.txId
         if (!txId) return

--- a/src/services/safe-wallet-provider/index.ts
+++ b/src/services/safe-wallet-provider/index.ts
@@ -27,7 +27,7 @@ interface RpcRequest {
   params?: unknown[]
 }
 
-enum RpcErrorCode {
+export enum RpcErrorCode {
   INVALID_PARAMS = -32602,
   USER_REJECTED = 4001,
   UNSUPPORTED_METHOD = 4200,

--- a/src/services/tx/txEvents.ts
+++ b/src/services/tx/txEvents.ts
@@ -2,6 +2,7 @@ import EventBus from '@/services/EventBus'
 import type { RequestId } from '@safe-global/safe-apps-sdk'
 
 export enum TxEvent {
+  CHANGE_FLOW = 'CLOSED_FLOW',
   SIGNED = 'SIGNED',
   SIGN_FAILED = 'SIGN_FAILED',
   PROPOSED = 'PROPOSED',
@@ -27,6 +28,7 @@ type Id = { txId: string; groupKey?: string } | { txId?: string; groupKey: strin
 type HumanDescription = { humanDescription?: string }
 
 interface TxEvents {
+  [TxEvent.CHANGE_FLOW]: undefined
   [TxEvent.SIGNED]: { txId?: string }
   [TxEvent.SIGN_FAILED]: HumanDescription & { txId?: string; error: Error }
   [TxEvent.PROPOSE_FAILED]: HumanDescription & { error: Error }


### PR DESCRIPTION
## What it solves

Resolves signature flow or >1 transaction in a row not working

## How this PR fixes it

If the transaction flow is either changed/closed the current signature request/transaction is rejected.

## How to test it

1. Sign a message off-chain on either OpenSea or Snapshot. Observe the signing flow _always_ opening, as well as successful signing.
2. Trigger the transaction flow to open via a DApp but cancel it. Trigger the same transaction again and observe the flow open, as well as successful transacting.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
