### PR TITLE
chore: update mpc-core-kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@web3-onboard/ledger": "2.3.2",
     "@web3-onboard/trezor": "^2.4.2",
     "@web3-onboard/walletconnect": "^2.4.7",
-    "@web3auth/mpc-core-kit": "^1.1.2",
+    "@web3auth/mpc-core-kit": "^1.1.3",
     "blo": "^1.1.1",
     "bn.js": "^5.2.1",
     "classnames": "^2.3.1",

--- a/src/hooks/wallets/mpc/useMPC.ts
+++ b/src/hooks/wallets/mpc/useMPC.ts
@@ -49,6 +49,7 @@ export const useInitMPC = () => {
       enableLogging: true,
       chainConfig,
       manualSync: true,
+      hashedFactorNonce: 'safe-global-sfa-nonce',
     })
 
     web3AuthCoreKit

--- a/yarn.lock
+++ b/yarn.lock
@@ -6195,10 +6195,10 @@
     loglevel "^1.8.1"
     ts-custom-error "^3.3.1"
 
-"@web3auth/mpc-core-kit@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@web3auth/mpc-core-kit/-/mpc-core-kit-1.1.2.tgz#308f9d441b1275ebcc2c96be8ff976decee6dbcf"
-  integrity sha512-bx16zYdC3D2KPp5wv55fn6W3RcMGUUbHeoClaDI2czwbUrZyql71A4qQdyi6tMTzy/uAXWZrfB+U4NGk+ec9Pw==
+"@web3auth/mpc-core-kit@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@web3auth/mpc-core-kit/-/mpc-core-kit-1.1.3.tgz#01c508157f11d5a6685fa578bb873f40678fa403"
+  integrity sha512-wpbrBDBxZ8vi7oY3zL3BEktKuwfs5miMga4R7qmc12k79gNJa8S6FvZQ38wZkwNJyrRb0iFQ1kOWR0NOteeMyg==
   dependencies:
     "@tkey-mpc/chrome-storage" "^9.0.2"
     "@tkey-mpc/common-types" "^9.0.2"


### PR DESCRIPTION
## What it solves
- Updates mpc-core-kit to 1.3.0
- Sets a static hashedFactorKeyNonce to be compatible with Safe{Core}
