### PR TITLE
Fix: close tx flow on "View transaction"

### DIFF
--- a/src/components/tx-flow/flows/SuccessScreen/index.tsx
+++ b/src/components/tx-flow/flows/SuccessScreen/index.tsx
@@ -39,7 +39,7 @@ export const SuccessScreen = ({ txId }: { txId: string }) => {
     return () => unsubFns.forEach((unsubscribe) => unsubscribe())
   }, [txId])
 
-  const onFinishClick = useCallback(() => {
+  const onClose = useCallback(() => {
     setTxFlow(undefined)
   }, [setTxFlow])
 
@@ -71,13 +71,13 @@ export const SuccessScreen = ({ txId }: { txId: string }) => {
       <div className={classnames(css.row, css.buttons)}>
         {txLink && (
           <Link {...txLink} passHref target="_blank" rel="noreferrer" legacyBehavior>
-            <Button data-testid="view-transaction-btn" variant="outlined" size="small">
+            <Button data-testid="view-transaction-btn" variant="outlined" size="small" onClick={onClose}>
               View transaction
             </Button>
           </Link>
         )}
 
-        <Button data-testid="finish-transaction-btn" variant="contained" size="small" onClick={onFinishClick}>
+        <Button data-testid="finish-transaction-btn" variant="contained" size="small" onClick={onClose}>
           Finish
         </Button>
       </div>


### PR DESCRIPTION
## What it solves

Bug: if you're on an individual transaction page and execute it, the View transaction button on the Success screen doesn't do anything (it navigates to the same page and doesn't close the modal).

Solution: it will now close the modal.