### PR TITLE
feat: recovery email settings structure

### DIFF
--- a/src/components/settings/RecoveryEmail/AddEmailDialog.tsx
+++ b/src/components/settings/RecoveryEmail/AddEmailDialog.tsx
@@ -1,0 +1,48 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  TextField,
+} from '@mui/material'
+import type { ReactElement } from 'react'
+
+import CloseIcon from '@/public/images/common/close.svg'
+
+import css from './styles.module.css'
+
+export default function AddEmailDialog({ open, onClose }: { open: boolean; onClose: () => void }): ReactElement {
+  const onConfirm = () => {
+    // TODO: Implement
+    onClose()
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} className={css.dialog}>
+      <DialogTitle className={css.title}>
+        Add email address
+        <IconButton onClick={onClose} className={css.close}>
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent dividers className={css.content}>
+        <DialogContentText color="text.primary" mb={3}>
+          You will need to sign a message to verify that you are the owner of this Safe Account.
+        </DialogContentText>
+
+        <TextField type="email" label="Email address" variant="outlined" fullWidth InputLabelProps={{ shrink: true }} />
+      </DialogContent>
+
+      <DialogActions className={css.actions}>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button variant="contained" onClick={onConfirm}>
+          Continue
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/src/components/settings/RecoveryEmail/index.tsx
+++ b/src/components/settings/RecoveryEmail/index.tsx
@@ -1,0 +1,89 @@
+import { Button, Grid, Paper, SvgIcon, Typography } from '@mui/material'
+import { VisibilityOutlined } from '@mui/icons-material'
+import { useState } from 'react'
+import type { ReactElement } from 'react'
+
+import ExternalLink from '@/components/common/ExternalLink'
+import AddEmailDialog from './AddEmailDialog'
+import EditIcon from '@/public/images/common/edit.svg'
+
+import css from './styles.module.css'
+
+export function RecoveryEmail(): ReactElement {
+  const [addEmail, setAddEmail] = useState(false)
+
+  const onAdd = () => {
+    setAddEmail(true)
+  }
+
+  const onReveal = () => {
+    // TODO: Implement
+  }
+
+  const onChange = () => {}
+
+  const onClose = () => {}
+
+  const randomString = Math.random().toString(36)
+
+  return (
+    <>
+      <Paper sx={{ p: 4, mb: 2 }}>
+        <Grid container spacing={3}>
+          <Grid item sm={4} xs={12}>
+            <Typography variant="h4" fontWeight={700}>
+              Recovery email
+            </Typography>
+          </Grid>
+
+          <Grid item xs>
+            <Typography mb={2}>
+              Receive important notifications about recovery attempts and their status. No spam. We promise!{' '}
+              {/* TODO: Add link */}
+              <ExternalLink href="#">Learn more</ExternalLink>
+            </Typography>
+
+            <div className={css.display}>
+              <div className={css.email}>
+                <VisibilityOutlined fontSize="small" />
+                <Typography variant="body2" fontWeight={700}>
+                  {randomString + randomString}
+                </Typography>
+                <div className={css.blur} />
+              </div>
+
+              <div className={css.buttons}>
+                <Button
+                  onClick={onReveal}
+                  variant="contained"
+                  size="small"
+                  startIcon={<VisibilityOutlined />}
+                  className={css.button}
+                  disableElevation
+                >
+                  Reveal
+                </Button>
+                <Button
+                  onClick={onChange}
+                  variant="contained"
+                  size="small"
+                  startIcon={<SvgIcon component={EditIcon} inheritViewBox />}
+                  className={css.button}
+                  disableElevation
+                >
+                  Change
+                </Button>
+              </div>
+            </div>
+
+            <Button variant="contained" onClick={onAdd}>
+              Add email address
+            </Button>
+          </Grid>
+        </Grid>
+      </Paper>
+
+      <AddEmailDialog open={addEmail} onClose={onClose} />
+    </>
+  )
+}

--- a/src/components/settings/RecoveryEmail/styles.module.css
+++ b/src/components/settings/RecoveryEmail/styles.module.css
@@ -1,0 +1,72 @@
+/* Settings */
+
+.display {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: var(--color-background-main);
+  border: 1px solid var(--color-border-light);
+  border-radius: 6px;
+  padding: var(--space-1);
+  padding-left: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.email {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  position: relative;
+}
+
+.blur {
+  backdrop-filter: blur(6px);
+  border-radius: 6px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: calc(100% + var(--space-3));
+  width: calc(100% + var(--space-6));
+  transform: translate(calc(var(--space-2) * -1), calc(calc(var(--space-1) * 1.5) * -1));
+}
+
+.buttons {
+  display: flex;
+  gap: var(--space-1);
+}
+
+.button {
+  color: var(--color-text-main);
+  border: 1px solid var(--color-border-light);
+  background-color: var(--color-background-paper);
+  padding-left: var(--space-2);
+  padding-right: var(--space-2);
+}
+
+/* Dialog */
+
+.dialog :global(.MuiDialog-paper) {
+  max-width: 500px;
+}
+
+.title {
+  display: flex;
+  align-items: center;
+  font-weight: 700;
+  padding-top: var(--space-3);
+}
+
+.close {
+  color: var(--color-text-secondary);
+  margin-left: auto;
+}
+
+.content {
+  padding: var(--space-2) var(--space-3) var(--space-4);
+}
+
+.actions {
+  display: flex;
+  justify-content: space-between;
+  padding: var(--space-3);
+}

--- a/src/components/tx-flow/common/OwnerList/index.tsx
+++ b/src/components/tx-flow/common/OwnerList/index.tsx
@@ -1,5 +1,5 @@
 import { Paper, Typography, SvgIcon } from '@mui/material'
-import type { SxProps } from '@mui/material'
+import type { PaperProps } from '@mui/material'
 import type { AddressEx } from '@safe-global/safe-gateway-typescript-sdk'
 import type { ReactElement } from 'react'
 
@@ -15,7 +15,7 @@ export function OwnerList({
 }: {
   owners: Array<AddressEx>
   title?: string
-  sx?: SxProps
+  sx?: PaperProps['sx']
 }): ReactElement {
   return (
     <Paper className={css.container} sx={sx}>

--- a/src/pages/settings/notifications.tsx
+++ b/src/pages/settings/notifications.tsx
@@ -5,11 +5,13 @@ import SettingsHeader from '@/components/settings/SettingsHeader'
 import { PushNotifications } from '@/components/settings/PushNotifications'
 import { useHasFeature } from '@/hooks/useChains'
 import { FEATURES } from '@/utils/chains'
+import { RecoveryEmail } from '@/components/settings/RecoveryEmail'
 
 const NotificationsPage: NextPage = () => {
   const isNotificationFeatureEnabled = useHasFeature(FEATURES.PUSH_NOTIFICATIONS)
+  const isRecoveryEnabled = useHasFeature(FEATURES.RECOVERY)
 
-  if (!isNotificationFeatureEnabled) {
+  if (!isNotificationFeatureEnabled || !isRecoveryEnabled) {
     return null
   }
 
@@ -22,7 +24,9 @@ const NotificationsPage: NextPage = () => {
       <SettingsHeader />
 
       <main>
-        <PushNotifications />
+        {isRecoveryEnabled && <RecoveryEmail />}
+
+        {isNotificationFeatureEnabled && <PushNotifications />}
       </main>
     </>
   )


### PR DESCRIPTION
## What it solves

Partially resolves #2757

## How this PR fixes it

This implements a basic setting structure and modal for adding a recovery email.

## How to test it

Open the "Notifications" setting and observe the new template structure, as well as modal that opens when clicking "Add email address".

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/d9c6ef79-a391-443a-bb45-c95fb6c49852)

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/3beea81a-bcc2-4b4f-bf3c-54c2fd59ae65)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
