### PR TITLE
Chore: prod build on staging (main)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: ./.github/workflows/build
         with:
           secrets: ${{ toJSON(secrets) }}
+          prod: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
## What it solves

In order to be able to test our app with production settings before a release, we'll be building and deploying a production version on staging from the main branch.

With this setup, https://safe-wallet-web.staging.5afe.dev can be used as a close-to-prod environment for pre-release testing.