### PR TITLE
Fix: on close callback for WalletConnect

### DIFF
--- a/src/components/tx-flow/index.tsx
+++ b/src/components/tx-flow/index.tsx
@@ -1,4 +1,5 @@
 import { createContext, type ReactElement, type ReactNode, useState, useEffect, useCallback, useRef } from 'react'
+import { usePathname } from 'next/navigation'
 import TxModalDialog from '@/components/common/TxModalDialog'
 import { SuccessScreen } from './flows/SuccessScreen'
 import useSafeAddress from '@/hooks/useSafeAddress'
@@ -29,6 +30,8 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
   const onClose = useRef<() => void>(noop)
   const safeId = useChainId() + useSafeAddress()
   const prevSafeId = useRef<string>(safeId ?? '')
+  const pathname = usePathname()
+  const prevPathname = useRef<string>(pathname)
 
   const handleModalClose = useCallback(() => {
     onClose.current()
@@ -73,8 +76,17 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
     if (txFlow) {
       handleShowWarning()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [txFlow, safeId])
+
+  // // Close the modal when the path changes
+  useEffect(() => {
+    if (pathname === prevPathname.current) return
+    prevPathname.current = pathname
+
+    if (txFlow) {
+      handleShowWarning()
+    }
+  }, [txFlow, pathname])
 
   return (
     <TxModalContext.Provider value={{ txFlow, setTxFlow, setFullWidth }}>

--- a/src/components/tx-flow/index.tsx
+++ b/src/components/tx-flow/index.tsx
@@ -1,7 +1,8 @@
 import { createContext, type ReactElement, type ReactNode, useState, useEffect, useCallback, useRef } from 'react'
 import TxModalDialog from '@/components/common/TxModalDialog'
-import { useSearchParams } from 'next/navigation'
 import { SuccessScreen } from './flows/SuccessScreen'
+import useSafeAddress from '@/hooks/useSafeAddress'
+import useChainId from '@/hooks/useChainId'
 
 const noop = () => {}
 
@@ -26,9 +27,8 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
   const [fullWidth, setFullWidth] = useState<boolean>(false)
   const shouldWarn = useRef<boolean>(true)
   const onClose = useRef<() => void>(noop)
-  const searchParams = useSearchParams()
-  const safeQuery = searchParams.get('safe')
-  const prevQuery = useRef<string>(safeQuery ?? '')
+  const safeId = useChainId() + useSafeAddress()
+  const prevSafeId = useRef<string>(safeId ?? '')
 
   const handleModalClose = useCallback(() => {
     onClose.current()
@@ -67,14 +67,14 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
 
   // // Close the modal when the Safe changes
   useEffect(() => {
-    if (safeQuery === prevQuery.current) return
-    prevQuery.current = safeQuery ?? ''
+    if (safeId === prevSafeId.current) return
+    prevSafeId.current = safeId
 
     if (txFlow) {
       handleShowWarning()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [txFlow, safeQuery])
+  }, [txFlow, safeId])
 
   return (
     <TxModalContext.Provider value={{ txFlow, setTxFlow, setFullWidth }}>

--- a/src/services/tx/txEvents.ts
+++ b/src/services/tx/txEvents.ts
@@ -2,7 +2,6 @@ import EventBus from '@/services/EventBus'
 import type { RequestId } from '@safe-global/safe-apps-sdk'
 
 export enum TxEvent {
-  USER_QUIT = 'USER_QUIT',
   SIGNED = 'SIGNED',
   SIGN_FAILED = 'SIGN_FAILED',
   PROPOSED = 'PROPOSED',
@@ -27,7 +26,6 @@ export enum TxEvent {
 type Id = { txId: string; groupKey?: string } | { txId?: string; groupKey: string }
 
 interface TxEvents {
-  [TxEvent.USER_QUIT]: {}
   [TxEvent.SIGNED]: { txId?: string }
   [TxEvent.SIGN_FAILED]: { txId?: string; error: Error }
   [TxEvent.PROPOSE_FAILED]: { error: Error }

--- a/src/services/walletconnect/WalletConnectContext.tsx
+++ b/src/services/walletconnect/WalletConnectContext.tsx
@@ -7,6 +7,7 @@ import useSafeWalletProvider from '@/services/safe-wallet-provider/useSafeWallet
 import WalletConnectWallet from './WalletConnectWallet'
 import { asError } from '../exceptions/utils'
 import { getPeerName, stripEip155Prefix } from './utils'
+import { IS_PRODUCTION } from '@/config/constants'
 
 const walletConnectSingleton = new WalletConnectWallet()
 
@@ -54,6 +55,10 @@ export const WalletConnectProvider = ({ children }: { children: ReactNode }) => 
     if (!walletConnect || !safeWalletProvider || !chainId) return
 
     return walletConnect.onRequest(async (event) => {
+      if (!IS_PRODUCTION) {
+        console.log('[WalletConnect] request', event)
+      }
+
       const { topic } = event
       const session = walletConnect.getActiveSessions().find((s) => s.topic === topic)
       const requestChainId = stripEip155Prefix(event.params.chainId)


### PR DESCRIPTION
The on-close callback wasn't correctly handled because of how we were setting state.

This wasn't setting the state to a new function, but was calling this function right away instead as it it was a setter callback.
```
setOnClose(onClose ?? noop)
```

I've changed onClose and shouldWarn to useRef to fix this.

Also removed the global USER_QUIT tx event and replaced with with direct onClose callbacks.