### PR TITLE
fix: allow execution of web assembly

### DIFF
--- a/src/config/securityHeaders.ts
+++ b/src/config/securityHeaders.ts
@@ -15,7 +15,7 @@ export const ContentSecurityPolicy = `
  script-src 'self' https://www.google-analytics.com https://ssl.google-analytics.com 'unsafe-inline' https://*.getbeamer.com https://www.googletagmanager.com https://*.ingest.sentry.io https://sentry.io ${
    !IS_PRODUCTION || /* TODO: remove after moving cypress to görli and testing in staging again!! */ CYPRESS_MNEMONIC
      ? "'unsafe-eval'"
-     : 'wasm-unsafe-eval'
+     : "'wasm-unsafe-eval'"
  };
  frame-src *;
  style-src 'self' 'unsafe-inline' https://*.getbeamer.com https://*.googleapis.com;

--- a/src/config/securityHeaders.ts
+++ b/src/config/securityHeaders.ts
@@ -15,7 +15,7 @@ export const ContentSecurityPolicy = `
  script-src 'self' https://www.google-analytics.com https://ssl.google-analytics.com 'unsafe-inline' https://*.getbeamer.com https://www.googletagmanager.com https://*.ingest.sentry.io https://sentry.io ${
    !IS_PRODUCTION || /* TODO: remove after moving cypress to görli and testing in staging again!! */ CYPRESS_MNEMONIC
      ? "'unsafe-eval'"
-     : ''
+     : 'wasm-unsafe-eval'
  };
  frame-src *;
  style-src 'self' 'unsafe-inline' https://*.getbeamer.com https://*.googleapis.com;


### PR DESCRIPTION
## What it solves
Signing txs with a social signer is blocked by out CSPs

## How this PR fixes it
Allows web assembly through the [CSP directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_webassembly_execution) 'wasm-unsafe-eval'

## How to test it
Set IS_PRODUCTION to true locally and check the social login

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
