### PR TITLE
fix: only group recovery transactions in arrays

### DIFF
--- a/src/utils/__tests__/tx-list.test.ts
+++ b/src/utils/__tests__/tx-list.test.ts
@@ -166,8 +166,9 @@ describe('tx-list', () => {
   })
 
   describe('groupRecoveryTransactions', () => {
-    it.only('should group recovery transactions with their cancellations', () => {
+    it('should group recovery transactions with their cancellations', () => {
       const moduleAddress = faker.finance.ethereumAddress()
+      const moduleAddress2 = faker.finance.ethereumAddress()
 
       const queue = [
         {
@@ -208,6 +209,9 @@ describe('tx-list', () => {
         {
           address: moduleAddress,
         },
+        {
+          address: moduleAddress2,
+        },
       ]
 
       expect(groupRecoveryTransactions(queue as any, recoveryQueue as any)).toEqual([
@@ -228,6 +232,9 @@ describe('tx-list', () => {
             },
           },
         ],
+        {
+          address: moduleAddress2,
+        },
       ])
     })
   })

--- a/src/utils/tx-list.ts
+++ b/src/utils/tx-list.ts
@@ -46,12 +46,12 @@ export function _getRecoveryCancellations(moduleAddress: string, transactions: A
   })
 }
 
-export type GroupedQueueItem = Transaction | RecoveryQueueItem
+type GroupedRecoveryQueueItem = Transaction | RecoveryQueueItem
 
 export function groupRecoveryTransactions(queue: Array<TransactionListItem>, recoveryQueue: Array<RecoveryQueueItem>) {
   const transactions = queue.filter(isTransactionListItem)
 
-  return recoveryQueue.reduce<Array<GroupedQueueItem | Array<GroupedQueueItem>>>((acc, item) => {
+  return recoveryQueue.reduce<Array<RecoveryQueueItem | Array<GroupedRecoveryQueueItem>>>((acc, item) => {
     const cancellations = _getRecoveryCancellations(item.address, transactions)
 
     if (cancellations.length === 0) {

--- a/src/utils/tx-list.ts
+++ b/src/utils/tx-list.ts
@@ -46,23 +46,22 @@ export function _getRecoveryCancellations(moduleAddress: string, transactions: A
   })
 }
 
+export type GroupedQueueItem = Transaction | RecoveryQueueItem
+
 export function groupRecoveryTransactions(queue: Array<TransactionListItem>, recoveryQueue: Array<RecoveryQueueItem>) {
   const transactions = queue.filter(isTransactionListItem)
 
-  return recoveryQueue.reduce<Array<Transaction | RecoveryQueueItem | Array<Transaction | RecoveryQueueItem>>>(
-    (acc, item) => {
-      const cancellations = _getRecoveryCancellations(item.address, transactions)
+  return recoveryQueue.reduce<Array<GroupedQueueItem | Array<GroupedQueueItem>>>((acc, item) => {
+    const cancellations = _getRecoveryCancellations(item.address, transactions)
 
-      if (cancellations.length === 0) {
-        acc.push(item)
-      } else {
-        acc.push([item, ...cancellations])
-      }
+    if (cancellations.length === 0) {
+      acc.push(item)
+    } else {
+      acc.push([item, ...cancellations])
+    }
 
-      return acc
-    },
-    [],
-  )
+    return acc
+  }, [])
 }
 
 export const getLatestTransactions = (list: TransactionListItem[] = []): Transaction[] => {

--- a/src/utils/tx-list.ts
+++ b/src/utils/tx-list.ts
@@ -49,18 +49,20 @@ export function _getRecoveryCancellations(moduleAddress: string, transactions: A
 export function groupRecoveryTransactions(queue: Array<TransactionListItem>, recoveryQueue: Array<RecoveryQueueItem>) {
   const transactions = queue.filter(isTransactionListItem)
 
-  return recoveryQueue.reduce<Array<Array<Transaction | RecoveryQueueItem>>>((acc, item) => {
-    acc.push([item])
+  return recoveryQueue.reduce<Array<Transaction | RecoveryQueueItem | Array<Transaction | RecoveryQueueItem>>>(
+    (acc, item) => {
+      const cancellations = _getRecoveryCancellations(item.address, transactions)
 
-    const cancellations = _getRecoveryCancellations(item.address, transactions)
+      if (cancellations.length === 0) {
+        acc.push(item)
+      } else {
+        acc.push([item, ...cancellations])
+      }
 
-    if (cancellations.length > 0) {
-      const prevItem = acc[acc.length - 1]
-      prevItem.push(...cancellations)
-    }
-
-    return acc
-  }, [])
+      return acc
+    },
+    [],
+  )
 }
 
 export const getLatestTransactions = (list: TransactionListItem[] = []): Transaction[] => {


### PR DESCRIPTION
## What it solves

Resolves [grouping non-recovery cancellations](https://www.notion.so/safe-global/Cancelling-Account-recovery-cc139f5915a04bc19a91b1fd44c1a21c)

## How this PR fixes it

Non-recovery related transactions are not grouped in arrays and relevant test coverage has been improved.

## How to test it

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/2e4be190-6718-46bc-b73d-8b4bfe9765eb)

## Screenshots

1. Propose a recovery attempt.
2. Cancel recovery attempt.
3. Queue a "standard" transaction.
4. Observe only the recovery cancellation grouped with the recovery attempt.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
