### PR TITLE
fix: don't reject when signing

### DIFF
--- a/src/components/tx-flow/index.tsx
+++ b/src/components/tx-flow/index.tsx
@@ -53,7 +53,7 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
 
   const setTxFlow = useCallback(
     (newTxFlow: TxModalContextType['txFlow'], onClose?: () => void, newShouldWarn?: boolean) => {
-      // If flow is open user opens a different one, show confirmation dialog if required
+      // If flow is open and user opens a different one, show confirmation dialog if required
       if (txFlow && newTxFlow && newTxFlow?.type !== SuccessScreen && shouldWarn) {
         if (!shouldClose()) return
 

--- a/src/components/tx-flow/index.tsx
+++ b/src/components/tx-flow/index.tsx
@@ -19,9 +19,11 @@ export const TxModalContext = createContext<TxModalContextType>({
   setFullWidth: noop,
 })
 
+const shouldClose = () => confirm('Closing this window will discard your current progress.')
+
 export const TxModalProvider = ({ children }: { children: ReactNode }): ReactElement => {
   const [txFlow, setFlow] = useState<TxModalContextType['txFlow']>(undefined)
-  const [shouldWarn, setShouldWarn] = useState<boolean>(true)
+  const [shouldWarn, setShouldWarn] = useState<boolean>(false)
   const [, setOnClose] = useState<Parameters<TxModalContextType['setTxFlow']>[1]>(noop)
   const [fullWidth, setFullWidth] = useState<boolean>(false)
   const pathname = usePathname()
@@ -42,29 +44,27 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
       return
     }
 
-    const ok = confirm('Closing this window will discard your current progress.')
-    if (!ok) return
+    if (!shouldClose()) return
 
-    // Reject if the flow is closed
     txDispatch(TxEvent.USER_QUIT, {})
 
     handleModalClose()
   }, [shouldWarn, handleModalClose])
 
   const setTxFlow = useCallback(
-    (newTxFlow: TxModalContextType['txFlow'], onClose?: () => void, shouldWarn?: boolean) => {
-      setFlow((prevFlow) => {
-        // Reject if a flow is open and the user changes to a different one
-        if (prevFlow && prevFlow !== newTxFlow && newTxFlow?.type !== SuccessScreen) {
-          txDispatch(TxEvent.USER_QUIT, {})
-        }
+    (newTxFlow: TxModalContextType['txFlow'], onClose?: () => void, newShouldWarn?: boolean) => {
+      // If flow is open user opens a different one, show confirmation dialog if required
+      if (txFlow && newTxFlow && newTxFlow?.type !== SuccessScreen && shouldWarn) {
+        if (!shouldClose()) return
 
-        return newTxFlow
-      })
+        txDispatch(TxEvent.USER_QUIT, {})
+      }
+
+      setFlow(newTxFlow)
       setOnClose(() => onClose ?? noop)
-      setShouldWarn(shouldWarn ?? true)
+      setShouldWarn(newShouldWarn ?? true)
     },
-    [],
+    [txFlow, shouldWarn],
   )
 
   // Show the confirmation dialog if user navigates


### PR DESCRIPTION
## What it solves

Resolves successful signing requests rejecting in dApps

## How this PR fixes it

The `USER_QUIT` event is nly dispatched to the dApp if a warning requirement was set and is accepted when closing the flow, ergo not when a signature request succeeds and closes the flow.

## How to test it

Observe successful swaps on Aave, CoWSwap, Curve and Sushi (on 1/n Safes).

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
