### PR TITLE
fix: emit `chainChanged` first

### DIFF
--- a/src/services/walletconnect/WalletConnectWallet.ts
+++ b/src/services/walletconnect/WalletConnectWallet.ts
@@ -165,11 +165,11 @@ class WalletConnectWallet {
       })
     }
 
-    // Switch to the new Safe
-    await this.accountsChanged(session.topic, chainId, safeAddress)
-
     // Switch to the new chain
     await this.chainChanged(session.topic, chainId)
+
+    // Switch to the new Safe
+    await this.accountsChanged(session.topic, chainId, safeAddress)
   }
 
   public async updateSessions(chainId: string, safeAddress: string) {

--- a/src/services/walletconnect/__tests__/WalletConnectWallet.test.ts
+++ b/src/services/walletconnect/__tests__/WalletConnectWallet.test.ts
@@ -344,36 +344,36 @@ describe('WalletConnectWallet', () => {
       expect(emitSessionEventSpy).toHaveBeenCalledTimes(2)
     })
 
-    it('should call emitSessionEvent with the correct parameters', async () => {
+    it.only('should call emitSessionEvent with the correct parameters', async () => {
       const emitSessionEventSpy = jest.spyOn((wallet as any).web3Wallet as IWeb3Wallet, 'emitSessionEvent')
 
       const session = {
         topic: 'topic',
         namespaces: {
           eip155: {
-            chains: ['eip155:1'],
+            chains: ['eip155:1', 'eip155:5'],
             accounts: [`eip155:1:${hexZeroPad('0x123', 20)}`],
           },
         },
       } as unknown as SessionTypes.Struct
 
-      await (wallet as any).updateSession(session, '1', hexZeroPad('0x456', 20))
+      await (wallet as any).updateSession(session, '5', hexZeroPad('0x456', 20))
 
       expect(emitSessionEventSpy).toHaveBeenCalledTimes(2)
 
       expect(emitSessionEventSpy).toHaveBeenNthCalledWith(1, {
         topic: 'topic',
-        event: {
-          name: 'accountsChanged',
-          data: [hexZeroPad('0x456', 20)],
-        },
-        chainId: 'eip155:1',
+        event: { data: 5, name: 'chainChanged' },
+        chainId: 'eip155:5',
       })
 
       expect(emitSessionEventSpy).toHaveBeenNthCalledWith(2, {
         topic: 'topic',
-        event: { data: 1, name: 'chainChanged' },
-        chainId: 'eip155:1',
+        event: {
+          name: 'accountsChanged',
+          data: [hexZeroPad('0x456', 20)],
+        },
+        chainId: 'eip155:5',
       })
     })
   })

--- a/src/services/walletconnect/__tests__/WalletConnectWallet.test.ts
+++ b/src/services/walletconnect/__tests__/WalletConnectWallet.test.ts
@@ -344,7 +344,7 @@ describe('WalletConnectWallet', () => {
       expect(emitSessionEventSpy).toHaveBeenCalledTimes(2)
     })
 
-    it.only('should call emitSessionEvent with the correct parameters', async () => {
+    it('should call emitSessionEvent with the correct parameters', async () => {
       const emitSessionEventSpy = jest.spyOn((wallet as any).web3Wallet as IWeb3Wallet, 'emitSessionEvent')
 
       const session = {


### PR DESCRIPTION
## What it solves

Resolves dApp chain alignment

## How this PR fixes it

The `chainChanged` event is not emitted before the `accountsChanged event when updating a session.

## How to test it

Connect to [Aura Finance](https://app.aura.finance) and observe the initial chain matching that of the Safe, as well as changing with Safe switches across chains.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
