### PR TITLE
fix: add help centre article

### DIFF
--- a/src/components/recovery/GroupedRecoveryListItems/index.tsx
+++ b/src/components/recovery/GroupedRecoveryListItems/index.tsx
@@ -8,6 +8,7 @@ import { isRecoveryQueueItem } from '@/utils/transaction-guards'
 import ExpandableTransactionItem from '@/components/transactions/TxListItem/ExpandableTransactionItem'
 import { RecoveryListItem } from '../RecoveryListItem'
 import ExternalLink from '@/components/common/ExternalLink'
+import { HelpCenterArticle } from '@/config/constants'
 
 import css from '@/components/transactions/GroupedTxListItems/styles.module.css'
 
@@ -22,11 +23,7 @@ function Disclaimer({ isMalicious }: { isMalicious: boolean }): ReactElement {
           Cancelling {isMalicious ? 'malicious transaction' : 'Account recovery'}.
         </Typography>{' '}
         You will need to execute the cancellation.{' '}
-        <ExternalLink
-          // TODO: Add link
-          href="#"
-          title="Learn more about Account recovery"
-        >
+        <ExternalLink href={HelpCenterArticle.RECOVERY} title="Learn more about the Account recovery process">
           Learn more
         </ExternalLink>
       </Typography>

--- a/src/components/recovery/RecoveryCards/RecoveryInProgressCard.tsx
+++ b/src/components/recovery/RecoveryCards/RecoveryInProgressCard.tsx
@@ -7,6 +7,7 @@ import { Countdown } from '@/components/common/Countdown'
 import RecoveryPending from '@/public/images/common/recovery-pending.svg'
 import ExternalLink from '@/components/common/ExternalLink'
 import { AppRoutes } from '@/config/routes'
+import { HelpCenterArticle } from '@/config/constants'
 import type { RecoveryQueueItem } from '@/services/recovery/recovery-state'
 
 import css from './styles.module.css'
@@ -42,10 +43,7 @@ export function RecoveryInProgressCard({ orientation = 'vertical', onClose, reco
     : 'The recovery process has started. This Account will be ready to recover in:'
 
   const link = (
-    <ExternalLink
-      href="#" // TODO: Link to docs
-      title="Learn about the Account recovery process"
-    >
+    <ExternalLink href={HelpCenterArticle.RECOVERY} title="Learn more about the Account recovery process">
       Learn more
     </ExternalLink>
   )

--- a/src/components/recovery/RecoveryCards/RecoveryProposalCard.tsx
+++ b/src/components/recovery/RecoveryCards/RecoveryProposalCard.tsx
@@ -8,6 +8,7 @@ import { RecoverAccountFlow } from '@/components/tx-flow/flows/RecoverAccount'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import madProps from '@/utils/mad-props'
 import { TxModalContext } from '@/components/tx-flow'
+import { HelpCenterArticle } from '@/config/constants'
 import type { TxModalContextType } from '@/components/tx-flow'
 import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 
@@ -40,10 +41,7 @@ export function _RecoveryProposalCard({ orientation = 'vertical', onClose, safe,
   } regain access by updating the owner list.`
 
   const link = (
-    <ExternalLink
-      href="#" // TODO: Link to docs
-      title="Learn about the Account recovery process"
-    >
+    <ExternalLink href={HelpCenterArticle.RECOVERY} title="Learn more about the Account recovery process">
       Learn more
     </ExternalLink>
   )

--- a/src/components/settings/Recovery/index.tsx
+++ b/src/components/settings/Recovery/index.tsx
@@ -13,7 +13,6 @@ import EnhancedTable from '@/components/common/EnhancedTable'
 import InfoIcon from '@/public/images/notifications/info.svg'
 import CheckWallet from '@/components/common/CheckWallet'
 import { getPeriod } from '@/utils/date'
-import { HelpCenterArticle } from '@/config/constants'
 
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
 

--- a/src/components/settings/Recovery/index.tsx
+++ b/src/components/settings/Recovery/index.tsx
@@ -17,6 +17,8 @@ import { HelpCenterArticle } from '@/config/constants'
 
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
 
+const FEEDBACK_FORM = 'https://noteforms.com/forms/safe-feedback-form-hk16ds?notionforms=1&utm_source=notionforms'
+
 enum HeadCells {
   Guardian = 'guardian',
   TxCooldown = 'txCooldown',
@@ -131,11 +133,7 @@ export function Recovery(): ReactElement {
             <>
               <Alert severity="info">
                 Unhappy with the provided option?
-                <ExternalLink
-                  noIcon
-                  href={HelpCenterArticle.RECOVERY}
-                  title="Learn more about Account recovery process"
-                >
+                <ExternalLink noIcon href={FEEDBACK_FORM} title="Give feedback about the Account recovery process">
                   Give us feedback
                 </ExternalLink>
               </Alert>

--- a/src/components/settings/Recovery/index.tsx
+++ b/src/components/settings/Recovery/index.tsx
@@ -13,6 +13,7 @@ import EnhancedTable from '@/components/common/EnhancedTable'
 import InfoIcon from '@/public/images/notifications/info.svg'
 import CheckWallet from '@/components/common/CheckWallet'
 import { getPeriod } from '@/utils/date'
+import { HelpCenterArticle } from '@/config/constants'
 
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
 
@@ -129,8 +130,12 @@ export function Recovery(): ReactElement {
           {!recovery || recovery.length === 0 ? (
             <>
               <Alert severity="info">
-                Unhappy with the provided option? {/* TODO: Add link */}
-                <ExternalLink noIcon href="#">
+                Unhappy with the provided option?
+                <ExternalLink
+                  noIcon
+                  href={HelpCenterArticle.RECOVERY}
+                  title="Learn more about Account recovery process"
+                >
                   Give us feedback
                 </ExternalLink>
               </Alert>

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -75,6 +75,7 @@ export const HelpCenterArticle = {
   CONFLICTING_TRANSACTIONS: `${HELP_CENTER_URL}/en/articles/40839-why-are-transactions-with-the-same-nonce-conflicting-with-each-other`,
   FALLBACK_HANDLER: `${HELP_CENTER_URL}/en/articles/40838-what-is-a-fallback-handler-and-how-does-it-relate-to-safe`,
   MOBILE_SAFE: `${HELP_CENTER_URL}/en/articles/40801-connect-to-web-with-mobile-safe`,
+  RECOVERY: `${HELP_CENTER_URL}/en/articles/110656-account-recovery-in-safe-wallet`,
   RELAYING: `${HELP_CENTER_URL}/en/articles/59203-what-is-gas-fee-sponsoring`,
   SAFE_SETUP: `${HELP_CENTER_URL}/en/articles/40835-what-safe-setup-should-i-use`,
   SIGNED_MESSAGES: `${HELP_CENTER_URL}/en/articles/40783-what-are-signed-messages`,


### PR DESCRIPTION
## What it solves

Resolves missing recovery documentation

## How this PR fixes it

This adds the forthcoming help centre article to all relevant recovery features.

## How to test it

- Info. above grouped recovery attempts and their cancellations
- Link on the recovery "in progress"/"proposal" modal/dashboard header widget
- Settings feedback section

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
