### PR TITLE
Analytics: add a Confirm transaction event

### DIFF
--- a/src/hooks/useTxTracking.ts
+++ b/src/hooks/useTxTracking.ts
@@ -1,10 +1,12 @@
 import { trackEvent, WALLET_EVENTS } from '@/services/analytics'
+import { TX_EVENTS } from '@/services/analytics/events/transactions'
 import { getTxDetails } from '@/services/tx/txDetails'
 import { TxEvent, txSubscribe } from '@/services/tx/txEvents'
 import { useEffect } from 'react'
 import useChainId from './useChainId'
 
 const events = {
+  [TxEvent.SIGNATURE_PROPOSED]: TX_EVENTS.CONFIRM,
   [TxEvent.SIGNED]: WALLET_EVENTS.OFFCHAIN_SIGNATURE,
   [TxEvent.PROCESSING]: WALLET_EVENTS.ONCHAIN_INTERACTION,
   [TxEvent.PROCESSING_MODULE]: WALLET_EVENTS.ONCHAIN_INTERACTION,

--- a/src/services/analytics/events/transactions.ts
+++ b/src/services/analytics/events/transactions.ts
@@ -37,4 +37,9 @@ export const TX_EVENTS = {
     category: TX_CATEGORY,
     // label: TX_TYPES,
   },
+  CONFIRM: {
+    event: EventType.META,
+    action: 'Confirm transaction',
+    category: TX_CATEGORY,
+  },
 }


### PR DESCRIPTION
## What it solves

In #2787, we added a new event `Create transaction`. Since a signature is required for both tx creation and confirmation, we cannot use the existing `Off-chain signature` event to track signatures for existing transactions.
So I've added another event, `Confirm transaction` to track specifically those kind of signatures.