### PR TITLE
Fix ARM64 docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ RUN apk add --no-cache libc6-compat git python3 py3-pip make g++ libusb-dev eude
 WORKDIR /app
 COPY . .
 
+# Fix arm64 timeouts
+RUN yarn config set network-timeout 300000 && yarn global add node-gyp
+
 # install deps
 RUN yarn install --frozen-lockfile
 RUN yarn after-install


### PR DESCRIPTION
- Add node-gyp before installing other packages
- Increase yarn timeout
