### PR TITLE
Fix: WalletConnect - track only tx and signature requests

### DIFF
--- a/src/components/common/FileUpload/index.tsx
+++ b/src/components/common/FileUpload/index.tsx
@@ -113,10 +113,7 @@ const FileUpload = ({
           sx={{ fill: 'none', color: ({ palette }) => palette.primary.light }}
         />
         <Typography>
-          Drag and drop a {fileType} file or{' '}
-          <Link href="#" color="secondary">
-            choose a file
-          </Link>
+          Drag and drop a {fileType} file or <Link color="secondary">choose a file</Link>
         </Typography>
       </Box>
     </Box>

--- a/src/components/walletconnect/WcSessionMananger/index.tsx
+++ b/src/components/walletconnect/WcSessionMananger/index.tsx
@@ -117,10 +117,12 @@ const WcSessionManager = ({ sessions, uri }: WcSessionManagerProps) => {
 
   // Track errors
   useEffect(() => {
-    if (error && open) {
-      trackEvent({ ...WALLETCONNECT_EVENTS.SHOW_ERROR, label: splitError(error.message || '')[0] })
+    if (error) {
+      // The summary of the error
+      const label = splitError(error.message || '')[0]
+      trackEvent({ ...WALLETCONNECT_EVENTS.SHOW_ERROR, label })
     }
-  }, [error, open])
+  }, [error])
 
   //
   // UI states

--- a/src/services/walletconnect/WalletConnectContext.tsx
+++ b/src/services/walletconnect/WalletConnectContext.tsx
@@ -8,10 +8,9 @@ import WalletConnectWallet from './WalletConnectWallet'
 import { asError } from '../exceptions/utils'
 import { getPeerName, stripEip155Prefix } from './utils'
 import { IS_PRODUCTION } from '@/config/constants'
-import { trackEvent } from '../analytics'
-import { WALLETCONNECT_EVENTS } from '../analytics/events/walletconnect'
 import { SafeAppsTag } from '@/config/constants'
 import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
+import { trackRequest } from './tracking'
 
 enum Errors {
   WRONG_CHAIN = '%%dappName%% made a request on a different chain than the one you are connected to',
@@ -82,9 +81,9 @@ export const WalletConnectProvider = ({ children }: { children: ReactNode }) => 
       const session = walletConnect.getActiveSessions().find((s) => s.topic === topic)
       const requestChainId = stripEip155Prefix(event.params.chainId)
 
-      // Track all requests
+      // Track requests
       if (session) {
-        trackEvent({ ...WALLETCONNECT_EVENTS.REQUEST, label: session.peer.metadata.url })
+        trackRequest(session.peer.metadata.url, event.params.request.method)
       }
 
       const getResponse = () => {

--- a/src/services/walletconnect/tracking.ts
+++ b/src/services/walletconnect/tracking.ts
@@ -1,0 +1,16 @@
+import { trackEvent } from '../analytics'
+import { WALLETCONNECT_EVENTS } from '../analytics/events/walletconnect'
+
+const trackedRequests = [
+  'personal_sign',
+  'eth_sign',
+  'eth_signTypedData',
+  'eth_signTypedData_v4',
+  'eth_sendTransaction',
+]
+
+export const trackRequest = (peerUrl: string, method: string) => {
+  if (trackedRequests.includes(method)) {
+    trackEvent({ ...WALLETCONNECT_EVENTS.REQUEST, label: peerUrl })
+  }
+}


### PR DESCRIPTION
## What it solves

WalletConnect RPC request tracking was added in #2717.
This PR limits the types of requests being tracked to only transaction and signature requests. Otherwise we would track all kinds of "read-only" requests like `eth_getChainid` etc.

Also, track errors only once when they are thrown, not every time they're shown.