### PR TITLE
fix: successfully connect after password recovery

### DIFF
--- a/src/components/common/SocialSigner/PasswordRecovery.tsx
+++ b/src/components/common/SocialSigner/PasswordRecovery.tsx
@@ -46,6 +46,7 @@ export const PasswordRecovery = ({
     setError(undefined)
     try {
       await recoverFactorWithPassword(data.password, storeDeviceFactor)
+
       onSuccess?.()
     } catch (e) {
       setError('Incorrect password')

--- a/src/components/common/SocialSigner/__tests__/SocialSignerLogin.test.tsx
+++ b/src/components/common/SocialSigner/__tests__/SocialSignerLogin.test.tsx
@@ -9,6 +9,7 @@ import { fireEvent } from '@testing-library/react'
 import { type ISocialWalletService } from '@/services/mpc/interfaces'
 import { connectedWalletBuilder } from '@/tests/builders/wallet'
 import { chainBuilder } from '@/tests/builders/chains'
+import PasswordRecoveryModal from '@/services/mpc/PasswordRecoveryModal'
 
 jest.mock('@/services/mpc/SocialWalletService')
 
@@ -35,6 +36,7 @@ describe('SocialSignerLogin', () => {
           isMPCLoginEnabled={true}
           onLogin={mockOnLogin}
         />
+        <PasswordRecoveryModal />
       </TxModalProvider>,
     )
 
@@ -63,6 +65,7 @@ describe('SocialSignerLogin', () => {
           isMPCLoginEnabled={true}
           onLogin={mockOnLogin}
         />
+        <PasswordRecoveryModal />
       </TxModalProvider>,
     )
 
@@ -85,6 +88,7 @@ describe('SocialSignerLogin', () => {
           isMPCLoginEnabled={true}
           onLogin={mockOnLogin}
         />
+        <PasswordRecoveryModal />
       </TxModalProvider>,
     )
 
@@ -113,7 +117,7 @@ describe('SocialSignerLogin', () => {
   it('should display Password Recovery form and display a Continue as button when login succeeds', async () => {
     const mockOnLogin = jest.fn()
     mockSocialWalletService.loginAndCreate = jest.fn(() => Promise.resolve(COREKIT_STATUS.REQUIRED_SHARE))
-    mockSocialWalletService.getUserInfo = jest.fn(undefined)
+    mockSocialWalletService.getUserInfo = jest.fn().mockReturnValue(undefined)
     mockSocialWalletService.recoverAccountWithPassword = jest.fn(() => Promise.resolve(true))
 
     const result = render(
@@ -125,6 +129,7 @@ describe('SocialSignerLogin', () => {
           isMPCLoginEnabled={true}
           onLogin={mockOnLogin}
         />
+        <PasswordRecoveryModal />
       </TxModalProvider>,
     )
 
@@ -153,13 +158,23 @@ describe('SocialSignerLogin', () => {
       submitButton.click()
     })
 
-    mockSocialWalletService.getUserInfo = jest.fn(
-      () =>
-        ({
-          email: 'test@testermann.com',
-          name: 'Test Testermann',
-          profileImage: 'test.testermann.local/profile.png',
-        } as unknown as UserInfo),
+    mockSocialWalletService.getUserInfo = jest.fn().mockReturnValue({
+      email: 'test@testermann.com',
+      name: 'Test Testermann',
+      profileImage: 'test.testermann.local/profile.png',
+    } as unknown as UserInfo)
+
+    result.rerender(
+      <TxModalProvider>
+        <SocialSigner
+          socialWalletService={mockSocialWalletService}
+          wallet={mockWallet}
+          supportedChains={['Goerli']}
+          isMPCLoginEnabled={true}
+          onLogin={mockOnLogin}
+        />
+        <PasswordRecoveryModal />
+      </TxModalProvider>,
     )
 
     await waitFor(() => {

--- a/src/components/common/SocialSigner/index.tsx
+++ b/src/components/common/SocialSigner/index.tsx
@@ -90,7 +90,6 @@ export const SocialSigner = ({
     }
   }
 
-  console.log('USER INFO:', userInfo)
   const isSocialLogin = isSocialLoginWallet(wallet?.label)
 
   return (

--- a/src/components/common/SocialSigner/index.tsx
+++ b/src/components/common/SocialSigner/index.tsx
@@ -2,7 +2,7 @@ import useSocialWallet from '@/hooks/wallets/mpc/useSocialWallet'
 import { type ISocialWalletService } from '@/services/mpc/interfaces'
 import { Box, Button, LinearProgress, SvgIcon, Tooltip, Typography } from '@mui/material'
 import { COREKIT_STATUS } from '@web3auth/mpc-core-kit'
-import { useCallback, useContext, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import GoogleLogo from '@/public/images/welcome/logo-google.svg'
 import InfoIcon from '@/public/images/notifications/info.svg'
 
@@ -16,7 +16,6 @@ import { isSocialWalletEnabled } from '@/hooks/wallets/wallets'
 import { isSocialLoginWallet } from '@/services/mpc/SocialLoginModule'
 import { CGW_NAMES } from '@/hooks/wallets/consts'
 import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
-import { TxModalContext } from '@/components/tx-flow'
 import madProps from '@/utils/mad-props'
 import { asError } from '@/services/exceptions/utils'
 import ErrorMessage from '@/components/tx/ErrorMessage'
@@ -60,24 +59,10 @@ export const SocialSigner = ({
 }: SocialSignerLoginProps) => {
   const [loginPending, setLoginPending] = useState<boolean>(false)
   const [loginError, setLoginError] = useState<string | undefined>(undefined)
-  const { setTxFlow } = useContext(TxModalContext)
   const userInfo = socialWalletService?.getUserInfo()
   const isDisabled = loginPending || !isMPCLoginEnabled
 
   const isWelcomePage = !!onLogin
-
-  const recoverPassword = useCallback(
-    async (password: string, storeDeviceFactor: boolean) => {
-      if (!socialWalletService) return
-
-      const success = await socialWalletService.recoverAccountWithPassword(password, storeDeviceFactor)
-
-      if (success) {
-        setTxFlow(undefined)
-      }
-    },
-    [setTxFlow, socialWalletService],
-  )
 
   const login = async () => {
     if (!socialWalletService) return
@@ -105,6 +90,7 @@ export const SocialSigner = ({
     }
   }
 
+  console.log('USER INFO:', userInfo)
   const isSocialLogin = isSocialLoginWallet(wallet?.label)
 
   return (

--- a/src/components/common/SocialSigner/index.tsx
+++ b/src/components/common/SocialSigner/index.tsx
@@ -3,7 +3,6 @@ import { type ISocialWalletService } from '@/services/mpc/interfaces'
 import { Box, Button, LinearProgress, SvgIcon, Tooltip, Typography } from '@mui/material'
 import { COREKIT_STATUS } from '@web3auth/mpc-core-kit'
 import { useCallback, useContext, useMemo, useState } from 'react'
-import { PasswordRecovery } from '@/components/common/SocialSigner/PasswordRecovery'
 import GoogleLogo from '@/public/images/welcome/logo-google.svg'
 import InfoIcon from '@/public/images/notifications/info.svg'
 
@@ -21,6 +20,7 @@ import { TxModalContext } from '@/components/tx-flow'
 import madProps from '@/utils/mad-props'
 import { asError } from '@/services/exceptions/utils'
 import ErrorMessage from '@/components/tx/ErrorMessage'
+import { open } from '@/services/mpc/PasswordRecoveryModal'
 
 export const _getSupportedChains = (chains: ChainInfo[]) => {
   return chains
@@ -94,8 +94,7 @@ export const SocialSigner = ({
 
       if (status === COREKIT_STATUS.REQUIRED_SHARE) {
         onRequirePassword?.()
-
-        setTxFlow(<PasswordRecovery recoverFactorWithPassword={recoverPassword} />, () => setLoginPending(false), false)
+        open(() => setLoginPending(false))
         return
       }
     } catch (err) {

--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -92,11 +92,19 @@ const isMobile = () => /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
 // Detect injected wallet
 const hasInjectedWallet = () => typeof window !== 'undefined' && !!window?.ethereum
 
+let isConnecting = false
+
 // Wrapper that tracks/sets the last used wallet
 export const connectWallet = async (
   onboard: OnboardAPI,
   options?: Parameters<OnboardAPI['connectWallet']>[0],
 ): Promise<WalletState[] | undefined> => {
+  if (isConnecting) {
+    return
+  }
+
+  isConnecting = true
+
   // On mobile, automatically choose WalletConnect if there is no injected wallet
   if (!options && isMobile() && !hasInjectedWallet()) {
     options = {
@@ -110,8 +118,12 @@ export const connectWallet = async (
     wallets = await onboard.connectWallet(options)
   } catch (e) {
     logError(Errors._302, e)
+    isConnecting = false
+
     return
   }
+
+  isConnecting = false
 
   return wallets
 }


### PR DESCRIPTION
## What it solves
The connect wallet request when connecting from the onboard module got stuck in a promise that never resolved after calling `connectWallet`.
Resolves #2863 

## How this PR fixes it
Does not allow two concurrent `connectWallet` requests.

## How to test it
- Ensure that for your social signer MFA is enabled
- Click connect wallet
- Select Social signer
- Login and recover password
- Observe the modal to close

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
