### PR TITLE
Tests: Add tests schedule

### DIFF
--- a/.github/workflows/ondemand.yml
+++ b/.github/workflows/ondemand.yml
@@ -2,6 +2,8 @@ name: Regression on demand tests
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * 1-5'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## What it solves

Resolves #2856 

## How this PR fixes it

- To optimise testing efforts and ensure the timely detection and addressing of potential bugs, we need to enable Cypress tests to run on a daily basis.

