### PR TITLE
feat: use mnemonic name for Social Safes 

### DIFF
--- a/src/components/new-safe/create/index.tsx
+++ b/src/components/new-safe/create/index.tsx
@@ -20,6 +20,7 @@ import { type ReactElement, useMemo, useState } from 'react'
 import ExternalLink from '@/components/common/ExternalLink'
 import { HelpCenterArticle } from '@/config/constants'
 import { isSocialLoginWallet } from '@/services/mpc/SocialLoginModule'
+import { useMnemonicSafeName } from '@/hooks/useMnemonicName'
 
 export type NewSafeFormData = {
   name: string
@@ -157,16 +158,18 @@ const CreateSafe = () => {
 
   const staticHint = useMemo(() => staticHints[activeStep], [activeStep])
 
-  const initialData: NewSafeFormData = {
-    name: '',
-    owners: [defaultOwner],
-    threshold: 1,
-    saltNonce: Date.now(),
-  }
+  const mnemonicSafeName = useMnemonicSafeName()
 
   // Jump to review screen when using social login
   const isSocialLogin = isSocialLoginWallet(wallet?.label)
   const initialStep = isSocialLogin ? 2 : 0
+
+  const initialData: NewSafeFormData = {
+    name: isSocialLogin ? mnemonicSafeName : '',
+    owners: [defaultOwner],
+    threshold: 1,
+    saltNonce: Date.now(),
+  }
 
   const onClose = () => {
     router.push(AppRoutes.welcome.index)

--- a/src/hooks/useMnemonicName/index.ts
+++ b/src/hooks/useMnemonicName/index.ts
@@ -5,13 +5,15 @@ import { animalsDict, adjectivesDict } from './dict'
 const animals: string[] = animalsDict.trim().split(/\s+/)
 const adjectives: string[] = adjectivesDict.trim().split(/\s+/)
 
+const capitalize = (word: string) => (word.length > 0 ? `${word.charAt(0).toUpperCase()}${word.slice(1)}` : word)
+
 const getRandomItem = <T>(arr: T[]): T => {
   return arr[Math.floor(arr.length * Math.random())]
 }
 
-export const getRandomName = (noun = getRandomItem<string>(animals)): string => {
-  const adj = getRandomItem<string>(adjectives)
-  return `${adj}-${noun}`
+export const getRandomName = (noun = capitalize(getRandomItem<string>(animals))): string => {
+  const adj = capitalize(getRandomItem<string>(adjectives))
+  return `${adj} ${noun}`
 }
 
 export const useMnemonicName = (noun?: string): string => {
@@ -19,6 +21,6 @@ export const useMnemonicName = (noun?: string): string => {
 }
 
 export const useMnemonicSafeName = (): string => {
-  const networkName = useCurrentChain()?.chainName.toLowerCase()
-  return useMnemonicName(`${networkName}-safe`)
+  const networkName = useCurrentChain()?.chainName
+  return useMnemonicName(`${networkName} Safe`)
 }

--- a/src/hooks/useMnemonicName/useMnemonicName.test.ts
+++ b/src/hooks/useMnemonicName/useMnemonicName.test.ts
@@ -11,34 +11,34 @@ jest.mock('@/hooks/useChains', () => ({
 
 describe('useMnemonicName tests', () => {
   it('should generate a random name', () => {
-    expect(getRandomName()).toMatch(/^[a-z-]+-[a-z]+$/)
-    expect(getRandomName()).toMatch(/^[a-z-]+-[a-z]+$/)
-    expect(getRandomName()).toMatch(/^[a-z-]+-[a-z]+$/)
+    expect(getRandomName()).toMatch(/^[A-Z][a-z-]+ [A-Z][a-z]+$/)
+    expect(getRandomName()).toMatch(/^[A-Z][a-z-]+ [A-Z][a-z]+$/)
+    expect(getRandomName()).toMatch(/^[A-Z][a-z-]+ [A-Z][a-z]+$/)
   })
 
   it('should work as a hook', () => {
     const { result } = renderHook(() => useMnemonicName())
-    expect(result.current).toMatch(/^[a-z-]+-[a-z]+$/)
+    expect(result.current).toMatch(/^[A-Z][a-z-]+ [A-Z][a-z]+$/)
   })
 
   it('should work as a hook with a noun param', () => {
     const { result } = renderHook(() => useMnemonicName('test'))
-    expect(result.current).toMatch(/^[a-z-]+-test$/)
+    expect(result.current).toMatch(/^[A-Z][a-z-]+ test$/)
   })
 
   it('should change if the noun changes', () => {
     let noun = 'test'
     const { result, rerender } = renderHook(() => useMnemonicName(noun))
-    expect(result.current).toMatch(/^[a-z-]+-test$/)
+    expect(result.current).toMatch(/^[A-Z][a-z-]+ test$/)
 
     noun = 'changed'
     rerender()
-    expect(result.current).toMatch(/^[a-z-]+-changed$/)
+    expect(result.current).toMatch(/^[A-Z][a-z-]+ changed$/)
   })
 
   it('should return a random safe name', () => {
     const { result } = renderHook(() => useMnemonicSafeName())
-    const regex = new RegExp(`^[a-z-]+-${mockChain.chainName.toLowerCase()}-safe$`)
+    const regex = new RegExp(`^[A-Z][a-z-]+ ${mockChain.chainName} Safe$`)
     expect(result.current).toMatch(regex)
   })
 })


### PR DESCRIPTION
## What it solves
- Uses mnemonic names for Safe creation with Social wallet connected
- Changes mnemonic name to be upper cased and with space instead of dashes

## How to test it
- Create a new Safe using social wallet
- Witness that a safe name is set

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
