### PR TITLE
Fix: wallet chain in wallet info

### DIFF
--- a/src/components/common/ChainIndicator/index.tsx
+++ b/src/components/common/ChainIndicator/index.tsx
@@ -2,27 +2,39 @@ import type { ReactElement } from 'react'
 import { useMemo } from 'react'
 import classnames from 'classnames'
 import { useAppSelector } from '@/store'
-import { selectChainById } from '@/store/chainsSlice'
+import { selectChainById, selectChains } from '@/store/chainsSlice'
 import css from './styles.module.css'
 import useChainId from '@/hooks/useChainId'
 import { Skeleton } from '@mui/material'
+import { isEmpty } from 'lodash'
 
 type ChainIndicatorProps = {
   chainId?: string
   inline?: boolean
   className?: string
-  renderWhiteSpaceIfNoChain?: boolean
+  showUnknown?: boolean
+}
+
+const fallbackChainConfig = {
+  chainName: 'Unknown chain',
+  theme: {
+    backgroundColor: '#ddd',
+    textColor: '#000',
+  },
 }
 
 const ChainIndicator = ({
   chainId,
   className,
   inline = false,
-  renderWhiteSpaceIfNoChain = true,
+  showUnknown = true,
 }: ChainIndicatorProps): ReactElement | null => {
   const currentChainId = useChainId()
   const id = chainId || currentChainId
-  const chainConfig = useAppSelector((state) => selectChainById(state, id))
+  const chains = useAppSelector(selectChains)
+  const chainConfig =
+    useAppSelector((state) => selectChainById(state, id)) || (showUnknown ? fallbackChainConfig : null)
+  const noChains = isEmpty(chains.data)
 
   const style = useMemo(() => {
     if (!chainConfig) return
@@ -34,15 +46,13 @@ const ChainIndicator = ({
     }
   }, [chainConfig])
 
-  if (!chainConfig?.chainName && !renderWhiteSpaceIfNoChain) return null
-
-  return chainConfig?.chainName ? (
+  return noChains ? (
+    <Skeleton width="100%" height="22px" variant="rectangular" sx={{ flexShrink: 0 }} />
+  ) : chainConfig ? (
     <span style={style} className={classnames(inline ? css.inlineIndicator : css.indicator, className)}>
       {chainConfig.chainName}
     </span>
-  ) : (
-    <Skeleton width="100%" height="22px" variant="rectangular" sx={{ flexShrink: 0 }} />
-  )
+  ) : null
 }
 
 export default ChainIndicator

--- a/src/components/common/Footer/index.tsx
+++ b/src/components/common/Footer/index.tsx
@@ -69,7 +69,7 @@ const Footer = (): ReactElement | null => {
               <FooterLink href={getHref(AppRoutes.settings.index)}>Preferences</FooterLink>
             </li>
             <li>
-              <ExternalLink href={HELP_CENTER_URL} noIcon>
+              <ExternalLink href={HELP_CENTER_URL} noIcon sx={{ textDecoration: 'underline' }}>
                 Help
               </ExternalLink>
             </li>

--- a/src/components/common/WalletInfo/index.tsx
+++ b/src/components/common/WalletInfo/index.tsx
@@ -61,7 +61,7 @@ export const WalletInfo = ({
   return (
     <Box className={css.container}>
       <Box className={css.accountContainer}>
-        <ChainIndicator />
+        <ChainIndicator chainId={wallet.chainId} />
 
         <Box className={css.addressContainer}>
           {isSocialLogin ? (

--- a/src/components/safe-apps/SafeAppLandingPage/SafeAppDetails.tsx
+++ b/src/components/safe-apps/SafeAppLandingPage/SafeAppDetails.tsx
@@ -47,7 +47,7 @@ const SafeAppDetails = ({ app, showDefaultListWarning }: DetailsProps) => (
       <Typography variant="body1">Available networks</Typography>
       <Box sx={{ display: 'flex', gap: 1, mt: 1, flexWrap: 'wrap' }}>
         {app.chainIds.map((chainId) => (
-          <ChainIndicator key={chainId} chainId={chainId} inline renderWhiteSpaceIfNoChain={false} />
+          <ChainIndicator key={chainId} chainId={chainId} inline showUnknown={false} />
         ))}
       </Box>
     </Box>

--- a/src/components/safe-apps/SafeAppPreviewDrawer/index.tsx
+++ b/src/components/safe-apps/SafeAppPreviewDrawer/index.tsx
@@ -84,7 +84,7 @@ const SafeAppPreviewDrawer = ({ isOpen, safeApp, isBookmarked, onClose, onBookma
 
         <Box sx={{ display: 'flex', gap: 1, mt: 2, flexWrap: 'wrap' }}>
           {safeApp?.chainIds.map((chainId) => (
-            <ChainIndicator key={chainId} chainId={chainId} inline renderWhiteSpaceIfNoChain={false} />
+            <ChainIndicator key={chainId} chainId={chainId} inline showUnknown={false} />
           ))}
         </Box>
 


### PR DESCRIPTION
The chain indicator in the WalletInfo popup should show the wallet's network, not Safe network.

<img width="359" alt="Screenshot 2023-11-24 at 09 45 19" src="https://github.com/safe-global/safe-wallet-web/assets/381895/736e1f95-0adb-4d89-9f43-ffa161e81d19">
