### PR TITLE
fix: Add social login option to onboard module

### DIFF
--- a/src/hooks/wallets/mpc/useSocialWallet.ts
+++ b/src/hooks/wallets/mpc/useSocialWallet.ts
@@ -13,23 +13,6 @@ import useMpc from './useMPC'
 
 const { getStore, setStore, useStore } = new ExternalStore<ISocialWalletService>()
 
-// Listen to onboard modal open and hide the social login button
-const hideOnboardButton = () => {
-  const onboardRoot = document.querySelector('onboard-v2')?.shadowRoot
-  if (!onboardRoot) return
-
-  const hideSocialLoginButton = () => {
-    const walletButtons = onboardRoot.querySelectorAll('.wallet-button-container') || []
-    const socialButton = Array.from(walletButtons).find((el) => el.textContent?.includes(ONBOARD_MPC_MODULE_LABEL))
-    socialButton?.remove()
-  }
-
-  const observer = new MutationObserver(hideSocialLoginButton)
-  observer.observe(onboardRoot, { childList: true })
-
-  return () => observer.disconnect()
-}
-
 export const useInitSocialWallet = () => {
   const mpcCoreKit = useMpc()
   const onboard = useOnboard()
@@ -71,13 +54,6 @@ export const useInitSocialWallet = () => {
       setStore(new SocialWalletService(mpcCoreKit))
     }
   }, [mpcCoreKit])
-
-  // Hide social login when onboard pops up
-  // @FIXME the button should work but atm it doesn't
-  useEffect(() => {
-    if (!onboard) return
-    return hideOnboardButton()
-  }, [onboard])
 }
 
 export const getSocialWalletService = getStore

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import PasswordRecoveryModal from '@/services/mpc/PasswordRecoveryModal'
 import Sentry from '@/services/sentry' // needs to be imported first
 import type { ReactNode } from 'react'
 import { type ReactElement } from 'react'
@@ -126,6 +127,8 @@ const WebCoreApp = ({
           <Notifications />
 
           <MobilePairingModal />
+
+          <PasswordRecoveryModal />
         </AppProviders>
       </CacheProvider>
     </StoreHydrator>

--- a/src/services/mpc/PasswordRecoveryModal.tsx
+++ b/src/services/mpc/PasswordRecoveryModal.tsx
@@ -1,0 +1,42 @@
+import { PasswordRecovery } from '@/components/common/SocialSigner/PasswordRecovery'
+import TxModalDialog from '@/components/common/TxModalDialog'
+import useSocialWallet from '@/hooks/wallets/mpc/useSocialWallet'
+import ExternalStore from '@/services/ExternalStore'
+
+const { useStore: useCloseCallback, setStore: setCloseCallback } = new ExternalStore<() => void>()
+
+export const open = (cb: () => void) => {
+  setCloseCallback(() => cb)
+}
+
+export const close = () => {
+  setCloseCallback(undefined)
+}
+
+const PasswordRecoveryModal = () => {
+  const socialWalletService = useSocialWallet()
+  const closeCallback = useCloseCallback()
+  const open = !!closeCallback
+
+  const handleClose = () => {
+    closeCallback?.()
+    setCloseCallback(undefined)
+    close()
+  }
+
+  const recoverPassword = async (password: string, storeDeviceFactor: boolean) => {
+    if (!socialWalletService) return
+
+    await socialWalletService.recoverAccountWithPassword(password, storeDeviceFactor)
+  }
+
+  if (!open) return null
+
+  return (
+    <TxModalDialog open={open} onClose={handleClose} fullWidth sx={{ zIndex: '10000 !important', top: '0 !important' }}>
+      <PasswordRecovery recoverFactorWithPassword={recoverPassword} onSuccess={handleClose} />
+    </TxModalDialog>
+  )
+}
+
+export default PasswordRecoveryModal


### PR DESCRIPTION
## What it solves

Part of #2452 

## How this PR fixes it

- Implements the `eth_requestAccounts` for the onboard module

## How to test it

1. Open the app
2. Press Connect wallet
3. Select Social Login
4. Observe getting logged in
5. Set a password
6. Log out and login again
7. Observe the password recovery modal opens
8. Submit the modal
9. Observe being logged in

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
