### PR TITLE
fix: prevent error from blocking WC popup

### DIFF
--- a/src/components/walletconnect/HeaderWidget/index.tsx
+++ b/src/components/walletconnect/HeaderWidget/index.tsx
@@ -26,7 +26,7 @@ const usePrepopulatedUri = (): [string, () => void] => {
 }
 
 const WalletConnectHeaderWidget = (): ReactElement => {
-  const { walletConnect } = useContext(WalletConnectContext)
+  const { walletConnect, setError } = useContext(WalletConnectContext)
   const [popupOpen, setPopupOpen] = useState(false)
   const iconRef = useRef<HTMLDivElement>(null)
   const sessions = useWalletConnectSessions()
@@ -37,7 +37,9 @@ const WalletConnectHeaderWidget = (): ReactElement => {
   const onCloseSessionManager = useCallback(() => {
     setPopupOpen(false)
     clearUri()
-  }, [clearUri])
+
+    setError(null)
+  }, [clearUri, setError])
 
   const onCloseSuccesBanner = useCallback(() => setMetadata(undefined), [])
   const onSuccess = useCallback(

--- a/src/components/walletconnect/SessionManager/ErrorMessage.tsx
+++ b/src/components/walletconnect/SessionManager/ErrorMessage.tsx
@@ -7,9 +7,11 @@ import css from './styles.module.css'
 
 export const WalletConnectErrorMessage = ({ error }: { error: Error }): ReactElement => {
   return (
-    <div className={css.errorMessage}>
+    <div className={css.errorContainer}>
       <WalletConnectHeader error />
-      <Typography>{error?.message}</Typography>
+      <Typography title={error.message} className={css.errorMessage}>
+        {error.message}
+      </Typography>
     </div>
   )
 }

--- a/src/components/walletconnect/SessionManager/styles.module.css
+++ b/src/components/walletconnect/SessionManager/styles.module.css
@@ -3,7 +3,7 @@
   width: 40px;
 }
 
-.errorMessage {
+.errorContainer {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -17,4 +17,10 @@
   background-color: var(--color-background-paper);
   border-radius: 50%;
   border: 1px solid var(--color-background-paper);
+}
+
+.errorMessage {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
 }

--- a/src/services/walletconnect/WalletConnectContext.tsx
+++ b/src/services/walletconnect/WalletConnectContext.tsx
@@ -1,6 +1,6 @@
 import { getSdkError } from '@walletconnect/utils'
 import { formatJsonRpcError } from '@walletconnect/jsonrpc-utils'
-import { type ReactNode, createContext, useEffect, useState } from 'react'
+import { type ReactNode, createContext, useEffect, useState, type Dispatch, type SetStateAction } from 'react'
 
 import useSafeInfo from '@/hooks/useSafeInfo'
 import useSafeWalletProvider from '@/services/safe-wallet-provider/useSafeWalletProvider'
@@ -13,9 +13,11 @@ const walletConnectSingleton = new WalletConnectWallet()
 export const WalletConnectContext = createContext<{
   walletConnect: WalletConnectWallet | null
   error: Error | null
+  setError: Dispatch<SetStateAction<Error | null>>
 }>({
   walletConnect: null,
   error: null,
+  setError: () => {},
 })
 
 export const WalletConnectProvider = ({ children }: { children: ReactNode }) => {
@@ -78,5 +80,7 @@ export const WalletConnectProvider = ({ children }: { children: ReactNode }) => 
     })
   }, [walletConnect, chainId, safeWalletProvider])
 
-  return <WalletConnectContext.Provider value={{ walletConnect, error }}>{children}</WalletConnectContext.Provider>
+  return (
+    <WalletConnectContext.Provider value={{ walletConnect, error, setError }}>{children}</WalletConnectContext.Provider>
+  )
 }


### PR DESCRIPTION
## What it solves

Resolves WC error never clearing

## How this PR fixes it

All WC-related errors are closed after viewing them, as well as being truncated if they are too long.

## How to test it

Connect to a dApp in one tab, then in another open the Safe on a chain that the connected-to dApp doesn't support. Refresh the former and observe an error present in the popup, truncated. When closing the popup, it should clear.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/b8fda97d-cff3-45a7-b85b-74c3d05fbdad)

![blocking-error](https://github.com/safe-global/safe-wallet-web/assets/20442784/2f3658ba-b726-4e2e-b8a5-40a7cc83581d)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
