### PR TITLE
fix: Add ramp view to assets page if there are no assets

### DIFF
--- a/cypress/e2e/smoke/assets.cy.js
+++ b/cypress/e2e/smoke/assets.cy.js
@@ -212,9 +212,7 @@ describe('Assets tests', () => {
     balances.selectTokenList(balances.tokenListOptions.allTokens)
     balances.showSendBtn(0)
     owner.verifyTooltiptext(owner.disconnectedUserErrorMsg)
-    cy.visit(constants.BALANCE_URL + constants.SEPOLIA_TEST_SAFE_4)
-    balances.selectTokenList(balances.tokenListOptions.allTokens)
-    balances.showSendBtn(0)
-    owner.verifyTooltiptext(owner.nonOwnerErrorMsg)
+    // Removed the part that checks for a non owner error message in the tooltip
+    // because the safe has no assets, and we don't have a safe with assets where e2e wallet is not an owner
   })
 })

--- a/cypress/e2e/smoke/batch_tx.cy.js
+++ b/cypress/e2e/smoke/batch_tx.cy.js
@@ -1,6 +1,7 @@
 import * as batch from '../pages/batches.pages'
 import * as constants from '../../support/constants'
 import * as main from '../../e2e/pages/main.page'
+import * as owner from '../../e2e/pages/owners.pages.js'
 
 const currentNonce = 3
 const funds_first_tx = '0.001'
@@ -10,6 +11,7 @@ describe('Batch transaction tests', () => {
   beforeEach(() => {
     cy.clearLocalStorage()
     cy.visit(constants.BALANCE_URL + constants.SEPOLIA_TEST_SAFE_5)
+    owner.waitForConnectionStatus()
     main.acceptCookies()
   })
 

--- a/src/components/balances/AssetsTable/index.tsx
+++ b/src/components/balances/AssetsTable/index.tsx
@@ -1,6 +1,7 @@
 import EthHashInfo from '@/components/common/EthHashInfo'
 import QRCode from '@/components/common/QRCode'
 import { AppRoutes } from '@/config/routes'
+import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
 import { useCurrentChain } from '@/hooks/useChains'
 import useSafeAddress from '@/hooks/useSafeAddress'
 import { useAppSelector } from '@/store'
@@ -277,6 +278,9 @@ const NoAssets = () => {
   const settings = useAppSelector(selectSettings)
   const qrPrefix = settings.shortName.qr ? `${chain?.shortName}:` : ''
   const qrCode = `${qrPrefix}${safeAddress}`
+  const [apps] = useRemoteSafeApps()
+
+  const rampSafeApp = apps?.find((app) => app.name === 'Ramp Network')
 
   return (
     <Paper>
@@ -296,14 +300,18 @@ const NoAssets = () => {
           <Box bgcolor="background.main" p={2} borderRadius="6px" alignSelf="flex-start" fontSize="14px">
             <EthHashInfo address={safeAddress} shortAddress={false} showCopyButton hasExplorer avatarSize={24} />
           </Box>
-          <Box alignSelf="flex-start">
-            {/* TODO: Insert link for Ramp app */}
-            <Link href={{ pathname: AppRoutes.apps.index, query: router.query }} passHref>
-              <Button variant="contained" size="small" startIcon={<AddIcon />}>
-                Buy crypto
-              </Button>
-            </Link>
-          </Box>
+          {rampSafeApp && (
+            <Box alignSelf="flex-start">
+              <Link
+                href={{ pathname: AppRoutes.apps.index, query: { safe: router.query.safe, appUrl: rampSafeApp.url } }}
+                passHref
+              >
+                <Button variant="contained" size="small" startIcon={<AddIcon />}>
+                  Buy crypto
+                </Button>
+              </Link>
+            </Box>
+          )}
         </Grid>
       </Grid>
     </Paper>


### PR DESCRIPTION
## What it solves

Adds a new screen to the assets page with the Safe QR Code and a link for on-ramping.

- [ ] Add correct on ramp safe app link

## How this PR fixes it

## How to test it

## Screenshots
<img width="1266" alt="Screenshot 2023-11-09 at 09 40 18" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/90f0a7a0-06d8-413c-bd58-156a50ae7cc9">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
