### PR TITLE
fix: add expiration state to in-progress modal

### DIFF
--- a/src/components/recovery/RecoveryCards/RecoveryInProgressCard.tsx
+++ b/src/components/recovery/RecoveryCards/RecoveryInProgressCard.tsx
@@ -25,7 +25,7 @@ type Props =
     }
 
 export function RecoveryInProgressCard({ orientation = 'vertical', onClose, recovery }: Props): ReactElement {
-  const { isExecutable, remainingSeconds } = useRecoveryTxState(recovery)
+  const { isExecutable, isExpired, remainingSeconds } = useRecoveryTxState(recovery)
   const router = useRouter()
 
   const onClick = async () => {
@@ -37,9 +37,15 @@ export function RecoveryInProgressCard({ orientation = 'vertical', onClose, reco
   }
 
   const icon = <RecoveryPending />
-  const title = isExecutable ? 'Account can be recovered' : 'Account recovery in progress'
+  const title = isExecutable
+    ? 'Account can be recovered'
+    : isExpired
+    ? 'Account recovery expired'
+    : 'Account recovery in progress'
   const desc = isExecutable
     ? 'The delay period has passed and it is now possible to execute the recovery transaction.'
+    : isExpired
+    ? 'The pending recovery transaction has expired and needs to be cancelled before a new one can be created.'
     : 'The recovery process has started. This Account will be ready to recover in:'
 
   const link = (

--- a/src/components/recovery/RecoveryCards/__tests__/RecoveryInProgressCard.test.tsx
+++ b/src/components/recovery/RecoveryCards/__tests__/RecoveryInProgressCard.test.tsx
@@ -49,6 +49,45 @@ describe('RecoveryInProgressCard', () => {
       })
     })
 
+    it('should render the expired state correctly', async () => {
+      mockUseRecoveryTxState.mockReturnValue({
+        isExecutable: false,
+        isExpired: true,
+        remainingSeconds: 0,
+      } as any)
+
+      const mockClose = jest.fn()
+
+      const { queryByText } = render(
+        <RecoveryInProgressCard
+          orientation="vertical"
+          onClose={mockClose}
+          recovery={{ validFrom: BigNumber.from(0) } as RecoveryQueueItem}
+        />,
+      )
+
+      ;['days', 'hrs', 'mins'].forEach((unit) => {
+        expect(queryByText(unit)).toBeFalsy()
+      })
+
+      expect(queryByText('Account recovery expired')).toBeTruthy()
+      expect(
+        queryByText(
+          'The pending recovery transaction has expired and needs to be cancelled before a new one can be created.',
+        ),
+      ).toBeTruthy()
+      expect(queryByText('Learn more')).toBeTruthy()
+
+      const queueButton = queryByText('Go to queue')
+      expect(queueButton).toBeTruthy()
+
+      fireEvent.click(queueButton!)
+
+      await waitFor(() => {
+        expect(mockClose).toHaveBeenCalled()
+      })
+    })
+
     it('should render non-executable recovery state correctly', async () => {
       mockUseRecoveryTxState.mockReturnValue({
         isExecutable: false,
@@ -102,6 +141,35 @@ describe('RecoveryInProgressCard', () => {
       expect(queryByText('Go to queue')).toBeFalsy()
 
       expect(queryByText('Account can be recovered')).toBeTruthy()
+      expect(queryByText('Learn more')).toBeTruthy()
+    })
+
+    it('should render the expired state correctly', async () => {
+      mockUseRecoveryTxState.mockReturnValue({
+        isExecutable: false,
+        isExpired: true,
+        remainingSeconds: 0,
+      } as any)
+
+      const mockClose = jest.fn()
+
+      const { queryByText } = render(
+        <RecoveryInProgressCard
+          orientation="horizontal"
+          recovery={{ validFrom: BigNumber.from(0) } as RecoveryQueueItem}
+        />,
+      )
+
+      ;['days', 'hrs', 'mins'].forEach((unit) => {
+        expect(queryByText(unit)).toBeFalsy()
+      })
+
+      expect(queryByText('Account recovery expired')).toBeTruthy()
+      expect(
+        queryByText(
+          'The pending recovery transaction has expired and needs to be cancelled before a new one can be created.',
+        ),
+      ).toBeTruthy()
       expect(queryByText('Learn more')).toBeTruthy()
     })
 


### PR DESCRIPTION
## What it solves

Resolves [unclear expired recovery transaction](https://www.notion.so/safe-global/Expired-recovery-process-blocks-start-recovery-from-the-dashboard-c9a79955b4eb4592a70d367445ca958b)

## How this PR fixes it

A new message is displayed in the "in-progress" modal/header widget on the dashboard if the "next" recovery transaction expired.

## How to test it

1. Queue a recovery transaction, ensuring that it will expire.
2. Observe the new text within the "in-progress" modal component.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/942745c7-9da2-4684-97f7-5a40964faf97)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
