### PR TITLE
[Seedless Onboarding] Catch errors during signing with social login

### DIFF
--- a/src/components/common/SocialSigner/index.tsx
+++ b/src/components/common/SocialSigner/index.tsx
@@ -82,6 +82,7 @@ export const SocialSigner = ({
     if (status === COREKIT_STATUS.LOGGED_IN) {
       onLogin?.()
       setLoginPending(false)
+      return
     }
 
     if (status === COREKIT_STATUS.REQUIRED_SHARE) {
@@ -96,7 +97,11 @@ export const SocialSigner = ({
         () => {},
         false,
       )
+      return
     }
+
+    // TODO: Show error if login fails
+    setLoginPending(false)
   }
 
   const isSocialLogin = isSocialLoginWallet(wallet?.label)

--- a/src/services/mpc/SocialLoginModule.ts
+++ b/src/services/mpc/SocialLoginModule.ts
@@ -45,7 +45,10 @@ function MpcModule(): WalletInit {
                  * We have to fallback to web3ReadOnly for eth_estimateGas because the provider by Web3Auth does not expose / implement it.
                  */
                 if ('eth_estimateGas' === request.method) {
-                  web3ReadOnly?.send(request.method, request.params ?? []).then(resolve)
+                  web3ReadOnly
+                    ?.send(request.method, request.params ?? [])
+                    .then(resolve)
+                    .catch(reject)
                   return
                 }
 
@@ -53,7 +56,7 @@ function MpcModule(): WalletInit {
                  * If the provider is defined we already have access to the accounts. So we can just reply with the current account.
                  */
                 if ('eth_requestAccounts' === request.method) {
-                  web3.request({ method: 'eth_accounts' }).then(resolve)
+                  web3.request({ method: 'eth_accounts' }).then(resolve).catch(reject)
                   return
                 }
 
@@ -64,7 +67,7 @@ function MpcModule(): WalletInit {
                 }
 
                 // Default: we call the inner provider
-                web3.request(request).then(resolve)
+                web3.request(request).then(resolve).catch(reject)
                 return
               } catch (error) {
                 reject(


### PR DESCRIPTION
## What it solves

Part of #2452 

## How this PR fixes it

- Rejects the promise from the MPC Provider calls so it can be caught by our components
- Resets the loading state during login if login fails
- Adds a TODO to show an error if login fails (Need to check this with design)

## How to test it

1. Open a Safe
2. Login with Social
3. Execute a transaction but block the network requests to w3a
4. Observe an error is shown in the modal

## Screenshots

![Screenshot 2023-10-31 at 11 38 44](https://github.com/safe-global/safe-wallet-web/assets/5880855/62bae9db-5b23-42c9-984c-791a3863ff4c)


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
