### PR TITLE
[Seedless Onboarding]: Adjust password form

### DIFF
--- a/public/images/common/bar-chart.svg
+++ b/public/images/common/bar-chart.svg
@@ -1,5 +1,5 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M4 13.3337V10.667" stroke="#FF5F72" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M8 13.3337V6.66699" stroke="#DCDEE0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M12 13.3337V2.66699" stroke="#DCDEE0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path class="illustration-very-light-stroke" d="M8 13.3337V6.66699" stroke="#DCDEE0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path class="illustration-very-light-stroke" d="M12 13.3337V2.66699" stroke="#DCDEE0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/components/common/PageHeader/styles.module.css
+++ b/src/components/common/PageHeader/styles.module.css
@@ -4,7 +4,7 @@
   flex-direction: column;
   justify-content: space-between;
   background-color: var(--color-background-main);
-  z-index: 1;
+  z-index: 2;
   width: 100%;
   position: sticky !important;
   top: calc(var(--header-height) - 76px);

--- a/src/components/new-safe/create/steps/SetNameStep/index.tsx
+++ b/src/components/new-safe/create/steps/SetNameStep/index.tsx
@@ -62,6 +62,7 @@ function SetNameStep({
   }
 
   const onCancel = () => {
+    trackEvent(CREATE_SAFE_EVENTS.CANCEL_CREATE_SAFE_FORM)
     router.push(AppRoutes.welcome)
   }
 

--- a/src/components/settings/SecurityLogin/SocialSignerExport/ExportMPCAccountModal.tsx
+++ b/src/components/settings/SecurityLogin/SocialSignerExport/ExportMPCAccountModal.tsx
@@ -107,7 +107,14 @@ const ExportMPCAccountModal = ({ onClose, open }: { onClose: () => void; open: b
             )}
             {error && <ErrorMessage className={css.modalError}>{error}</ErrorMessage>}
 
-            <Box display="flex" flexDirection="row" justifyContent="space-between" alignItems="center" width="100%">
+            <Box
+              display="flex"
+              flexDirection="row"
+              justifyContent="space-between"
+              alignItems="center"
+              width="100%"
+              mt={2}
+            >
               <Button variant="outlined" onClick={handleClose}>
                 Close
               </Button>

--- a/src/components/settings/SecurityLogin/SocialSignerMFA/helper.ts
+++ b/src/components/settings/SecurityLogin/SocialSignerMFA/helper.ts
@@ -5,8 +5,6 @@ import { logError } from '@/services/exceptions'
 import ErrorCodes from '@/services/exceptions/ErrorCodes'
 import { asError } from '@/services/exceptions/utils'
 import { type Web3AuthMPCCoreKit } from '@web3auth/mpc-core-kit'
-import { showNotification } from '@/store/notificationsSlice'
-import { type AppDispatch } from '@/store'
 
 export const isMFAEnabled = (mpcCoreKit: Web3AuthMPCCoreKit) => {
   if (!mpcCoreKit) {

--- a/src/components/settings/SecurityLogin/SocialSignerMFA/helper.ts
+++ b/src/components/settings/SecurityLogin/SocialSignerMFA/helper.ts
@@ -17,14 +17,13 @@ export const isMFAEnabled = (mpcCoreKit: Web3AuthMPCCoreKit) => {
 }
 
 export const enableMFA = async (
-  dispatch: AppDispatch,
   mpcCoreKit: Web3AuthMPCCoreKit,
   {
     newPassword,
-    oldPassword,
+    currentPassword,
   }: {
     newPassword: string
-    oldPassword: string | undefined
+    currentPassword: string | undefined
   },
 ) => {
   if (!mpcCoreKit) {
@@ -33,7 +32,7 @@ export const enableMFA = async (
   const securityQuestions = new SecurityQuestionRecovery(mpcCoreKit)
   try {
     // 1. setup device factor with password recovery
-    await securityQuestions.upsertPassword(newPassword, oldPassword)
+    await securityQuestions.upsertPassword(newPassword, currentPassword)
     const securityQuestionFactor = await securityQuestions.recoverWithPassword(newPassword)
     if (!securityQuestionFactor) {
       throw Error('Could not recover using the new password recovery')
@@ -46,25 +45,9 @@ export const enableMFA = async (
     }
 
     await mpcCoreKit.commitChanges()
-
-    dispatch(
-      showNotification({
-        variant: 'success',
-        groupKey: 'global-upsert-password',
-        message: 'Successfully created or updated password',
-      }),
-    )
   } catch (e) {
     const error = asError(e)
     logError(ErrorCodes._304, error.message)
-
-    // TODO: Check if we should use a notification or show an error inside the form
-    dispatch(
-      showNotification({
-        variant: 'error',
-        groupKey: 'global-upsert-password',
-        message: 'Failed to create or update password',
-      }),
-    )
+    throw error
   }
 }

--- a/src/components/settings/SecurityLogin/SocialSignerMFA/index.tsx
+++ b/src/components/settings/SecurityLogin/SocialSignerMFA/index.tsx
@@ -83,6 +83,7 @@ const SocialSignerMFA = () => {
   const mpcCoreKit = useMPC()
   const [passwordStrength, setPasswordStrength] = useState<PasswordStrength>()
   const [submitError, setSubmitError] = useState<string>()
+  const [open, setOpen] = useState<boolean>(false)
 
   const formMethods = useForm<PasswordFormData>({
     mode: 'all',
@@ -107,6 +108,8 @@ const SocialSignerMFA = () => {
 
     try {
       await enableMFA(mpcCoreKit, data)
+      onReset()
+      setOpen(false)
     } catch (e) {
       setSubmitError('The password you entered is incorrect. Please try again.')
     }
@@ -116,6 +119,10 @@ const SocialSignerMFA = () => {
     reset()
     setPasswordStrength(undefined)
     setSubmitError(undefined)
+  }
+
+  const toggleAccordion = () => {
+    setOpen((prev) => !prev)
   }
 
   const confirmPassword = watch(PasswordFieldNames.confirmPassword)
@@ -137,7 +144,7 @@ const SocialSignerMFA = () => {
             Protect your social login signer with a password. It will be used to restore access in another browser or on
             another device.
           </Typography>
-          <Accordion>
+          <Accordion expanded={open} defaultExpanded={false} onChange={toggleAccordion}>
             <AccordionSummary expandIcon={<ExpandMoreIcon />}>
               <Box display="flex" alignItems="center" gap={1}>
                 <SvgIcon component={CheckIcon} sx={{ color: isPasswordSet ? 'success.main' : 'border.light' }} />

--- a/src/components/settings/SecurityLogin/SocialSignerMFA/styles.module.css
+++ b/src/components/settings/SecurityLogin/SocialSignerMFA/styles.module.css
@@ -29,6 +29,19 @@
   margin-bottom: 0;
 }
 
+.defaultPassword,
+.passwordsShouldMatch {
+  color: var(--color-border-main);
+}
+
+.passwordsShouldMatch svg path {
+  stroke: var(--color-border-main);
+}
+
+.defaultPassword svg path {
+  stroke: var(--color-border-main);
+}
+
 .weakPassword {
   color: var(--color-error-main);
 }

--- a/src/services/analytics/events/createLoadSafe.ts
+++ b/src/services/analytics/events/createLoadSafe.ts
@@ -42,6 +42,10 @@ export const CREATE_SAFE_EVENTS = {
     action: 'Retry Safe creation',
     category: CREATE_SAFE_CATEGORY,
   },
+  CANCEL_CREATE_SAFE_FORM: {
+    action: 'Cancel safe creation form',
+    category: CREATE_SAFE_CATEGORY,
+  },
   CANCEL_CREATE_SAFE: {
     event: EventType.META,
     action: 'Cancel Safe creation',

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -70,6 +70,10 @@ input[type='number'] {
   stroke: var(--color-border-main);
 }
 
+.illustration-very-light-stroke {
+  stroke: var(--color-border-light);
+}
+
 .illustration-background-stroke {
   stroke: var(--color-logo-background);
 }


### PR DESCRIPTION
## What it solves

Part of #2452 

## How this PR fixes it

- Renames `oldPassword` to `currentPassword`
- Renames `Confirm new password` to `Confirm password`
- Displays a submit error inside the form
- Fixes z-index issue on the settings page when scrolling
- Adds an event to track create safe form cancels
- Adds visual default states for `passwordStrength` and `passwordsMatch`
- Closes the accordion on successful form submission

## How to test it

1. Open a Safe and login with google
2. Go to the settings page
3. Compare form design with [Figma](https://www.figma.com/file/WSpulDIM1EoSCI6Ph9QdWq/Seedless-onboarding?node-id=909%3A26336&mode=dev)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
