### PR TITLE
Fix: adjust WalletConnect events

### DIFF
--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -142,7 +142,6 @@ const AppFrame = ({ appUrl, allowedFeaturesList, safeAppFromManifest }: AppFrame
           <SignMessageOnChainFlow
             props={{
               app: safeAppFromManifest,
-              appId: remoteApp?.id,
               requestId,
               message,
               method,

--- a/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
+++ b/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
@@ -63,7 +63,7 @@ const MessageHashField = ({ label, hashValue }: { label: string; hashValue: stri
     <Typography variant="body2" fontWeight={700} mt={2}>
       {label}:
     </Typography>
-    <Typography variant="body2">
+    <Typography variant="body2" component="div">
       <EthHashInfo address={hashValue} showAvatar={false} shortAddress={false} showCopyButton />
     </Typography>
   </>

--- a/src/components/tx-flow/flows/SignMessageOnChain/ReviewSignMessageOnChain.test.tsx
+++ b/src/components/tx-flow/flows/SignMessageOnChain/ReviewSignMessageOnChain.test.tsx
@@ -39,7 +39,6 @@ describe('ReviewSignMessageOnChain', () => {
             type: SafeAppAccessPolicyTypes.NoRestrictions,
           },
         }}
-        appId={73}
         requestId="73"
         message={{
           types: {

--- a/src/components/tx-flow/flows/SignMessageOnChain/ReviewSignMessageOnChain.tsx
+++ b/src/components/tx-flow/flows/SignMessageOnChain/ReviewSignMessageOnChain.tsx
@@ -27,7 +27,6 @@ import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { asError } from '@/services/exceptions/utils'
 
 export type SignMessageOnChainProps = {
-  appId?: number
   app?: SafeAppData
   requestId: RequestId
   message: string | EIP712TypedData

--- a/src/components/walletconnect/WcConnectionForm/index.tsx
+++ b/src/components/walletconnect/WcConnectionForm/index.tsx
@@ -10,6 +10,8 @@ import WcInput from '../WcInput'
 import WcLogoHeader from '../WcLogoHeader'
 import css from './styles.module.css'
 import useSafeInfo from '@/hooks/useSafeInfo'
+import Track from '@/components/common/Track'
+import { WALLETCONNECT_EVENTS } from '@/services/analytics/events/walletconnect'
 
 const WC_HINTS_KEY = 'wcHints'
 
@@ -44,9 +46,11 @@ export const WcConnectionForm = ({
           className={css.infoIcon}
         >
           <span>
-            <IconButton onClick={onToggle}>
-              <SvgIcon component={InfoIcon} inheritViewBox color="border" />
-            </IconButton>
+            <Track {...(showHints ? WALLETCONNECT_EVENTS.HINTS_HIDE : WALLETCONNECT_EVENTS.HINTS_SHOW)}>
+              <IconButton onClick={onToggle}>
+                <SvgIcon component={InfoIcon} inheritViewBox color="border" />
+              </IconButton>
+            </Track>
           </span>
         </Tooltip>
 

--- a/src/components/walletconnect/WcErrorMessage/index.tsx
+++ b/src/components/walletconnect/WcErrorMessage/index.tsx
@@ -3,13 +3,18 @@ import WcLogoHeader from '../WcLogoHeader'
 import css from './styles.module.css'
 
 const WcErrorMessage = ({ error, onClose }: { error: Error; onClose: () => void }) => {
+  const message = error.message || 'An error occurred'
+  const [summary, details] = message.split(':')
+
   return (
     <div className={css.errorContainer}>
       <WcLogoHeader error />
 
       <Typography title={error.message} className={css.errorMessage} mb={3}>
-        {error.message || 'An error occurred'}
+        {summary}
       </Typography>
+
+      {details && <Typography variant="body2">{details}</Typography>}
 
       <Button variant="contained" onClick={onClose} className={css.button}>
         OK

--- a/src/components/walletconnect/WcErrorMessage/index.tsx
+++ b/src/components/walletconnect/WcErrorMessage/index.tsx
@@ -11,7 +11,11 @@ const WcErrorMessage = ({ error, onClose }: { error: Error; onClose: () => void 
     <div className={css.errorContainer}>
       <WcLogoHeader errorMessage={summary} />
 
-      {details && <Typography mt={1}>{details}</Typography>}
+      {details && (
+        <Typography mt={1} className={css.details}>
+          {details}
+        </Typography>
+      )}
 
       <Button variant="contained" onClick={onClose} className={css.button}>
         OK

--- a/src/components/walletconnect/WcErrorMessage/index.tsx
+++ b/src/components/walletconnect/WcErrorMessage/index.tsx
@@ -1,10 +1,11 @@
+import { splitError } from '@/services/walletconnect/utils'
 import { Button, Typography } from '@mui/material'
 import WcLogoHeader from '../WcLogoHeader'
 import css from './styles.module.css'
 
 const WcErrorMessage = ({ error, onClose }: { error: Error; onClose: () => void }) => {
   const message = error.message || 'An error occurred'
-  const [summary, details] = message.split(':')
+  const [summary, details] = splitError(message)
 
   return (
     <div className={css.errorContainer}>

--- a/src/components/walletconnect/WcErrorMessage/index.tsx
+++ b/src/components/walletconnect/WcErrorMessage/index.tsx
@@ -9,13 +9,9 @@ const WcErrorMessage = ({ error, onClose }: { error: Error; onClose: () => void 
 
   return (
     <div className={css.errorContainer}>
-      <WcLogoHeader error />
+      <WcLogoHeader errorMessage={summary} />
 
-      <Typography title={error.message} className={css.errorMessage} mb={3}>
-        {summary}
-      </Typography>
-
-      {details && <Typography variant="body2">{details}</Typography>}
+      {details && <Typography mt={1}>{details}</Typography>}
 
       <Button variant="contained" onClick={onClose} className={css.button}>
         OK

--- a/src/components/walletconnect/WcErrorMessage/styles.module.css
+++ b/src/components/walletconnect/WcErrorMessage/styles.module.css
@@ -5,12 +5,7 @@
   text-align: center;
 }
 
-.errorMessage {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  width: 100%;
-}
-
 .button {
   padding: var(--space-1) var(--space-4);
+  margin-top: var(--space-3);
 }

--- a/src/components/walletconnect/WcErrorMessage/styles.module.css
+++ b/src/components/walletconnect/WcErrorMessage/styles.module.css
@@ -9,3 +9,10 @@
   padding: var(--space-1) var(--space-4);
   margin-top: var(--space-3);
 }
+
+.details {
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  hyphens: auto;
+}

--- a/src/components/walletconnect/WcHints/index.tsx
+++ b/src/components/walletconnect/WcHints/index.tsx
@@ -12,7 +12,7 @@ import {
   ListItemAvatar,
   ListItemText,
 } from '@mui/material'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import type { ReactElement } from 'react'
 import Question from '@/public/images/common/question.svg'
 import css from './styles.module.css'
@@ -83,10 +83,6 @@ const WcHints = (): ReactElement => {
 
     trackEvent(WALLETCONNECT_EVENTS.HINTS_EXPAND)
   }
-
-  useEffect(() => {
-    trackEvent(WALLETCONNECT_EVENTS.HINTS_SHOW)
-  }, [])
 
   return (
     <Box display="flex" flexDirection="column" gap={1}>

--- a/src/components/walletconnect/WcLogoHeader/index.tsx
+++ b/src/components/walletconnect/WcLogoHeader/index.tsx
@@ -4,16 +4,16 @@ import WalletConnect from '@/public/images/common/walletconnect.svg'
 import Alert from '@/public/images/notifications/alert.svg'
 import css from './styles.module.css'
 
-const WcLogoHeader = ({ error }: { error?: boolean }): ReactElement => {
+const WcLogoHeader = ({ errorMessage }: { errorMessage?: string }): ReactElement => {
   return (
     <>
       <div>
         <SvgIcon component={WalletConnect} inheritViewBox className={css.icon} />
-        {error && <SvgIcon component={Alert} inheritViewBox className={css.errorBadge} fontSize="small" />}
+        {errorMessage && <SvgIcon component={Alert} inheritViewBox className={css.errorBadge} fontSize="small" />}
       </div>
 
-      <Typography variant="h5" mt={2} mb={0.5}>
-        Connect dApps to {`Safe{Wallet}`}
+      <Typography variant="h5" mt={2} mb={0.5} className={css.title}>
+        {errorMessage || 'Connect dApps to Safe{Wallet}'}
       </Typography>
     </>
   )

--- a/src/components/walletconnect/WcLogoHeader/styles.module.css
+++ b/src/components/walletconnect/WcLogoHeader/styles.module.css
@@ -11,3 +11,9 @@
   border-radius: 50%;
   border: 1px solid var(--color-background-paper);
 }
+
+.title {
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/components/walletconnect/WcLogoHeader/styles.module.css
+++ b/src/components/walletconnect/WcLogoHeader/styles.module.css
@@ -16,5 +16,4 @@
   width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
-  hyphens: auto;
 }

--- a/src/components/walletconnect/WcLogoHeader/styles.module.css
+++ b/src/components/walletconnect/WcLogoHeader/styles.module.css
@@ -16,4 +16,5 @@
   width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
+  hyphens: auto;
 }

--- a/src/components/walletconnect/WcSessionList/WcNoSessions.tsx
+++ b/src/components/walletconnect/WcSessionList/WcNoSessions.tsx
@@ -21,12 +21,12 @@ const WcSampleDapps = ({ onUnload }: { onUnload: () => void }) => {
   return (
     <Typography variant="body2" display="flex" justifyContent="space-between" alignItems="center" mt={3}>
       {SAMPLE_DAPPS.map((item) => (
-        <ExternalLink href={item.url} key={item.url} noIcon px={1}>
-          <img src={item.icon} alt={item.name} width={32} height={32} />
-          <Typography variant="body2" ml={1}>
+        <Typography variant="body2" ml={1} key={item.url}>
+          <ExternalLink href={item.url} noIcon px={1}>
+            <img src={item.icon} alt={item.name} width={32} height={32} />
             {item.name}
-          </Typography>
-        </ExternalLink>
+          </ExternalLink>
+        </Typography>
       ))}
     </Typography>
   )

--- a/src/components/walletconnect/WcSessionList/index.tsx
+++ b/src/components/walletconnect/WcSessionList/index.tsx
@@ -12,8 +12,13 @@ type WcSesstionListProps = {
 }
 
 const WcSessionListItem = ({ session, onDisconnect }: { session: SessionTypes.Struct; onDisconnect: () => void }) => {
+  const MAX_NAME_LENGTH = 23
   const { safeLoaded } = useSafeInfo()
-  const name = getPeerName(session.peer) || 'Unknown dApp'
+  let name = getPeerName(session.peer) || 'Unknown dApp'
+
+  if (name.length > MAX_NAME_LENGTH + 1) {
+    name = `${name.slice(0, MAX_NAME_LENGTH)}…`
+  }
 
   return (
     <ListItem className={css.sessionListItem}>

--- a/src/components/walletconnect/WcSessionMananger/index.tsx
+++ b/src/components/walletconnect/WcSessionMananger/index.tsx
@@ -121,7 +121,7 @@ const WcSessionManager = ({ sessions, uri }: WcSessionManagerProps) => {
   // Track errors
   useEffect(() => {
     if (error && open) {
-      trackEvent({ ...WALLETCONNECT_EVENTS.SHOW_ERROR, label: error.message })
+      trackEvent({ ...WALLETCONNECT_EVENTS.SHOW_ERROR, label: (error.message || '').split(':')[0] })
     }
   }, [error, open])
 

--- a/src/components/walletconnect/WcSessionMananger/index.tsx
+++ b/src/components/walletconnect/WcSessionMananger/index.tsx
@@ -17,7 +17,7 @@ type WcSessionManagerProps = {
   uri: string
 }
 
-const SESSION_INFO_TIMEOUT = 2000
+const SESSION_INFO_TIMEOUT = 1000
 
 const WcSessionManager = ({ sessions, uri }: WcSessionManagerProps) => {
   const { safe, safeAddress } = useSafeInfo()

--- a/src/components/walletconnect/WcSessionMananger/index.tsx
+++ b/src/components/walletconnect/WcSessionMananger/index.tsx
@@ -10,6 +10,7 @@ import WcProposalForm from '../WcProposalForm'
 import WcConnectionState from '../WcConnectionState'
 import { trackEvent } from '@/services/analytics'
 import { WALLETCONNECT_EVENTS } from '@/services/analytics/events/walletconnect'
+import { splitError } from '@/services/walletconnect/utils'
 
 type WcSessionManagerProps = {
   sessions: SessionTypes.Struct[]
@@ -121,7 +122,7 @@ const WcSessionManager = ({ sessions, uri }: WcSessionManagerProps) => {
   // Track errors
   useEffect(() => {
     if (error && open) {
-      trackEvent({ ...WALLETCONNECT_EVENTS.SHOW_ERROR, label: (error.message || '').split(':')[0] })
+      trackEvent({ ...WALLETCONNECT_EVENTS.SHOW_ERROR, label: splitError(error.message || '')[0] })
     }
   }, [error, open])
 

--- a/src/components/walletconnect/WcSessionMananger/index.tsx
+++ b/src/components/walletconnect/WcSessionMananger/index.tsx
@@ -108,12 +108,8 @@ const WcSessionManager = ({ sessions, uri }: WcSessionManagerProps) => {
 
     setOpen(true)
 
-    let timer = setTimeout(() => {
-      setOpen(false)
-
-      timer = setTimeout(() => {
-        setChangedSession(undefined)
-      }, 500)
+    const timer = setTimeout(() => {
+      setChangedSession(undefined)
     }, SESSION_INFO_TIMEOUT)
 
     return () => clearTimeout(timer)

--- a/src/pages/apps/open.tsx
+++ b/src/pages/apps/open.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
-import { useCallback } from 'react'
+import { useCallback, useContext } from 'react'
 import { Box, CircularProgress } from '@mui/material'
 
 import { useSafeAppUrl } from '@/hooks/safe-apps/useSafeAppUrl'
@@ -15,6 +15,10 @@ import { useBrowserPermissions } from '@/hooks/safe-apps/permissions'
 import useChainId from '@/hooks/useChainId'
 import { AppRoutes } from '@/config/routes'
 import { getOrigin } from '@/components/safe-apps/utils'
+import { WalletConnectContext } from '@/services/walletconnect/WalletConnectContext'
+
+// TODO: Remove this once we properly deprecate the WC app
+const WC_SAFE_APP = /wallet-connect/
 
 const SafeApps: NextPage = () => {
   const chainId = useChainId()
@@ -42,6 +46,8 @@ const SafeApps: NextPage = () => {
     remoteSafeAppsLoading,
   })
 
+  const { setOpen } = useContext(WalletConnectContext)
+
   const goToList = useCallback(() => {
     router.push({
       pathname: AppRoutes.apps.index,
@@ -51,6 +57,12 @@ const SafeApps: NextPage = () => {
 
   // appUrl is required to be present
   if (!appUrl || !router.isReady) return null
+
+  if (WC_SAFE_APP.test(appUrl)) {
+    setOpen(true)
+    goToList()
+    return null
+  }
 
   if (isModalVisible) {
     return (

--- a/src/services/analytics/events/walletconnect.ts
+++ b/src/services/analytics/events/walletconnect.ts
@@ -32,6 +32,10 @@ export const WALLETCONNECT_EVENTS = {
     action: 'WC show hints',
     category: WALLETCONNECT_CATEGORY,
   },
+  HINTS_HIDE: {
+    action: 'WC hide hints',
+    category: WALLETCONNECT_CATEGORY,
+  },
   HINTS_EXPAND: {
     action: 'WC expand hints',
     category: WALLETCONNECT_CATEGORY,
@@ -58,5 +62,10 @@ export const WALLETCONNECT_EVENTS = {
   SWITCH_FROM_UNSUPPORTED_CHAIN: {
     action: 'WC switch from unsupported chain',
     category: WALLETCONNECT_CATEGORY,
+  },
+  REQUEST: {
+    action: 'WC request',
+    category: WALLETCONNECT_CATEGORY,
+    event: EventType.META,
   },
 }

--- a/src/services/exceptions/ErrorCodes.ts
+++ b/src/services/exceptions/ErrorCodes.ts
@@ -64,8 +64,6 @@ enum ErrorCodes {
   _902 = '902: Error loading Safe Apps list',
   _903 = '903: Error loading Safe App manifest',
   _905 = '905: Third party cookies are disabled',
-
-  _910 = '910: WalletConnect failed to switch chain',
 }
 
 export default ErrorCodes

--- a/src/services/onboard.ts
+++ b/src/services/onboard.ts
@@ -51,7 +51,7 @@ export const createOnboard = (
     appMetadata: {
       name: 'Safe{Wallet}',
       // Both heights need be set to correctly size the image in the connecting screen/modal
-      icon: '<svg height="100%"><image href="/images/safe-logo-green.png" height="100%" /></svg>',
+      icon: 'https://app.safe.global/images/safe-logo-green.png',
       description: 'Please select a wallet to connect to Safe{Wallet}',
       recommendedInjectedWallets: getRecommendedInjectedWallets(),
     },

--- a/src/services/safe-wallet-provider/index.test.ts
+++ b/src/services/safe-wallet-provider/index.test.ts
@@ -7,6 +7,7 @@ const safe = {
 }
 
 const appInfo = {
+  id: 1,
   name: 'test',
   description: 'test',
   iconUrl: 'test',

--- a/src/services/safe-wallet-provider/index.ts
+++ b/src/services/safe-wallet-provider/index.ts
@@ -8,6 +8,7 @@ type SafeSettings = {
 }
 
 export type AppInfo = {
+  id: number
   name: string
   description: string
   url: string

--- a/src/services/safe-wallet-provider/useSafeWalletProvider.test.tsx
+++ b/src/services/safe-wallet-provider/useSafeWalletProvider.test.tsx
@@ -131,7 +131,6 @@ describe('useSafeWalletProvider', () => {
       // SignMessageOnChainFlow props
       expect(mockSetTxFlow.mock.calls[0][0].props).toStrictEqual({
         props: {
-          appId: undefined,
           requestId: expect.any(String),
           message: 'message',
           method: 'signMessage',
@@ -254,6 +253,7 @@ describe('useSafeWalletProvider', () => {
           appId: undefined,
           app: {
             name: appInfo.name,
+            description: appInfo.description,
             url: appInfo.url,
             iconUrl: appInfo.iconUrl,
           },

--- a/src/services/safe-wallet-provider/useSafeWalletProvider.test.tsx
+++ b/src/services/safe-wallet-provider/useSafeWalletProvider.test.tsx
@@ -12,6 +12,7 @@ import * as messages from '@/utils/safe-messages'
 import { createStoreHydrator } from '@/store/storeHydrator'
 
 const appInfo = {
+  id: 1,
   name: 'test',
   description: 'test',
   iconUrl: 'test',
@@ -90,6 +91,7 @@ describe('useSafeWalletProvider', () => {
         name: appInfo.name,
         message: 'message',
         requestId: expect.any(String),
+        safeAppId: 1,
       })
 
       expect(resp).toBeInstanceOf(Promise)
@@ -204,6 +206,7 @@ describe('useSafeWalletProvider', () => {
         name: appInfo.name,
         message: typedMessage,
         requestId: expect.any(String),
+        safeAppId: 1,
       })
 
       expect(resp).toBeInstanceOf(Promise)
@@ -251,12 +254,7 @@ describe('useSafeWalletProvider', () => {
       expect(mockSetTxFlow.mock.calls[0][0].props).toStrictEqual({
         data: {
           appId: undefined,
-          app: {
-            name: appInfo.name,
-            description: appInfo.description,
-            url: appInfo.url,
-            iconUrl: appInfo.iconUrl,
-          },
+          app: appInfo,
           requestId: expect.any(String),
           txs: [
             {

--- a/src/services/safe-wallet-provider/useSafeWalletProvider.tsx
+++ b/src/services/safe-wallet-provider/useSafeWalletProvider.tsx
@@ -19,17 +19,10 @@ import { getAddress } from 'ethers/lib/utils'
 import { AppRoutes } from '@/config/routes'
 import useChains, { useCurrentChain } from '@/hooks/useChains'
 import { NotificationMessages, showNotification } from './notifications'
-import { SafeAppsTag } from '@/config/constants'
-import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
 import SignMessageOnChainFlow from '@/components/tx-flow/flows/SignMessageOnChain'
 import { useAppSelector } from '@/store'
 import { selectOnChainSigning } from '@/store/settingsSlice'
 import { isOffchainEIP1271Supported } from '@/utils/safe-messages'
-
-const useWalletConnectApp = () => {
-  const [matchingApps] = useRemoteSafeApps(SafeAppsTag.WALLET_CONNECT)
-  return matchingApps?.[0]
-}
 
 export const _useTxFlowApi = (chainId: string, safeAddress: string): WalletSDK | undefined => {
   const { safe } = useSafeInfo()
@@ -39,7 +32,6 @@ export const _useTxFlowApi = (chainId: string, safeAddress: string): WalletSDK |
   const router = useRouter()
   const { configs } = useChains()
   const pendingTxs = useRef<Record<string, string>>({})
-  const wcApp = useWalletConnectApp()
 
   const onChainSigning = useAppSelector(selectOnChainSigning)
   const [settings, setSettings] = useState<SafeSettings>({
@@ -99,7 +91,7 @@ export const _useTxFlowApi = (chainId: string, safeAddress: string): WalletSDK |
             onClose,
           )
         } else {
-          setTxFlow(<SignMessageOnChainFlow props={{ appId: wcApp?.id, requestId: id, message, method }} />, onClose)
+          setTxFlow(<SignMessageOnChainFlow props={{ requestId: id, message, method }} />, onClose)
         }
       })
     }
@@ -156,12 +148,7 @@ export const _useTxFlowApi = (chainId: string, safeAddress: string): WalletSDK |
             <SafeAppsTxFlow
               data={{
                 appId: undefined,
-                app: {
-                  name: appInfo.name,
-                  // Show WC details in transaction list
-                  url: wcApp?.url ?? appInfo.url,
-                  iconUrl: appInfo.iconUrl,
-                },
+                app: appInfo,
                 requestId: id,
                 txs: transactions,
                 params: params.params,
@@ -215,20 +202,7 @@ export const _useTxFlowApi = (chainId: string, safeAddress: string): WalletSDK |
         return data.result
       },
     }
-  }, [
-    chainId,
-    safeAddress,
-    safe,
-    currentChain,
-    onChainSigning,
-    settings,
-    setTxFlow,
-    wcApp?.id,
-    wcApp?.url,
-    configs,
-    router,
-    web3ReadOnly,
-  ])
+  }, [chainId, safeAddress, safe, currentChain, onChainSigning, settings, setTxFlow, configs, router, web3ReadOnly])
 }
 
 const useSafeWalletProvider = (): SafeWalletProvider | undefined => {

--- a/src/services/safe-wallet-provider/useSafeWalletProvider.tsx
+++ b/src/services/safe-wallet-provider/useSafeWalletProvider.tsx
@@ -87,7 +87,13 @@ export const _useTxFlowApi = (chainId: string, safeAddress: string): WalletSDK |
 
         if (shouldSignOffChain) {
           setTxFlow(
-            <SignMessageFlow logoUri={appInfo.iconUrl} name={appInfo.name} message={message} requestId={id} />,
+            <SignMessageFlow
+              logoUri={appInfo.iconUrl}
+              name={appInfo.name}
+              message={message}
+              requestId={id}
+              safeAppId={appInfo.id}
+            />,
             onClose,
           )
         } else {

--- a/src/services/walletconnect/WalletConnectContext.tsx
+++ b/src/services/walletconnect/WalletConnectContext.tsx
@@ -13,6 +13,15 @@ import { WALLETCONNECT_EVENTS } from '../analytics/events/walletconnect'
 import { SafeAppsTag } from '@/config/constants'
 import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
 
+enum Errors {
+  WRONG_CHAIN = '%%dappName%% made a request on a different chain than the one you are connected to',
+}
+
+const getWrongChainError = (dappName: string): Error => {
+  const message = Errors.WRONG_CHAIN.replace('%%dappName%%', dappName)
+  return new Error(message)
+}
+
 const walletConnectSingleton = new WalletConnectWallet()
 
 export const WalletConnectContext = createContext<{
@@ -81,8 +90,11 @@ export const WalletConnectProvider = ({ children }: { children: ReactNode }) => 
       const getResponse = () => {
         // Get error if wrong chain
         if (!session || requestChainId !== chainId) {
+          if (session) {
+            setError(getWrongChainError(getPeerName(session.peer)))
+          }
+
           const error = getSdkError('UNSUPPORTED_CHAINS')
-          setError(new Error(error.message))
           return formatJsonRpcError(event.id, error)
         }
 

--- a/src/services/walletconnect/WalletConnectContext.tsx
+++ b/src/services/walletconnect/WalletConnectContext.tsx
@@ -74,6 +74,7 @@ export const WalletConnectProvider = ({ children }: { children: ReactNode }) => 
         // Get error if wrong chain
         if (!session || requestChainId !== chainId) {
           const error = getSdkError('UNSUPPORTED_CHAINS')
+          setError(new Error(error.message))
           return formatJsonRpcError(event.id, error)
         }
 

--- a/src/services/walletconnect/WalletConnectContext.tsx
+++ b/src/services/walletconnect/WalletConnectContext.tsx
@@ -8,6 +8,8 @@ import WalletConnectWallet from './WalletConnectWallet'
 import { asError } from '../exceptions/utils'
 import { getPeerName, stripEip155Prefix } from './utils'
 import { IS_PRODUCTION } from '@/config/constants'
+import { trackEvent } from '../analytics'
+import { WALLETCONNECT_EVENTS } from '../analytics/events/walletconnect'
 
 const walletConnectSingleton = new WalletConnectWallet()
 
@@ -62,6 +64,11 @@ export const WalletConnectProvider = ({ children }: { children: ReactNode }) => 
       const { topic } = event
       const session = walletConnect.getActiveSessions().find((s) => s.topic === topic)
       const requestChainId = stripEip155Prefix(event.params.chainId)
+
+      // Track all requests
+      if (session) {
+        trackEvent({ ...WALLETCONNECT_EVENTS.REQUEST, label: session.peer.metadata.url })
+      }
 
       const getResponse = () => {
         // Get error if wrong chain

--- a/src/services/walletconnect/WalletConnectContext.tsx
+++ b/src/services/walletconnect/WalletConnectContext.tsx
@@ -27,6 +27,10 @@ export const WalletConnectContext = createContext<{
   setOpen: (_open: boolean) => {},
 })
 
+// Always use this URL for the origin field of transactions
+// This will give the txs the right icon in the history
+const WC_SAFE_APP_URL = 'https://apps-portal.safe.global/wallet-connect'
+
 export const WalletConnectProvider = ({ children }: { children: ReactNode }) => {
   const {
     safe: { chainId },
@@ -82,7 +86,7 @@ export const WalletConnectProvider = ({ children }: { children: ReactNode }) => 
         return safeWalletProvider.request(event.id, event.params.request, {
           name: getPeerName(session.peer) || 'Unknown dApp',
           description: session.peer.metadata.description,
-          url: session.peer.metadata.url,
+          url: WC_SAFE_APP_URL,
           iconUrl: session.peer.metadata.icons[0],
         })
       }

--- a/src/services/walletconnect/WalletConnectWallet.ts
+++ b/src/services/walletconnect/WalletConnectWallet.ts
@@ -11,8 +11,6 @@ import { IS_PRODUCTION, WC_PROJECT_ID } from '@/config/constants'
 import { EIP155, SAFE_COMPATIBLE_METHODS, SAFE_WALLET_METADATA } from './constants'
 import { invariant } from '@/utils/helpers'
 import { getEip155ChainId, stripEip155Prefix } from './utils'
-import { logError } from '../exceptions'
-import ErrorCodes from '../exceptions/ErrorCodes'
 
 const SESSION_ADD_EVENT = 'session_add' as Web3WalletTypes.Event // Workaround: WalletConnect doesn't emit session_add event
 const SESSION_REJECT_EVENT = 'session_reject' as Web3WalletTypes.Event // Workaround: WalletConnect doesn't emit session_reject event
@@ -113,19 +111,6 @@ class WalletConnectWallet {
     })
   }
 
-  /**
-   * Switch chain and catch errors.
-   * Just log the errors because they happen all the time.
-   */
-  private async switchChain(topic: string, chainId: string) {
-    try {
-      // Align the session with the current chainId
-      return await this.chainChanged(topic, chainId)
-    } catch (e) {
-      logError(ErrorCodes._910, e)
-    }
-  }
-
   public async approveSession(proposal: Web3WalletTypes.SessionProposal, currentChainId: string, safeAddress: string) {
     assertWeb3Wallet(this.web3Wallet)
 
@@ -137,7 +122,7 @@ class WalletConnectWallet {
       namespaces,
     })
 
-    await this.switchChain(session.topic, currentChainId)
+    await this.chainChanged(session.topic, currentChainId)
 
     // Workaround: WalletConnect doesn't have a session_add event
     this.web3Wallet?.events.emit(SESSION_ADD_EVENT, session)
@@ -180,7 +165,7 @@ class WalletConnectWallet {
     }
 
     // Switch to the new chain
-    await this.switchChain(session.topic, chainId)
+    await this.chainChanged(session.topic, chainId)
 
     // Switch to the new Safe
     await this.accountsChanged(session.topic, chainId, safeAddress)

--- a/src/services/walletconnect/__tests__/WalletConnectContext.test.tsx
+++ b/src/services/walletconnect/__tests__/WalletConnectContext.test.tsx
@@ -354,7 +354,7 @@ describe('WalletConnectProvider', () => {
             metadata: {
               name: 'name',
               description: 'description',
-              url: 'url',
+              url: 'https://apps-portal.safe.global/wallet-connect',
               icons: ['iconUrl'],
             },
           },
@@ -412,7 +412,7 @@ describe('WalletConnectProvider', () => {
         {
           name: 'name',
           description: 'description',
-          url: 'url',
+          url: 'https://apps-portal.safe.global/wallet-connect',
           iconUrl: 'iconUrl',
         },
       )
@@ -432,7 +432,7 @@ describe('WalletConnectProvider', () => {
             metadata: {
               name: 'name',
               description: 'description',
-              url: 'url',
+              url: 'https://apps-portal.safe.global/wallet-connect',
               icons: ['iconUrl'],
             },
           },

--- a/src/services/walletconnect/__tests__/WalletConnectContext.test.tsx
+++ b/src/services/walletconnect/__tests__/WalletConnectContext.test.tsx
@@ -285,7 +285,9 @@ describe('WalletConnectProvider', () => {
       jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
       jest
         .spyOn(WalletConnectWallet.prototype, 'getActiveSessions')
-        .mockImplementation(() => [{ topic: 'topic' } as unknown as SessionTypes.Struct])
+        .mockImplementation(() => [
+          { topic: 'topic', peer: { metadata: { url: 'https://test.com' } } } as unknown as SessionTypes.Struct,
+        ])
 
       const onRequestSpy = jest.spyOn(WalletConnectWallet.prototype, 'onRequest')
       const sendSessionResponseSpy = jest.spyOn(WalletConnectWallet.prototype, 'sendSessionResponse')

--- a/src/services/walletconnect/__tests__/WalletConnectContext.test.tsx
+++ b/src/services/walletconnect/__tests__/WalletConnectContext.test.tsx
@@ -4,7 +4,7 @@ import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import type { Web3WalletTypes } from '@walletconnect/web3wallet'
 import type { SessionTypes } from '@walletconnect/types'
 
-import { fireEvent, render, waitFor } from '@/tests/test-utils'
+import { act, fireEvent, render, waitFor } from '@/tests/test-utils'
 import { WalletConnectContext, WalletConnectProvider } from '../WalletConnectContext'
 import WalletConnectWallet from '../WalletConnectWallet'
 import { safeInfoSlice } from '@/store/safeInfoSlice'
@@ -13,6 +13,22 @@ import * as useSafeWalletProvider from '@/services/safe-wallet-provider/useSafeW
 
 jest.mock('../WalletConnectWallet')
 jest.mock('@/services/safe-wallet-provider/useSafeWalletProvider')
+
+jest.mock('@/hooks/safe-apps/useRemoteSafeApps', () => ({
+  useRemoteSafeApps: () => [
+    [
+      {
+        id: 111,
+        url: 'https://apps-portal.safe.global/wallet-connect',
+        name: 'WC App',
+        iconUrl: 'https://test.com/icon.png',
+        description: 'Test App Description',
+      },
+    ],
+    undefined,
+    false,
+  ],
+}))
 
 const TestComponent = () => {
   const { walletConnect, error } = useContext(WalletConnectContext)
@@ -391,6 +407,8 @@ describe('WalletConnectProvider', () => {
         },
       )
 
+      await act(() => Promise.resolve())
+
       await waitFor(() => {
         expect(onRequestSpy).toHaveBeenCalled()
       })
@@ -410,6 +428,7 @@ describe('WalletConnectProvider', () => {
         1,
         { method: 'fake', params: [] },
         {
+          id: 111,
           name: 'name',
           description: 'description',
           url: 'https://apps-portal.safe.global/wallet-connect',

--- a/src/services/walletconnect/__tests__/utils.test.ts
+++ b/src/services/walletconnect/__tests__/utils.test.ts
@@ -1,0 +1,19 @@
+import { splitError } from '../utils'
+
+describe('WalletConnect utils', () => {
+  describe('splitError', () => {
+    it('should return the error summary and detail', () => {
+      const error = new Error('WalletConnect failed to switch chain: { session: "0x1234", chainId: 1 }')
+      const [summary, detail] = splitError(error.message)
+      expect(summary).toEqual('WalletConnect failed to switch chain')
+      expect(detail).toEqual('{ session: "0x1234", chainId: 1 }')
+    })
+
+    it('should return the error summary if no details', () => {
+      const error = new Error('WalletConnect failed to switch chain')
+      const [summary, detail] = splitError(error.message)
+      expect(summary).toEqual('WalletConnect failed to switch chain')
+      expect(detail).toBeUndefined()
+    })
+  })
+})

--- a/src/services/walletconnect/utils.ts
+++ b/src/services/walletconnect/utils.ts
@@ -58,3 +58,7 @@ export const isWarnedBridge = (origin: string, name: string) => {
 export const getPeerName = (peer: SessionTypes.Struct['peer'] | ProposalTypes.Struct['proposer']): string => {
   return peer.metadata?.name || peer.metadata?.url || ''
 }
+
+export const splitError = (message: string): string[] => {
+  return message.split(': ')
+}

--- a/src/services/walletconnect/utils.ts
+++ b/src/services/walletconnect/utils.ts
@@ -60,5 +60,5 @@ export const getPeerName = (peer: SessionTypes.Struct['peer'] | ProposalTypes.St
 }
 
 export const splitError = (message: string): string[] => {
-  return message.split(': ')
+  return message.split(/: (.+)/).slice(0, 2)
 }


### PR DESCRIPTION
## What it solves

* Change the "WC show hints" event to trigger on i-icon click + add a "WC hide hints" event - verified
* Add an event for all RPC requests made through WalletConnect – "WC request"
* Don't ignore chain switch errors
* Display errors in two lines: summary and details - changed , the error is displayed in a few lines. The connection code is too long for one line
* Limit the displayed dapp name to 22 characters in the session list - verified
* Reduce the time to show a connect/disconnect message to 1 second (was 2) - verified
* Fix Safe logo for WalletConnect (resolves #2720) - verified
* Show the new WC popup when the old WC Safe App is opened - verified