### PR TITLE
Fix: disable spindl on dev

### DIFF
--- a/src/services/analytics/spindl.ts
+++ b/src/services/analytics/spindl.ts
@@ -2,14 +2,20 @@ import spindl from '@spindl-xyz/attribution-lite'
 import { IS_PRODUCTION } from '@/config/constants'
 
 export const spindlInit = () => {
+  if (!IS_PRODUCTION) return
+
   const SPINDL_SDK_KEY = process.env.NEXT_PUBLIC_SPINDL_SDK_KEY
 
   spindl.configure({
     sdkKey: SPINDL_SDK_KEY || '',
-    debugMode: !IS_PRODUCTION,
+    debugMode: false,
   })
 
   spindl.enableAutoPageViews()
 }
 
-export default spindl
+export const spindlAttribute = (address: string) => {
+  if (!IS_PRODUCTION) return
+
+  spindl.attribute(address)
+}

--- a/src/services/analytics/useGtm.ts
+++ b/src/services/analytics/useGtm.ts
@@ -14,7 +14,7 @@ import {
   gtmSetUserProperty,
   gtmTrack,
 } from '@/services/analytics/gtm'
-import spindl, { spindlInit } from './spindl'
+import { spindlInit, spindlAttribute } from './spindl'
 import { useAppSelector } from '@/store'
 import { CookieType, selectCookies } from '@/store/cookiesSlice'
 import useChainId from '@/hooks/useChainId'
@@ -97,7 +97,7 @@ const useGtm = () => {
   useEffect(() => {
     if (wallet?.address) {
       gtmSetUserProperty(AnalyticsUserProperties.WALLET_ADDRESS, wallet.address)
-      spindl.attribute(wallet.address)
+      spindlAttribute(wallet.address)
     }
   }, [wallet?.address])
 


### PR DESCRIPTION
## What it solves

We were planning to allowlist only the prod domain via Spindl's settings, but this setting doesn't seem to work (error 500) on their side, so we'll have to disable it on the client.
