### PR TITLE
fix: handle recovery errors

### DIFF
--- a/src/components/recovery/ExecuteRecoveryButton/index.tsx
+++ b/src/components/recovery/ExecuteRecoveryButton/index.tsx
@@ -9,8 +9,10 @@ import { dispatchRecoveryExecution } from '@/services/tx/tx-sender'
 import useOnboard from '@/hooks/wallets/useOnboard'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { useRecoveryTxState } from '@/hooks/useRecoveryTxState'
-import { Errors, logError } from '@/services/exceptions'
+import { Errors, trackError } from '@/services/exceptions'
+import { asError } from '@/services/exceptions/utils'
 import { RecoveryContext } from '../RecoveryContext'
+import { RecoveryListItemContext } from '../RecoveryListItem/RecoveryListItemContext'
 import type { RecoveryQueueItem } from '@/services/recovery/recovery-state'
 
 export function ExecuteRecoveryButton({
@@ -20,6 +22,7 @@ export function ExecuteRecoveryButton({
   recovery: RecoveryQueueItem
   compact?: boolean
 }): ReactElement {
+  const { setSubmitError } = useContext(RecoveryListItemContext)
   const { isExecutable } = useRecoveryTxState(recovery)
   const onboard = useOnboard()
   const { safe } = useSafeInfo()
@@ -41,8 +44,11 @@ export function ExecuteRecoveryButton({
         delayModifierAddress: recovery.address,
         refetchRecoveryData: refetch,
       })
-    } catch (e) {
-      logError(Errors._812, e)
+    } catch (_err) {
+      const err = asError(_err)
+
+      trackError(Errors._812, e)
+      setSubmitError(err)
     }
   }
 

--- a/src/components/recovery/RecoveryListItem/RecoveryListItemContext.tsx
+++ b/src/components/recovery/RecoveryListItem/RecoveryListItemContext.tsx
@@ -1,0 +1,22 @@
+import { createContext, useState } from 'react'
+import type { Dispatch, ReactElement, SetStateAction } from 'react'
+
+type SubmitError = Error | undefined
+
+export const RecoveryListItemContext = createContext<{
+  submitError: SubmitError
+  setSubmitError: Dispatch<SetStateAction<SubmitError>>
+}>({
+  submitError: undefined,
+  setSubmitError: () => {},
+})
+
+export function RecoveryListItemProvider({ children }: { children: ReactElement }): ReactElement {
+  const [submitError, setSubmitError] = useState<SubmitError>(undefined)
+
+  return (
+    <RecoveryListItemContext.Provider value={{ submitError, setSubmitError }}>
+      {children}
+    </RecoveryListItemContext.Provider>
+  )
+}

--- a/src/components/recovery/RecoveryListItem/index.tsx
+++ b/src/components/recovery/RecoveryListItem/index.tsx
@@ -1,15 +1,37 @@
 import { Accordion, AccordionDetails, AccordionSummary } from '@mui/material'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
-import type { ReactElement } from 'react'
+import { useContext, useState } from 'react'
+import type { ComponentProps, ReactElement } from 'react'
 
 import txListItemCss from '@/components/transactions/TxListItem/styles.module.css'
 import { RecoverySummary } from '../RecoverySummary'
 import { RecoveryDetails } from '../RecoveryDetails'
+import { RecoveryListItemContext, RecoveryListItemProvider } from './RecoveryListItemContext'
 import type { RecoveryQueueItem } from '@/services/recovery/recovery-state'
 
-export function RecoveryListItem({ item }: { item: RecoveryQueueItem }): ReactElement {
+function ProvidedRecoveryListItem({ item }: { item: RecoveryQueueItem }): ReactElement {
+  const { submitError, setSubmitError } = useContext(RecoveryListItemContext)
+  const [expanded, setExpanded] = useState(false)
+
+  const isExpanded = !!submitError || expanded
+
+  const onChange = () => {
+    if (isExpanded) {
+      setExpanded(false)
+      setSubmitError(undefined)
+    } else {
+      setExpanded(true)
+    }
+  }
+
   return (
-    <Accordion disableGutters elevation={0} className={txListItemCss.accordion}>
+    <Accordion
+      disableGutters
+      elevation={0}
+      className={txListItemCss.accordion}
+      expanded={isExpanded}
+      onChange={onChange}
+    >
       <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ justifyContent: 'flex-start', overflowX: 'auto' }}>
         <RecoverySummary item={item} />
       </AccordionSummary>
@@ -18,5 +40,13 @@ export function RecoveryListItem({ item }: { item: RecoveryQueueItem }): ReactEl
         <RecoveryDetails item={item} />
       </AccordionDetails>
     </Accordion>
+  )
+}
+
+export function RecoveryListItem(props: ComponentProps<typeof ProvidedRecoveryListItem>): ReactElement {
+  return (
+    <RecoveryListItemProvider>
+      <ProvidedRecoveryListItem {...props} />
+    </RecoveryListItemProvider>
   )
 }

--- a/src/components/recovery/RecoverySigners/index.tsx
+++ b/src/components/recovery/RecoverySigners/index.tsx
@@ -1,4 +1,5 @@
 import { Box, List, ListItem, ListItemIcon, ListItemText, SvgIcon, Typography } from '@mui/material'
+import { useContext } from 'react'
 import type { ReactElement } from 'react'
 
 import CircleIcon from '@/public/images/common/circle.svg'
@@ -8,12 +9,15 @@ import { Countdown } from '@/components/common/Countdown'
 import { ExecuteRecoveryButton } from '../ExecuteRecoveryButton'
 import { CancelRecoveryButton } from '../CancelRecoveryButton'
 import { useRecoveryTxState } from '@/hooks/useRecoveryTxState'
+import { formatDate } from '@/utils/date'
+import ErrorMessage from '@/components/tx/ErrorMessage'
+import { RecoveryListItemContext } from '../RecoveryListItem/RecoveryListItemContext'
 import type { RecoveryQueueItem } from '@/services/recovery/recovery-state'
 
 import txSignersCss from '@/components/transactions/TxSigners/styles.module.css'
-import { formatDate } from '@/utils/date'
 
 export function RecoverySigners({ item }: { item: RecoveryQueueItem }): ReactElement {
+  const { submitError } = useContext(RecoveryListItemContext)
   const { isExecutable, isNext, remainingSeconds } = useRecoveryTxState(item)
 
   return (
@@ -66,6 +70,10 @@ export function RecoverySigners({ item }: { item: RecoveryQueueItem }): ReactEle
 
         {isNext && <Countdown seconds={remainingSeconds} />}
       </Box>
+
+      {submitError && (
+        <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
+      )}
 
       <Box display="flex" alignItems="center" justifyContent="center" gap={1} mt={2}>
         <ExecuteRecoveryButton recovery={item} />

--- a/src/services/tx/tx-sender/dispatch.ts
+++ b/src/services/tx/tx-sender/dispatch.ts
@@ -441,12 +441,14 @@ export async function dispatchRecoveryProposal({
 
   const signer = provider.getSigner()
 
-  delayModifier
-    .connect(signer)
-    .execTransactionFromModule(safeTx.data.to, safeTx.data.value, safeTx.data.data, safeTx.data.operation)
-    .then((result) => {
-      reloadRecoveryDataAfterProcessed(result, refetchRecoveryData)
-    })
+  try {
+    const tx = await delayModifier
+      .connect(signer)
+      .execTransactionFromModule(safeTx.data.to, safeTx.data.value, safeTx.data.data, safeTx.data.operation)
+    reloadRecoveryDataAfterProcessed(tx, refetchRecoveryData)
+  } catch (error) {
+    throw error
+  }
 }
 
 export async function dispatchRecoveryExecution({
@@ -469,12 +471,12 @@ export async function dispatchRecoveryExecution({
 
   const signer = provider.getSigner()
 
-  delayModifier
-    .connect(signer)
-    .executeNextTx(args.to, args.value, args.data, args.operation)
-    .then((result) => {
-      reloadRecoveryDataAfterProcessed(result, refetchRecoveryData)
-    })
+  try {
+    const tx = await delayModifier.connect(signer).executeNextTx(args.to, args.value, args.data, args.operation)
+    reloadRecoveryDataAfterProcessed(tx, refetchRecoveryData)
+  } catch (error) {
+    throw error
+  }
 }
 
 export async function dispatchRecoverySkipExpired({
@@ -495,10 +497,10 @@ export async function dispatchRecoverySkipExpired({
 
   const signer = provider.getSigner()
 
-  delayModifier
-    .connect(signer)
-    .skipExpired()
-    .then((result) => {
-      reloadRecoveryDataAfterProcessed(result, refetchRecoveryData)
-    })
+  try {
+    const tx = await delayModifier.connect(signer).skipExpired()
+    reloadRecoveryDataAfterProcessed(tx, refetchRecoveryData)
+  } catch (error) {
+    throw error
+  }
 }


### PR DESCRIPTION
## What it solves

Resolves [recovery transaction error handling](https://www.notion.so/safe-global/Error-when-creating-editing-recovery-setup-without-changes-f82ad44386e547c99d2a9444854e4344?d=3775d9c982be43949926b42571b746bb)

## How this PR fixes it

A new error-specific context has been added around each `RecoveryListItem` which is rendered when present above the execution buttons. On top of this, errors thrown by the respective recovery transaction dispatchers are now thrown again as they were not being caught correctly.

## How to test it

1. Propose a recovery and reject it, observing the error object showing as we do with "normal" transactions.
2. Execute/reject a recovery proposal (as a Guardian) and observe the new error message showing above the execution buttons, or alternatively opening the respective accordion if done so via the summary buttons.

## Screenshots

![reject recovery](https://github.com/safe-global/safe-wallet-web/assets/20442784/636184de-7bd2-4729-90fd-6f652b655373)

![reject recovery execution](https://github.com/safe-global/safe-wallet-web/assets/20442784/b2b0f519-a657-444d-a7e0-6e9f2022ecba)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
