### PR TITLE
Fix: double scroll bar in safe apps

### DIFF
--- a/src/components/safe-apps/AppFrame/styles.module.css
+++ b/src/components/safe-apps/AppFrame/styles.module.css
@@ -4,6 +4,7 @@
 }
 
 .iframe {
+  display: block;
   height: 100%;
   width: 100%;
   overflow: auto;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -35,7 +35,6 @@ button {
 :root {
   --header-height: 52px;
   --footer-height: 67px;
-  --import-export-widget-height: 166px;
 }
 
 input::-webkit-outer-spin-button,


### PR DESCRIPTION
## What it solves

Resolves #2827

## How this PR fixes it
The iframe was inline-block which created an extra 6px space below it, causing an unnecessary scrollbar on the body.