### PR TITLE
[Seedless-Onboarding] Add signer account to address book on login

### DIFF
--- a/src/hooks/wallets/mpc/__tests__/useMPCWallet.test.ts
+++ b/src/hooks/wallets/mpc/__tests__/useMPCWallet.test.ts
@@ -15,9 +15,8 @@ import { ONBOARD_MPC_MODULE_LABEL } from '@/services/mpc/module'
 import { ethers } from 'ethers'
 import BN from 'bn.js'
 import * as addressBookSlice from '@/store/addressBookSlice'
-import * as chains from '@/hooks/useChains'
+import * as useChainId from '@/hooks/useChainId'
 import { hexZeroPad } from 'ethers/lib/utils'
-import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import * as useAddressBook from '@/hooks/useAddressBook'
 
 /** time until mock login resolves */
@@ -87,9 +86,7 @@ describe('useMPCWallet', () => {
   beforeEach(() => {
     jest.resetAllMocks()
     setMPCCoreKitInstance(undefined)
-    jest
-      .spyOn(chains, 'useCurrentChain')
-      .mockReturnValue({ chainId: '100', disabledWallets: [] } as unknown as ChainInfo)
+    jest.spyOn(useChainId, 'default').mockReturnValue('100')
   })
   afterAll(() => {
     jest.useRealTimers()

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -1,6 +1,10 @@
 import { getAddress } from 'ethers/lib/utils'
 import { isAddress } from '@ethersproject/address'
-
+/**
+ * Checksums the given address
+ * @param address ethereum address
+ * @returns the checksummed address if the given address is valid otherwise returns the address unchanged
+ */
 export const checksumAddress = (address: string): string => {
   return isAddress(address) ? getAddress(address) : address
 }


### PR DESCRIPTION
## What it solves
Adds the mpc signer address into the addressbook after login.

## How to test it
1. If the google signer address is in the addressbook, delete it.
2. Re-Login with google
3. Observe that the resolved address is added to the addressbook.

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
