### PR TITLE
chore: mock data builder for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "semver": "^7.5.2"
   },
   "devDependencies": {
+    "@faker-js/faker": "^8.1.0",
     "@next/bundle-analyzer": "^13.1.1",
     "@openzeppelin/contracts": "^4.9.2",
     "@safe-global/safe-core-sdk-types": "^1.9.1",

--- a/src/components/common/AddressInput/index.test.tsx
+++ b/src/components/common/AddressInput/index.test.tsx
@@ -4,15 +4,14 @@ import { useForm, FormProvider } from 'react-hook-form'
 import AddressInput, { type AddressInputProps } from '.'
 import { useCurrentChain } from '@/hooks/useChains'
 import useNameResolver from '@/components/common/AddressInput/useNameResolver'
+import { chainBuilder } from '@/tests/builders/chains'
+import { FEATURES } from '@safe-global/safe-gateway-typescript-sdk'
+
+const mockChain = chainBuilder().with('features', [FEATURES.DOMAIN_LOOKUP]).build()
 
 // mock useCurrentChain
 jest.mock('@/hooks/useChains', () => ({
-  useCurrentChain: jest.fn(() => ({
-    shortName: 'gor',
-    chainId: '5',
-    chainName: 'Goerli',
-    features: ['DOMAIN_LOOKUP'],
-  })),
+  useCurrentChain: jest.fn(() => mockChain),
 }))
 
 // mock useNameResolver
@@ -92,7 +91,7 @@ describe('AddressInput tests', () => {
     )
 
     act(() => {
-      fireEvent.change(input, { target: { value: 'gor:0x123' } })
+      fireEvent.change(input, { target: { value: `${mockChain.shortName}:0x123` } })
       jest.advanceTimersByTime(1000)
     })
 
@@ -103,14 +102,14 @@ describe('AddressInput tests', () => {
     const { input, utils } = setup('', (val) => `${val} is wrong`)
 
     act(() => {
-      fireEvent.change(input, { target: { value: `gor:${TEST_ADDRESS_A}` } })
+      fireEvent.change(input, { target: { value: `${mockChain.shortName}:${TEST_ADDRESS_A}` } })
       jest.advanceTimersByTime(1000)
     })
 
     await waitFor(() => expect(utils.getByLabelText(`${TEST_ADDRESS_A} is wrong`, { exact: false })).toBeDefined())
 
     act(() => {
-      fireEvent.change(input, { target: { value: `gor:${TEST_ADDRESS_B}` } })
+      fireEvent.change(input, { target: { value: `${mockChain.shortName}:${TEST_ADDRESS_B}` } })
       jest.advanceTimersByTime(1000)
     })
 
@@ -126,7 +125,7 @@ describe('AddressInput tests', () => {
     })
 
     act(() => {
-      fireEvent.change(input, { target: { value: `gor:${TEST_ADDRESS_A}` } })
+      fireEvent.change(input, { target: { value: `${mockChain.shortName}:${TEST_ADDRESS_A}` } })
       jest.advanceTimersByTime(1000)
     })
 
@@ -195,17 +194,13 @@ describe('AddressInput tests', () => {
   })
 
   it('should not show the adornment prefix when the value contains correct prefix', async () => {
-    ;(useCurrentChain as jest.Mock).mockImplementation(() => ({
-      shortName: 'gor',
-      chainId: '5',
-      chainName: 'Goerli',
-      features: [],
-    }))
+    const mockChain = chainBuilder().with('features', []).build()
+    ;(useCurrentChain as jest.Mock).mockImplementation(() => mockChain)
 
-    const { input } = setup(`gor:${TEST_ADDRESS_A}`)
+    const { input } = setup(`${mockChain.shortName}:${TEST_ADDRESS_A}`)
 
     act(() => {
-      fireEvent.change(input, { target: { value: `gor:${TEST_ADDRESS_B}` } })
+      fireEvent.change(input, { target: { value: `${mockChain.shortName}:${TEST_ADDRESS_B}` } })
     })
 
     await waitFor(() => expect(input.previousElementSibling?.textContent).toBe(''))

--- a/src/components/common/AddressInput/index.test.tsx
+++ b/src/components/common/AddressInput/index.test.tsx
@@ -7,7 +7,9 @@ import useNameResolver from '@/components/common/AddressInput/useNameResolver'
 import { chainBuilder } from '@/tests/builders/chains'
 import { FEATURES } from '@safe-global/safe-gateway-typescript-sdk'
 
-const mockChain = chainBuilder().with('features', [FEATURES.DOMAIN_LOOKUP]).build()
+const mockChain = chainBuilder()
+  .with({ features: [FEATURES.DOMAIN_LOOKUP] })
+  .build()
 
 // mock useCurrentChain
 jest.mock('@/hooks/useChains', () => ({
@@ -194,7 +196,7 @@ describe('AddressInput tests', () => {
   })
 
   it('should not show the adornment prefix when the value contains correct prefix', async () => {
-    const mockChain = chainBuilder().with('features', []).build()
+    const mockChain = chainBuilder().with({ features: [] }).build()
     ;(useCurrentChain as jest.Mock).mockImplementation(() => mockChain)
 
     const { input } = setup(`${mockChain.shortName}:${TEST_ADDRESS_A}`)

--- a/src/components/common/CheckWallet/index.test.tsx
+++ b/src/components/common/CheckWallet/index.test.tsx
@@ -3,6 +3,7 @@ import CheckWallet from '.'
 import useIsOnlySpendingLimitBeneficiary from '@/hooks/useIsOnlySpendingLimitBeneficiary'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import useWallet from '@/hooks/wallets/useWallet'
+import { chainBuilder } from '@/tests/builders/chains'
 
 // mock useWallet
 jest.mock('@/hooks/wallets/useWallet', () => ({
@@ -27,9 +28,7 @@ jest.mock('@/hooks/useIsOnlySpendingLimitBeneficiary', () => ({
 // mock useCurrentChain
 jest.mock('@/hooks/useChains', () => ({
   __esModule: true,
-  useCurrentChain: jest.fn(() => ({
-    chainName: 'Optimism',
-  })),
+  useCurrentChain: jest.fn(() => chainBuilder().build()),
 }))
 
 const renderButton = () => render(<CheckWallet>{(isOk) => <button disabled={!isOk}>Continue</button>}</CheckWallet>)

--- a/src/components/new-safe/create/steps/StatusStep/__tests__/useSafeCreation.test.ts
+++ b/src/components/new-safe/create/steps/StatusStep/__tests__/useSafeCreation.test.ts
@@ -9,7 +9,7 @@ import * as txMonitor from '@/services/tx/txMonitor'
 import * as usePendingSafe from '@/components/new-safe/create/steps/StatusStep/usePendingSafe'
 import { JsonRpcProvider, Web3Provider } from '@ethersproject/providers'
 import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
-import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { chainBuilder } from '@/tests/builders/chains'
 import { BigNumber } from '@ethersproject/bignumber'
 import { waitFor } from '@testing-library/react'
 import type Safe from '@safe-global/safe-core-sdk'
@@ -44,10 +44,7 @@ describe('useSafeCreation', () => {
   beforeEach(() => {
     jest.resetAllMocks()
 
-    const mockChain = {
-      chainId: '4',
-      features: [],
-    } as unknown as ChainInfo
+    const mockChain = chainBuilder().with('features', []).build()
 
     jest.spyOn(web3, 'useWeb3').mockImplementation(() => mockProvider)
     jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(() => mockProvider)
@@ -89,12 +86,11 @@ describe('useSafeCreation', () => {
         false,
       ])
 
-    jest.spyOn(chain, 'useCurrentChain').mockImplementation(
-      () =>
-        ({
-          chainId: '4',
-          features: [FEATURES.EIP1559],
-        } as unknown as ChainInfo),
+    jest.spyOn(chain, 'useCurrentChain').mockImplementation(() =>
+      chainBuilder()
+        // @ts-expect-error - we are using a local FEATURES enum
+        .with('features', [FEATURES.EIP1559])
+        .build(),
     )
     jest.spyOn(usePendingSafe, 'usePendingSafe').mockReturnValue([mockPendingSafe, mockSetPendingSafe])
 

--- a/src/components/new-safe/create/steps/StatusStep/__tests__/useSafeCreation.test.ts
+++ b/src/components/new-safe/create/steps/StatusStep/__tests__/useSafeCreation.test.ts
@@ -15,7 +15,7 @@ import { waitFor } from '@testing-library/react'
 import type Safe from '@safe-global/safe-core-sdk'
 import { hexZeroPad } from 'ethers/lib/utils'
 import type CompatibilityFallbackHandlerEthersContract from '@safe-global/safe-ethers-lib/dist/src/contracts/CompatibilityFallbackHandler/CompatibilityFallbackHandlerEthersContract'
-import { FEATURES } from '@/utils/chains'
+import { FEATURES } from '@safe-global/safe-gateway-typescript-sdk'
 import * as gasPrice from '@/hooks/useGasPrice'
 
 const mockSafeInfo = {
@@ -44,7 +44,7 @@ describe('useSafeCreation', () => {
   beforeEach(() => {
     jest.resetAllMocks()
 
-    const mockChain = chainBuilder().with('features', []).build()
+    const mockChain = chainBuilder().with({ features: [] }).build()
 
     jest.spyOn(web3, 'useWeb3').mockImplementation(() => mockProvider)
     jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(() => mockProvider)
@@ -88,8 +88,7 @@ describe('useSafeCreation', () => {
 
     jest.spyOn(chain, 'useCurrentChain').mockImplementation(() =>
       chainBuilder()
-        // @ts-expect-error - we are using a local FEATURES enum
-        .with('features', [FEATURES.EIP1559])
+        .with({ features: [FEATURES.EIP1559] })
         .build(),
     )
     jest.spyOn(usePendingSafe, 'usePendingSafe').mockReturnValue([mockPendingSafe, mockSetPendingSafe])

--- a/src/components/tx-flow/flows/SignMessage/SignMessage.test.tsx
+++ b/src/components/tx-flow/flows/SignMessage/SignMessage.test.tsx
@@ -1,5 +1,5 @@
 import { hexlify, hexZeroPad, toUtf8Bytes } from 'ethers/lib/utils'
-import type { ChainInfo, SafeInfo, SafeMessage, SafeMessageListPage } from '@safe-global/safe-gateway-typescript-sdk'
+import type { SafeInfo, SafeMessage, SafeMessageListPage } from '@safe-global/safe-gateway-typescript-sdk'
 import { SafeMessageListItemType } from '@safe-global/safe-gateway-typescript-sdk'
 
 import SignMessage from './SignMessage'
@@ -17,6 +17,7 @@ import type { EIP1193Provider, WalletState, AppState, OnboardAPI } from '@web3-o
 import { generateSafeMessageHash } from '@/utils/safe-messages'
 import { getSafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
 import useSafeMessages from '@/hooks/messages/useSafeMessages'
+import { chainBuilder } from '@/tests/builders/chains'
 
 jest.mock('@safe-global/safe-gateway-typescript-sdk', () => ({
   ...jest.requireActual('@safe-global/safe-gateway-typescript-sdk'),
@@ -400,7 +401,7 @@ describe('SignMessage', () => {
     jest.spyOn(onboard, 'default').mockReturnValue(mockOnboard)
     jest.spyOn(useIsSafeOwnerHook, 'default').mockImplementation(() => true)
     jest.spyOn(useIsWrongChainHook, 'default').mockImplementation(() => true)
-    jest.spyOn(useChainsHook, 'useCurrentChain').mockReturnValue({ chainName: 'Goerli' } as ChainInfo)
+    jest.spyOn(useChainsHook, 'useCurrentChain').mockReturnValue(chainBuilder().build())
 
     const { getByText } = render(
       <SignMessage

--- a/src/hooks/__tests__/useRemainingRelays.test.ts
+++ b/src/hooks/__tests__/useRemainingRelays.test.ts
@@ -10,8 +10,8 @@ const SAFE_ADDRESS = '0x0000000000000000000000000000000000000001'
 
 describe('fetch remaining relays hooks', () => {
   const mockChain = chainBuilder()
-    // @ts-expect-error - we are using a local FEATURES enum
-    .with('features', [FEATURES.RELAYING])
+    // @ts-expect-error - using local FEATURES enum
+    .with({ features: [FEATURES.RELAYING] })
     .build()
   beforeEach(() => {
     jest.spyOn(useChains, 'useCurrentChain').mockReturnValue(mockChain)
@@ -51,7 +51,7 @@ describe('fetch remaining relays hooks', () => {
     })
 
     it('should not do a network request if chain does not support relay', () => {
-      jest.spyOn(useChains, 'useCurrentChain').mockReturnValue(chainBuilder().with('features', []).build())
+      jest.spyOn(useChains, 'useCurrentChain').mockReturnValue(chainBuilder().with({ features: [] }).build())
 
       global.fetch = jest.fn()
       const mockFetch = jest.spyOn(global, 'fetch')
@@ -153,7 +153,7 @@ describe('fetch remaining relays hooks', () => {
     })
 
     it('should not do a network request if chain does not support relay', () => {
-      jest.spyOn(useChains, 'useCurrentChain').mockReturnValue(chainBuilder().with('features', []).build())
+      jest.spyOn(useChains, 'useCurrentChain').mockReturnValue(chainBuilder().with({ features: [] }).build())
       global.fetch = jest
         .fn()
         .mockResolvedValue({

--- a/src/hooks/__tests__/useRemainingRelays.test.ts
+++ b/src/hooks/__tests__/useRemainingRelays.test.ts
@@ -2,17 +2,19 @@ import { renderHook, waitFor } from '@/tests/test-utils'
 import { useLeastRemainingRelays, useRelaysBySafe } from '@/hooks/useRemainingRelays'
 import * as useSafeInfo from '@/hooks/useSafeInfo'
 import * as useChains from '@/hooks/useChains'
-import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { chainBuilder } from '@/tests/builders/chains'
 import { FEATURES } from '@/utils/chains'
 import { SAFE_RELAY_SERVICE_URL } from '@/services/tx/relaying'
 
 const SAFE_ADDRESS = '0x0000000000000000000000000000000000000001'
 
 describe('fetch remaining relays hooks', () => {
+  const mockChain = chainBuilder()
+    // @ts-expect-error - we are using a local FEATURES enum
+    .with('features', [FEATURES.RELAYING])
+    .build()
   beforeEach(() => {
-    jest
-      .spyOn(useChains, 'useCurrentChain')
-      .mockReturnValue({ chainId: '5', features: FEATURES.RELAYING } as unknown as ChainInfo)
+    jest.spyOn(useChains, 'useCurrentChain').mockReturnValue(mockChain)
     jest.spyOn(useSafeInfo, 'default').mockReturnValue({
       safe: {
         txHistoryTag: '0',
@@ -41,7 +43,7 @@ describe('fetch remaining relays hooks', () => {
       global.fetch = jest.fn()
       const mockFetch = jest.spyOn(global, 'fetch')
 
-      const url = `${SAFE_RELAY_SERVICE_URL}/5/${SAFE_ADDRESS}`
+      const url = `${SAFE_RELAY_SERVICE_URL}/${mockChain.chainId}/${SAFE_ADDRESS}`
 
       renderHook(() => useRelaysBySafe())
       expect(mockFetch).toHaveBeenCalledTimes(1)
@@ -49,7 +51,7 @@ describe('fetch remaining relays hooks', () => {
     })
 
     it('should not do a network request if chain does not support relay', () => {
-      jest.spyOn(useChains, 'useCurrentChain').mockReturnValue({ chainId: '5', features: [] } as unknown as ChainInfo)
+      jest.spyOn(useChains, 'useCurrentChain').mockReturnValue(chainBuilder().with('features', []).build())
 
       global.fetch = jest.fn()
       const mockFetch = jest.spyOn(global, 'fetch')
@@ -151,7 +153,7 @@ describe('fetch remaining relays hooks', () => {
     })
 
     it('should not do a network request if chain does not support relay', () => {
-      jest.spyOn(useChains, 'useCurrentChain').mockReturnValue({ chainId: '5', features: [] } as unknown as ChainInfo)
+      jest.spyOn(useChains, 'useCurrentChain').mockReturnValue(chainBuilder().with('features', []).build())
       global.fetch = jest
         .fn()
         .mockResolvedValue({

--- a/src/hooks/useMnemonicName/useMnemonicName.test.ts
+++ b/src/hooks/useMnemonicName/useMnemonicName.test.ts
@@ -1,11 +1,12 @@
 import { getRandomName, useMnemonicName, useMnemonicSafeName } from '.'
 import { renderHook } from '@/tests/test-utils'
+import { chainBuilder } from '@/tests/builders/chains'
+
+const mockChain = chainBuilder().build()
 
 // Mock useCurrentChain hook
 jest.mock('@/hooks/useChains', () => ({
-  useCurrentChain: () => ({
-    chainName: 'Rinkeby',
-  }),
+  useCurrentChain: () => mockChain,
 }))
 
 describe('useMnemonicName tests', () => {
@@ -37,6 +38,7 @@ describe('useMnemonicName tests', () => {
 
   it('should return a random safe name', () => {
     const { result } = renderHook(() => useMnemonicSafeName())
-    expect(result.current).toMatch(/^[a-z-]+-rinkeby-safe$/)
+    const regex = new RegExp(`^[a-z-]+-${mockChain.chainName.toLowerCase()}-safe$`)
+    expect(result.current).toMatch(regex)
   })
 })

--- a/src/tests/Builder.ts
+++ b/src/tests/Builder.ts
@@ -1,5 +1,5 @@
 export interface IBuilder<T> {
-  with<K extends keyof T>(key: K, value: T[K]): IBuilder<T>
+  with(override: Partial<T>): IBuilder<T>
 
   build(): T
 }
@@ -10,11 +10,10 @@ export class Builder<T> implements IBuilder<T> {
   /**
    * Returns a new {@link Builder} with the property {@link key} set to {@link value}.
    *
-   * @param key - the name of the property from T to be set
-   * @param value - the value of the property from T to be set
+   * @param override - the override value to apply
    */
-  with<K extends keyof T>(key: K, value: T[K]): IBuilder<T> {
-    const target: Partial<T> = { ...this.target, [key]: value }
+  with(override: Partial<T>): IBuilder<T> {
+    const target: Partial<T> = { ...this.target, ...override }
     return new Builder<T>(target)
   }
 

--- a/src/tests/Builder.ts
+++ b/src/tests/Builder.ts
@@ -1,0 +1,31 @@
+export interface IBuilder<T> {
+  with<K extends keyof T>(key: K, value: T[K]): IBuilder<T>
+
+  build(): T
+}
+
+export class Builder<T> implements IBuilder<T> {
+  private constructor(private target: Partial<T>) {}
+
+  /**
+   * Returns a new {@link Builder} with the property {@link key} set to {@link value}.
+   *
+   * @param key - the name of the property from T to be set
+   * @param value - the value of the property from T to be set
+   */
+  with<K extends keyof T>(key: K, value: T[K]): IBuilder<T> {
+    const target: Partial<T> = { ...this.target, [key]: value }
+    return new Builder<T>(target)
+  }
+
+  /**
+   * Returns an instance of T with the values that were set so far
+   */
+  build(): T {
+    return this.target as T
+  }
+
+  public static new<T>(): IBuilder<T> {
+    return new Builder<T>({})
+  }
+}

--- a/src/tests/builders/chains.ts
+++ b/src/tests/builders/chains.ts
@@ -1,0 +1,118 @@
+import { faker } from '@faker-js/faker'
+import { RPC_AUTHENTICATION, GAS_PRICE_TYPE } from '@safe-global/safe-gateway-typescript-sdk'
+import type {
+  BlockExplorerUriTemplate,
+  ChainInfo,
+  GasPriceFixed,
+  GasPriceFixedEIP1559,
+  GasPriceOracle,
+  GasPriceUnknown,
+  NativeCurrency,
+  RpcUri,
+  Theme,
+} from '@safe-global/safe-gateway-typescript-sdk'
+
+import { Builder } from '@/tests/Builder'
+import { FEATURES } from '@/utils/chains'
+import { generateRandomArray } from './utils'
+import type { IBuilder } from '@/tests/Builder'
+import type useChains from '@/hooks/useChains'
+
+const rpcUriBuilder = (): IBuilder<RpcUri> => {
+  return Builder.new<RpcUri>()
+    .with('authentication', RPC_AUTHENTICATION.NO_AUTHENTICATION)
+    .with('value', faker.internet.url({ appendSlash: false }))
+}
+
+const blockExplorerUriTemplateBuilder = (): IBuilder<BlockExplorerUriTemplate> => {
+  return Builder.new<BlockExplorerUriTemplate>()
+    .with('address', faker.finance.ethereumAddress())
+    .with('txHash', faker.string.hexadecimal())
+    .with('api', faker.internet.url({ appendSlash: false }))
+}
+
+const nativeCurrencyBuilder = (): IBuilder<NativeCurrency> => {
+  return Builder.new<NativeCurrency>()
+    .with('name', faker.finance.currencyName())
+    .with('symbol', faker.finance.currencySymbol())
+    .with('decimals', 18)
+    .with('logoUri', faker.internet.url({ appendSlash: false }))
+}
+
+const themeBuilder = (): IBuilder<Theme> => {
+  return Builder.new<Theme>().with('textColor', faker.color.rgb()).with('backgroundColor', faker.color.rgb())
+}
+
+const gasPriceFixedBuilder = (): IBuilder<GasPriceFixed> => {
+  return Builder.new<GasPriceFixed>().with('type', GAS_PRICE_TYPE.FIXED).with('weiValue', faker.string.numeric())
+}
+
+const gasPriceFixedEIP1559Builder = (): IBuilder<GasPriceFixedEIP1559> => {
+  return Builder.new<GasPriceFixedEIP1559>()
+    .with('type', GAS_PRICE_TYPE.FIXED_1559)
+    .with('maxFeePerGas', faker.string.numeric())
+    .with('maxPriorityFeePerGas', faker.string.numeric())
+}
+
+const gasPriceOracleBuilder = (): IBuilder<GasPriceOracle> => {
+  return Builder.new<GasPriceOracle>()
+    .with('type', GAS_PRICE_TYPE.ORACLE)
+    .with('uri', faker.internet.url({ appendSlash: false }))
+    .with('gasParameter', faker.word.sample())
+    .with('gweiFactor', faker.string.numeric())
+}
+
+const gasPriceOracleUnknownBuilder = (): IBuilder<GasPriceUnknown> => {
+  return Builder.new<GasPriceUnknown>().with('type', GAS_PRICE_TYPE.UNKNOWN)
+}
+
+const getRandomGasPriceBuilder = () => {
+  const gasPriceBuilders = [
+    gasPriceFixedBuilder(),
+    gasPriceFixedEIP1559Builder(),
+    gasPriceOracleBuilder(),
+    gasPriceOracleUnknownBuilder(),
+  ]
+
+  const randomIndex = Math.floor(Math.random() * gasPriceBuilders.length)
+  return gasPriceBuilders[randomIndex]
+}
+
+export const chainBuilder = (): IBuilder<ChainInfo> => {
+  return Builder.new<ChainInfo>()
+    .with('chainId', faker.string.numeric())
+    .with('chainName', faker.word.sample())
+    .with('description', faker.word.words())
+    .with('l2', faker.datatype.boolean())
+    .with('shortName', faker.word.sample())
+    .with('rpcUri', rpcUriBuilder().build())
+    .with('safeAppsRpcUri', rpcUriBuilder().build())
+    .with('publicRpcUri', rpcUriBuilder().build())
+    .with('blockExplorerUriTemplate', blockExplorerUriTemplateBuilder().build())
+    .with('nativeCurrency', nativeCurrencyBuilder().build())
+    .with('transactionService', faker.internet.url({ appendSlash: true }))
+    .with('theme', themeBuilder().build())
+    .with(
+      'gasPrice',
+      generateRandomArray(() => getRandomGasPriceBuilder().build(), { min: 1, max: 4 }),
+    )
+    .with('ensRegistryAddress', faker.finance.ethereumAddress())
+    .with(
+      'disabledWallets',
+      generateRandomArray(() => faker.word.sample(), { min: 1, max: 10 }),
+    )
+    .with(
+      'features',
+      // @ts-expect-error - we are using a local FEATURES enum
+      generateRandomArray(() => faker.helpers.enumValue(FEATURES), { min: 1, max: 10 }),
+    )
+}
+
+export const useChainsBuilder = (): IBuilder<ReturnType<typeof useChains>> => {
+  return Builder.new<ReturnType<typeof useChains>>()
+    .with(
+      'configs',
+      generateRandomArray(() => chainBuilder().build(), { min: 1, max: 25 }),
+    )
+    .with('loading', false)
+}

--- a/src/tests/builders/chains.ts
+++ b/src/tests/builders/chains.ts
@@ -19,51 +19,64 @@ import type { IBuilder } from '@/tests/Builder'
 import type useChains from '@/hooks/useChains'
 
 const rpcUriBuilder = (): IBuilder<RpcUri> => {
-  return Builder.new<RpcUri>()
-    .with('authentication', RPC_AUTHENTICATION.NO_AUTHENTICATION)
-    .with('value', faker.internet.url({ appendSlash: false }))
+  return Builder.new<RpcUri>().with({
+    authentication: RPC_AUTHENTICATION.NO_AUTHENTICATION,
+    value: faker.internet.url({ appendSlash: false }),
+  })
 }
 
 const blockExplorerUriTemplateBuilder = (): IBuilder<BlockExplorerUriTemplate> => {
-  return Builder.new<BlockExplorerUriTemplate>()
-    .with('address', faker.finance.ethereumAddress())
-    .with('txHash', faker.string.hexadecimal())
-    .with('api', faker.internet.url({ appendSlash: false }))
+  return Builder.new<BlockExplorerUriTemplate>().with({
+    address: faker.finance.ethereumAddress(),
+    txHash: faker.string.hexadecimal(),
+    api: faker.internet.url({ appendSlash: false }),
+  })
 }
 
 const nativeCurrencyBuilder = (): IBuilder<NativeCurrency> => {
-  return Builder.new<NativeCurrency>()
-    .with('name', faker.finance.currencyName())
-    .with('symbol', faker.finance.currencySymbol())
-    .with('decimals', 18)
-    .with('logoUri', faker.internet.url({ appendSlash: false }))
+  return Builder.new<NativeCurrency>().with({
+    name: faker.finance.currencyName(),
+    symbol: faker.finance.currencySymbol(),
+    decimals: 18,
+    logoUri: faker.internet.url({ appendSlash: false }),
+  })
 }
 
 const themeBuilder = (): IBuilder<Theme> => {
-  return Builder.new<Theme>().with('textColor', faker.color.rgb()).with('backgroundColor', faker.color.rgb())
+  return Builder.new<Theme>().with({
+    textColor: faker.color.rgb(),
+    backgroundColor: faker.color.rgb(),
+  })
 }
 
 const gasPriceFixedBuilder = (): IBuilder<GasPriceFixed> => {
-  return Builder.new<GasPriceFixed>().with('type', GAS_PRICE_TYPE.FIXED).with('weiValue', faker.string.numeric())
+  return Builder.new<GasPriceFixed>().with({
+    type: GAS_PRICE_TYPE.FIXED,
+    weiValue: faker.string.numeric(),
+  })
 }
 
 const gasPriceFixedEIP1559Builder = (): IBuilder<GasPriceFixedEIP1559> => {
-  return Builder.new<GasPriceFixedEIP1559>()
-    .with('type', GAS_PRICE_TYPE.FIXED_1559)
-    .with('maxFeePerGas', faker.string.numeric())
-    .with('maxPriorityFeePerGas', faker.string.numeric())
+  return Builder.new<GasPriceFixedEIP1559>().with({
+    type: GAS_PRICE_TYPE.FIXED_1559,
+    maxFeePerGas: faker.string.numeric(),
+    maxPriorityFeePerGas: faker.string.numeric(),
+  })
 }
 
 const gasPriceOracleBuilder = (): IBuilder<GasPriceOracle> => {
-  return Builder.new<GasPriceOracle>()
-    .with('type', GAS_PRICE_TYPE.ORACLE)
-    .with('uri', faker.internet.url({ appendSlash: false }))
-    .with('gasParameter', faker.word.sample())
-    .with('gweiFactor', faker.string.numeric())
+  return Builder.new<GasPriceOracle>().with({
+    type: GAS_PRICE_TYPE.ORACLE,
+    uri: faker.internet.url({ appendSlash: false }),
+    gasParameter: faker.word.sample(),
+    gweiFactor: faker.string.numeric(),
+  })
 }
 
 const gasPriceOracleUnknownBuilder = (): IBuilder<GasPriceUnknown> => {
-  return Builder.new<GasPriceUnknown>().with('type', GAS_PRICE_TYPE.UNKNOWN)
+  return Builder.new<GasPriceUnknown>().with({
+    type: GAS_PRICE_TYPE.UNKNOWN,
+  })
 }
 
 const getRandomGasPriceBuilder = () => {
@@ -79,40 +92,30 @@ const getRandomGasPriceBuilder = () => {
 }
 
 export const chainBuilder = (): IBuilder<ChainInfo> => {
-  return Builder.new<ChainInfo>()
-    .with('chainId', faker.string.numeric())
-    .with('chainName', faker.word.sample())
-    .with('description', faker.word.words())
-    .with('l2', faker.datatype.boolean())
-    .with('shortName', faker.word.sample())
-    .with('rpcUri', rpcUriBuilder().build())
-    .with('safeAppsRpcUri', rpcUriBuilder().build())
-    .with('publicRpcUri', rpcUriBuilder().build())
-    .with('blockExplorerUriTemplate', blockExplorerUriTemplateBuilder().build())
-    .with('nativeCurrency', nativeCurrencyBuilder().build())
-    .with('transactionService', faker.internet.url({ appendSlash: true }))
-    .with('theme', themeBuilder().build())
-    .with(
-      'gasPrice',
-      generateRandomArray(() => getRandomGasPriceBuilder().build(), { min: 1, max: 4 }),
-    )
-    .with('ensRegistryAddress', faker.finance.ethereumAddress())
-    .with(
-      'disabledWallets',
-      generateRandomArray(() => faker.word.sample(), { min: 1, max: 10 }),
-    )
-    .with(
-      'features',
-      // @ts-expect-error - we are using a local FEATURES enum
-      generateRandomArray(() => faker.helpers.enumValue(FEATURES), { min: 1, max: 10 }),
-    )
+  return Builder.new<ChainInfo>().with({
+    chainId: faker.string.numeric(),
+    chainName: faker.word.sample(),
+    description: faker.word.words(),
+    l2: faker.datatype.boolean(),
+    shortName: faker.word.sample(),
+    rpcUri: rpcUriBuilder().build(),
+    safeAppsRpcUri: rpcUriBuilder().build(),
+    publicRpcUri: rpcUriBuilder().build(),
+    blockExplorerUriTemplate: blockExplorerUriTemplateBuilder().build(),
+    nativeCurrency: nativeCurrencyBuilder().build(),
+    transactionService: faker.internet.url({ appendSlash: false }),
+    theme: themeBuilder().build(),
+    gasPrice: generateRandomArray(() => getRandomGasPriceBuilder().build(), { min: 1, max: 4 }),
+    ensRegistryAddress: faker.finance.ethereumAddress(),
+    disabledWallets: generateRandomArray(() => faker.word.sample(), { min: 1, max: 10 }),
+    // @ts-expect-error - we are using a local FEATURES enum
+    features: generateRandomArray(() => faker.helpers.enumValue(FEATURES), { min: 1, max: 10 }),
+  })
 }
 
 export const useChainsBuilder = (): IBuilder<ReturnType<typeof useChains>> => {
-  return Builder.new<ReturnType<typeof useChains>>()
-    .with(
-      'configs',
-      generateRandomArray(() => chainBuilder().build(), { min: 1, max: 25 }),
-    )
-    .with('loading', false)
+  return Builder.new<ReturnType<typeof useChains>>().with({
+    configs: generateRandomArray(() => chainBuilder().build(), { min: 1, max: 25 }),
+    loading: false,
+  })
 }

--- a/src/tests/builders/utils.ts
+++ b/src/tests/builders/utils.ts
@@ -1,0 +1,6 @@
+import { faker } from '@faker-js/faker'
+import type { NumberModule } from '@faker-js/faker'
+
+export const generateRandomArray = <T>(generator: () => T, options?: Parameters<NumberModule['int']>[0]): Array<T> => {
+  return Array.from({ length: faker.number.int(options) }, generator)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2263,6 +2263,11 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
+"@faker-js/faker@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-8.1.0.tgz#e14896f1c57af2495e341dc4c7bf04125c8aeafd"
+  integrity sha512-38DT60rumHfBYynif3lmtxMqMqmsOQIxQgEuPZxCk2yUYN0eqWpTACgxi0VpidvsJB8CRxCpvP7B3anK85FjtQ==
+
 "@firebase/analytics-compat@0.2.6":
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/@firebase/analytics-compat/-/analytics-compat-0.2.6.tgz#50063978c42f13eb800e037e96ac4b17236841f4"


### PR DESCRIPTION
## What it solves

Resolves brittle tests

## How this PR fixes it

A new `Builder` class has been added that facilitates mock data generation for tests. An example `chainBuilder` has been created and used in a few demonstrative tests where `useCurrentChain` is mocked.

## How to test it

Observe the tests passing.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
