### PR TITLE
Feat: custom ENS lookup for Sepolia

### DIFF
--- a/src/services/ens/config.ts
+++ b/src/services/ens/config.ts
@@ -1,0 +1,6 @@
+/**
+ * @see https://docs.ens.domains/ens-deployments
+ */
+export const CUSTOM_REGISTRIES: Record<string, string> = {
+  '11155111': '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e', // ENS on Sepolia
+}

--- a/src/services/ens/custom.ts
+++ b/src/services/ens/custom.ts
@@ -3,6 +3,7 @@ import { Contract, utils, constants } from 'ethers'
 
 // ENS Registry ABI (simplified version)
 const ensRegistryAbi = ['function resolver(bytes32 node) external view returns (address)']
+const resolverAbi = ['function addr(bytes32 node) external view returns (address)']
 
 export const customResolveName = async (
   registryAddress: string,
@@ -17,7 +18,7 @@ export const customResolveName = async (
     return undefined
   }
 
-  const resolver = new Contract(resolverAddress, ensRegistryAbi, rpcProvider)
+  const resolver = new Contract(resolverAddress, resolverAbi, rpcProvider)
   const address = await resolver.addr(namehash)
 
   return address || undefined

--- a/src/services/ens/custom.ts
+++ b/src/services/ens/custom.ts
@@ -1,0 +1,24 @@
+import { type JsonRpcProvider } from '@ethersproject/providers'
+import { Contract, utils, constants } from 'ethers'
+
+// ENS Registry ABI (simplified version)
+const ensRegistryAbi = ['function resolver(bytes32 node) external view returns (address)']
+
+export const customResolveName = async (
+  registryAddress: string,
+  rpcProvider: JsonRpcProvider,
+  name: string,
+): Promise<string | undefined> => {
+  const ensRegistry = new Contract(registryAddress, ensRegistryAbi, rpcProvider)
+  const namehash = utils.namehash(name)
+  const resolverAddress = await ensRegistry.resolver(namehash)
+
+  if (resolverAddress === constants.AddressZero) {
+    return undefined
+  }
+
+  const resolver = new Contract(resolverAddress, ensRegistryAbi, rpcProvider)
+  const address = await resolver.addr(namehash)
+
+  return address || undefined
+}

--- a/src/services/ens/index.test.ts
+++ b/src/services/ens/index.test.ts
@@ -1,5 +1,5 @@
 import { type JsonRpcProvider } from '@ethersproject/providers'
-import { resolveName, lookupAddress, isDomain } from '../ens'
+import { resolveName, lookupAddress, isDomain } from '.'
 import { logError } from '../exceptions'
 
 // mock rpcProvider
@@ -11,6 +11,7 @@ const rpcProvider = {
 const badRpcProvider = {
   resolveName: jest.fn(() => Promise.reject(new Error('bad resolveName'))),
   lookupAddress: jest.fn(() => Promise.reject(new Error('bad lookupAddress'))),
+  getNetwork: jest.fn(() => Promise.resolve({ chainId: 1 })),
 } as unknown as JsonRpcProvider
 
 // mock logError

--- a/src/services/ens/index.test.ts
+++ b/src/services/ens/index.test.ts
@@ -6,6 +6,7 @@ import { logError } from '../exceptions'
 const rpcProvider = {
   resolveName: jest.fn(() => Promise.resolve('0x0000000000000000000000000000000000000000')),
   lookupAddress: jest.fn(() => Promise.resolve('safe.eth')),
+  getNetwork: jest.fn(() => Promise.resolve({ chainId: 1 })),
 } as unknown as JsonRpcProvider
 
 const badRpcProvider = {
@@ -17,6 +18,10 @@ const badRpcProvider = {
 // mock logError
 jest.mock('../exceptions', () => ({
   logError: jest.fn(),
+}))
+
+jest.mock('./custom', () => ({
+  customResolveName: jest.fn(() => Promise.resolve('0x0000001111111111111111111111111111111111')),
 }))
 
 describe('domains', () => {
@@ -39,6 +44,15 @@ describe('domains', () => {
       const address = await resolveName(badRpcProvider, 'safe.eth')
       expect(address).toBe(undefined)
       expect(logError).toHaveBeenCalledWith('101: Failed to resolve the address', 'bad resolveName')
+    })
+
+    it('should look up names on Sepolia', async () => {
+      // mock rpcProvider
+      const rpcProvider = {
+        getNetwork: jest.fn(() => Promise.resolve({ chainId: 11155111 })),
+      } as unknown as JsonRpcProvider
+
+      expect(await resolveName(rpcProvider, 'sepolia.eth')).toBe('0x0000001111111111111111111111111111111111')
     })
   })
 


### PR DESCRIPTION
## What it solves

Resolves #2687.

Ethers v5.7 unfortunately doesn't support Sepolia out of the box, and upgrading to the latest version is complicated.
So as a temporary fix, I'm adding a custom resolver for Sepolia.