### PR TITLE
Fix: WC verification wording

### DIFF
--- a/src/components/walletconnect/WcProposalForm/ProposalVerification.tsx
+++ b/src/components/walletconnect/WcProposalForm/ProposalVerification.tsx
@@ -29,7 +29,7 @@ const Validation: {
   },
   INVALID: {
     color: 'error',
-    desc: 'has been flagged as a high risk by WalletConnect.',
+    desc: 'has a domain that does not match the sender of this request. Approving it may result in a loss of funds.',
     Icon: CloseIcon,
   },
 }


### PR DESCRIPTION
## What it solves

Adjust the warning as per Derek's request.

> :pray:for implementing Verify API - caveat
your language for “mismatch” is a bit strong and also wrong - we do not flag this scenario as “high risk”. Can you pls make the messaging a bit more clear?