### PR TITLE
Allow safe deployments to be higher than the version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@safe-global/safe-apps-sdk": "^8.1.0",
     "@safe-global/safe-core-sdk": "^3.3.5",
     "@safe-global/safe-core-sdk-utils": "^1.7.4",
-    "@safe-global/safe-deployments": "1.25.0",
+    "@safe-global/safe-deployments": "^1.25.0",
     "@safe-global/safe-ethers-lib": "^1.9.4",
     "@safe-global/safe-gateway-typescript-sdk": "^3.12.0",
     "@safe-global/safe-modules-deployments": "^1.0.0",


### PR DESCRIPTION
## What it solves
When there is a new version of safe deployments it is not downloaded as the package is set to a specific version

## How this PR fixes it
Allow the package to download a higher version if one is released.
I dont know if there is a very specific reason why the deployments is locked to a version, but it does mean that anyone who is trying to use safe-web on a chain that was recently added to deployments cant. 

## How to test it
`npm install` - should see the current release of safe-deployments downloaded instead of locked to 1.25.0
eg. current release is 1.28.0

## Screenshots
n/a

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
