### PR TITLE
fix: fix and optimise fetching the recovery state

### DIFF
--- a/src/services/recovery/__tests__/recovery-state.test.ts
+++ b/src/services/recovery/__tests__/recovery-state.test.ts
@@ -1,16 +1,17 @@
 import { faker } from '@faker-js/faker'
-import { BigNumber } from 'ethers'
+import { BigNumber, ethers } from 'ethers'
 import { JsonRpcProvider } from '@ethersproject/providers'
 import type { Delay, TransactionAddedEvent } from '@gnosis.pm/zodiac/dist/cjs/types/Delay'
 import type { TransactionReceipt } from '@ethersproject/abstract-provider'
 
 import {
   getRecoveryState,
-  _getQueuedTransactionsAdded,
+  normalizeTxServiceUrl,
   _getRecoveryQueueItem,
   _getSafeCreationReceipt,
 } from '../recovery-state'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
+import { cloneDeep } from 'lodash'
 
 jest.mock('@/hooks/wallets/web3')
 
@@ -20,43 +21,6 @@ describe('recovery-state', () => {
   beforeEach(() => {
     // Clear memoization cache
     _getSafeCreationReceipt.cache.clear?.()
-  })
-
-  describe('getQueuedTransactionsAdded', () => {
-    it('should filter queued transactions with queueNonce >= current txNonce', () => {
-      const transactionsAdded = [
-        {
-          args: {
-            queueNonce: BigNumber.from(1),
-          },
-        } as unknown,
-        {
-          args: {
-            queueNonce: BigNumber.from(2),
-          },
-        } as unknown,
-        {
-          args: {
-            queueNonce: BigNumber.from(3),
-          },
-        } as unknown,
-      ] as Array<TransactionAddedEvent>
-
-      const txNonce = BigNumber.from(2)
-
-      expect(_getQueuedTransactionsAdded(transactionsAdded, txNonce)).toStrictEqual([
-        {
-          args: {
-            queueNonce: BigNumber.from(2),
-          },
-        } as unknown,
-        {
-          args: {
-            queueNonce: BigNumber.from(3),
-          },
-        },
-      ])
-    })
   })
 
   describe('getRecoveryQueueItem', () => {
@@ -191,9 +155,9 @@ describe('recovery-state', () => {
       const safeAddress = faker.finance.ethereumAddress()
       const transactionService = faker.internet.url({ appendSlash: false })
       const transactionHash = `0x${faker.string.hexadecimal()}`
-      const blockHash = faker.string.alphanumeric()
+      const blockNumber = faker.number.int()
       const provider = {
-        getTransactionReceipt: () => Promise.resolve({ blockHash } as TransactionReceipt),
+        getTransactionReceipt: () => Promise.resolve({ blockNumber } as TransactionReceipt),
       } as unknown as JsonRpcProvider
 
       global.fetch = jest.fn().mockImplementation((_url: string) => {
@@ -208,14 +172,8 @@ describe('recovery-state', () => {
       const txExpiration = BigNumber.from(0)
       const txCooldown = BigNumber.from(69420)
       const txNonce = BigNumber.from(2)
-      const queueNonce = BigNumber.from(3)
+      const queueNonce = BigNumber.from(4)
       const transactionsAdded = [
-        {
-          getBlock: () => Promise.resolve({ timestamp: 69 }),
-          args: {
-            queueNonce: BigNumber.from(1),
-          },
-        } as unknown,
         {
           getBlock: () => Promise.resolve({ timestamp: 420 }),
           args: {
@@ -231,9 +189,13 @@ describe('recovery-state', () => {
       ] as Array<TransactionAddedEvent>
 
       const queryFilterMock = jest.fn()
+      const defaultTransactionAddedFilter = {
+        address: faker.finance.ethereumAddress(),
+        topics: [ethers.utils.id('TransactionAdded(uint256,bytes32,address,uint256,bytes,uint8)')],
+      }
       const delayModifier = {
         filters: {
-          TransactionAdded: () => ({}),
+          TransactionAdded: () => cloneDeep(defaultTransactionAddedFilter),
         },
         address: faker.finance.ethereumAddress(),
         getModulesPaginated: () => Promise.resolve([modules]),
@@ -260,20 +222,90 @@ describe('recovery-state', () => {
         queueNonce,
         queue: [
           {
-            ...transactionsAdded[1],
+            ...transactionsAdded[0],
             timestamp: 420,
             validFrom: BigNumber.from(420).add(txCooldown),
             expiresAt: null,
           },
           {
-            ...transactionsAdded[2],
+            ...transactionsAdded[1],
             timestamp: 69420,
             validFrom: BigNumber.from(69420).add(txCooldown),
             expiresAt: null,
           },
         ],
       })
-      expect(queryFilterMock).toHaveBeenCalledWith(delayModifier.filters.TransactionAdded(), blockHash)
+      expect(queryFilterMock).toHaveBeenCalledWith(
+        {
+          ...defaultTransactionAddedFilter,
+          topics: [
+            ...defaultTransactionAddedFilter.topics,
+            [ethers.utils.hexZeroPad('0x2', 32), ethers.utils.hexZeroPad('0x3', 32)],
+          ],
+        },
+        blockNumber,
+        'latest',
+      )
+    })
+
+    it('should not query data if the queueNonce equals the txNonce', async () => {
+      const safeAddress = faker.finance.ethereumAddress()
+      const transactionService = faker.internet.url({ appendSlash: true })
+      const provider = {} as unknown as JsonRpcProvider
+
+      const modules = [faker.finance.ethereumAddress()]
+      const txExpiration = BigNumber.from(0)
+      const txCooldown = BigNumber.from(69420)
+      const txNonce = BigNumber.from(2)
+      const queueNonce = BigNumber.from(2)
+
+      const queryFilterMock = jest.fn()
+      const defaultTransactionAddedFilter = {
+        address: faker.finance.ethereumAddress(),
+        topics: [ethers.utils.id('TransactionAdded(uint256,bytes32,address,uint256,bytes,uint8)')],
+      }
+      const delayModifier = {
+        filters: {
+          TransactionAdded: () => cloneDeep(defaultTransactionAddedFilter),
+        },
+        address: faker.finance.ethereumAddress(),
+        getModulesPaginated: () => Promise.resolve([modules]),
+        txExpiration: () => Promise.resolve(txExpiration),
+        txCooldown: () => Promise.resolve(txCooldown),
+        txNonce: () => Promise.resolve(txNonce),
+        queueNonce: () => Promise.resolve(queueNonce),
+        queryFilter: queryFilterMock.mockRejectedValue('Not required'),
+      }
+
+      const recoveryState = await getRecoveryState({
+        delayModifier: delayModifier as unknown as Delay,
+        safeAddress,
+        transactionService,
+        provider,
+      })
+
+      expect(recoveryState).toStrictEqual({
+        address: delayModifier.address,
+        modules,
+        txExpiration,
+        txCooldown,
+        txNonce,
+        queueNonce,
+        queue: [],
+      })
+      expect(queryFilterMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('normalizeTxServiceUrl', () => {
+    it('should append slash if missing', () => {
+      const urlWithoutSlash = faker.internet.url({ appendSlash: false })
+      expect(normalizeTxServiceUrl(urlWithoutSlash)).toEqual(urlWithoutSlash + '/')
+    })
+
+    it('should not change urls with ending slash ', () => {
+      const urlWithSlash = faker.internet.url({ appendSlash: true })
+      expect(normalizeTxServiceUrl(urlWithSlash)).toEqual(urlWithSlash)
     })
   })
 })

--- a/src/services/recovery/__tests__/recovery-state.test.ts
+++ b/src/services/recovery/__tests__/recovery-state.test.ts
@@ -4,12 +4,7 @@ import { JsonRpcProvider } from '@ethersproject/providers'
 import type { Delay, TransactionAddedEvent } from '@gnosis.pm/zodiac/dist/cjs/types/Delay'
 import type { TransactionReceipt } from '@ethersproject/abstract-provider'
 
-import {
-  getRecoveryState,
-  normalizeTxServiceUrl,
-  _getRecoveryQueueItem,
-  _getSafeCreationReceipt,
-} from '../recovery-state'
+import { getRecoveryState, _getRecoveryQueueItem, _getSafeCreationReceipt } from '../recovery-state'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { cloneDeep } from 'lodash'
 
@@ -294,18 +289,6 @@ describe('recovery-state', () => {
         queue: [],
       })
       expect(queryFilterMock).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('normalizeTxServiceUrl', () => {
-    it('should append slash if missing', () => {
-      const urlWithoutSlash = faker.internet.url({ appendSlash: false })
-      expect(normalizeTxServiceUrl(urlWithoutSlash)).toEqual(urlWithoutSlash + '/')
-    })
-
-    it('should not change urls with ending slash ', () => {
-      const urlWithSlash = faker.internet.url({ appendSlash: true })
-      expect(normalizeTxServiceUrl(urlWithSlash)).toEqual(urlWithSlash)
     })
   })
 })

--- a/src/services/recovery/recovery-state.ts
+++ b/src/services/recovery/recovery-state.ts
@@ -8,10 +8,9 @@ import type { TransactionReceipt } from '@ethersproject/abstract-provider'
 
 import type { RecoveryQueueItem, RecoveryState } from '@/store/recoverySlice'
 import { hexZeroPad } from 'ethers/lib/utils'
+import { trimTrailingSlash } from '@/utils/url'
 
 const MAX_PAGE_SIZE = 100
-
-export const normalizeTxServiceUrl = (url: string): string => (url.endsWith('/') ? url : `${url}/`)
 
 export const _getRecoveryQueueItem = async (
   transactionAdded: TransactionAddedEvent,
@@ -43,7 +42,7 @@ export const _getSafeCreationReceipt = memoize(
     safeAddress: string
     provider: JsonRpcProvider
   }): Promise<TransactionReceipt> => {
-    const url = `${normalizeTxServiceUrl(transactionService)}api/v1/safes/${safeAddress}/creation/`
+    const url = `${trimTrailingSlash(transactionService)}/api/v1/safes/${safeAddress}/creation/`
 
     const { transactionHash } = await fetch(url).then((res) => {
       if (res.ok && res.status === 200) {


### PR DESCRIPTION
## What it solves
Querying the recovery state does not work.

## How this PR fixes it
- Uses `blockNumber` instead of `blockHash`
- Fixes the endpoint of our tx service
- filters the queueNonces while querying and not afterwards

## How to test it
- Load a Safe that has a recovery tx queued
- Observe the redux state

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
