### PR TITLE
Chore: after-install in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY . .
 
 # install deps
 RUN yarn install --frozen-lockfile
+RUN yarn after-install
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
## What it solves

Resolves #2697

## How this PR fixes it

`after-install` needs to be run manually on CI.