### PR TITLE
Optimize docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,10 +2,14 @@ Dockerfile
 .dockerignore
 node_modules
 npm-debug.log
-README.md
 .next
 .git
 coverage
 .DS_Store
 .idea
 dist
+
+build/
+coverage/
+cypress/
+out/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,34 @@
-FROM node:18-alpine
-RUN apk add --no-cache libc6-compat git python3 py3-pip make g++ libusb-dev eudev-dev linux-headers
-WORKDIR /app
-COPY . .
-
-# install deps
-RUN yarn install --frozen-lockfile
-RUN yarn after-install
-
-ENV NODE_ENV production
-
-# Next.js collects completely anonymous telemetry data about general usage.
-# Learn more here: https://nextjs.org/telemetry
-# Uncomment the following line in case you want to disable telemetry during the build.
+FROM node:18-alpine AS base
 ENV NEXT_TELEMETRY_DISABLED 1
 
-EXPOSE 3000
+FROM base AS builder
 
-ENV PORT 3000
+RUN apk add --no-cache libc6-compat git python3 py3-pip make g++ libusb-dev eudev-dev linux-headers
+WORKDIR /app
 
-CMD ["yarn", "static-serve"]
+# Install dependencies
+COPY package.json yarn.lock* ./
+RUN yarn --frozen-lockfile
+COPY . .
+RUN yarn run after-install
+
+RUN yarn build
+
+# Production image
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV production
+ENV REVERSE_PROXY_UI_PORT 8080
+
+RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
+COPY --from=builder /app/out ./out
+
+# Set the correct permission for prerender cache
+RUN mkdir .next && chown nextjs:nodejs .next
+
+USER nextjs
+
+EXPOSE ${REVERSE_PROXY_UI_PORT}
+
+CMD npx -y serve out -p ${REVERSE_PROXY_UI_PORT}


### PR DESCRIPTION
- Reduce size by using multistage builds
- Run `yarn build` on the build process and not when the docker image starts (it can take a few minutes to complete)
