### PR TITLE
feat: skip recovery transactions

### DIFF
--- a/src/components/recovery/SkipRecoveryButton/index.tsx
+++ b/src/components/recovery/SkipRecoveryButton/index.tsx
@@ -6,6 +6,7 @@ import ErrorIcon from '@/public/images/notifications/error.svg'
 import IconButton from '@mui/material/IconButton'
 import CheckWallet from '@/components/common/CheckWallet'
 import { TxModalContext } from '@/components/tx-flow'
+import { SkipRecoveryFlow } from '@/components/tx-flow/flows/SkipRecovery'
 import type { RecoveryQueueItem } from '@/store/recoverySlice'
 
 export function SkipRecoveryButton({
@@ -21,8 +22,7 @@ export function SkipRecoveryButton({
     e.stopPropagation()
     e.preventDefault()
 
-    // TODO: Implement skip recovery flow
-    setTxFlow(undefined)
+    setTxFlow(<SkipRecoveryFlow recovery={recovery} />)
   }
 
   return (

--- a/src/components/sidebar/SidebarNavigation/index.tsx
+++ b/src/components/sidebar/SidebarNavigation/index.tsx
@@ -13,6 +13,8 @@ import { navItems } from './config'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { AppRoutes } from '@/config/routes'
 import useTxQueue from '@/hooks/useTxQueue'
+import { useAppSelector } from '@/store'
+import { selectAllRecoveryQueues } from '@/store/recoverySlice'
 
 const getSubdirectory = (pathname: string): string => {
   return pathname.split('/')[1]
@@ -23,6 +25,7 @@ const Navigation = (): ReactElement => {
   const { safe } = useSafeInfo()
   const currentSubdirectory = getSubdirectory(router.pathname)
   const hasQueuedTxs = Boolean(useTxQueue().page?.results.length)
+  const hasRecoveryTxs = Boolean(useAppSelector(selectAllRecoveryQueues).length)
 
   // Indicate whether the current Safe needs an upgrade
   const setupItem = navItems.find((item) => item.href === AppRoutes.settings.setup)
@@ -33,12 +36,12 @@ const Navigation = (): ReactElement => {
   // Route Transactions to Queue if there are queued txs, otherwise to History
   const getRoute = useCallback(
     (href: string) => {
-      if (href === AppRoutes.transactions.history && hasQueuedTxs) {
+      if (href === AppRoutes.transactions.history && (hasQueuedTxs || hasRecoveryTxs)) {
         return AppRoutes.transactions.queue
       }
       return href
     },
-    [hasQueuedTxs],
+    [hasQueuedTxs, hasRecoveryTxs],
   )
 
   return (

--- a/src/components/tx-flow/flows/SkipRecovery/SkipRecoveryFlowReview.tsx
+++ b/src/components/tx-flow/flows/SkipRecovery/SkipRecoveryFlowReview.tsx
@@ -1,0 +1,38 @@
+import { Typography } from '@mui/material'
+import { useContext, useEffect } from 'react'
+import type { ReactElement } from 'react'
+
+import { SafeTxContext } from '../../SafeTxProvider'
+import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
+import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
+import { getRecoverySkipTransaction } from '@/services/recovery/transaction'
+import { createTx } from '@/services/tx/tx-sender'
+import type { RecoveryQueueItem } from '@/store/recoverySlice'
+
+export function SkipRecoveryFlowReview({ recovery }: { recovery: RecoveryQueueItem }): ReactElement {
+  const web3ReadOnly = useWeb3ReadOnly()
+  const { setSafeTx, setSafeTxError } = useContext(SafeTxContext)
+
+  useEffect(() => {
+    if (!web3ReadOnly) {
+      return
+    }
+    const transaction = getRecoverySkipTransaction(recovery, web3ReadOnly)
+    createTx(transaction).then(setSafeTx).catch(setSafeTxError)
+  }, [setSafeTx, setSafeTxError, recovery, web3ReadOnly])
+
+  return (
+    <SignOrExecuteForm onSubmit={() => null} isBatchable={false}>
+      <Typography mb={2}>
+        To reject the recovery attempt, a separate transaction will be created to increase the nonce beyond the
+        proposal.
+      </Typography>
+
+      <Typography mb={2}>
+        Queue nonce: <b>{recovery.args.queueNonce.toNumber()}</b>
+      </Typography>
+
+      <Typography mb={2}>You will need to confirm the transaction with your currently connected wallet.</Typography>
+    </SignOrExecuteForm>
+  )
+}

--- a/src/components/tx-flow/flows/SkipRecovery/index.tsx
+++ b/src/components/tx-flow/flows/SkipRecovery/index.tsx
@@ -1,0 +1,13 @@
+import type { ReactElement } from 'react'
+
+import TxLayout from '../../common/TxLayout'
+import { SkipRecoveryFlowReview } from './SkipRecoveryFlowReview'
+import type { RecoveryQueueItem } from '@/store/recoverySlice'
+
+export function SkipRecoveryFlow({ recovery }: { recovery: RecoveryQueueItem }): ReactElement {
+  return (
+    <TxLayout title="Confirm transaction" subtitle="Skip recovery" step={0}>
+      <SkipRecoveryFlowReview recovery={recovery} />
+    </TxLayout>
+  )
+}


### PR DESCRIPTION
## What it solves

Resolves #2763

## How this PR fixes it

A new flow for skipping recovery transactions has been added which is opened via the "Skip" buttons in the transaction list.

Note: a hard refresh is required after skipping is executed but this will be fixed in a follow up PR.

## How to test it

1. Propose a recovery attempt.
2. Skip it via the transaction list.
3. Refresh and observe no more recovery attempts listed.

## Screenshots

![skip-recovery](https://github.com/safe-global/safe-wallet-web/assets/20442784/4fd797f9-e24f-4f50-a8d7-5bc0cd28dbf9)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
