### PR TITLE
chore: add event label to google login button

### DIFF
--- a/src/components/common/SocialSigner/index.tsx
+++ b/src/components/common/SocialSigner/index.tsx
@@ -63,6 +63,8 @@ export const SocialSigner = ({
   const userInfo = socialWalletService?.getUserInfo()
   const isDisabled = loginPending || !isMPCLoginEnabled
 
+  const isWelcomePage = !!onLogin
+
   const recoverPassword = useCallback(
     async (password: string, storeDeviceFactor: boolean) => {
       if (!socialWalletService) return
@@ -136,7 +138,7 @@ export const SocialSigner = ({
             </Button>
           </Track>
         ) : (
-          <Track {...MPC_WALLET_EVENTS.CONNECT_GOOGLE}>
+          <Track {...MPC_WALLET_EVENTS.CONNECT_GOOGLE} label={isWelcomePage ? 'welcomePage' : 'navBar'}>
             <Button
               variant="outlined"
               onClick={login}

--- a/src/services/analytics/events/mpcWallet.ts
+++ b/src/services/analytics/events/mpcWallet.ts
@@ -10,12 +10,17 @@ export const MPC_WALLET_EVENTS = {
   },
   MANUAL_RECOVERY: {
     event: EventType.META,
-    action: 'Account recovery started',
+    action: 'MFA login started',
     category: MPC_WALLET_CATEGORY,
   },
   RECOVER_PASSWORD: {
     event: EventType.CLICK,
     action: 'Recover account using password',
+    category: MPC_WALLET_CATEGORY,
+  },
+  RECOVERED_SOCIAL_SIGNER: {
+    event: EventType.META,
+    action: 'Recovered social signer',
     category: MPC_WALLET_CATEGORY,
   },
   UPSERT_PASSWORD: {

--- a/src/services/mpc/SocialWalletService.ts
+++ b/src/services/mpc/SocialWalletService.ts
@@ -45,7 +45,7 @@ class SocialWalletService implements ISocialWalletService {
       }
 
       if (!this.isMFAEnabled()) {
-        trackEvent(MPC_WALLET_EVENTS.ENABLE_MFA)
+        trackEvent({ ...MPC_WALLET_EVENTS.ENABLE_MFA, label: 'password' })
         // 2. enable MFA in mpcCoreKit
         await this.mpcCoreKit.enableMFA({}, false)
       }
@@ -126,6 +126,10 @@ class SocialWalletService implements ISocialWalletService {
       }
 
       await this.finalizeLogin()
+    }
+
+    if (this.mpcCoreKit.status === COREKIT_STATUS.LOGGED_IN) {
+      trackEvent({ ...MPC_WALLET_EVENTS.RECOVERED_SOCIAL_SIGNER, label: 'password' })
     }
 
     return this.mpcCoreKit.status === COREKIT_STATUS.LOGGED_IN


### PR DESCRIPTION
## What it solves
Currently we cannot differentiate between a click on the Google login button in the navigation bar or on our welcome page.

## How this PR fixes it
Adds an event label which is either "welcome or 

## How to test it
Click on login with google button in header and welcome page and observe different event labels.

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
