### PR TITLE
[Seedless-Onboarding] fix: login error handling 

### DIFF
--- a/src/components/common/SocialSigner/index.tsx
+++ b/src/components/common/SocialSigner/index.tsx
@@ -116,7 +116,6 @@ export const SocialSigner = ({
   return (
     <>
       <Box display="flex" flexDirection="column" gap={2} sx={{ width: '100%' }}>
-        {loginError && <ErrorMessage className={css.loginError}>{loginError}</ErrorMessage>}
         {isSocialLogin && userInfo ? (
           <Track {...CREATE_SAFE_EVENTS.CONTINUE_TO_CREATION}>
             <Button
@@ -160,6 +159,7 @@ export const SocialSigner = ({
             </Button>
           </Track>
         )}
+        {loginError && <ErrorMessage className={css.loginError}>{loginError}</ErrorMessage>}
       </Box>
 
       {!isMPCLoginEnabled && (

--- a/src/components/common/SocialSigner/index.tsx
+++ b/src/components/common/SocialSigner/index.tsx
@@ -18,6 +18,8 @@ import { TxModalContext } from '@/components/tx-flow'
 import { COREKIT_STATUS } from '@web3auth/mpc-core-kit'
 import useSocialWallet from '@/hooks/wallets/mpc/useSocialWallet'
 import madProps from '@/utils/mad-props'
+import { asError } from '@/services/exceptions/utils'
+import ErrorMessage from '@/components/tx/ErrorMessage'
 
 export const _getSupportedChains = (chains: ChainInfo[]) => {
   return chains
@@ -54,6 +56,7 @@ export const SocialSigner = ({
   onLogin,
 }: SocialSignerLoginProps) => {
   const [loginPending, setLoginPending] = useState<boolean>(false)
+  const [loginError, setLoginError] = useState<string | undefined>(undefined)
   const { setTxFlow } = useContext(TxModalContext)
   const userInfo = socialWalletService?.getUserInfo()
   const isDisabled = loginPending || !isMPCLoginEnabled
@@ -76,39 +79,44 @@ export const SocialSigner = ({
     if (!socialWalletService) return
 
     setLoginPending(true)
+    setLoginError(undefined)
+    try {
+      const status = await socialWalletService.loginAndCreate()
 
-    const status = await socialWalletService.loginAndCreate()
+      if (status === COREKIT_STATUS.LOGGED_IN) {
+        onLogin?.()
+        setLoginPending(false)
+        return
+      }
 
-    if (status === COREKIT_STATUS.LOGGED_IN) {
-      onLogin?.()
+      if (status === COREKIT_STATUS.REQUIRED_SHARE) {
+        setTxFlow(
+          <PasswordRecovery
+            recoverFactorWithPassword={recoverPassword}
+            onSuccess={() => {
+              onLogin?.()
+              setLoginPending(false)
+            }}
+          />,
+          () => {},
+          false,
+        )
+        return
+      }
+    } catch (err) {
+      const error = asError(err)
+      setLoginError(error.message)
+    } finally {
       setLoginPending(false)
-      return
     }
-
-    if (status === COREKIT_STATUS.REQUIRED_SHARE) {
-      setTxFlow(
-        <PasswordRecovery
-          recoverFactorWithPassword={recoverPassword}
-          onSuccess={() => {
-            onLogin?.()
-            setLoginPending(false)
-          }}
-        />,
-        () => {},
-        false,
-      )
-      return
-    }
-
-    // TODO: Show error if login fails
-    setLoginPending(false)
   }
 
   const isSocialLogin = isSocialLoginWallet(wallet?.label)
 
   return (
     <>
-      <Box sx={{ width: '100%' }}>
+      <Box display="flex" flexDirection="column" gap={2} sx={{ width: '100%' }}>
+        {loginError && <ErrorMessage className={css.loginError}>{loginError}</ErrorMessage>}
         {isSocialLogin && userInfo ? (
           <Track {...CREATE_SAFE_EVENTS.CONTINUE_TO_CREATION}>
             <Button

--- a/src/services/exceptions/ErrorCodes.ts
+++ b/src/services/exceptions/ErrorCodes.ts
@@ -18,6 +18,7 @@ enum ErrorCodes {
   _303 = '303: Error creating pairing session',
   _304 = '304: Error enabling MFA',
   _305 = '305: Error exporting account key',
+  _306 = '306: Error logging in',
 
   _400 = '400: Error requesting browser notification permissions',
   _401 = '401: Error tracking push notifications',

--- a/src/services/mpc/SocialWalletService.ts
+++ b/src/services/mpc/SocialWalletService.ts
@@ -98,7 +98,7 @@ class SocialWalletService implements ISocialWalletService {
     } catch (err) {
       const error = asError(err)
       logError(ErrorCodes._306, error)
-      throw new Error('Something went wrong on our side. Please try to login again,')
+      throw new Error('Something went wrong. Please try to login again.')
     }
   }
 

--- a/src/services/mpc/SocialWalletService.ts
+++ b/src/services/mpc/SocialWalletService.ts
@@ -98,7 +98,7 @@ class SocialWalletService implements ISocialWalletService {
     } catch (err) {
       const error = asError(err)
       logError(ErrorCodes._306, error)
-      throw new Error('Error while logging in to your account or creating your Social signer wallet')
+      throw new Error('Something went wrong on our side. Please try to login again,')
     }
   }
 

--- a/src/services/mpc/SocialWalletService.ts
+++ b/src/services/mpc/SocialWalletService.ts
@@ -95,9 +95,10 @@ class SocialWalletService implements ISocialWalletService {
 
       await this.finalizeLogin()
       return this.mpcCoreKit.status
-    } catch (error) {
-      console.error(error)
-      return this.mpcCoreKit.status
+    } catch (err) {
+      const error = asError(err)
+      logError(ErrorCodes._306, error)
+      throw new Error('Error while logging in to your account or creating your Social signer wallet')
     }
   }
 


### PR DESCRIPTION
## What it solves
Login errors are caught and ignored.

## How this PR fixes it
- Calls logError and throws a new Error.
- Displays the error in the login screens

## How to test it
- Break the local config by configuring a wrong verifier ID or block the network requests
- Try to login
- Witness new errors

## Screenshots
![Screenshot 2023-11-01 at 18 29 49](https://github.com/safe-global/safe-wallet-web/assets/2670790/91ab060d-2223-45f4-9a23-927b5290128c)
![Screenshot 2023-11-01 at 18 29 32](https://github.com/safe-global/safe-wallet-web/assets/2670790/08d8fa66-1914-486b-a2ac-0e55f60d8e8c)



## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
