### PR TITLE
Analytics: track wallet address

### DIFF
--- a/src/services/analytics/types.ts
+++ b/src/services/analytics/types.ts
@@ -32,4 +32,5 @@ export enum DeviceType {
 
 export enum AnalyticsUserProperties {
   WALLET_LABEL = 'walletLabel',
+  WALLET_ADDRESS = 'walletAddress',
 }

--- a/src/services/analytics/useGtm.ts
+++ b/src/services/analytics/useGtm.ts
@@ -37,7 +37,7 @@ const useGtm = () => {
   const isTablet = useMediaQuery(theme.breakpoints.down('md'))
   const deviceType = isMobile ? DeviceType.MOBILE : isTablet ? DeviceType.TABLET : DeviceType.DESKTOP
   const safeAddress = useSafeAddress()
-  const walletLabel = useWallet()?.label
+  const wallet = useWallet()
 
   // Initialize GTM
   useEffect(() => {
@@ -83,10 +83,16 @@ const useGtm = () => {
   }, [router.pathname])
 
   useEffect(() => {
-    if (walletLabel) {
-      gtmSetUserProperty(AnalyticsUserProperties.WALLET_LABEL, walletLabel)
+    if (wallet?.label) {
+      gtmSetUserProperty(AnalyticsUserProperties.WALLET_LABEL, wallet?.label)
     }
-  }, [walletLabel])
+  }, [wallet?.label])
+
+  useEffect(() => {
+    if (wallet?.address) {
+      gtmSetUserProperty(AnalyticsUserProperties.WALLET_ADDRESS, wallet?.address)
+    }
+  }, [wallet?.address])
 
   // Track meta events on app load
   useMetaEvents()


### PR DESCRIPTION
## What it solves

I've added a new user property `walletAddress`.
The Privacy Policy for this has been updated in #2840.

## How to test it

* Open the console
* Connect a wallet
* See that it logs a new GTM user property
