### PR TITLE
feat: change redirect behaviour after login on welcome page

### DIFF
--- a/src/components/welcome/NewSafe.tsx
+++ b/src/components/welcome/NewSafe.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Box, Grid, SvgIcon, Typography } from '@mui/material'
 import css from './styles.module.css'
 import CheckFilled from '@/public/images/common/check-filled.svg'
@@ -16,16 +16,17 @@ const BulletListItem = ({ text }: { text: string }) => (
 )
 
 const NewSafe = () => {
+  const [drawerOpen, setDrawerOpen] = useState(false)
   return (
     <>
       <Grid container spacing={3} p={3} pb={0} flex={1} direction="row-reverse">
         <Grid item xs={12} lg={6}>
-          <WelcomeLogin />
+          <WelcomeLogin setOpenSafeList={setDrawerOpen} />
         </Grid>
         <Grid item xs={12} lg={6} flex={1}>
           <div className={css.content}>
             <Box minWidth={{ md: 480 }} className={css.sidebar}>
-              <SafeListDrawer />
+              <SafeListDrawer open={drawerOpen} setOpen={setDrawerOpen} />
             </Box>
 
             <Typography variant="h1" fontSize={[44, null, 52]} lineHeight={1} letterSpacing={-1.5} color="static.main">

--- a/src/components/welcome/NewSafeSocial.tsx
+++ b/src/components/welcome/NewSafeSocial.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Box, Button, Grid, Typography } from '@mui/material'
 import css from './styles.module.css'
 import Link from 'next/link'
@@ -28,16 +28,18 @@ const MarqueeItem = () => {
 }
 
 const NewSafeSocial = () => {
+  const [drawerOpen, setDrawerOpen] = useState(false)
+
   return (
     <>
       <Grid container spacing={3} p={3} pb={0} flex={1} direction="row-reverse">
         <Grid item xs={12} lg={6}>
-          <WelcomeLogin />
+          <WelcomeLogin setOpenSafeList={setDrawerOpen} />
         </Grid>
         <Grid item xs={12} lg={6} flex={1}>
           <div className={css.content}>
             <Box minWidth={{ md: 480 }} className={css.sidebar}>
-              <SafeListDrawer />
+              <SafeListDrawer open={drawerOpen} setOpen={setDrawerOpen} />
             </Box>
 
             <Box pt={5} alignSelf="center" margin="auto">

--- a/src/components/welcome/SafeListDrawer/index.tsx
+++ b/src/components/welcome/SafeListDrawer/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import SafeList from '@/components/sidebar/SafeList'
 import { DataWidget } from '@/components/welcome/SafeListDrawer/DataWidget'
 import { Button, Drawer, Typography } from '@mui/material'
@@ -9,14 +9,13 @@ import useOwnedSafes from '@/hooks/useOwnedSafes'
 import drawerCSS from '@/components/sidebar/Sidebar/styles.module.css'
 import css from './styles.module.css'
 
-const SafeListDrawer = () => {
+const SafeListDrawer = ({ open, setOpen }: { open: boolean; setOpen: (open: boolean) => void }) => {
   const numberOfAddedSafes = useAppSelector(selectTotalAdded)
   const ownedSafes = useOwnedSafes()
   const numberOfOwnedSafes = Object.values(ownedSafes).reduce((acc, curr) => acc + curr.length, 0)
   const totalNumberOfSafes = numberOfOwnedSafes + numberOfAddedSafes
-  const [showSidebar, setShowSidebar] = useState(false)
 
-  const closeSidebar = () => setShowSidebar(false)
+  const closeSidebar = () => setOpen(false)
 
   if (totalNumberOfSafes <= 0) {
     return null
@@ -24,7 +23,7 @@ const SafeListDrawer = () => {
 
   return (
     <>
-      <Drawer variant="temporary" anchor="left" open={showSidebar} onClose={closeSidebar}>
+      <Drawer variant="temporary" anchor="left" open={open} onClose={closeSidebar}>
         <div className={drawerCSS.drawer}>
           <SafeList closeDrawer={closeSidebar} />
 
@@ -39,7 +38,7 @@ const SafeListDrawer = () => {
         variant="contained"
         color="background"
         startIcon={<ChevronRightIcon />}
-        onClick={() => setShowSidebar(true)}
+        onClick={() => setOpen(true)}
       >
         <Typography className={css.buttonText} fontWeight="bold">
           My Safe Accounts{' '}

--- a/src/components/welcome/WelcomeLogin/WalletLogin.tsx
+++ b/src/components/welcome/WelcomeLogin/WalletLogin.tsx
@@ -6,17 +6,25 @@ import { CREATE_SAFE_EVENTS } from '@/services/analytics'
 import { Box, Button, Typography } from '@mui/material'
 import { EthHashInfo } from '@safe-global/safe-react-components'
 
-const WalletLogin = ({ onLogin }: { onLogin: () => void }) => {
+const WalletLogin = ({ onLogin }: { onLogin: (address: string) => void }) => {
   const wallet = useWallet()
   const connectWallet = useConnectWallet()
 
   const isSocialLogin = isSocialLoginWallet(wallet?.label)
 
+  const login = async () => {
+    const walletState = await connectWallet()
+
+    if (walletState && walletState.length > 0 && walletState[0].accounts.length > 0) {
+      onLogin(walletState[0].accounts[0].address)
+    }
+  }
+
   if (wallet !== null && !isSocialLogin) {
     return (
       <Box sx={{ width: '100%' }}>
         <Track {...CREATE_SAFE_EVENTS.CONTINUE_TO_CREATION}>
-          <Button variant="contained" sx={{ padding: '8px 16px' }} fullWidth onClick={onLogin}>
+          <Button variant="contained" sx={{ padding: '8px 16px' }} fullWidth onClick={() => onLogin(wallet.address)}>
             <Box
               width="100%"
               justifyContent="space-between"
@@ -47,14 +55,7 @@ const WalletLogin = ({ onLogin }: { onLogin: () => void }) => {
   }
 
   return (
-    <Button
-      onClick={connectWallet}
-      sx={{ minHeight: '42px' }}
-      variant="contained"
-      size="small"
-      disableElevation
-      fullWidth
-    >
+    <Button onClick={login} sx={{ minHeight: '42px' }} variant="contained" size="small" disableElevation fullWidth>
       Connect wallet
     </Button>
   )

--- a/src/components/welcome/WelcomeLogin/index.tsx
+++ b/src/components/welcome/WelcomeLogin/index.tsx
@@ -10,12 +10,21 @@ import WalletLogin from './WalletLogin'
 import { LOAD_SAFE_EVENTS, CREATE_SAFE_EVENTS } from '@/services/analytics/events/createLoadSafe'
 import Track from '@/components/common/Track'
 import { trackEvent } from '@/services/analytics'
+import { getOwnedSafes } from '@safe-global/safe-gateway-typescript-sdk'
+import useChainId from '@/hooks/useChainId'
+import { checksumAddress } from '@/utils/addresses'
 
-const WelcomeLogin = () => {
+const WelcomeLogin = ({ setOpenSafeList }: { setOpenSafeList: (open: boolean) => void }) => {
   const router = useRouter()
   const isSocialLoginEnabled = useHasFeature(FEATURES.SOCIAL_LOGIN)
+  const currentChainId = useChainId()
 
-  const continueToCreation = () => {
+  const continueToCreation = async (address: string) => {
+    const ownedSafes = await getOwnedSafes(currentChainId, checksumAddress(address))
+    if (ownedSafes.safes.length > 0) {
+      setOpenSafeList(true)
+      return
+    }
     trackEvent(CREATE_SAFE_EVENTS.OPEN_SAFE_CREATION)
     router.push({ pathname: AppRoutes.newSafe.create, query: router.query })
   }

--- a/src/services/mpc/SocialWalletService.ts
+++ b/src/services/mpc/SocialWalletService.ts
@@ -35,6 +35,14 @@ class SocialWalletService implements ISocialWalletService {
     return this.securityQuestionRecovery.isEnabled()
   }
 
+  async getSignerAddress(): Promise<string | undefined> {
+    if (!this.mpcCoreKit.provider) {
+      return undefined
+    }
+    const accounts = await this.mpcCoreKit.provider.request({ method: 'eth_accounts', params: [] })
+    return (accounts as string[])[0]
+  }
+
   async enableMFA(oldPassword: string | undefined, newPassword: string): Promise<void> {
     try {
       // 1. setup device factor with password recovery
@@ -110,7 +118,6 @@ class SocialWalletService implements ISocialWalletService {
   private async finalizeLogin() {
     if (this.mpcCoreKit.status === COREKIT_STATUS.LOGGED_IN) {
       await this.mpcCoreKit.commitChanges()
-      await this.mpcCoreKit.provider?.request({ method: 'eth_accounts', params: [] })
       await this.onConnect()
     }
   }

--- a/src/services/mpc/interfaces.ts
+++ b/src/services/mpc/interfaces.ts
@@ -49,4 +49,6 @@ export interface ISocialWalletService {
   getUserInfo(): UserInfo | undefined
 
   setOnConnect(onConnect: () => Promise<void>): void
+
+  getSignerAddress(): Promise<string | undefined>
 }


### PR DESCRIPTION
## What it solves
Users were confused by being redirected to Safe creation after logging in with their wallet.

## How this PR fixes it
Only redirects to Safe creation if the wallet does not own a Safe yet.

## How to test it
1. Create a fresh wallet
2. Login on the welcome page
3. Observe that Safe creation starts
4. Once a Safe is created re-login on welcome page
5. The sidebar should open after the login

## Screenshots

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
