### PR TITLE
[Seedless Onboarding] Only continue to safe creation if login succeeds

### DIFF
--- a/src/components/welcome/WelcomeLogin/WalletLogin.tsx
+++ b/src/components/welcome/WelcomeLogin/WalletLogin.tsx
@@ -12,7 +12,8 @@ const WalletLogin = ({ onLogin }: { onLogin: () => void }) => {
 
   const login = async () => {
     const walletState = await connectWallet()
-    if (walletState) {
+
+    if (walletState && walletState.length > 0) {
       onLogin()
     }
   }

--- a/src/components/welcome/WelcomeLogin/__tests__/WalletLogin.test.tsx
+++ b/src/components/welcome/WelcomeLogin/__tests__/WalletLogin.test.tsx
@@ -68,4 +68,27 @@ describe('WalletLogin', () => {
       expect(mockOnLogin).toHaveBeenCalled()
     })
   })
+
+  it('should not invoke the callback if connection fails', async () => {
+    const mockOnLogin = jest.fn()
+    jest.spyOn(useConnectWallet, 'default').mockReturnValue(jest.fn().mockReturnValue([]))
+
+    const result = render(<WalletLogin onLogin={mockOnLogin} />)
+
+    await waitFor(() => {
+      expect(result.findByText('Connect wallet')).resolves.toBeDefined()
+    })
+
+    // We do not automatically invoke the callback as the user did not actively connect
+    expect(mockOnLogin).not.toHaveBeenCalled()
+
+    act(() => {
+      const button = result.getByRole('button')
+      button.click()
+    })
+
+    await waitFor(() => {
+      expect(mockOnLogin).not.toHaveBeenCalled()
+    })
+  })
 })


### PR DESCRIPTION
## What it solves

Part of #2452

## How this PR fixes it

- Checks for `wallets.length` since onboard returns an empty array if no wallet is connected

## How to test it

1. Open the welcome page
2. Press Connect wallet
3. Close the modal
4. Observe no flashing

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
