### PR TITLE
Tests: Add Chrome version to smoke tests workflow

### DIFF
--- a/.github/workflows/ondemand.yml
+++ b/.github/workflows/ondemand.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: browser-actions/setup-chrome@v1
+
       - uses: ./.github/workflows/yarn
 
       - name: Install Cypress

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: browser-actions/setup-chrome@v1
+
       - uses: ./.github/workflows/yarn
 
       - name: Install Cypress

--- a/.github/workflows/safe-apps-e2e.yml
+++ b/.github/workflows/safe-apps-e2e.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: browser-actions/setup-chrome@v1
+
       - uses: ./.github/workflows/yarn
 
       - name: Install Cypress

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,10 +11,14 @@ jobs:
   e2e:
     runs-on: ubuntu-20.04
     name: Cypress Smoke tests
+    container:
+      image: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
+
     strategy:
       fail-fast: false
       matrix:
         containers: [1, 2, 3, 4, 5]
+
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,8 +11,6 @@ jobs:
   e2e:
     runs-on: ubuntu-20.04
     name: Cypress Smoke tests
-    container:
-      image: cypress/browsers:node-20.9.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
 
     strategy:
       fail-fast: false
@@ -21,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - uses: browser-actions/setup-chrome@v1
 
       - uses: ./.github/workflows/yarn
 

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
   trashAssetsBeforeRuns: true,
 
   retries: {
-    runMode: 1,
+    runMode: 2,
     openMode: 0,
   },
   e2e: {


### PR DESCRIPTION
## What it solves

Resolves #2825 

## How this PR fixes it

Recently it was noticed that some machines started to fail when running Cypress tests in parallel. This was due to different version of Chrome passed by random machines, where Cypress requires all machines pass identical environment. The fix was to use specific version of Chrome and add this step to our test workflows. 

Part of this task also included increasing number of test retries to reduce flaky tests. This will be observed and adjusted as needed. 