### PR TITLE
fix: don't filter expired recovery attempts from queue

### DIFF
--- a/src/components/recovery/ExecuteRecoveryButton/index.tsx
+++ b/src/components/recovery/ExecuteRecoveryButton/index.tsx
@@ -52,7 +52,7 @@ export function ExecuteRecoveryButton({
         const isDisabled = !isOk || !isExecutable
 
         return (
-          <Tooltip title={isDisabled ? 'Previous recovery attempts must be executed or skipped first' : null}>
+          <Tooltip title={isDisabled ? 'Previous recovery attempts must be executed or cancelled first' : null}>
             <span>
               {compact ? (
                 <IconButton onClick={onClick} color="primary" disabled={isDisabled} size="small">

--- a/src/components/recovery/RecoverySigners/index.tsx
+++ b/src/components/recovery/RecoverySigners/index.tsx
@@ -58,7 +58,7 @@ export function RecoverySigners({ item }: { item: RecoveryQueueItem }): ReactEle
               'now.'
             )
           ) : !isNext ? (
-            'after the previous recovery attempts are executed or skipped and the delay period has passed:'
+            'after the previous recovery attempts are executed or cancelled and the delay period has passed:'
           ) : (
             'after the delay period:'
           )}

--- a/src/components/tx-flow/flows/CancelRecovery/CancelRecoveryFlowReview.tsx
+++ b/src/components/tx-flow/flows/CancelRecovery/CancelRecoveryFlowReview.tsx
@@ -31,7 +31,7 @@ export function CancelRecoveryFlowReview({ recovery }: { recovery: RecoveryQueue
       </Typography>
 
       <ErrorMessage level="info">
-        All actions initiated by the Guardian will be skipped. The current owners will remain the owners of the Safe
+        All actions initiated by the Guardian will be cancelled. The current owners will remain the owners of the Safe
         Account.
       </ErrorMessage>
     </SignOrExecuteForm>

--- a/src/hooks/useRecoveryQueue.ts
+++ b/src/hooks/useRecoveryQueue.ts
@@ -1,18 +1,10 @@
 import { selectRecoveryQueues } from '@/services/recovery/selectors'
-import { useClock } from './useClock'
 import { useRecovery } from '@/components/recovery/RecoveryContext'
 import type { RecoveryQueueItem } from '@/services/recovery/recovery-state'
 
 export function useRecoveryQueue(): Array<RecoveryQueueItem> {
   const [recovery] = useRecovery()
   const queue = recovery && selectRecoveryQueues(recovery)
-  const clock = useClock()
 
-  if (!queue) {
-    return []
-  }
-
-  return queue.filter(({ expiresAt }) => {
-    return expiresAt ? expiresAt.gt(clock) : true
-  })
+  return queue ?? []
 }


### PR DESCRIPTION
## What it solves

Resolves [malformed queue](https://www.notion.so/safe-global/Wrong-message-about-expired-recovery-in-the-next-recovery-tx-7a61aef7aa1949f98cfcedad587b6588)

## How this PR fixes it

Expired recovery attempts are no longer filtered from the queue.

The Delay Modifier requires the "next" transaction to be executed/cancelled before the [`txNonce` + n transaction can be executed](https://github.com/gnosis/zodiac-modifier-delay/blob/main/contracts/Delay.sol#L195-L198).

Note: missed instances of "skipped" have been changed to "cancelled" as per previous requirements.

## How to test it

1. Ensuring the recovery module is enabled with a low expiration period, queue two recovery attempts.
2. After expiration has passed, observe both attempts remaining in the queue and the first cancellable, the second not.
3. After cancelling the first, the second is then executable.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
