### PR TITLE
fix: expose `skipExpired` for Guardians

### DIFF
--- a/src/components/recovery/CancelRecoveryButton/index.tsx
+++ b/src/components/recovery/CancelRecoveryButton/index.tsx
@@ -14,6 +14,7 @@ import useOnboard from '@/hooks/wallets/useOnboard'
 import { logError, Errors } from '@/services/exceptions'
 import { RecoveryContext } from '../RecoveryContext'
 import { useIsGuardian } from '@/hooks/useIsGuardian'
+import { useRecoveryTxState } from '@/hooks/useRecoveryTxState'
 import type { RecoveryQueueItem } from '@/services/recovery/recovery-state'
 
 export function CancelRecoveryButton({
@@ -25,6 +26,7 @@ export function CancelRecoveryButton({
 }): ReactElement {
   const isOwner = useIsSafeOwner()
   const isGuardian = useIsGuardian()
+  const { isExpired } = useRecoveryTxState(recovery)
   const { setTxFlow } = useContext(TxModalContext)
   const onboard = useOnboard()
   const { safe } = useSafeInfo()
@@ -53,7 +55,7 @@ export function CancelRecoveryButton({
   return (
     <CheckWallet allowNonOwner>
       {(isOk) => {
-        const isDisabled = !isOk || !isGuardian
+        const isDisabled = !isOk || (isGuardian && !isExpired)
 
         return compact ? (
           <IconButton onClick={onClick} color="error" size="small" disabled={isDisabled}>

--- a/src/components/recovery/CancelRecoveryButton/index.tsx
+++ b/src/components/recovery/CancelRecoveryButton/index.tsx
@@ -7,6 +7,13 @@ import IconButton from '@mui/material/IconButton'
 import CheckWallet from '@/components/common/CheckWallet'
 import { TxModalContext } from '@/components/tx-flow'
 import { CancelRecoveryFlow } from '@/components/tx-flow/flows/CancelRecovery'
+import useIsSafeOwner from '@/hooks/useIsSafeOwner'
+import { dispatchRecoverySkipExpired } from '@/services/tx/tx-sender'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import useOnboard from '@/hooks/wallets/useOnboard'
+import { logError, Errors } from '@/services/exceptions'
+import { RecoveryContext } from '../RecoveryContext'
+import { useIsGuardian } from '@/hooks/useIsGuardian'
 import type { RecoveryQueueItem } from '@/services/recovery/recovery-state'
 
 export function CancelRecoveryButton({
@@ -16,28 +23,48 @@ export function CancelRecoveryButton({
   recovery: RecoveryQueueItem
   compact?: boolean
 }): ReactElement {
+  const isOwner = useIsSafeOwner()
+  const isGuardian = useIsGuardian()
   const { setTxFlow } = useContext(TxModalContext)
+  const onboard = useOnboard()
+  const { safe } = useSafeInfo()
+  const { refetch } = useContext(RecoveryContext)
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()
     e.preventDefault()
 
-    setTxFlow(<CancelRecoveryFlow recovery={recovery} />)
+    if (isOwner) {
+      setTxFlow(<CancelRecoveryFlow recovery={recovery} />)
+    } else if (onboard) {
+      try {
+        dispatchRecoverySkipExpired({
+          onboard,
+          chainId: safe.chainId,
+          delayModifierAddress: recovery.address,
+          refetchRecoveryData: refetch,
+        })
+      } catch (e) {
+        logError(Errors._813, e)
+      }
+    }
   }
 
   return (
-    <CheckWallet>
-      {(isOk) =>
-        compact ? (
-          <IconButton onClick={onClick} color="error" size="small" disabled={!isOk}>
+    <CheckWallet allowNonOwner>
+      {(isOk) => {
+        const isDisabled = !isOk || !isGuardian
+
+        return compact ? (
+          <IconButton onClick={onClick} color="error" size="small" disabled={isDisabled}>
             <SvgIcon component={ErrorIcon} inheritViewBox fontSize="small" />
           </IconButton>
         ) : (
-          <Button onClick={onClick} variant="danger" disabled={!isOk} size="stretched">
+          <Button onClick={onClick} variant="danger" disabled={isDisabled} size="stretched">
             Cancel
           </Button>
         )
-      }
+      }}
     </CheckWallet>
   )
 }

--- a/src/services/exceptions/ErrorCodes.ts
+++ b/src/services/exceptions/ErrorCodes.ts
@@ -63,6 +63,7 @@ enum ErrorCodes {
   _810 = '810: Error executing a recovery proposal transaction',
   _811 = '811: Error decoding a recovery proposal transaction',
   _812 = '812: Failed to recover',
+  _813 = '813: Failed to cancel recovery',
 
   _900 = '900: Error loading Safe App',
   _901 = '901: Error processing Safe Apps SDK request',

--- a/src/services/tx/tx-sender/dispatch.ts
+++ b/src/services/tx/tx-sender/dispatch.ts
@@ -476,3 +476,29 @@ export async function dispatchRecoveryExecution({
       reloadRecoveryDataAfterProcessed(result, refetchRecoveryData)
     })
 }
+
+export async function dispatchRecoverySkipExpired({
+  onboard,
+  chainId,
+  delayModifierAddress,
+  refetchRecoveryData,
+}: {
+  onboard: OnboardAPI
+  chainId: string
+  delayModifierAddress: string
+  refetchRecoveryData: () => void
+}) {
+  const wallet = await assertWalletChain(onboard, chainId)
+  const provider = createWeb3(wallet.provider)
+
+  const delayModifier = getModuleInstance(KnownContracts.DELAY, delayModifierAddress, provider)
+
+  const signer = provider.getSigner()
+
+  delayModifier
+    .connect(signer)
+    .skipExpired()
+    .then((result) => {
+      reloadRecoveryDataAfterProcessed(result, refetchRecoveryData)
+    })
+}


### PR DESCRIPTION
## What it solves

Resolves #2882

## How this PR fixes it

This allows Guardians to cancel recovery attempts if they have expired. A new `dispatchRecoverySkipExpired` dispatcher is now called when connected to the Safe as a Guardian and clicking "Cancel" on an expired recovery attempt.

## How to test it

1. Ensure recovery is enabled and an expired proposal exists.
2. Observe "Cancel" enabled which, when clicked, skips all expired recovery attempts.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
