### PR TITLE
fix: filter Zodiac-deployed Delay Modifiers

### DIFF
--- a/src/components/recovery/RecoveryContext/__tests__/useRecoveryDelayModifiers.test.ts
+++ b/src/components/recovery/RecoveryContext/__tests__/useRecoveryDelayModifiers.test.ts
@@ -2,14 +2,14 @@ import { useHasFeature } from '@/hooks/useChains'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimitContracts'
-import { getDelayModifiers } from '@/services/recovery/delay-modifier'
+import { getRecoveryDelayModifiers } from '@/services/recovery/delay-modifier'
 import { addressExBuilder, safeInfoBuilder } from '@/tests/builders/safe'
 import { act, renderHook } from '@/tests/test-utils'
-import { useDelayModifiers } from '../useDelayModifiers'
+import { useRecoveryDelayModifiers } from '../useRecoveryDelayModifiers'
 
 jest.mock('@/services/recovery/delay-modifier')
 
-const mockGetDelayModifiers = getDelayModifiers as jest.MockedFunction<typeof getDelayModifiers>
+const mockGetRecoveryDelayModifiers = getRecoveryDelayModifiers as jest.MockedFunction<typeof getRecoveryDelayModifiers>
 
 jest.mock('@/hooks/useSafeInfo')
 jest.mock('@/hooks/wallets/web3')
@@ -19,7 +19,7 @@ const mockUseSafeInfo = useSafeInfo as jest.MockedFunction<typeof useSafeInfo>
 const mockUseWeb3ReadOnly = useWeb3ReadOnly as jest.MockedFunction<typeof useWeb3ReadOnly>
 const mockUseHasFeature = useHasFeature as jest.MockedFunction<typeof useHasFeature>
 
-describe('useDelayModifiers', () => {
+describe('useRecoveryDelayModifiers', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
@@ -34,7 +34,7 @@ describe('useDelayModifiers', () => {
     const safeInfo = { safe, safeAddress: safe.address.value }
     mockUseSafeInfo.mockReturnValue(safeInfo as any)
 
-    const { result } = renderHook(() => useDelayModifiers())
+    const { result } = renderHook(() => useRecoveryDelayModifiers())
 
     // Give enough time for loading to occur, if it will
     await act(async () => {
@@ -42,7 +42,7 @@ describe('useDelayModifiers', () => {
     })
 
     expect(result.current).toEqual([undefined, undefined, false])
-    expect(mockGetDelayModifiers).not.toHaveBeenCalledTimes(1)
+    expect(mockGetRecoveryDelayModifiers).not.toHaveBeenCalledTimes(1)
 
     jest.useRealTimers()
   })
@@ -56,7 +56,7 @@ describe('useDelayModifiers', () => {
     const safeInfo = { safe, safeAddress: safe.address.value }
     mockUseSafeInfo.mockReturnValue(safeInfo as any)
 
-    const { result } = renderHook(() => useDelayModifiers())
+    const { result } = renderHook(() => useRecoveryDelayModifiers())
 
     // Give enough time for loading to occur, if it will
     await act(async () => {
@@ -64,7 +64,7 @@ describe('useDelayModifiers', () => {
     })
 
     expect(result.current).toEqual([undefined, undefined, false])
-    expect(mockGetDelayModifiers).not.toHaveBeenCalledTimes(1)
+    expect(mockGetRecoveryDelayModifiers).not.toHaveBeenCalledTimes(1)
 
     jest.useRealTimers()
   })
@@ -79,7 +79,7 @@ describe('useDelayModifiers', () => {
     const safeInfo = { safe, safeAddress: safe.address.value }
     mockUseSafeInfo.mockReturnValue(safeInfo as any)
 
-    const { result } = renderHook(() => useDelayModifiers())
+    const { result } = renderHook(() => useRecoveryDelayModifiers())
 
     // Give enough time for loading to occur, if it will
     await act(async () => {
@@ -87,7 +87,7 @@ describe('useDelayModifiers', () => {
     })
 
     expect(result.current).toEqual([undefined, undefined, false])
-    expect(mockGetDelayModifiers).not.toHaveBeenCalledTimes(1)
+    expect(mockGetRecoveryDelayModifiers).not.toHaveBeenCalledTimes(1)
 
     jest.useRealTimers()
   })
@@ -105,7 +105,7 @@ describe('useDelayModifiers', () => {
     const safeInfo = { safe, safeAddress: safe.address.value }
     mockUseSafeInfo.mockReturnValue(safeInfo as any)
 
-    const { result } = renderHook(() => useDelayModifiers())
+    const { result } = renderHook(() => useRecoveryDelayModifiers())
 
     // Give enough time for loading to occur, if it will
     await act(async () => {
@@ -113,7 +113,7 @@ describe('useDelayModifiers', () => {
     })
 
     expect(result.current).toEqual([undefined, undefined, false])
-    expect(mockGetDelayModifiers).not.toHaveBeenCalledTimes(1)
+    expect(mockGetRecoveryDelayModifiers).not.toHaveBeenCalledTimes(1)
 
     jest.useRealTimers()
   })
@@ -129,8 +129,8 @@ describe('useDelayModifiers', () => {
     const safeInfo = { safe, safeAddress: safe.address.value }
     mockUseSafeInfo.mockReturnValue(safeInfo as any)
 
-    renderHook(() => useDelayModifiers())
+    renderHook(() => useRecoveryDelayModifiers())
 
-    expect(mockGetDelayModifiers).toHaveBeenCalledTimes(1)
+    expect(mockGetRecoveryDelayModifiers).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/components/recovery/RecoveryContext/index.tsx
+++ b/src/components/recovery/RecoveryContext/index.tsx
@@ -6,7 +6,7 @@ import { sameAddress } from '@/utils/addresses'
 import { getTxDetails } from '@/services/tx/txDetails'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { useRecoveryState } from './useRecoveryState'
-import { useDelayModifiers } from './useDelayModifiers'
+import { useRecoveryDelayModifiers } from './useRecoveryDelayModifiers'
 import type { AsyncResult } from '@/hooks/useAsync'
 import type { RecoveryState } from '@/services/recovery/recovery-state'
 
@@ -22,7 +22,7 @@ export const RecoveryContext = createContext<{
 export function RecoveryProvider({ children }: { children: ReactNode }): ReactElement {
   const { safe } = useSafeInfo()
 
-  const [delayModifiers, delayModifiersError, delayModifiersLoading] = useDelayModifiers()
+  const [delayModifiers, delayModifiersError, delayModifiersLoading] = useRecoveryDelayModifiers()
   const {
     data: [recoveryState, recoveryStateError, recoveryStateLoading],
     refetch,

--- a/src/components/recovery/RecoveryContext/useRecoveryDelayModifiers.ts
+++ b/src/components/recovery/RecoveryContext/useRecoveryDelayModifiers.ts
@@ -1,7 +1,7 @@
 import type { Delay } from '@gnosis.pm/zodiac'
 import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 
-import { getDelayModifiers } from '@/services/recovery/delay-modifier'
+import { getRecoveryDelayModifiers } from '@/services/recovery/delay-modifier'
 import { FEATURES } from '@/utils/chains'
 import useAsync from '@/hooks/useAsync'
 import { useHasFeature } from '@/hooks/useChains'
@@ -14,7 +14,7 @@ function isOnlySpendingLimitEnabled(chainId: string, modules: SafeInfo['modules'
   return modules?.length === 1 && modules[0].value === getSpendingLimitModuleAddress(chainId)
 }
 
-export function useDelayModifiers(): AsyncResult<Delay[]> {
+export function useRecoveryDelayModifiers(): AsyncResult<Delay[]> {
   const supportsRecovery = useHasFeature(FEATURES.RECOVERY)
   const web3ReadOnly = useWeb3ReadOnly()
   const { safe, safeAddress } = useSafeInfo()
@@ -29,11 +29,10 @@ export function useDelayModifiers(): AsyncResult<Delay[]> {
         safe.modules.length > 0 &&
         !isOnlySpendingLimitEnabled(safe.chainId, safe.modules)
       ) {
-        // TODO: Don't fetch _every_ Delay Modifier, but only those which _don't_ have Zodiac
-        // contracts as guardians. Zodiac only use the Delay Modifier with their contracts enabled
-        return getDelayModifiers(safe.chainId, safe.modules, web3ReadOnly)
+        return getRecoveryDelayModifiers(safe.chainId, safe.modules, web3ReadOnly)
       }
     },
+    // Only fetch delay modifiers again if the chain or enabled modules of current Safe changes
     // Need to check length of modules array to prevent new request every time Safe info polls
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [safeAddress, safe.chainId, safe.modules?.length, web3ReadOnly, supportsRecovery],

--- a/src/components/settings/Recovery/index.tsx
+++ b/src/components/settings/Recovery/index.tsx
@@ -69,6 +69,8 @@ export function Recovery(): ReactElement {
   const { setTxFlow } = useContext(TxModalContext)
   const [recovery] = useRecovery()
 
+  console.log(recovery)
+
   const rows = useMemo(() => {
     return recovery?.flatMap((delayModifier) => {
       const { guardians, txCooldown, txExpiration } = delayModifier
@@ -135,7 +137,7 @@ export function Recovery(): ReactElement {
             Enabling the Account recovery module will require a transactions.
           </Typography>
 
-          {recovery?.length === 0 ? (
+          {!recovery || recovery.length === 0 ? (
             <>
               <Alert severity="info">
                 Unhappy with the provided option? {/* TODO: Add link */}

--- a/src/components/settings/Recovery/index.tsx
+++ b/src/components/settings/Recovery/index.tsx
@@ -69,8 +69,6 @@ export function Recovery(): ReactElement {
   const { setTxFlow } = useContext(TxModalContext)
   const [recovery] = useRecovery()
 
-  console.log(recovery)
-
   const rows = useMemo(() => {
     return recovery?.flatMap((delayModifier) => {
       const { guardians, txCooldown, txExpiration } = delayModifier

--- a/src/services/recovery/__tests__/delay-modifier.test.ts
+++ b/src/services/recovery/__tests__/delay-modifier.test.ts
@@ -1,7 +1,9 @@
 import { faker } from '@faker-js/faker'
+import { KnownContracts } from '@gnosis.pm/zodiac'
+import type { Delay } from '@gnosis.pm/zodiac'
 import type { JsonRpcProvider } from '@ethersproject/providers'
 
-import { isOfficialDelayModifier } from '../delay-modifier'
+import { _getZodiacContract, _isOfficialRecoveryDelayModifier } from '../delay-modifier'
 import * as proxies from '../proxies'
 
 const DELAY_MODULE = {
@@ -11,30 +13,30 @@ const DELAY_MODULE = {
 const DELAY_MODULE_ADDRESSES = Object.values(DELAY_MODULE)
 
 describe('delay-modifier', () => {
-  describe('isOfficialDelayModifier', () => {
+  describe('getZodiacContract', () => {
     DELAY_MODULE_ADDRESSES.forEach((moduleAddress) => {
       it('should return true for an official Delay Modifier', async () => {
         const chainId = '5'
-        const bytecode = '0x' + faker.string.hexadecimal()
+        const bytecode = faker.string.hexadecimal()
         const provider = {
           getCode: () => Promise.resolve(bytecode),
         } as unknown as JsonRpcProvider
 
-        const isOfficial = await isOfficialDelayModifier(chainId, moduleAddress, provider)
-        expect(isOfficial).toBe(true)
+        const type = await _getZodiacContract(chainId, moduleAddress, provider)
+        expect(type).toBe(KnownContracts.DELAY)
       })
     })
 
     it('should otherwise return false', async () => {
       const chainId = '5'
       const moduleAddress = faker.finance.ethereumAddress()
-      const bytecode = '0x' + faker.string.hexadecimal()
+      const bytecode = faker.string.hexadecimal()
       const provider = {
         getCode: () => Promise.resolve(bytecode),
       } as unknown as JsonRpcProvider
 
-      const isOfficial = await isOfficialDelayModifier(chainId, moduleAddress, provider)
-      expect(isOfficial).toBe(false)
+      const type = await _getZodiacContract(chainId, moduleAddress, provider)
+      expect(type).toBe(undefined)
     })
 
     describe('generic proxies', () => {
@@ -42,7 +44,7 @@ describe('delay-modifier', () => {
         '0x363d3d373d3d3d363d73' + faker.string.hexadecimal({ length: 38 }) + '5af43d82803e903d91602b57fd5bf3'
 
       DELAY_MODULE_ADDRESSES.forEach((moduleAddress) => {
-        it('should return true for an official Delay Modifier', async () => {
+        it('should return the type for an official Delay Modifier', async () => {
           const chainId = '5'
           const proxyAddress = faker.finance.ethereumAddress()
           const bytecode = faker.string.hexadecimal()
@@ -52,12 +54,12 @@ describe('delay-modifier', () => {
 
           jest.spyOn(proxies, 'getGenericProxyMasterCopy').mockReturnValue(moduleAddress)
 
-          const isOfficial = await isOfficialDelayModifier(chainId, proxyAddress, provider)
-          expect(isOfficial).toBe(true)
+          const type = await _getZodiacContract(chainId, proxyAddress, provider)
+          expect(type).toBe(KnownContracts.DELAY)
         })
       })
 
-      it('should otherwise return false', async () => {
+      it('should otherwise return undefined', async () => {
         const chainId = '5'
         const proxyAddress = faker.finance.ethereumAddress()
         const moduleAddress = faker.finance.ethereumAddress()
@@ -68,8 +70,8 @@ describe('delay-modifier', () => {
 
         jest.spyOn(proxies, 'getGenericProxyMasterCopy').mockReturnValue(moduleAddress)
 
-        const isOfficial = await isOfficialDelayModifier(chainId, proxyAddress, provider)
-        expect(isOfficial).toBe(false)
+        const type = await _getZodiacContract(chainId, proxyAddress, provider)
+        expect(type).toBe(undefined)
       })
     })
 
@@ -78,7 +80,7 @@ describe('delay-modifier', () => {
         '0x608060405273ffffffffffffffffffffffffffffffffffffffff600054167fa619486e0000000000000000000000000000000000000000000000000000000060003514156050578060005260206000f35b3660008037600080366000845af43d6000803e60008114156070573d6000fd5b3d6000f3fea265627a7a72315820d8a00dc4fe6bf675a9d7416fc2d00bb3433362aa8186b750f76c4027269667ff64736f6c634300050e0032'
 
       DELAY_MODULE_ADDRESSES.forEach((moduleAddress) => {
-        it('should return true for an official Delay Modifier', async () => {
+        it('should return the type for an official Delay Modifier', async () => {
           const chainId = '5'
           const proxyAddress = faker.finance.ethereumAddress()
           const bytecode = faker.string.hexadecimal()
@@ -88,12 +90,12 @@ describe('delay-modifier', () => {
 
           jest.spyOn(proxies, 'getGnosisProxyMasterCopy').mockResolvedValue(moduleAddress)
 
-          const isOfficial = await isOfficialDelayModifier(chainId, proxyAddress, provider)
-          expect(isOfficial).toBe(true)
+          const type = await _getZodiacContract(chainId, proxyAddress, provider)
+          expect(type).toBe(KnownContracts.DELAY)
         })
       })
 
-      it('should otherwise return false', async () => {
+      it('should otherwise return undefined', async () => {
         const chainId = '5'
         const proxyAddress = faker.finance.ethereumAddress()
         const moduleAddress = faker.finance.ethereumAddress()
@@ -104,8 +106,41 @@ describe('delay-modifier', () => {
 
         jest.spyOn(proxies, 'getGnosisProxyMasterCopy').mockResolvedValue(moduleAddress)
 
-        const isOfficial = await isOfficialDelayModifier(chainId, proxyAddress, provider)
-        expect(isOfficial).toBe(false)
+        const type = await _getZodiacContract(chainId, proxyAddress, provider)
+        expect(type).toBe(undefined)
+      })
+    })
+  })
+
+  describe('isOfficialRecoveryDelayModifier', () => {
+    it('should return true if no Zodiac contract is enabled as a module', async () => {
+      const chainId = '5'
+      const bytecode = faker.string.hexadecimal()
+      const provider = {
+        getCode: () => Promise.resolve(bytecode),
+      } as unknown as JsonRpcProvider
+      const moduleAddress = faker.finance.ethereumAddress()
+      const delayModifier = {
+        getModulesPaginated: () => Promise.resolve([[moduleAddress]]),
+      } as unknown as Delay
+
+      const isRecoveryDelayModifier = await _isOfficialRecoveryDelayModifier(chainId, delayModifier, provider)
+      expect(isRecoveryDelayModifier).toBe(true)
+    })
+
+    DELAY_MODULE_ADDRESSES.forEach((moduleAddress) => {
+      it('should return false if a Zodiac contract is enabled as a module', async () => {
+        const chainId = '5'
+        const bytecode = faker.string.hexadecimal()
+        const provider = {
+          getCode: () => Promise.resolve(bytecode),
+        } as unknown as JsonRpcProvider
+        const delayModifier = {
+          getModulesPaginated: () => Promise.resolve([[moduleAddress]]),
+        } as unknown as Delay
+
+        const isRecoveryDelayModifier = await _isOfficialRecoveryDelayModifier(chainId, delayModifier, provider)
+        expect(isRecoveryDelayModifier).toBe(false)
       })
     })
   })

--- a/src/services/recovery/delay-modifier.ts
+++ b/src/services/recovery/delay-modifier.ts
@@ -1,26 +1,28 @@
 import { ContractVersions, getModuleInstance, KnownContracts } from '@gnosis.pm/zodiac'
+import { SENTINEL_ADDRESS } from '@safe-global/safe-core-sdk/dist/src/utils/constants'
 import type { Delay, SupportedNetworks } from '@gnosis.pm/zodiac'
 import type { JsonRpcProvider } from '@ethersproject/providers'
 import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 
 import { sameAddress } from '@/utils/addresses'
 import { getGenericProxyMasterCopy, getGnosisProxyMasterCopy, isGenericProxy, isGnosisProxy } from './proxies'
+import { MAX_GUARDIAN_PAGE_SIZE } from './recovery-state'
 
-export async function isOfficialDelayModifier(
+export async function _getZodiacContract(
   chainId: string,
   moduleAddress: string,
   provider: JsonRpcProvider,
-): Promise<boolean> {
+): Promise<string | undefined> {
   const bytecode = await provider.getCode(moduleAddress)
 
   if (isGenericProxy(bytecode)) {
     const masterCopy = getGenericProxyMasterCopy(bytecode)
-    return await isOfficialDelayModifier(chainId, masterCopy, provider)
+    return await _getZodiacContract(chainId, masterCopy, provider)
   }
 
   if (isGnosisProxy(bytecode)) {
     const masterCopy = await getGnosisProxyMasterCopy(moduleAddress, provider)
-    return await isOfficialDelayModifier(chainId, masterCopy, provider)
+    return await _getZodiacContract(chainId, masterCopy, provider)
   }
 
   const zodiacChainContracts = ContractVersions[Number(chainId) as SupportedNetworks]
@@ -30,10 +32,34 @@ export async function isOfficialDelayModifier(
     })
   })
 
-  return zodiacContract?.[0] === KnownContracts.DELAY
+  return zodiacContract?.[0]
 }
 
-export async function getDelayModifiers(
+async function isOfficialDelayModifier(chainId: string, moduleAddress: string, provider: JsonRpcProvider) {
+  const zodiacContract = await _getZodiacContract(chainId, moduleAddress, provider)
+  return zodiacContract === KnownContracts.DELAY
+}
+
+export async function _isOfficialRecoveryDelayModifier(
+  chainId: string,
+  delayModifier: Delay,
+  provider: JsonRpcProvider,
+) {
+  // Zodiac-deployed Delay Modifiers only have other Zodiac contracts added as modules
+  // If Delay Modifier only has non-Zodiac contracts as modules, it's a recovery-specific Delay Modifier
+  const [modules] = await delayModifier.getModulesPaginated(SENTINEL_ADDRESS, MAX_GUARDIAN_PAGE_SIZE)
+
+  if (modules.length === 0) {
+    return false
+  }
+
+  const types = await Promise.all(modules.map((module) => _getZodiacContract(chainId, module, provider)))
+
+  const knownContracts = Object.values(KnownContracts)
+  return types.every((type) => !knownContracts.includes(type as KnownContracts))
+}
+
+export async function getRecoveryDelayModifiers(
   chainId: string,
   modules: SafeInfo['modules'],
   provider: JsonRpcProvider,
@@ -42,17 +68,21 @@ export async function getDelayModifiers(
     return []
   }
 
-  const instances = await Promise.all(
+  const delayModifiers = await Promise.all(
     modules.map(async ({ value }) => {
       const isDelayModifier = await isOfficialDelayModifier(chainId, value, provider)
-
-      if (!isDelayModifier) {
-        return null
-      }
-
-      return getModuleInstance(KnownContracts.DELAY, value, provider)
+      return isDelayModifier && getModuleInstance(KnownContracts.DELAY, value, provider)
     }),
-  )
+  ).then((instances) => instances.filter(Boolean) as Array<Delay>)
 
-  return instances.filter(Boolean) as Array<Delay>
+  const recoveryDelayModifiers = await Promise.all(
+    delayModifiers.map(async (delayModifier) => {
+      // TODO: Fetches "guardians" of Delay Modifier, but we later fetch them again
+      // in useRecoveryState. Could optimise this by returning the guardians here
+      const isRecoveryDelayModifier = await _isOfficialRecoveryDelayModifier(chainId, delayModifier, provider)
+      return isRecoveryDelayModifier && delayModifier
+    }),
+  ).then((instances) => instances.filter(Boolean) as Array<Delay>)
+
+  return recoveryDelayModifiers
 }


### PR DESCRIPTION
## What it solves

Resolves Zodiac-deployed Delay Modifiers from showing as recovery guardians

## How this PR fixes it

The modules of a Delay Modifier are iterated over checked whether they are other Zodiac contracts. (Zodiac only either deploy the Delay Modifier _without_ modules and/or with [Zodiac contracts as modules](https://github.com/gnosis/zodiac-safe-app/blob/e5d6d3d251d128245104ddc638e26d290689bb14/packages/app/src/views/AddModule/wizards/RealityModule/service/moduleDeployment.ts#L88).) In contrasts, we deploy the Delay Modifier with non-Zodiac contracts added enables as modules.

## How to test it

Enable a Delay Modifier via the Zodiac Safe App directly, or alternatively by enabling the Reality module. Observe that neither appears in the recovery settings of the Safe.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
