### PR TITLE
Chore: update GitHub workflow permissions + quote version in the release workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,8 @@ concurrency:
 
 jobs:
   e2e:
+    permissions: write-all
+
     runs-on: ubuntu-20.04
     name: Smoke E2E tests
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,8 @@ concurrency:
 
 jobs:
   eslint:
+    permissions: write-all
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/safe-apps-e2e.yml
+++ b/.github/workflows/safe-apps-e2e.yml
@@ -10,6 +10,8 @@ concurrency:
 
 jobs:
   e2e:
+    permissions: write-all
+
     runs-on: ubuntu-latest
     name: Safe Apps E2E tests
     steps:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -6,6 +6,10 @@ on:
       - main
     types: [closed]
 
+permissions:
+  contents:
+    write
+
 jobs:
   tag-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -21,11 +21,11 @@ jobs:
         id: version
         run: |
           NEW_VERSION=$(node -p 'require("./package.json").version')
-          echo "version=v$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "version=\"v${NEW_VERSION}\"" >> $GITHUB_OUTPUT
 
       - name: Create a git tag
         if: github.event.pull_request.merged == true
-        run: git tag ${{ steps.version.outputs.version }} && git push --tags
+        run: git tag "${{ steps.version.outputs.version }}" && git push --tags
 
       - name: GitHub release
         if: success()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ concurrency:
 
 jobs:
   test:
+    permissions: write-all
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The default permissions were changed to read-only. Some actions need to write comments and create releases.

Docs: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs