### PR TITLE
fix: handle empty metadata

### DIFF
--- a/src/components/walletconnect/ProposalForm/__tests__/useCompatibilityWarning.test.ts
+++ b/src/components/walletconnect/ProposalForm/__tests__/useCompatibilityWarning.test.ts
@@ -6,56 +6,115 @@ import * as bridges from '../bridges'
 import { useCompatibilityWarning } from '../useCompatibilityWarning'
 
 describe('useCompatibilityWarning', () => {
-  it('should return an error for a dangerous bridge', () => {
-    jest.spyOn(bridges, 'isStrictAddressBridge').mockReturnValue(true)
+  describe('should return an error for a dangerous bridge', () => {
+    it('if the dApp is named', () => {
+      jest.spyOn(bridges, 'isStrictAddressBridge').mockReturnValue(true)
 
-    const proposal = {
-      params: { proposer: { metadata: { name: 'Fake Bridge' } } },
-      verifyContext: { verified: { origin: '' } },
-    } as unknown as Web3WalletTypes.SessionProposal
+      const proposal = {
+        params: { proposer: { metadata: { name: 'Fake Bridge' } } },
+        verifyContext: { verified: { origin: '' } },
+      } as unknown as Web3WalletTypes.SessionProposal
 
-    const { result } = renderHook(() => useCompatibilityWarning(proposal, false))
+      const { result } = renderHook(() => useCompatibilityWarning(proposal, false))
 
-    expect(result.current).toEqual({
-      message:
-        'Fake Bridge is a bridge that is unusable in Safe{Wallet} due to the current implementation of WalletConnect — the bridged funds will be lost. Consider using a different bridge.',
-      severity: 'error',
+      expect(result.current).toEqual({
+        message:
+          'Fake Bridge is a bridge that is unusable in Safe{Wallet} due to the current implementation of WalletConnect — the bridged funds will be lost. Consider using a different bridge.',
+        severity: 'error',
+      })
+    })
+
+    it('if the dApp is not named', () => {
+      jest.spyOn(bridges, 'isStrictAddressBridge').mockReturnValue(true)
+
+      const proposal = {
+        params: { proposer: { metadata: { name: '' } } },
+        verifyContext: { verified: { origin: '' } },
+      } as unknown as Web3WalletTypes.SessionProposal
+
+      const { result } = renderHook(() => useCompatibilityWarning(proposal, false))
+
+      expect(result.current).toEqual({
+        message:
+          'This dApp is a bridge that is unusable in Safe{Wallet} due to the current implementation of WalletConnect — the bridged funds will be lost. Consider using a different bridge.',
+        severity: 'error',
+      })
     })
   })
 
-  it('should return a warning for a risky bridge', () => {
-    jest.spyOn(bridges, 'isStrictAddressBridge').mockReturnValue(false)
-    jest.spyOn(bridges, 'isDefaultAddressBridge').mockReturnValue(true)
+  describe('should return a warning for a risky bridge', () => {
+    it('if the dApp is named', () => {
+      jest.spyOn(bridges, 'isStrictAddressBridge').mockReturnValue(false)
+      jest.spyOn(bridges, 'isDefaultAddressBridge').mockReturnValue(true)
 
-    const proposal = {
-      params: { proposer: { metadata: { name: 'Fake Bridge' } } },
-      verifyContext: { verified: { origin: '' } },
-    } as unknown as Web3WalletTypes.SessionProposal
+      const proposal = {
+        params: { proposer: { metadata: { name: 'Fake Bridge' } } },
+        verifyContext: { verified: { origin: '' } },
+      } as unknown as Web3WalletTypes.SessionProposal
 
-    const { result } = renderHook(() => useCompatibilityWarning(proposal, false))
+      const { result } = renderHook(() => useCompatibilityWarning(proposal, false))
 
-    expect(result.current).toEqual({
-      message:
-        'While using Fake Bridge, please make sure that the desination address you send funds to matches the Safe address you have on the respective chain. Otherwise, the funds will be lost.',
-      severity: 'warning',
+      expect(result.current).toEqual({
+        message:
+          'While using Fake Bridge, please make sure that the desination address you send funds to matches the Safe address you have on the respective chain. Otherwise, the funds will be lost.',
+        severity: 'warning',
+      })
+    })
+
+    it('if the dApp is not named', () => {
+      jest.spyOn(bridges, 'isStrictAddressBridge').mockReturnValue(false)
+      jest.spyOn(bridges, 'isDefaultAddressBridge').mockReturnValue(true)
+
+      const proposal = {
+        params: { proposer: { metadata: { name: '' } } },
+        verifyContext: { verified: { origin: '' } },
+      } as unknown as Web3WalletTypes.SessionProposal
+
+      const { result } = renderHook(() => useCompatibilityWarning(proposal, false))
+
+      expect(result.current).toEqual({
+        message:
+          'While using this dApp, please make sure that the desination address you send funds to matches the Safe address you have on the respective chain. Otherwise, the funds will be lost.',
+        severity: 'warning',
+      })
     })
   })
 
-  it('should return an error for an unsupported chain', () => {
-    jest.spyOn(bridges, 'isStrictAddressBridge').mockReturnValue(false)
-    jest.spyOn(bridges, 'isDefaultAddressBridge').mockReturnValue(false)
+  describe('it should return an error for an unsupported chain', () => {
+    it('if the dApp is named', () => {
+      jest.spyOn(bridges, 'isStrictAddressBridge').mockReturnValue(false)
+      jest.spyOn(bridges, 'isDefaultAddressBridge').mockReturnValue(false)
 
-    const proposal = {
-      params: { proposer: { metadata: { name: 'Fake dApp' } } },
-      verifyContext: { verified: { origin: '' } },
-    } as unknown as Web3WalletTypes.SessionProposal
+      const proposal = {
+        params: { proposer: { metadata: { name: 'Fake dApp' } } },
+        verifyContext: { verified: { origin: '' } },
+      } as unknown as Web3WalletTypes.SessionProposal
 
-    const { result } = renderHook(() => useCompatibilityWarning(proposal, true))
+      const { result } = renderHook(() => useCompatibilityWarning(proposal, true))
 
-    expect(result.current).toEqual({
-      message:
-        'Fake dApp does not support the Safe Account network. If you want to interact with Fake dApp, please switch to a Safe Account on a supported network.',
-      severity: 'error',
+      expect(result.current).toEqual({
+        message:
+          'Fake dApp does not support the Safe Account network. If you want to interact with Fake dApp, please switch to a Safe Account on a supported network.',
+        severity: 'error',
+      })
+    })
+
+    it('if the dApp is not named', () => {
+      jest.spyOn(bridges, 'isStrictAddressBridge').mockReturnValue(false)
+      jest.spyOn(bridges, 'isDefaultAddressBridge').mockReturnValue(false)
+
+      const proposal = {
+        params: { proposer: { metadata: { name: '' } } },
+        verifyContext: { verified: { origin: '' } },
+      } as unknown as Web3WalletTypes.SessionProposal
+
+      const { result } = renderHook(() => useCompatibilityWarning(proposal, true))
+
+      expect(result.current).toEqual({
+        message:
+          'This dApp does not support the Safe Account network. If you want to interact with this dApp, please switch to a Safe Account on a supported network.',
+        severity: 'error',
+      })
     })
   })
 

--- a/src/components/walletconnect/ProposalForm/index.tsx
+++ b/src/components/walletconnect/ProposalForm/index.tsx
@@ -43,7 +43,7 @@ const ProposalForm = ({ proposal, onApprove, onReject }: ProposalFormProps): Rea
             src={proposer.metadata.icons[0]}
             width={32}
             height={32}
-            alt={`${proposer.metadata.name} logo`}
+            alt={`${proposer.metadata.name || 'dApp'} logo`}
           />
         </div>
       )}

--- a/src/components/walletconnect/ProposalForm/index.tsx
+++ b/src/components/walletconnect/ProposalForm/index.tsx
@@ -37,14 +37,16 @@ const ProposalForm = ({ proposal, onApprove, onReject }: ProposalFormProps): Rea
         WalletConnect
       </Typography>
 
-      <div className={css.icon}>
-        <SafeAppIconCard
-          src={proposer.metadata.icons[0] || ''}
-          width={32}
-          height={32}
-          alt={`${proposer.metadata.name} logo`}
-        />
-      </div>
+      {proposer.metadata.icons[0] && (
+        <div className={css.icon}>
+          <SafeAppIconCard
+            src={proposer.metadata.icons[0]}
+            width={32}
+            height={32}
+            alt={`${proposer.metadata.name} logo`}
+          />
+        </div>
+      )}
 
       <Typography mb={1}>{proposer.metadata.name} wants to connect</Typography>
 

--- a/src/components/walletconnect/ProposalForm/index.tsx
+++ b/src/components/walletconnect/ProposalForm/index.tsx
@@ -39,7 +39,7 @@ const ProposalForm = ({ proposal, onApprove, onReject }: ProposalFormProps): Rea
 
       <div className={css.icon}>
         <SafeAppIconCard
-          src={proposer.metadata.icons[0]}
+          src={proposer.metadata.icons[0] || ''}
           width={32}
           height={32}
           alt={`${proposer.metadata.name} logo`}


### PR DESCRIPTION
## What it solves

Resolves crashes when `metadata` is empty

## How this PR fixes it

The icon is no longer rendered in the `ProposalForm` if none is provided in the `metadata.icons` array, and `this dApp` is used as a fallback for the `metadata.name`.

## How to test it

Connect to [Satellite](https://satellite.money) and observe no error, as well as successful transacting.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
