### PR TITLE
fix: only display proposal modal to Guardians

### DIFF
--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -11,7 +11,6 @@ import useDebounce from '@/hooks/useDebounce'
 import { useRouter } from 'next/router'
 import { TxModalContext } from '@/components/tx-flow'
 import BatchSidebar from '@/components/batch/BatchSidebar'
-import { RecoveryModal } from '@/components/recovery/RecoveryModal'
 
 const PageLayout = ({ pathname, children }: { pathname: string; children: ReactElement }): ReactElement => {
   const router = useRouter()
@@ -48,9 +47,7 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
         })}
       >
         <div className={css.content}>
-          <SafeLoadingError>
-            <RecoveryModal>{children}</RecoveryModal>
-          </SafeLoadingError>
+          <SafeLoadingError>{children}</SafeLoadingError>
         </div>
 
         <BatchSidebar isOpen={isBatchOpen} onToggle={setBatchOpen} />

--- a/src/components/recovery/RecoveryModal/index.test.tsx
+++ b/src/components/recovery/RecoveryModal/index.test.tsx
@@ -23,148 +23,20 @@ describe('RecoveryModal', () => {
       _RecoveryModal = require('./index')._RecoveryModal
     })
 
-    it('should not render the modal if there is a queue but the user is not an owner or guardian', () => {
-      const wallet = connectedWalletBuilder().build()
-      const queue = [{ validFrom: BigNumber.from(0) } as RecoveryQueueItem]
-
-      const { queryByText } = render(
-        <RecoveryContext.Provider value={{ state: [[{ queue }]] } as any}>
-          <_RecoveryModal wallet={wallet} isOwner={false} isGuardian={false} queue={queue}>
-            Test
-          </_RecoveryModal>
-        </RecoveryContext.Provider>,
-      )
-
-      expect(queryByText('Test')).toBeTruthy()
-      expect(queryByText('recovery')).toBeFalsy()
-    })
-
-    it('should not render the modal if there is no queue and the user is a guardian', () => {
+    it('should not render either modal if there is no queue and the user is an owner', () => {
       const wallet = connectedWalletBuilder().build()
       const queue = [] as Array<RecoveryQueueItem>
 
-      const { queryByText } = render(
+      const { container, queryByText } = render(
         <RecoveryContext.Provider value={{ state: [[{ queue }]] } as any}>
-          <_RecoveryModal wallet={wallet} isOwner={false} isGuardian queue={queue}>
-            Test
-          </_RecoveryModal>
+          <_RecoveryModal wallet={wallet} isOwner isGuardian={false} queue={queue} />
         </RecoveryContext.Provider>,
       )
 
-      expect(queryByText('Test')).toBeTruthy()
+      expect(container.innerHTML).toBe(
+        '<div aria-hidden="true" class="MuiBackdrop-root css-1ejpag9-MuiBackdrop-root" style="opacity: 0; visibility: hidden;"></div>',
+      )
       expect(queryByText('recovery')).toBeFalsy()
-    })
-
-    it('should not render the modal if there is no queue and the user is an owner', () => {
-      const wallet = connectedWalletBuilder().build()
-      const queue = [] as Array<RecoveryQueueItem>
-
-      const { queryByText } = render(
-        <RecoveryContext.Provider value={{ state: [[{ queue }]] } as any}>
-          <_RecoveryModal wallet={wallet} isOwner isGuardian={false} queue={queue}>
-            Test
-          </_RecoveryModal>
-        </RecoveryContext.Provider>,
-      )
-
-      expect(queryByText('Test')).toBeTruthy()
-      expect(queryByText('recovery')).toBeFalsy()
-    })
-
-    it('should not render the in-progress modal when there is a queue for guardians on a non-sidebar route', () => {
-      const wallet = connectedWalletBuilder().build()
-      const queue = [{ validFrom: BigNumber.from(0) } as RecoveryQueueItem]
-
-      const { queryByText } = render(
-        <RecoveryContext.Provider value={{ state: [[{ queue }]] } as any}>
-          <_RecoveryModal wallet={wallet} isOwner={false} isGuardian queue={queue} isSidebarRoute={false}>
-            Test
-          </_RecoveryModal>
-        </RecoveryContext.Provider>,
-      )
-
-      expect(queryByText('Test')).toBeTruthy()
-      expect(queryByText('recovery')).toBeFalsy()
-    })
-
-    it('should render the in-progress modal when there is a queue for guardians', () => {
-      const wallet = connectedWalletBuilder().build()
-      const queue = [{ validFrom: BigNumber.from(0) } as RecoveryQueueItem]
-
-      const { queryByText } = render(
-        <RecoveryContext.Provider value={{ state: [[{ queue }]] } as any}>
-          <_RecoveryModal wallet={wallet} isOwner={false} isGuardian queue={queue}>
-            Test
-          </_RecoveryModal>
-        </RecoveryContext.Provider>,
-      )
-
-      expect(queryByText('Test')).toBeTruthy()
-      expect(queryByText('Account recovery in progress')).toBeTruthy()
-    })
-
-    it('should render the in-progress modal when there is a queue for owners', () => {
-      const wallet = connectedWalletBuilder().build()
-      const queue = [{ validFrom: BigNumber.from(0) } as RecoveryQueueItem]
-
-      const { queryByText } = render(
-        <RecoveryContext.Provider value={{ state: [[{ queue }]] } as any}>
-          <_RecoveryModal wallet={wallet} isOwner isGuardian={false} queue={queue}>
-            Test
-          </_RecoveryModal>
-        </RecoveryContext.Provider>,
-      )
-
-      expect(queryByText('Test')).toBeTruthy()
-      expect(queryByText('Account recovery in progress')).toBeTruthy()
-    })
-
-    it('should not render the proposal modal when there is no queue for guardians on a non-sidebar route', () => {
-      const wallet = connectedWalletBuilder().build()
-      const queue = [] as Array<RecoveryQueueItem>
-
-      const { queryByText } = render(
-        <RecoveryContext.Provider value={{ state: [[{ queue }]] } as any}>
-          <_RecoveryModal wallet={wallet} isOwner={false} isGuardian queue={queue} isSidebarRoute={false}>
-            Test
-          </_RecoveryModal>
-        </RecoveryContext.Provider>,
-      )
-
-      expect(queryByText('Test')).toBeTruthy()
-      expect(queryByText('recovery')).toBeFalsy()
-    })
-
-    it('should render the proposal modal when there is no queue for guardians', () => {
-      const wallet = connectedWalletBuilder().build()
-      const queue = [] as Array<RecoveryQueueItem>
-
-      const { queryByText } = render(
-        <RecoveryContext.Provider value={{ state: [[{ queue }]] } as any}>
-          <_RecoveryModal wallet={wallet} isOwner={false} isGuardian queue={queue}>
-            Test
-          </_RecoveryModal>
-        </RecoveryContext.Provider>,
-      )
-
-      expect(queryByText('Test')).toBeTruthy()
-      expect(queryByText('Recover this Account')).toBeTruthy()
-    })
-
-    it('should not render the proposal modal when there is no queue for owners', () => {
-      const wallet = connectedWalletBuilder().build()
-      const queue = [] as Array<RecoveryQueueItem>
-
-      const { queryByText } = render(
-        <RecoveryContext.Provider value={{ state: [[{ queue }]] } as any}>
-          <_RecoveryModal wallet={wallet} isOwner isGuardian={false} queue={queue}>
-            Test
-          </_RecoveryModal>
-        </RecoveryContext.Provider>,
-      )
-
-      expect(queryByText('Test')).toBeTruthy()
-      expect(queryByText('Recover this Account')).toBeFalsy()
     })
 
     it('should close the modal when the user navigates away', async () => {
@@ -182,15 +54,13 @@ describe('RecoveryModal', () => {
       const wallet = connectedWalletBuilder().build()
       const queue = [{ validFrom: BigNumber.from(0), transactionHash: faker.string.hexadecimal() } as RecoveryQueueItem]
 
-      const { queryByText } = render(
+      const { container, queryByText } = render(
         <RecoveryContext.Provider value={{ state: [[{ queue }]] } as any}>
-          <_RecoveryModal wallet={wallet} isOwner isGuardian={false} queue={queue}>
-            Test
-          </_RecoveryModal>
+          <_RecoveryModal wallet={wallet} isOwner isGuardian={false} queue={queue} />
         </RecoveryContext.Provider>,
       )
 
-      expect(queryByText('Test')).toBeTruthy()
+      expect(container).not.toBeEmptyDOMElement()
       expect(queryByText('Account recovery in progress')).toBeTruthy()
 
       // Trigger the route change
@@ -198,6 +68,128 @@ describe('RecoveryModal', () => {
 
       await waitFor(() => {
         expect(queryByText('Account recovery in progress')).toBeFalsy()
+      })
+    })
+
+    describe('in-progress', () => {
+      it('should render the in-progress modal when there is a queue for guardians', () => {
+        const wallet = connectedWalletBuilder().build()
+        const queue = [{ validFrom: BigNumber.from(0) } as RecoveryQueueItem]
+
+        const { container, queryByText } = render(
+          <RecoveryContext.Provider value={{ state: [[{ queue }]] } as any}>
+            <_RecoveryModal wallet={wallet} isOwner={false} isGuardian queue={queue} />
+          </RecoveryContext.Provider>,
+        )
+
+        expect(container).not.toBeEmptyDOMElement()
+        expect(queryByText('Account recovery in progress')).toBeTruthy()
+      })
+
+      it('should render the in-progress modal when there is a queue for owners', () => {
+        const wallet = connectedWalletBuilder().build()
+        const queue = [{ validFrom: BigNumber.from(0) } as RecoveryQueueItem]
+
+        const { container, queryByText } = render(
+          <RecoveryContext.Provider value={{ state: [[{ queue }]] } as any}>
+            <_RecoveryModal wallet={wallet} isOwner isGuardian={false} queue={queue} />
+          </RecoveryContext.Provider>,
+        )
+
+        expect(container).not.toBeEmptyDOMElement()
+        expect(queryByText('Account recovery in progress')).toBeTruthy()
+      })
+
+      it('should not render the in-progress modal when there is a queue but the user is not an owner or guardian', () => {
+        const wallet = connectedWalletBuilder().build()
+        const queue = [{ validFrom: BigNumber.from(0) } as RecoveryQueueItem]
+
+        const { container, queryByText } = render(
+          <RecoveryContext.Provider value={{ state: [[{ queue }]] } as any}>
+            <_RecoveryModal wallet={wallet} isOwner={false} isGuardian={false} queue={queue} />
+          </RecoveryContext.Provider>,
+        )
+
+        expect(container).not.toBeEmptyDOMElement()
+        expect(queryByText('recovery')).toBeFalsy()
+      })
+
+      it('should not render the in-progress modal when there is a queue for guardians on a non-sidebar route', () => {
+        const wallet = connectedWalletBuilder().build()
+        const queue = [{ validFrom: BigNumber.from(0) } as RecoveryQueueItem]
+
+        const { container, queryByText } = render(
+          <RecoveryContext.Provider value={{ state: [[{ queue }]] } as any}>
+            <_RecoveryModal wallet={wallet} isOwner={false} isGuardian queue={queue} isSidebarRoute={false} />
+          </RecoveryContext.Provider>,
+        )
+
+        expect(container).not.toBeEmptyDOMElement()
+        expect(queryByText('recovery')).toBeFalsy()
+      })
+    })
+
+    describe('proposal', () => {
+      it('should render the proposal modal if there is no queue and the user is a guardian', () => {
+        const wallet = connectedWalletBuilder().build()
+        const queue = [] as Array<RecoveryQueueItem>
+
+        const { container, queryByText } = render(
+          <RecoveryContext.Provider value={{ state: [[{ queue }]] } as any}>
+            <_RecoveryModal wallet={wallet} isOwner={false} isGuardian queue={queue} />
+          </RecoveryContext.Provider>,
+        )
+
+        expect(container).not.toBeEmptyDOMElement()
+        expect(queryByText('recovery')).toBeFalsy()
+      })
+
+      it('should not render the proposal modal when there is no queue for owners', () => {
+        const wallet = connectedWalletBuilder().build()
+        const queue = [] as Array<RecoveryQueueItem>
+
+        const { container, queryByText } = render(
+          <RecoveryContext.Provider value={{ state: [[{ queue }]] } as any}>
+            <_RecoveryModal wallet={wallet} isOwner isGuardian={false} queue={queue} />
+          </RecoveryContext.Provider>,
+        )
+
+        expect(container.innerHTML).toBe(
+          '<div aria-hidden="true" class="MuiBackdrop-root css-1ejpag9-MuiBackdrop-root" style="opacity: 0; visibility: hidden;"></div>',
+        )
+        expect(queryByText('Recover this Account')).toBeFalsy()
+      })
+
+      it('should not render the proposal modal when there is no queue for guardians on a non-sidebar route', () => {
+        const wallet = connectedWalletBuilder().build()
+        const queue = [] as Array<RecoveryQueueItem>
+
+        const { container, queryByText } = render(
+          <RecoveryContext.Provider value={{ state: [[{ queue }]] } as any}>
+            <_RecoveryModal wallet={wallet} isOwner={false} isGuardian queue={queue} isSidebarRoute={false} />
+          </RecoveryContext.Provider>,
+        )
+
+        expect(container.innerHTML).toBe(
+          '<div aria-hidden="true" class="MuiBackdrop-root css-1ejpag9-MuiBackdrop-root" style="opacity: 0; visibility: hidden;"></div>',
+        )
+        expect(queryByText('recovery')).toBeFalsy()
+      })
+
+      it('should not render the proposal modal when there is no queue for non-owners', () => {
+        const wallet = connectedWalletBuilder().build()
+        const queue = [] as Array<RecoveryQueueItem>
+
+        const { container, queryByText } = render(
+          <RecoveryContext.Provider value={{ state: [[{ queue }]] } as any}>
+            <_RecoveryModal wallet={wallet} isOwner={false} isGuardian={false} queue={queue} />
+          </RecoveryContext.Provider>,
+        )
+
+        expect(container.innerHTML).toBe(
+          '<div aria-hidden="true" class="MuiBackdrop-root css-1ejpag9-MuiBackdrop-root" style="opacity: 0; visibility: hidden;"></div>',
+        )
+        expect(queryByText('Recover this Account')).toBeFalsy()
       })
     })
   })

--- a/src/components/recovery/RecoveryModal/index.tsx
+++ b/src/components/recovery/RecoveryModal/index.tsx
@@ -44,12 +44,12 @@ export function _RecoveryModal({
 
   // Trigger modal
   useEffect(() => {
-    if (!isSidebarRoute && (!isOwner || !isGuardian)) {
+    if (!isSidebarRoute) {
       return
     }
 
     setModal(() => {
-      if (next && !wasInProgressDismissed(next.transactionHash)) {
+      if (next && (isOwner || isGuardian) && !wasInProgressDismissed(next.transactionHash)) {
         const onCloseWithDismiss = () => {
           dismissInProgress(next.transactionHash)
           onClose()

--- a/src/components/recovery/RecoveryModal/index.tsx
+++ b/src/components/recovery/RecoveryModal/index.tsx
@@ -1,7 +1,7 @@
 import { Backdrop, Fade } from '@mui/material'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/router'
-import type { ReactElement, ReactNode } from 'react'
+import type { ReactElement } from 'react'
 
 import { useRecoveryQueue } from '@/hooks/useRecoveryQueue'
 import { RecoveryInProgressCard } from '../RecoveryCards/RecoveryInProgressCard'
@@ -17,14 +17,12 @@ import { useIsSidebarRoute } from '@/hooks/useIsSidebarRoute'
 import type { RecoveryQueueItem } from '@/services/recovery/recovery-state'
 
 export function _RecoveryModal({
-  children,
   isOwner,
   isGuardian,
   queue,
   wallet,
   isSidebarRoute = true,
 }: {
-  children: ReactNode
   isOwner: boolean
   isGuardian: boolean
   queue: Array<RecoveryQueueItem>
@@ -46,7 +44,7 @@ export function _RecoveryModal({
 
   // Trigger modal
   useEffect(() => {
-    if (!isSidebarRoute) {
+    if (!isSidebarRoute && (!isOwner || !isGuardian)) {
       return
     }
 
@@ -60,7 +58,7 @@ export function _RecoveryModal({
         return <RecoveryInProgressCard onClose={onCloseWithDismiss} recovery={next} />
       }
 
-      if (wallet?.address && !isOwner && !wasProposalDismissed(wallet.address)) {
+      if (wallet?.address && isGuardian && !wasProposalDismissed(wallet.address)) {
         const onCloseWithDismiss = () => {
           dismissProposal(wallet.address)
           onClose()
@@ -94,14 +92,11 @@ export function _RecoveryModal({
   }, [router])
 
   return (
-    <>
-      <Fade in={!!modal}>
-        <Backdrop open={!!modal} sx={{ zIndex: 3, bgcolor: ({ palette }) => palette.background.main }}>
-          {modal}
-        </Backdrop>
-      </Fade>
-      {children}
-    </>
+    <Fade in={!!modal}>
+      <Backdrop open={!!modal} sx={{ zIndex: 3, bgcolor: ({ palette }) => palette.background.main }}>
+        {modal}
+      </Backdrop>
+    </Fade>
   )
 }
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -44,6 +44,7 @@ import useABTesting from '@/services/tracking/useAbTesting'
 import { AbTest } from '@/services/tracking/abTesting'
 import { useNotificationTracking } from '@/components/settings/PushNotifications/hooks/useNotificationTracking'
 import { RecoveryProvider } from '@/components/recovery/RecoveryContext'
+import { RecoveryModal } from '@/components/recovery/RecoveryModal'
 
 const GATEWAY_URL = IS_PRODUCTION || cgwDebugStorage.get() ? GATEWAY_URL_PRODUCTION : GATEWAY_URL_STAGING
 
@@ -129,6 +130,8 @@ const WebCoreApp = ({
           <Notifications />
 
           <PasswordRecoveryModal />
+
+          <RecoveryModal />
         </AppProviders>
       </CacheProvider>
     </StoreHydrator>


### PR DESCRIPTION
## What it solves

Resolves proposal modal opening for non-Guardians

## How this PR fixes it

The recovery proposal now _only_ opens if a Guardian is connected.

Note: the `RecoveryModal` was also refactored be not take `children` for future safety.

## How to test it

1. Ensuring recovery is enabled, open a Safe as a Guardian and observe the proposal modal.
2. Switch to a non-Guardian and observe no proposal modal.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
