### PR TITLE
fix: ignore empty names in addressbook

### DIFF
--- a/src/store/__tests__/addressBookSlice.test.ts
+++ b/src/store/__tests__/addressBookSlice.test.ts
@@ -32,6 +32,21 @@ describe('addressBookSlice', () => {
     })
   })
 
+  it('should ignore empty names in the address book', () => {
+    const state = addressBookSlice.reducer(
+      initialState,
+      upsertAddressBookEntry({
+        chainId: '1',
+        address: '0x2',
+        name: '',
+      }),
+    )
+    expect(state).toEqual({
+      '1': { '0x0': 'Alice', '0x1': 'Bob' },
+      '4': { '0x0': 'Charlie', '0x1': 'Dave' },
+    })
+  })
+
   it('should edit an entry in the address book', () => {
     const state = addressBookSlice.reducer(
       initialState,

--- a/src/store/__tests__/addressBookSlice.test.ts
+++ b/src/store/__tests__/addressBookSlice.test.ts
@@ -41,10 +41,7 @@ describe('addressBookSlice', () => {
         name: '',
       }),
     )
-    expect(state).toEqual({
-      '1': { '0x0': 'Alice', '0x1': 'Bob' },
-      '4': { '0x0': 'Charlie', '0x1': 'Dave' },
-    })
+    expect(state).toEqual(initialState)
   })
 
   it('should edit an entry in the address book', () => {

--- a/src/store/addressBookSlice.ts
+++ b/src/store/addressBookSlice.ts
@@ -26,6 +26,9 @@ export const addressBookSlice = createSlice({
 
     upsertAddressBookEntry: (state, action: PayloadAction<{ chainId: string; address: string; name: string }>) => {
       const { chainId, address, name } = action.payload
+      if (name.trim() === '') {
+        return
+      }
       if (!state[chainId]) state[chainId] = {}
       state[chainId][address] = name
     },


### PR DESCRIPTION
## What it solves
Creating a Safe with social signers lead to empty names in the addressbook.

## How this PR fixes it
We ignore addressBook entries with empty names and do not insert those anymore.

## How to test it
1. Create a Safe with social signer
2. Witness that no empty entry is created for that Safe anymore

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
