### PR TITLE
Tests: Add junitparser to TestRail in CI

### DIFF
--- a/.github/workflows/e2e-ondemand.yml
+++ b/.github/workflows/e2e-ondemand.yml
@@ -33,6 +33,14 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Install junitparser
+        run: |
+          pip install junitparser
+
+      - name: Merge JUnit reports for TestRail
+        run: |
+          junitparser merge --suite-name "Root Suite" --glob "reports/junit-*" "reports/junit-report.xml"
+
       - name: TestRail CLI upload results
         if: always()
         run: |
@@ -45,4 +53,4 @@ jobs:
           parse_junit \
           --title "Automated Tests, branch: ${GITHUB_REF_NAME}" \
           --run-description ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \
-          -f "reports/junit*.xml"
+          -f "reports/junit-report.xml"


### PR DESCRIPTION
## What it solves

Resolves #2859 

## How this PR fixes it

- In order for TestRail to accept JUnit tests reports, we need to generate a single report by merging already generated ones. 