### PR TITLE
feat: recovery attempt + cancellation grouping

### DIFF
--- a/src/components/common/PaginatedTxns/index.tsx
+++ b/src/components/common/PaginatedTxns/index.tsx
@@ -52,7 +52,7 @@ const TxPage = ({
 
       {page && page.results.length > 0 && <TxList items={page.results} />}
 
-      {isQueue && page?.results.length === 0 && recoveryQueue.lengh === 0 && !hasPending && <NoQueuedTxns />}
+      {isQueue && page?.results.length === 0 && recoveryQueue.length === 0 && !hasPending && <NoQueuedTxns />}
 
       {error && <ErrorMessage>Error loading transactions</ErrorMessage>}
 

--- a/src/components/common/PaginatedTxns/index.tsx
+++ b/src/components/common/PaginatedTxns/index.tsx
@@ -13,6 +13,7 @@ import { isTransactionListItem } from '@/utils/transaction-guards'
 import NoTransactionsIcon from '@/public/images/transactions/no-transactions.svg'
 import { useHasPendingTxs } from '@/hooks/usePendingTxs'
 import useSafeInfo from '@/hooks/useSafeInfo'
+import { useRecoveryQueue } from '@/hooks/useRecoveryQueue'
 
 const NoQueuedTxns = () => {
   return <PagePlaceholder img={<NoTransactionsIcon />} text="Queued transactions will appear here" />
@@ -38,6 +39,7 @@ const TxPage = ({
   const { page, error, loading } = useTxns(pageUrl)
   const [filter] = useTxFilter()
   const isQueue = useTxns === useTxQueue
+  const recoveryQueue = useRecoveryQueue()
   const hasPending = useHasPendingTxs()
 
   return (
@@ -50,7 +52,7 @@ const TxPage = ({
 
       {page && page.results.length > 0 && <TxList items={page.results} />}
 
-      {isQueue && page?.results.length === 0 && !hasPending && <NoQueuedTxns />}
+      {isQueue && page?.results.length === 0 && recoveryQueue.lengh === 0 && !hasPending && <NoQueuedTxns />}
 
       {error && <ErrorMessage>Error loading transactions</ErrorMessage>}
 

--- a/src/components/dashboard/PendingTxs/PendingTxsList.tsx
+++ b/src/components/dashboard/PendingTxs/PendingTxsList.tsx
@@ -9,7 +9,7 @@ import useTxQueue from '@/hooks/useTxQueue'
 import { AppRoutes } from '@/config/routes'
 import NoTransactionsIcon from '@/public/images/transactions/no-transactions.svg'
 import css from './styles.module.css'
-import { isSignableBy, isExecutable } from '@/utils/transaction-guards'
+import { isSignableBy, isExecutable, isRecoveryQueueItem } from '@/utils/transaction-guards'
 import useWallet from '@/hooks/wallets/useWallet'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { useRecoveryQueue } from '@/hooks/useRecoveryQueue'
@@ -71,10 +71,6 @@ export function _getTransactionsToDisplay({
   const queueToDisplay = _queue.slice(0, MAX_TXS - recoveryQueue.length)
 
   return [...recoveryQueue, ...queueToDisplay]
-}
-
-function isRecoveryQueueItem(tx: Transaction | RecoveryQueueItem): tx is RecoveryQueueItem {
-  return 'args' in tx
 }
 
 const PendingTxsList = (): ReactElement | null => {

--- a/src/components/recovery/GroupedRecoveryListItems/index.tsx
+++ b/src/components/recovery/GroupedRecoveryListItems/index.tsx
@@ -21,7 +21,7 @@ function Disclaimer({ isMalicious }: { isMalicious: boolean }): ReactElement {
         <Typography component="span" fontWeight={700}>
           Cancelling {isMalicious ? 'malicious transaction' : 'Account recovery'}.
         </Typography>{' '}
-        You can approve or reject the cancellation.{' '}
+        You will need to execute the cancellation.{' '}
         <ExternalLink
           // TODO: Add link
           href="#"

--- a/src/components/recovery/GroupedRecoveryListItems/index.tsx
+++ b/src/components/recovery/GroupedRecoveryListItems/index.tsx
@@ -19,7 +19,7 @@ function Disclaimer({ isMalicious }: { isMalicious: boolean }): ReactElement {
     >
       <Typography>
         <Typography component="span" fontWeight={700}>
-          Rejecting {isMalicious ? 'malicious transaction' : 'Account recovery'}.
+          Cancelling {isMalicious ? 'malicious transaction' : 'Account recovery'}.
         </Typography>{' '}
         You can approve or reject the cancellation.{' '}
         <ExternalLink

--- a/src/components/recovery/GroupedRecoveryListItems/index.tsx
+++ b/src/components/recovery/GroupedRecoveryListItems/index.tsx
@@ -1,0 +1,56 @@
+import { Box, Paper, Typography } from '@mui/material'
+import { partition } from 'lodash'
+import type { RecoveryQueueItem } from '@/services/recovery/recovery-state'
+import type { Transaction } from '@safe-global/safe-gateway-typescript-sdk'
+import type { ReactElement } from 'react'
+
+import { isRecoveryQueueItem } from '@/utils/transaction-guards'
+import ExpandableTransactionItem from '@/components/transactions/TxListItem/ExpandableTransactionItem'
+import { RecoveryListItem } from '../RecoveryListItem'
+import ExternalLink from '@/components/common/ExternalLink'
+
+import css from '@/components/transactions/GroupedTxListItems/styles.module.css'
+
+function Disclaimer({ isMalicious }: { isMalicious: boolean }): ReactElement {
+  return (
+    <Box
+      className={css.disclaimerContainer}
+      sx={{ bgcolor: ({ palette }) => `${palette.warning.background} !important` }}
+    >
+      <Typography>
+        <Typography component="span" fontWeight={700}>
+          Rejecting {isMalicious ? 'malicious transaction' : 'Account recovery'}.
+        </Typography>{' '}
+        You can approve or reject the cancellation.{' '}
+        <ExternalLink
+          // TODO: Add link
+          href="#"
+          title="Learn more about Account recovery"
+        >
+          Learn more
+        </ExternalLink>
+      </Typography>
+    </Box>
+  )
+}
+
+export function GroupedRecoveryListItems({ items }: { items: Array<Transaction | RecoveryQueueItem> }): ReactElement {
+  const [recoveries, cancellations] = partition(items, isRecoveryQueueItem)
+
+  // Should only be one recovery item but check array in case
+  const isMalicious = recoveries.some((recovery) => recovery.isMalicious)
+
+  return (
+    <Paper className={css.container} variant="outlined" sx={{ borderColor: ({ palette }) => palette.warning.light }}>
+      <Disclaimer isMalicious={isMalicious} />
+
+      {cancellations.map((tx) => (
+        <ExpandableTransactionItem key={tx.transaction.id} item={tx} />
+      ))}
+
+      {recoveries.map((recovery) => (
+        <RecoveryListItem key={recovery.transactionHash} item={recovery} />
+      ))}
+    </Paper>
+  )
+}

--- a/src/components/recovery/RecoveryList/index.tsx
+++ b/src/components/recovery/RecoveryList/index.tsx
@@ -1,15 +1,21 @@
+import { useMemo } from 'react'
 import type { ReactElement } from 'react'
 
 import { TxListGrid } from '@/components/transactions/TxList'
 import { RecoveryListItem } from '@/components/recovery/RecoveryListItem'
 import { useRecoveryQueue } from '@/hooks/useRecoveryQueue'
+import { groupRecoveryTransactions } from '@/utils/tx-list'
+import useTxQueue from '@/hooks/useTxQueue'
+import { GroupedRecoveryListItems } from '../GroupedRecoveryListItems'
+import { isRecoveryQueueItem } from '@/utils/transaction-guards'
+import type { RecoveryQueueItem } from '@/services/recovery/recovery-state'
 
 import labelCss from '@/components/transactions/GroupLabel/styles.module.css'
 
 export function RecoveryList(): ReactElement | null {
-  const queue = useRecoveryQueue()
+  const recoveryQueue = useRecoveryQueue()
 
-  if (queue.length === 0) {
+  if (recoveryQueue.length === 0) {
     return null
   }
 
@@ -18,10 +24,37 @@ export function RecoveryList(): ReactElement | null {
       <div className={labelCss.container}>Pending recovery</div>
 
       <TxListGrid>
-        {queue.map((item) => (
-          <RecoveryListItem item={item} key={item.transactionHash} />
-        ))}
+        <_RecoveryList recoveryQueue={recoveryQueue} />
       </TxListGrid>
     </>
   )
+}
+
+// Conditional hook
+function _RecoveryList({ recoveryQueue }: { recoveryQueue: Array<RecoveryQueueItem> }): ReactElement {
+  const queue = useTxQueue()
+
+  const groupedItems = useMemo(() => {
+    if (!queue?.page?.results || queue.page.results.length === 0) {
+      return recoveryQueue
+    }
+    return groupRecoveryTransactions(queue.page.results, recoveryQueue)
+  }, [queue, recoveryQueue])
+
+  const transactions = useMemo(() => {
+    return groupedItems.map((item, index) => {
+      if (Array.isArray(item)) {
+        return <GroupedRecoveryListItems items={item} key={index} />
+      }
+
+      if (isRecoveryQueueItem(item)) {
+        return <RecoveryListItem item={item} key={item.transactionHash} />
+      }
+
+      // Will never have non-recovery transactions here
+      return null
+    })
+  }, [groupedItems])
+
+  return <TxListGrid>{transactions}</TxListGrid>
 }

--- a/src/components/tx-flow/flows/RecoverAccount/RecoverAccountFlowReview.tsx
+++ b/src/components/tx-flow/flows/RecoverAccount/RecoverAccountFlowReview.tsx
@@ -53,6 +53,26 @@ export function RecoverAccountFlowReview({ params }: { params: RecoverAccountFlo
   const newThreshold = Number(params[RecoverAccountFlowFields.threshold])
   const newOwners = params[RecoverAccountFlowFields.owners]
 
+  const countdownPeriod = txCooldownCountdown
+    ? txCooldownCountdown.days > 0
+      ? txCooldownCountdown.days
+      : txCooldownCountdown.hours > 0
+      ? txCooldownCountdown.hours
+      : txCooldownCountdown.minutes > 0
+      ? txCooldownCountdown.minutes
+      : 0
+    : 0
+
+  const countdownUnit = txCooldownCountdown
+    ? txCooldownCountdown.days > 0
+      ? 'day'
+      : txCooldownCountdown.hours
+      ? 'hour'
+      : txCooldownCountdown.minutes
+      ? 'minute'
+      : ''
+    : ''
+
   useEffect(() => {
     const transactions = getRecoveryProposalTransactions({
       safe,
@@ -152,7 +172,7 @@ export function RecoverAccountFlowReview({ params }: { params: RecoverAccountFlo
           Recovery will be{' '}
           {txCooldown === 0
             ? 'immediately possible'
-            : `possible ${txCooldownCountdown?.days} day${txCooldownCountdown?.days === 1 ? '' : 's'}`}{' '}
+            : `possible ${countdownPeriod} ${countdownUnit}${countdownPeriod === 1 ? '' : 's'}`}{' '}
           after this transaction is executed.
         </ErrorMessage>
 

--- a/src/components/tx-flow/flows/RecoverAccount/RecoverAccountFlowReview.tsx
+++ b/src/components/tx-flow/flows/RecoverAccount/RecoverAccountFlowReview.tsx
@@ -53,26 +53,6 @@ export function RecoverAccountFlowReview({ params }: { params: RecoverAccountFlo
   const newThreshold = Number(params[RecoverAccountFlowFields.threshold])
   const newOwners = params[RecoverAccountFlowFields.owners]
 
-  const countdownPeriod = txCooldownCountdown
-    ? txCooldownCountdown.days > 0
-      ? txCooldownCountdown.days
-      : txCooldownCountdown.hours > 0
-      ? txCooldownCountdown.hours
-      : txCooldownCountdown.minutes > 0
-      ? txCooldownCountdown.minutes
-      : 0
-    : 0
-
-  const countdownUnit = txCooldownCountdown
-    ? txCooldownCountdown.days > 0
-      ? 'day'
-      : txCooldownCountdown.hours
-      ? 'hour'
-      : txCooldownCountdown.minutes
-      ? 'minute'
-      : ''
-    : ''
-
   useEffect(() => {
     const transactions = getRecoveryProposalTransactions({
       safe,
@@ -172,7 +152,7 @@ export function RecoverAccountFlowReview({ params }: { params: RecoverAccountFlo
           Recovery will be{' '}
           {txCooldown === 0
             ? 'immediately possible'
-            : `possible ${countdownPeriod} ${countdownUnit}${countdownPeriod === 1 ? '' : 's'}`}{' '}
+            : `possible ${txCooldownCountdown?.days} day${txCooldownCountdown?.days === 1 ? '' : 's'}`}{' '}
           after this transaction is executed.
         </ErrorMessage>
 

--- a/src/utils/__tests__/tx-list.test.ts
+++ b/src/utils/__tests__/tx-list.test.ts
@@ -166,11 +166,12 @@ describe('tx-list', () => {
   })
 
   describe('groupRecoveryTransactions', () => {
-    it('should group recovery transactions with their cancellations', () => {
+    it.only('should group recovery transactions with their cancellations', () => {
       const moduleAddress = faker.finance.ethereumAddress()
 
       const queue = [
         {
+          type: 'TRANSACTION',
           transaction: {
             txInfo: {
               type: TransactionInfoType.CUSTOM,
@@ -182,6 +183,7 @@ describe('tx-list', () => {
           },
         },
         {
+          type: 'TRANSACTION',
           transaction: {
             txInfo: {
               type: TransactionInfoType.TRANSFER,
@@ -189,6 +191,7 @@ describe('tx-list', () => {
           },
         },
         {
+          type: 'TRANSACTION',
           transaction: {
             txInfo: {
               type: TransactionInfoType.CUSTOM,
@@ -213,6 +216,7 @@ describe('tx-list', () => {
             address: moduleAddress,
           },
           {
+            type: 'TRANSACTION',
             transaction: {
               txInfo: {
                 type: TransactionInfoType.CUSTOM,

--- a/src/utils/__tests__/tx-list.test.ts
+++ b/src/utils/__tests__/tx-list.test.ts
@@ -1,6 +1,8 @@
+import { faker } from '@faker-js/faker'
+import { TransactionInfoType } from '@safe-global/safe-gateway-typescript-sdk'
 import type { TransactionListItem } from '@safe-global/safe-gateway-typescript-sdk'
 
-import { groupConflictingTxs } from '@/utils/tx-list'
+import { groupConflictingTxs, groupRecoveryTransactions, _getRecoveryCancellations } from '@/utils/tx-list'
 
 describe('tx-list', () => {
   describe('groupConflictingTxs', () => {
@@ -108,6 +110,121 @@ describe('tx-list', () => {
 
       const result = groupConflictingTxs(list as unknown as TransactionListItem[])
       expect(result).toEqual(list)
+    })
+  })
+
+  describe('getRecoveryCancellations', () => {
+    it('should return cancellation transactions', () => {
+      const moduleAddress = faker.finance.ethereumAddress()
+
+      const transactions = [
+        {
+          transaction: {
+            txInfo: {
+              type: TransactionInfoType.CUSTOM,
+              to: {
+                value: moduleAddress,
+              },
+              methodName: 'enableModule',
+            },
+          },
+        },
+        {
+          transaction: {
+            txInfo: {
+              type: TransactionInfoType.TRANSFER,
+            },
+          },
+        },
+        {
+          transaction: {
+            txInfo: {
+              type: TransactionInfoType.CUSTOM,
+              to: {
+                value: moduleAddress,
+              },
+              methodName: 'setTxNonce',
+            },
+          },
+        },
+      ]
+
+      expect(_getRecoveryCancellations(moduleAddress, transactions as any)).toEqual([
+        {
+          transaction: {
+            txInfo: {
+              type: TransactionInfoType.CUSTOM,
+              to: {
+                value: moduleAddress,
+              },
+              methodName: 'setTxNonce',
+            },
+          },
+        },
+      ])
+    })
+  })
+
+  describe('groupRecoveryTransactions', () => {
+    it('should group recovery transactions with their cancellations', () => {
+      const moduleAddress = faker.finance.ethereumAddress()
+
+      const queue = [
+        {
+          transaction: {
+            txInfo: {
+              type: TransactionInfoType.CUSTOM,
+              to: {
+                value: moduleAddress,
+              },
+              methodName: 'enableModule',
+            },
+          },
+        },
+        {
+          transaction: {
+            txInfo: {
+              type: TransactionInfoType.TRANSFER,
+            },
+          },
+        },
+        {
+          transaction: {
+            txInfo: {
+              type: TransactionInfoType.CUSTOM,
+              to: {
+                value: moduleAddress,
+              },
+              methodName: 'setTxNonce',
+            },
+          },
+        },
+      ]
+
+      const recoveryQueue = [
+        {
+          address: moduleAddress,
+        },
+      ]
+
+      expect(groupRecoveryTransactions(queue as any, recoveryQueue as any)).toEqual([
+        [
+          {
+            address: moduleAddress,
+          },
+          {
+            transaction: {
+              txInfo: {
+                type: TransactionInfoType.CUSTOM,
+                to: {
+                  value: moduleAddress,
+                },
+                methodName: 'setTxNonce',
+              },
+            },
+          },
+        ],
+      ])
     })
   })
 })

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -36,6 +36,7 @@ import {
 import { getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimitContracts'
 import { sameAddress } from '@/utils/addresses'
 import type { NamedAddress } from '@/components/new-safe/create/types'
+import type { RecoveryQueueItem } from '@/services/recovery/recovery-state'
 
 export const isTxQueued = (value: TransactionStatus): boolean => {
   return [TransactionStatus.AWAITING_CONFIRMATIONS, TransactionStatus.AWAITING_EXECUTION].includes(value)
@@ -108,6 +109,10 @@ export const isDateLabel = (value: TransactionListItem): value is DateLabel => {
 
 export const isTransactionListItem = (value: TransactionListItem): value is Transaction => {
   return value.type === TransactionListItemType.TRANSACTION
+}
+
+export function isRecoveryQueueItem(value: TransactionListItem | RecoveryQueueItem): value is RecoveryQueueItem {
+  return 'args' in value
 }
 
 // Narrows `Transaction`

--- a/src/utils/tx-list.ts
+++ b/src/utils/tx-list.ts
@@ -1,5 +1,9 @@
+import { TransactionInfoType } from '@safe-global/safe-gateway-typescript-sdk'
 import type { Transaction, TransactionListItem } from '@safe-global/safe-gateway-typescript-sdk'
+
 import { isConflictHeaderListItem, isNoneConflictType, isTransactionListItem } from '@/utils/transaction-guards'
+import { sameAddress } from './addresses'
+import type { RecoveryQueueItem } from '@/services/recovery/recovery-state'
 
 type GroupedTxs = Array<TransactionListItem | Transaction[]>
 
@@ -27,6 +31,36 @@ export const groupConflictingTxs = (list: TransactionListItem[]): GroupedTxs => 
       }
       return item
     })
+}
+
+export function _getRecoveryCancellations(moduleAddress: string, transactions: Array<Transaction>) {
+  const CANCELLATION_TX_METHOD_NAME = 'setTxNonce'
+
+  return transactions.filter(({ transaction }) => {
+    const { txInfo } = transaction
+    return (
+      txInfo.type === TransactionInfoType.CUSTOM &&
+      sameAddress(txInfo.to.value, moduleAddress) &&
+      txInfo.methodName === CANCELLATION_TX_METHOD_NAME
+    )
+  })
+}
+
+export function groupRecoveryTransactions(queue: Array<TransactionListItem>, recoveryQueue: Array<RecoveryQueueItem>) {
+  const transactions = queue.filter(isTransactionListItem)
+
+  return recoveryQueue.reduce<Array<Array<Transaction | RecoveryQueueItem>>>((acc, item) => {
+    acc.push([item])
+
+    const cancellations = _getRecoveryCancellations(item.address, transactions)
+
+    if (cancellations.length > 0) {
+      const prevItem = acc[acc.length - 1]
+      prevItem.push(...cancellations)
+    }
+
+    return acc
+  }, [])
 }
 
 export const getLatestTransactions = (list: TransactionListItem[] = []): Transaction[] => {


### PR DESCRIPTION
## What it solves

Resolves #2763

## How this PR fixes it

This groups recovery attempts and their cancellations together as we do with conflicting transactions.

## How to test it

Ensuring recovery is enabled, queue a recovery attempt and cancel it. Observe the grouping at the top of the queue.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/7283d858-df97-49c4-b188-03c25507baca)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
