### PR TITLE
fix: Update to new recommended nonce endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@safe-global/safe-core-sdk-utils": "^1.7.4",
     "@safe-global/safe-deployments": "1.25.0",
     "@safe-global/safe-ethers-lib": "^1.9.4",
-    "@safe-global/safe-gateway-typescript-sdk": "^3.12.0",
+    "@safe-global/safe-gateway-typescript-sdk": "^3.13.2",
     "@safe-global/safe-modules-deployments": "^1.0.0",
     "@safe-global/safe-react-components": "^2.0.6",
     "@sentry/react": "^7.74.0",

--- a/src/components/tx/SignOrExecuteForm/hooks.ts
+++ b/src/components/tx/SignOrExecuteForm/hooks.ts
@@ -15,7 +15,7 @@ import {
 import { useHasPendingTxs } from '@/hooks/usePendingTxs'
 import type { ConnectedWallet } from '@/services/onboard'
 import type { OnboardAPI } from '@web3-onboard/core'
-import { getSafeTxGas, getRecommendedNonce } from '@/services/tx/tx-sender/recommendedNonce'
+import { getSafeTxGas, getNonces } from '@/services/tx/tx-sender/recommendedNonce'
 import useAsync from '@/hooks/useAsync'
 import { useUpdateBatch } from '@/hooks/useDraftBatch'
 import { type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
@@ -163,9 +163,9 @@ export const useRecommendedNonce = (): number | undefined => {
     async () => {
       if (!safe.chainId || !safeAddress) return
 
-      const recommendedNonce = await getRecommendedNonce(safe.chainId, safeAddress)
+      const nonces = await getNonces(safe.chainId, safeAddress)
 
-      return recommendedNonce !== undefined ? Math.max(safe.nonce, recommendedNonce) : undefined
+      return nonces?.recommendedNonce
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [safeAddress, safe.chainId, safe.txQueuedTag], // update when tx queue changes

--- a/src/services/tx/tx-sender/recommendedNonce.ts
+++ b/src/services/tx/tx-sender/recommendedNonce.ts
@@ -1,9 +1,12 @@
-import type { SafeTransactionEstimation } from '@safe-global/safe-gateway-typescript-sdk'
-import { Operation, postSafeGasEstimation } from '@safe-global/safe-gateway-typescript-sdk'
+import {
+  Operation,
+  postSafeGasEstimation,
+  getNonces as fetchNonces,
+  type SafeTransactionEstimation,
+} from '@safe-global/safe-gateway-typescript-sdk'
 import type { MetaTransactionData, SafeTransactionDataPartial } from '@safe-global/safe-core-sdk-types'
 import { isLegacyVersion } from '@/hooks/coreSDK/safeCoreSDK'
 import { Errors, logError } from '@/services/exceptions'
-import { EMPTY_DATA } from '@safe-global/safe-core-sdk/dist/src/utils/constants'
 
 const fetchRecommendedParams = async (
   chainId: string,
@@ -37,11 +40,9 @@ export const getSafeTxGas = async (
   }
 }
 
-export const getRecommendedNonce = async (chainId: string, safeAddress: string): Promise<number | undefined> => {
-  const blankTxParams = { data: EMPTY_DATA, to: safeAddress, value: '0' }
+export const getNonces = async (chainId: string, safeAddress: string) => {
   try {
-    const estimation = await fetchRecommendedParams(chainId, safeAddress, blankTxParams)
-    return Number(estimation.recommendedNonce)
+    return fetchNonces(chainId, safeAddress)
   } catch (e) {
     logError(Errors._616, e)
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3789,7 +3789,12 @@
     "@safe-global/safe-core-sdk-utils" "^1.7.4"
     ethers "5.7.2"
 
-"@safe-global/safe-gateway-typescript-sdk@^3.12.0", "@safe-global/safe-gateway-typescript-sdk@^3.5.3":
+"@safe-global/safe-gateway-typescript-sdk@^3.13.2":
+  version "3.13.2"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.13.2.tgz#f03884c7eb766f5508085d95ab96063a28e20920"
+  integrity sha512-kGlJecJHBzGrGTq/yhLANh56t+Zur6Ubpt+/w03ARX1poDb4TM8vKU3iV8tuYpk359PPWp+Qvjnqb9oW2YQcYw==
+
+"@safe-global/safe-gateway-typescript-sdk@^3.5.3":
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.12.0.tgz#aa767a32f4d10f4ec9a47ad7e32d547d3b51e94c"
   integrity sha512-hExCo62lScVC9/ztVqYEYL2pFxcqLTvB8fj0WtdP5FWrvbtEgD0pbVolchzD5bf85pbzvEwdAxSVS7EdCZxTNw==


### PR DESCRIPTION
## What it solves

Use the new recommended nonce endpoint on the CGW

## How this PR fixes it

- The recommended nonce request on tx creation uses the new `/nonces` endpoint

## How to test it

1. Open a Safe
2. Switch to staging CGW
3. Create a new transaction
4. Observe the recommended nonce is loading and correct

CGW ticket - https://github.com/safe-global/safe-client-gateway/issues/681

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
