### PR TITLE
Tests: Add TestRail integration to CI

### DIFF
--- a/.github/workflows/e2e-ondemand.yml
+++ b/.github/workflows/e2e-ondemand.yml
@@ -22,6 +22,27 @@ jobs:
 
       - uses: ./.github/workflows/cypress
         with:
+          command: npx cypress run --reporter "junit" --reporter-options "mochaFile=reports/junit-[hash].xml,testsuitesTitle=Root Suite"
           secrets: ${{ toJSON(secrets) }}
           spec: cypress/e2e/**/*.cy.js
           group: 'Regression on demand tests'
+
+      - name: Python setup
+        if: always()
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+
+      - name: TestRail CLI upload results
+        if: always()
+        run: |
+          pip install trcli
+          trcli -y \
+          -h https:/https://gno.testrail.io/ \
+          --project "Safe- Web App" \
+          --username ${{ secrets.TESTRAIL_USERNAME }} \
+          --password ${{ secrets.TESTRAIL_PASSWORD }} \
+          parse_junit \
+          --title "Automated Tests, branch: ${GITHUB_REF_NAME}" \
+          --run-description ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \
+          -f "reports/junit*.xml"


### PR DESCRIPTION
## What it solves

Resolves #2859 

## How this PR fixes it

- To be able to generate test run reports in TestRail, this integration needs to be added to Cypress on demand tests. By doing this, we will get recorded results and will be able to track them going forward.