### PR TITLE
feat: on-chain WC signing

### DIFF
--- a/src/components/tx-flow/flows/SignMessage/index.tsx
+++ b/src/components/tx-flow/flows/SignMessage/index.tsx
@@ -4,7 +4,7 @@ import { Box, Typography } from '@mui/material'
 import SafeAppIconCard from '@/components/safe-apps/SafeAppIconCard'
 
 const APP_LOGO_FALLBACK_IMAGE = '/images/apps/apps-icon.svg'
-const APP_NAME_FALLBACK = 'Sign message off-chain'
+const APP_NAME_FALLBACK = 'Sign message'
 
 export const AppTitle = ({ name, logoUri }: { name?: string | null; logoUri?: string | null }) => {
   const appName = name || APP_NAME_FALLBACK

--- a/src/services/safe-wallet-provider/index.ts
+++ b/src/services/safe-wallet-provider/index.ts
@@ -3,6 +3,10 @@ type SafeInfo = {
   chainId: number
 }
 
+type SafeSettings = {
+  offChainSigning?: boolean
+}
+
 export type AppInfo = {
   name: string
   description: string
@@ -19,6 +23,7 @@ export type WalletSDK = {
   ) => Promise<{ safeTxHash: string; txHash?: string }>
   getBySafeTxHash: (safeTxHash: string) => Promise<{ txHash?: string }>
   switchChain: (chainId: string, appInfo: AppInfo) => Promise<null>
+  setSafeSettings: (safeSettings: SafeSettings) => SafeSettings
   proxy: (method: string, params: unknown[]) => Promise<unknown>
 }
 
@@ -179,6 +184,10 @@ export class SafeWalletProvider {
           txHash = resp.txHash || txHash
         } catch (e) {}
         return this.sdk.proxy(method, params)
+      }
+
+      case 'safe_setSettings': {
+        return this.sdk.setSafeSettings(params[0] as SafeSettings)
       }
 
       default: {

--- a/src/services/safe-wallet-provider/useSafeWalletProvider.tsx
+++ b/src/services/safe-wallet-provider/useSafeWalletProvider.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo, useRef } from 'react'
+import { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { BigNumber } from 'ethers'
 import { useRouter } from 'next/router'
 
@@ -11,15 +11,20 @@ import SignMessageFlow from '@/components/tx-flow/flows/SignMessage'
 import { safeMsgSubscribe, SafeMsgEvent } from '@/services/safe-messages/safeMsgEvents'
 import SafeAppsTxFlow from '@/components/tx-flow/flows/SafeAppsTx'
 import { TxEvent, txSubscribe } from '@/services/tx/txEvents'
-import type { EIP712TypedData } from '@safe-global/safe-apps-sdk'
+import { Methods } from '@safe-global/safe-apps-sdk'
+import type { EIP712TypedData, SafeSettings } from '@safe-global/safe-apps-sdk'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { getTransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 import { getAddress } from 'ethers/lib/utils'
 import { AppRoutes } from '@/config/routes'
-import useChains from '@/hooks/useChains'
+import useChains, { useCurrentChain } from '@/hooks/useChains'
 import { NotificationMessages, showNotification } from './notifications'
 import { SafeAppsTag } from '@/config/constants'
 import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
+import SignMessageOnChainFlow from '@/components/tx-flow/flows/SignMessageOnChain'
+import { useAppSelector } from '@/store'
+import { selectOnChainSigning } from '@/store/settingsSlice'
+import { isOffchainEIP1271Supported } from '@/utils/safe-messages'
 
 const useWalletConnectApp = () => {
   const [matchingApps] = useRemoteSafeApps(SafeAppsTag.WALLET_CONNECT)
@@ -27,12 +32,19 @@ const useWalletConnectApp = () => {
 }
 
 export const _useTxFlowApi = (chainId: string, safeAddress: string): WalletSDK | undefined => {
+  const { safe } = useSafeInfo()
+  const currentChain = useCurrentChain()
   const { setTxFlow } = useContext(TxModalContext)
   const web3ReadOnly = useWeb3ReadOnly()
   const router = useRouter()
   const { configs } = useChains()
   const pendingTxs = useRef<Record<string, string>>({})
   const wcApp = useWalletConnectApp()
+
+  const onChainSigning = useAppSelector(selectOnChainSigning)
+  const [settings, setSettings] = useState<SafeSettings>({
+    offChainSigning: true,
+  })
 
   useEffect(() => {
     const unsubscribe = txSubscribe(TxEvent.PROCESSING, async ({ txId, txHash }) => {
@@ -45,10 +57,20 @@ export const _useTxFlowApi = (chainId: string, safeAddress: string): WalletSDK |
   return useMemo<WalletSDK | undefined>(() => {
     if (!chainId || !safeAddress) return
 
-    const signMessage = (message: string | EIP712TypedData, appInfo: AppInfo): Promise<{ signature: string }> => {
+    const signMessage = (
+      message: string | EIP712TypedData,
+      appInfo: AppInfo,
+      method: Methods.signMessage | Methods.signTypedMessage,
+    ): Promise<{ signature: string }> => {
       const id = Math.random().toString(36).slice(2)
-      setTxFlow(<SignMessageFlow logoUri={appInfo.iconUrl} name={appInfo.name} message={message} requestId={id} />)
+      const shouldSignOffChain =
+        isOffchainEIP1271Supported(safe, currentChain) && !onChainSigning && settings.offChainSigning
 
+      if (shouldSignOffChain) {
+        setTxFlow(<SignMessageFlow logoUri={appInfo.iconUrl} name={appInfo.name} message={message} requestId={id} />)
+      } else {
+        setTxFlow(<SignMessageOnChainFlow props={{ appId: wcApp?.id, requestId: id, message, method }} />)
+      }
       const { title, options } = NotificationMessages.SIGNATURE_REQUEST(appInfo)
       showNotification(title, options)
 
@@ -80,11 +102,11 @@ export const _useTxFlowApi = (chainId: string, safeAddress: string): WalletSDK |
 
     return {
       async signMessage(message, appInfo) {
-        return await signMessage(message, appInfo)
+        return await signMessage(message, appInfo, Methods.signMessage)
       },
 
       async signTypedMessage(typedData, appInfo) {
-        return await signMessage(typedData as EIP712TypedData, appInfo)
+        return await signMessage(typedData as EIP712TypedData, appInfo, Methods.signTypedMessage)
       },
 
       async send(params: { txs: any[]; params: { safeTxGas: number } }, appInfo) {
@@ -172,12 +194,36 @@ export const _useTxFlowApi = (chainId: string, safeAddress: string): WalletSDK |
         return null
       },
 
+      setSafeSettings(newSettings) {
+        const res = {
+          ...settings,
+          ...newSettings,
+        }
+
+        setSettings(newSettings)
+
+        return res
+      },
+
       async proxy(method, params) {
         const data = await web3ReadOnly?.send(method, params)
         return data.result
       },
     }
-  }, [chainId, safeAddress, setTxFlow, wcApp?.url, configs, router, web3ReadOnly])
+  }, [
+    chainId,
+    safeAddress,
+    safe,
+    currentChain,
+    onChainSigning,
+    settings,
+    setTxFlow,
+    wcApp?.id,
+    wcApp?.url,
+    configs,
+    router,
+    web3ReadOnly,
+  ])
 }
 
 const useSafeWalletProvider = (): SafeWalletProvider | undefined => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -88,7 +88,7 @@ export const _hydrationReducer: typeof rootReducer = (state, action) => {
   return rootReducer(state, action)
 }
 
-const makeStore = (initialState?: Record<string, any>) => {
+export const makeStore = (initialState?: Record<string, any>) => {
   return configureStore({
     reducer: _hydrationReducer,
     middleware: (getDefaultMiddleware) => {

--- a/src/utils/__tests__/safe-messages.test.ts
+++ b/src/utils/__tests__/safe-messages.test.ts
@@ -336,5 +336,20 @@ describe('safe-messages', () => {
         ),
       ).toBeFalsy()
     })
+
+    it('true for no safeAppsSdk version', () => {
+      expect(
+        isOffchainEIP1271Supported(
+          {
+            chainId: '5',
+            version: '1.3.0',
+            fallbackHandler: { value: hexZeroPad('0x2222', 20) },
+          } as any,
+          {
+            features: [FEATURES.EIP1271],
+          } as any,
+        ),
+      ).toBeTruthy()
+    })
   })
 })

--- a/src/utils/safe-messages.ts
+++ b/src/utils/safe-messages.ts
@@ -73,7 +73,7 @@ export const generateSafeMessageHash = (safe: SafeInfo, message: SafeMessage['me
 export const isOffchainEIP1271Supported = (
   { version, fallbackHandler }: SafeInfo,
   chain: ChainInfo | undefined,
-  sdkVersion: string,
+  sdkVersion?: string,
 ): boolean => {
   if (!version) {
     return false
@@ -85,7 +85,7 @@ export const isOffchainEIP1271Supported = (
   }
 
   // If the Safe apps sdk does not support off-chain signing yet
-  if (!gte(sdkVersion, EIP1271_OFFCHAIN_SUPPORTED_SAFE_APPS_SDK_VERSION)) {
+  if (sdkVersion && !gte(sdkVersion, EIP1271_OFFCHAIN_SUPPORTED_SAFE_APPS_SDK_VERSION)) {
     return false
   }
 


### PR DESCRIPTION
## What it solves

Resolves on-chain signing capibility

## How this PR fixes it

Toggling between on-/off-chain signing is now possible via WC, handling the `safe_setSettings` RPC call.

## How to test it

Open the EIP-1271 example dApp and connect via WC (on the `wallet-connect-v2` branch). Observe signing (typed) messages works as expected after toggling between on-/off-chain signing.

## Screenshots

![off-chain signing](https://github.com/safe-global/safe-wallet-web/assets/20442784/4c82347e-dc48-4467-a818-6661f78acc03)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
