### PR TITLE
fix: help block not hiding

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -25,5 +25,5 @@ const customJestConfig = {
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
 module.exports = async () => ({
   ...(await createJestConfig(customJestConfig)()),
-  transformIgnorePatterns: ['node_modules/(?!(uint8arrays)/)'],
+  transformIgnorePatterns: ['node_modules/(?!(uint8arrays|multiformats)/)'],
 })

--- a/src/components/walletconnect/ConnectionForm/index.tsx
+++ b/src/components/walletconnect/ConnectionForm/index.tsx
@@ -25,17 +25,15 @@ export const ConnectionForm = ({
   uri: string
 }): ReactElement => {
   const { walletConnect } = useContext(WalletConnectContext)
-  const [dismissedHints = false, setDismissedHints] = useLocalStorage<boolean>(WC_HINTS_KEY)
-  const [showHints, setShowHints] = useState(!dismissedHints)
+  const [showHints = false, setShowHints] = useLocalStorage<boolean>(WC_HINTS_KEY)
 
   const onToggle = () => {
     setShowHints((prev) => !prev)
   }
 
   const onHide = useCallback(() => {
-    setDismissedHints(true)
     setShowHints(false)
-  }, [setDismissedHints])
+  }, [setShowHints])
 
   useEffect(() => {
     if (!walletConnect) {
@@ -49,8 +47,7 @@ export const ConnectionForm = ({
     <Grid className={css.container}>
       <Grid item textAlign="center">
         <Tooltip
-          title="How does WalletConnect work?"
-          hidden={!dismissedHints}
+          title={showHints ? 'Hide how WalletConnect works' : 'How does WalletConnect work?'}
           placement="top"
           arrow
           className={css.infoIcon}
@@ -77,7 +74,7 @@ export const ConnectionForm = ({
         <SessionList sessions={sessions} onDisconnect={onDisconnect} />
       </Grid>
 
-      {(!dismissedHints || showHints) && (
+      {showHints && (
         <>
           <Divider flexItem className={css.divider} />
 

--- a/src/components/walletconnect/ConnectionForm/index.tsx
+++ b/src/components/walletconnect/ConnectionForm/index.tsx
@@ -1,6 +1,6 @@
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
 import { Grid, Typography, Divider, SvgIcon, IconButton, Tooltip } from '@mui/material'
-import { useCallback, useContext, useEffect, useState } from 'react'
+import { useCallback, useContext, useEffect } from 'react'
 import type { ReactElement } from 'react'
 import type { SessionTypes } from '@walletconnect/types'
 

--- a/src/components/walletconnect/ProposalForm/useCompatibilityWarning.ts
+++ b/src/components/walletconnect/ProposalForm/useCompatibilityWarning.ts
@@ -40,9 +40,9 @@ export const useCompatibilityWarning = (
     const { proposer } = proposal.params
 
     let { message, severity } = isStrictAddressBridge(origin)
-      ? Warnings.DANGEROUS_BRIDGE
+      ? Warnings.BLOCKED_BRIDGE
       : isDefaultAddressBridge(origin)
-      ? Warnings.RISKY_BRIDGE
+      ? Warnings.WARNED_BRIDGE
       : isUnsupportedChain
       ? Warnings.UNSUPPORTED_CHAIN
       : Warnings.WRONG_CHAIN

--- a/src/services/walletconnect/__tests__/WalletConnectContext.test.tsx
+++ b/src/services/walletconnect/__tests__/WalletConnectContext.test.tsx
@@ -10,7 +10,6 @@ import WalletConnectWallet from '../WalletConnectWallet'
 import { safeInfoSlice } from '@/store/safeInfoSlice'
 import { useAppDispatch } from '@/store'
 import * as useSafeWalletProvider from '@/services/safe-wallet-provider/useSafeWalletProvider'
-import * as useWalletConnectSearchParamUri from '../useWalletConnectSearchParamUri'
 
 jest.mock('../WalletConnectWallet')
 jest.mock('@/services/safe-wallet-provider/useSafeWalletProvider')
@@ -87,55 +86,6 @@ describe('WalletConnectProvider', () => {
     await waitFor(() => {
       expect(getByText('Test init failed')).toBeInTheDocument()
     })
-  })
-
-  it('connects to the session present in the URL', async () => {
-    jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
-    jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
-    jest.spyOn(WalletConnectWallet.prototype, 'connect').mockImplementation(() => Promise.resolve())
-    jest.spyOn(WalletConnectWallet.prototype, 'onSessionAdd').mockImplementation(jest.fn())
-
-    const mockSetWcUri = jest.fn()
-    jest
-      .spyOn(useWalletConnectSearchParamUri, 'useWalletConnectSearchParamUri')
-      .mockImplementation(() => ['wc:123', mockSetWcUri])
-
-    const { getByText } = render(
-      <WalletConnectProvider>
-        <TestComponent />
-      </WalletConnectProvider>,
-      {
-        initialReduxState: {
-          safeInfo: {
-            loading: false,
-            data: {
-              address: {
-                value: hexZeroPad('0x123', 20),
-              },
-              chainId: '5',
-            } as SafeInfo,
-          },
-        },
-        routerProps: {
-          query: {
-            wc: 'wc:123',
-          },
-        },
-      },
-    )
-
-    await waitFor(() => {
-      expect(getByText('WalletConnect initialized')).toBeInTheDocument()
-      expect(WalletConnectWallet.prototype.connect).toHaveBeenCalledWith('wc:123')
-      expect(WalletConnectWallet.prototype.onSessionAdd).toHaveBeenCalled()
-    })
-
-    // Manually assert that handler will remove the search param
-    const onSessionAddHandler = (WalletConnectWallet.prototype.onSessionAdd as jest.Mock).mock.calls[0][0]
-
-    expect(mockSetWcUri).not.toHaveBeenCalled()
-    onSessionAddHandler()
-    expect(mockSetWcUri).toHaveBeenCalledWith(null)
   })
 
   describe('updateSessions', () => {


### PR DESCRIPTION
## What it solves

Resolves help blocks not hiding after session then refresh

## How this PR fixes it

Duplicate state leftover from the debounced checkbox has been removed.

## How to test it

Connect a session and observe the help blocks hidden, remaining hidden after refreshing. The info box that toggled the help box should have an explanatory tooltip that works as expected.

## Screenshots

![help-blocks](https://github.com/safe-global/safe-wallet-web/assets/20442784/dcac4f98-d022-4e79-9009-1eb49758d4e8)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
