### PR TITLE
Fix: rm redirect from root to last safe

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,30 +1,17 @@
-import { useEffect, useLayoutEffect } from 'react'
+import { useEffect } from 'react'
 import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
-import useLastSafe from '@/hooks/useLastSafe'
 import { AppRoutes } from '@/config/routes'
-
-const useIsomorphicEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
 const IndexPage: NextPage = () => {
   const router = useRouter()
-  const { safe, chain } = router.query
-  const lastSafe = useLastSafe()
-  const safeAddress = safe || lastSafe
+  const { chain } = router.query
 
-  useIsomorphicEffect(() => {
-    if (router.pathname !== AppRoutes.index) {
-      return
+  useEffect(() => {
+    if (router.pathname === AppRoutes.index) {
+      router.replace(chain ? `${AppRoutes.welcome}?chain=${chain}` : AppRoutes.welcome)
     }
-
-    router.replace(
-      safeAddress
-        ? `${AppRoutes.home}?safe=${safeAddress}`
-        : chain
-        ? `${AppRoutes.welcome}?chain=${chain}`
-        : AppRoutes.welcome,
-    )
-  }, [router, safeAddress, chain])
+  }, [router, chain])
 
   return <></>
 }


### PR DESCRIPTION
The index page should now always redirect to the Welcome page as the starting page of the app.