### PR TITLE
fix: ref warning

### DIFF
--- a/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowSettings.tsx
+++ b/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowSettings.tsx
@@ -14,7 +14,7 @@ import {
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import { useForm, FormProvider, Controller } from 'react-hook-form'
-import { useState } from 'react'
+import { forwardRef, useState } from 'react'
 import type { TextFieldProps } from '@mui/material'
 import type { ReactElement } from 'react'
 
@@ -214,10 +214,11 @@ export function UpsertRecoveryFlowSettings({
   )
 }
 
-function SelectField(props: TextFieldProps) {
+const SelectField = forwardRef<TextFieldProps['ref'], TextFieldProps>((props, ref) => {
   return (
     <TextField
       {...props}
+      ref={ref}
       select
       sx={{
         '& .MuiSelect-select': {
@@ -235,4 +236,5 @@ function SelectField(props: TextFieldProps) {
       }}
     />
   )
-}
+})
+SelectField.displayName = 'SelectField'

--- a/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowSettings.tsx
+++ b/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowSettings.tsx
@@ -14,7 +14,7 @@ import {
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import { useForm, FormProvider, Controller } from 'react-hook-form'
-import { forwardRef, useState } from 'react'
+import { useState } from 'react'
 import type { TextFieldProps } from '@mui/material'
 import type { ReactElement } from 'react'
 
@@ -112,8 +112,8 @@ export function UpsertRecoveryFlowSettings({
             <Controller
               control={formMethods.control}
               name={UpsertRecoveryFlowFields.txCooldown}
-              render={({ field }) => (
-                <SelectField label="Recovery delay" fullWidth {...field}>
+              render={({ field: { ref, ...field } }) => (
+                <SelectField label="Recovery delay" fullWidth inputRef={ref} {...field}>
                   {periods.delay.map(({ label, value }, index) => (
                     <MenuItem key={index} value={value}>
                       {label}
@@ -137,8 +137,8 @@ export function UpsertRecoveryFlowSettings({
                 name={UpsertRecoveryFlowFields.txExpiration}
                 // Don't reset value if advanced section is collapsed
                 shouldUnregister={false}
-                render={({ field }) => (
-                  <SelectField label="Transaction expiry" fullWidth {...field}>
+                render={({ field: { ref, ...field } }) => (
+                  <SelectField label="Transaction expiry" fullWidth inputRef={ref} {...field}>
                     {periods.expiration.map(({ label, value }, index) => (
                       <MenuItem key={index} value={value}>
                         {label}
@@ -214,11 +214,10 @@ export function UpsertRecoveryFlowSettings({
   )
 }
 
-const SelectField = forwardRef<TextFieldProps['ref'], TextFieldProps>((props, ref) => {
+function SelectField(props: TextFieldProps) {
   return (
     <TextField
       {...props}
-      ref={ref}
       select
       sx={{
         '& .MuiSelect-select': {
@@ -236,5 +235,4 @@ const SelectField = forwardRef<TextFieldProps['ref'], TextFieldProps>((props, re
       }}
     />
   )
-})
-SelectField.displayName = 'SelectField'
+}


### PR DESCRIPTION
## What it solves

Resolves `ref` warning

## How this PR fixes it

The `ref`s within the recovery upsertion flow are now forwarded correctly.

## How to test it

Enable/edit the recovery feature and on the settings page where the delay/expiration period can be edited, observe no `ref` warning:

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/addd557f-2506-40b8-8e02-9ab70c27f7b1)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
