### PR TITLE
fix: show "none"/"never" for no cooldown/expiration

### DIFF
--- a/src/components/settings/Recovery/index.tsx
+++ b/src/components/settings/Recovery/index.tsx
@@ -86,7 +86,7 @@ export function Recovery(): ReactElement {
             },
             [HeadCells.TxCooldown]: {
               rawValue: txCooldownSeconds,
-              content: <Typography>{txCooldownSeconds === 0 ? 'never' : getPeriod(txCooldownSeconds)}</Typography>,
+              content: <Typography>{txCooldownSeconds === 0 ? 'none' : getPeriod(txCooldownSeconds)}</Typography>,
             },
             [HeadCells.TxExpiration]: {
               rawValue: txExpirationSeconds,

--- a/src/components/settings/Recovery/index.tsx
+++ b/src/components/settings/Recovery/index.tsx
@@ -86,11 +86,11 @@ export function Recovery(): ReactElement {
             },
             [HeadCells.TxCooldown]: {
               rawValue: txCooldownSeconds,
-              content: <Typography>{getPeriod(txCooldownSeconds)}</Typography>,
+              content: <Typography>{txCooldownSeconds === 0 ? 'never' : getPeriod(txCooldownSeconds)}</Typography>,
             },
             [HeadCells.TxExpiration]: {
               rawValue: txExpirationSeconds,
-              content: <Typography>{getPeriod(txExpirationSeconds)}</Typography>,
+              content: <Typography>{txExpirationSeconds === 0 ? 'never' : getPeriod(txExpirationSeconds)}</Typography>,
             },
             [HeadCells.Actions]: {
               rawValue: '',


### PR DESCRIPTION
## What it solves

Resolves [missing label for cooldown/expiration](https://www.notion.so/safe-global/Never-is-not-displayed-as-Expiry-6e1056ce860d48f4be043025afb19fc6)

## How this PR fixes it

If the cooldown or expiration is set to `0`, the periods are labelled as "none"/"never" respectively.

## How to test it

1. Ensure recovery is enabled with a cooldown of `0` and expiration of `0`.
2. Observe a cooldown period of "none" and expiration of "never" in the recovery settings.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/acdfd7a2-c23d-4026-9c19-f1977713e78a)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
