### PR TITLE
Feat: track app version in all events

### DIFF
--- a/src/services/analytics/__tests__/gtm.test.ts
+++ b/src/services/analytics/__tests__/gtm.test.ts
@@ -1,18 +1,140 @@
-import { normalizeAppName } from '../gtm'
+import * as gtm from '../gtm'
+import TagManager from '../TagManager'
+import { EventType, DeviceType } from '../types'
+
+// Mock dependencies
+jest.mock('../TagManager', () => ({
+  initialize: jest.fn(),
+  dataLayer: jest.fn(),
+  enableCookies: jest.fn(),
+  disableCookies: jest.fn(),
+  setUserProperty: jest.fn(),
+}))
 
 const FAKE_SAFE_APP_NAME = 'Safe App'
 const FAKE_DOMAIN = 'http://domain.crypto'
 
 describe('gtm', () => {
+  // Reset mocks before each test
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
   describe('normalizeAppName', () => {
     it('should return the app name if is not an URL', () => {
-      expect(normalizeAppName(FAKE_SAFE_APP_NAME)).toBe(FAKE_SAFE_APP_NAME)
+      expect(gtm.normalizeAppName(FAKE_SAFE_APP_NAME)).toBe(FAKE_SAFE_APP_NAME)
     })
 
     it('should strip the querystring or hash when is an URL', () => {
-      expect(normalizeAppName(FAKE_DOMAIN)).toBe(FAKE_DOMAIN)
-      expect(normalizeAppName(`${FAKE_DOMAIN}?q1=query1&q2=query2`)).toBe(FAKE_DOMAIN)
-      expect(normalizeAppName(`${FAKE_DOMAIN}#hash`)).toBe(FAKE_DOMAIN)
+      expect(gtm.normalizeAppName(FAKE_DOMAIN)).toBe(FAKE_DOMAIN)
+      expect(gtm.normalizeAppName(`${FAKE_DOMAIN}?q1=query1&q2=query2`)).toBe(FAKE_DOMAIN)
+      expect(gtm.normalizeAppName(`${FAKE_DOMAIN}#hash`)).toBe(FAKE_DOMAIN)
+    })
+  })
+
+  describe('gtmInit', () => {
+    gtm.gtmInit()
+
+    expect(TagManager.initialize).toHaveBeenCalledWith({
+      auth: expect.any(String),
+      gtmId: expect.any(String),
+      preview: 'env-3',
+    })
+  })
+
+  describe('gtmTrack', () => {
+    it('should send correct data to the dataLayer', () => {
+      const mockEventData = {
+        event: EventType.CLICK,
+        category: 'testCategory',
+        action: 'testAction',
+        chainId: '1234',
+        label: 'testLabel',
+      }
+
+      gtm.gtmTrack(mockEventData)
+
+      expect(TagManager.dataLayer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: mockEventData.event,
+          eventCategory: mockEventData.category,
+          eventAction: mockEventData.action,
+          chainId: mockEventData.chainId,
+          eventLabel: mockEventData.label,
+          appVersion: expect.any(String),
+          deviceType: DeviceType.DESKTOP,
+        }),
+      )
+    })
+
+    it('should set the chain ID correctly', () => {
+      const testChainId = '1234'
+      gtm.gtmSetChainId(testChainId)
+
+      const mockEventData = {
+        event: EventType.CLICK,
+        category: 'testCategory',
+        action: 'testAction',
+        label: 'testLabel',
+      }
+
+      gtm.gtmTrack(mockEventData)
+
+      expect(TagManager.dataLayer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: mockEventData.event,
+          eventCategory: mockEventData.category,
+          eventAction: mockEventData.action,
+          chainId: testChainId,
+          eventLabel: mockEventData.label,
+          appVersion: expect.any(String),
+          deviceType: DeviceType.DESKTOP,
+        }),
+      )
+    })
+  })
+
+  describe('gtmTrackSafeApp', () => {
+    it('should send correct data to the dataLayer for a Safe App event', () => {
+      Object.defineProperty(window, 'location', {
+        writable: true,
+        value: {
+          pathname: '/apps',
+        },
+      })
+
+      const mockEventData = {
+        event: EventType.SAFE_APP,
+        category: 'testCategory',
+        action: 'testAction',
+        label: 'testLabel',
+        chainId: '1234',
+      }
+
+      const mockAppName = 'Test App'
+      const mockSdkEventData = {
+        method: 'testMethod',
+        ethMethod: 'testEthMethod',
+        version: '1.0.0',
+      }
+
+      gtm.gtmTrackSafeApp(mockEventData, mockAppName, mockSdkEventData)
+
+      expect(TagManager.dataLayer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appVersion: expect.any(String),
+          chainId: expect.any(String),
+          deviceType: DeviceType.DESKTOP,
+          event: EventType.SAFE_APP,
+          eventAction: 'testAction',
+          eventCategory: 'testCategory',
+          eventLabel: 'testLabel',
+          safeAddress: '',
+          safeAppEthMethod: '',
+          safeAppMethod: '',
+          safeAppName: 'Test App',
+          safeAppSDKVersion: '',
+        }),
+      )
     })
   })
 })

--- a/src/services/analytics/gtm.ts
+++ b/src/services/analytics/gtm.ts
@@ -22,6 +22,7 @@ import { SAFE_APPS_SDK_CATEGORY } from './events'
 import { getAbTest } from '../tracking/abTesting'
 import type { AbTest } from '../tracking/abTesting'
 import { AppRoutes } from '@/config/routes'
+import packageJson from '../../../package.json'
 
 type GTMEnvironment = 'LIVE' | 'LATEST' | 'DEVELOPMENT'
 type GTMEnvironmentArgs = Required<Pick<TagManagerArgs, 'auth' | 'preview'>>
@@ -42,6 +43,7 @@ const GTM_ENV_AUTH: Record<GTMEnvironment, GTMEnvironmentArgs> = {
 }
 
 const commonEventParams = {
+  appVersion: packageJson.version,
   chainId: '',
   deviceType: DeviceType.DESKTOP,
   safeAddress: '',


### PR DESCRIPTION
## What it solves

This PR adds a new custom tracking dimension, `appVersion`, which look like `v1.22.2`. Trackign the app version will help compare changes across releases.
