### PR TITLE
fix: allow cancellation after expiration

### DIFF
--- a/src/components/recovery/CancelRecoveryButton/index.tsx
+++ b/src/components/recovery/CancelRecoveryButton/index.tsx
@@ -13,7 +13,6 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import useOnboard from '@/hooks/wallets/useOnboard'
 import { logError, Errors } from '@/services/exceptions'
 import { RecoveryContext } from '../RecoveryContext'
-import { useIsGuardian } from '@/hooks/useIsGuardian'
 import { useRecoveryTxState } from '@/hooks/useRecoveryTxState'
 import type { RecoveryQueueItem } from '@/services/recovery/recovery-state'
 
@@ -25,7 +24,6 @@ export function CancelRecoveryButton({
   compact?: boolean
 }): ReactElement {
   const isOwner = useIsSafeOwner()
-  const isGuardian = useIsGuardian()
   const { isExpired } = useRecoveryTxState(recovery)
   const { setTxFlow } = useContext(TxModalContext)
   const onboard = useOnboard()
@@ -55,7 +53,7 @@ export function CancelRecoveryButton({
   return (
     <CheckWallet allowNonOwner>
       {(isOk) => {
-        const isDisabled = isOwner ? !isOk : !isOk && !isExpired
+        const isDisabled = isOwner ? !isOk : !isOk || !isExpired
 
         return compact ? (
           <IconButton onClick={onClick} color="error" size="small" disabled={isDisabled}>

--- a/src/components/recovery/CancelRecoveryButton/index.tsx
+++ b/src/components/recovery/CancelRecoveryButton/index.tsx
@@ -55,7 +55,7 @@ export function CancelRecoveryButton({
   return (
     <CheckWallet allowNonOwner>
       {(isOk) => {
-        const isDisabled = !isOk || (isGuardian && !isExpired)
+        const isDisabled = !isOk || isGuardian
 
         return compact ? (
           <IconButton onClick={onClick} color="error" size="small" disabled={isDisabled}>

--- a/src/components/recovery/CancelRecoveryButton/index.tsx
+++ b/src/components/recovery/CancelRecoveryButton/index.tsx
@@ -55,7 +55,7 @@ export function CancelRecoveryButton({
   return (
     <CheckWallet allowNonOwner>
       {(isOk) => {
-        const isDisabled = !isOk || isGuardian
+        const isDisabled = isOwner ? !isOk : !isOk && !isExpired
 
         return compact ? (
           <IconButton onClick={onClick} color="error" size="small" disabled={isDisabled}>

--- a/src/components/settings/Recovery/index.tsx
+++ b/src/components/settings/Recovery/index.tsx
@@ -32,7 +32,7 @@ const headCells = [
     label: (
       <>
         Recovery delay{' '}
-        <Tooltip title="You can cancel any recovery attempt when it is not needed or wanted within the delay period.">
+        <Tooltip title="You can cancel any recovery attempt when it is not needed or wanted.">
           <span>
             <SvgIcon
               component={InfoIcon}

--- a/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowReview.tsx
+++ b/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowReview.tsx
@@ -72,10 +72,7 @@ export function UpsertRecoveryFlowReview({
         title={
           <>
             Recovery delay
-            <Tooltip
-              placement="top"
-              title="You can cancel any recovery attempt when it is not needed or wanted within the delay period."
-            >
+            <Tooltip placement="top" title="You can cancel any recovery attempt when it is not needed or wanted.">
               <span>
                 <SvgIcon
                   component={InfoIcon}

--- a/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowSettings.tsx
+++ b/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowSettings.tsx
@@ -105,7 +105,7 @@ export function UpsertRecoveryFlowSettings({
               </Typography>
 
               <Typography variant="body2">
-                You can cancel any recovery attempt when it is not needed or wanted within the delay period.
+                You can cancel any recovery attempt when it is not needed or wanted.
               </Typography>
             </div>
 


### PR DESCRIPTION
## What it solves

Resolves ability to [cancel recovery attempts after expiration](https://www.notion.so/safe-global/Cancel-recovery-tx-after-Recovery-delay-f8af1f46751f41a2bb735aec783a388c)

## How this PR fixes it

The disable logic has been altered to only take the expiration into account when not connected as an owner, as well as adjusting the information about cancellation throughout the app.

## How to test it

Observe cancellation is _always_ possible as an owner, wheras if not an owner only after expiration.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
