### PR TITLE
feat: recovery transaction processing state

### DIFF
--- a/src/components/recovery/CancelRecoveryButton/index.tsx
+++ b/src/components/recovery/CancelRecoveryButton/index.tsx
@@ -8,12 +8,11 @@ import CheckWallet from '@/components/common/CheckWallet'
 import { TxModalContext } from '@/components/tx-flow'
 import { CancelRecoveryFlow } from '@/components/tx-flow/flows/CancelRecovery'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
-import { dispatchRecoverySkipExpired } from '@/services/tx/tx-sender'
+import { dispatchRecoverySkipExpired } from '@/services/recovery/recovery-sender'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import useOnboard from '@/hooks/wallets/useOnboard'
 import { trackError, Errors } from '@/services/exceptions'
 import { asError } from '@/services/exceptions/utils'
-import { RecoveryContext } from '../RecoveryContext'
 import { useIsGuardian } from '@/hooks/useIsGuardian'
 import { useRecoveryTxState } from '@/hooks/useRecoveryTxState'
 import { RecoveryListItemContext } from '../RecoveryListItem/RecoveryListItemContext'
@@ -33,7 +32,6 @@ export function CancelRecoveryButton({
   const { setTxFlow } = useContext(TxModalContext)
   const onboard = useOnboard()
   const { safe } = useSafeInfo()
-  const { refetch } = useContext(RecoveryContext)
 
   const onClick = async (e: SyntheticEvent) => {
     e.stopPropagation()
@@ -47,7 +45,7 @@ export function CancelRecoveryButton({
           onboard,
           chainId: safe.chainId,
           delayModifierAddress: recovery.address,
-          refetchRecoveryData: refetch,
+          recoveryTxHash: recovery.args.txHash,
         })
       } catch (_err) {
         const err = asError(_err)

--- a/src/components/recovery/CancelRecoveryButton/index.tsx
+++ b/src/components/recovery/CancelRecoveryButton/index.tsx
@@ -29,7 +29,7 @@ export function CancelRecoveryButton({
   const { setSubmitError } = useContext(RecoveryListItemContext)
   const isOwner = useIsSafeOwner()
   const isGuardian = useIsGuardian()
-  const { isExpired } = useRecoveryTxState(recovery)
+  const { isExpired, isPending } = useRecoveryTxState(recovery)
   const { setTxFlow } = useContext(TxModalContext)
   const onboard = useOnboard()
   const { safe } = useSafeInfo()
@@ -61,7 +61,7 @@ export function CancelRecoveryButton({
   return (
     <CheckWallet allowNonOwner>
       {(isOk) => {
-        const isDisabled = !isOk || (isGuardian && !isExpired)
+        const isDisabled = !isOk || isPending || (isGuardian && !isExpired)
 
         return compact ? (
           <IconButton onClick={onClick} color="error" size="small" disabled={isDisabled}>

--- a/src/components/recovery/ExecuteRecoveryButton/index.tsx
+++ b/src/components/recovery/ExecuteRecoveryButton/index.tsx
@@ -5,13 +5,12 @@ import type { SyntheticEvent, ReactElement } from 'react'
 import RocketIcon from '@/public/images/transactions/rocket.svg'
 import IconButton from '@mui/material/IconButton'
 import CheckWallet from '@/components/common/CheckWallet'
-import { dispatchRecoveryExecution } from '@/services/tx/tx-sender'
+import { dispatchRecoveryExecution } from '@/services/recovery/recovery-sender'
 import useOnboard from '@/hooks/wallets/useOnboard'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { useRecoveryTxState } from '@/hooks/useRecoveryTxState'
 import { Errors, trackError } from '@/services/exceptions'
 import { asError } from '@/services/exceptions/utils'
-import { RecoveryContext } from '../RecoveryContext'
 import { RecoveryListItemContext } from '../RecoveryListItem/RecoveryListItemContext'
 import type { RecoveryQueueItem } from '@/services/recovery/recovery-state'
 
@@ -24,10 +23,8 @@ export function ExecuteRecoveryButton({
 }): ReactElement {
   const { setSubmitError } = useContext(RecoveryListItemContext)
   const { isExecutable, isPending } = useRecoveryTxState(recovery)
-  const { setPending } = useContext(RecoveryContext)
   const onboard = useOnboard()
   const { safe } = useSafeInfo()
-  const { refetch } = useContext(RecoveryContext)
 
   const onClick = async (e: SyntheticEvent) => {
     e.stopPropagation()
@@ -37,26 +34,18 @@ export function ExecuteRecoveryButton({
       return
     }
 
-    setPending((prev) => ({ ...prev, [recovery.transactionHash]: true }))
-
     try {
       await dispatchRecoveryExecution({
         onboard,
         chainId: safe.chainId,
         args: recovery.args,
         delayModifierAddress: recovery.address,
-        refetchRecoveryData: refetch,
       })
     } catch (_err) {
       const err = asError(_err)
 
       trackError(Errors._812, e)
       setSubmitError(err)
-    } finally {
-      setPending((prev) => {
-        const { [recovery.transactionHash]: _, ...rest } = prev
-        return rest
-      })
     }
   }
 

--- a/src/components/recovery/RecoveryContext/__tests__/useRecoveryPendingTxs.test.ts
+++ b/src/components/recovery/RecoveryContext/__tests__/useRecoveryPendingTxs.test.ts
@@ -1,0 +1,75 @@
+import { RecoveryEvent, recoveryDispatch } from '@/services/recovery/recoveryEvents'
+import { PendingStatus } from '@/store/pendingTxsSlice'
+import { act, renderHook } from '@/tests/test-utils'
+import { faker } from '@faker-js/faker'
+import { useRecoveryPendingTxs } from '../useRecoveryPendingTxs'
+
+describe('useRecoveryPendingTxs', () => {
+  it('should set pending status to SUBMITTING when EXECUTING event is emitted', () => {
+    const delayModifierAddress = faker.finance.ethereumAddress()
+    const transactionHash = faker.string.hexadecimal()
+    const { result } = renderHook(() => useRecoveryPendingTxs())
+
+    expect(result.current).toStrictEqual({})
+
+    act(() => {
+      recoveryDispatch(RecoveryEvent.EXECUTING, { moduleAddress: delayModifierAddress, transactionHash })
+    })
+
+    expect(result.current).toStrictEqual({
+      [transactionHash]: PendingStatus.SUBMITTING,
+    })
+  })
+
+  it('should set pending status to PROCESSING when PROCESSING event is emitted', () => {
+    const delayModifierAddress = faker.finance.ethereumAddress()
+    const transactionHash = faker.string.hexadecimal()
+    const { result } = renderHook(() => useRecoveryPendingTxs())
+
+    expect(result.current).toStrictEqual({})
+
+    act(() => {
+      recoveryDispatch(RecoveryEvent.PROCESSING, { moduleAddress: delayModifierAddress, transactionHash })
+    })
+
+    expect(result.current).toStrictEqual({
+      [transactionHash]: PendingStatus.PROCESSING,
+    })
+  })
+
+  it('should set remove the pending status when REVERTED event is emitted', () => {
+    const delayModifierAddress = faker.finance.ethereumAddress()
+    const transactionHash = faker.string.hexadecimal()
+    const { result } = renderHook(() => useRecoveryPendingTxs())
+
+    expect(result.current).toStrictEqual({})
+
+    act(() => {
+      recoveryDispatch(RecoveryEvent.EXECUTING, { moduleAddress: delayModifierAddress, transactionHash })
+      recoveryDispatch(RecoveryEvent.REVERTED, {
+        moduleAddress: delayModifierAddress,
+        transactionHash,
+        error: new Error(),
+      })
+    })
+
+    expect(result.current).toStrictEqual({})
+  })
+
+  it('should set remove the pending status when PROCESSED event is emitted', () => {
+    const delayModifierAddress = faker.finance.ethereumAddress()
+    const transactionHash = faker.string.hexadecimal()
+    const { result } = renderHook(() => useRecoveryPendingTxs())
+
+    expect(result.current).toStrictEqual({})
+
+    act(() => {
+      recoveryDispatch(RecoveryEvent.EXECUTING, { moduleAddress: delayModifierAddress, transactionHash })
+      recoveryDispatch(RecoveryEvent.PROCESSED, { moduleAddress: delayModifierAddress, transactionHash })
+    })
+
+    expect(result.current).toStrictEqual({})
+  })
+
+  // No need to test RecoveryEvent.FAILED as pending status is not set before it is dispatched
+})

--- a/src/components/recovery/RecoveryContext/index.tsx
+++ b/src/components/recovery/RecoveryContext/index.tsx
@@ -1,18 +1,24 @@
-import { createContext, useContext } from 'react'
-import type { ReactElement, ReactNode } from 'react'
+import { createContext, useContext, useState } from 'react'
+import type { ReactElement, ReactNode, Dispatch, SetStateAction } from 'react'
 
 import { useRecoveryState } from './useRecoveryState'
 import { useRecoveryDelayModifiers } from './useRecoveryDelayModifiers'
 import type { AsyncResult } from '@/hooks/useAsync'
 import type { RecoveryState } from '@/services/recovery/recovery-state'
 
+type PendingRecoveryTransactions = { [txHash: string]: boolean }
+
 // State of current Safe, populated on load
 export const RecoveryContext = createContext<{
   state: AsyncResult<RecoveryState>
   refetch: () => void
+  pending: PendingRecoveryTransactions
+  setPending: Dispatch<SetStateAction<PendingRecoveryTransactions>>
 }>({
   state: [undefined, undefined, false],
   refetch: () => {},
+  pending: {},
+  setPending: () => {},
 })
 
 export function RecoveryProvider({ children }: { children: ReactNode }): ReactElement {
@@ -21,13 +27,16 @@ export function RecoveryProvider({ children }: { children: ReactNode }): ReactEl
     data: [recoveryState, recoveryStateError, recoveryStateLoading],
     refetch,
   } = useRecoveryState(delayModifiers)
+  const [pending, setPending] = useState<PendingRecoveryTransactions>({})
 
   const data = recoveryState
   const error = delayModifiersError || recoveryStateError
   const loading = delayModifiersLoading || recoveryStateLoading
 
   return (
-    <RecoveryContext.Provider value={{ state: [data, error, loading], refetch }}>{children}</RecoveryContext.Provider>
+    <RecoveryContext.Provider value={{ state: [data, error, loading], refetch, pending, setPending }}>
+      {children}
+    </RecoveryContext.Provider>
   )
 }
 

--- a/src/components/recovery/RecoveryContext/useRecoveryPendingTxs.ts
+++ b/src/components/recovery/RecoveryContext/useRecoveryPendingTxs.ts
@@ -1,0 +1,44 @@
+import { RecoveryEvent, recoverySubscribe } from '@/services/recovery/recoveryEvents'
+import { PendingStatus } from '@/store/pendingTxsSlice'
+import { useEffect, useState } from 'react'
+
+type PendingRecoveryTransactions = { [recoveryTxHash: string]: PendingStatus }
+
+const pendingStatuses: { [key in RecoveryEvent]: PendingStatus | null } = {
+  [RecoveryEvent.EXECUTING]: PendingStatus.SUBMITTING,
+  [RecoveryEvent.PROCESSING]: PendingStatus.PROCESSING,
+  [RecoveryEvent.REVERTED]: null,
+  [RecoveryEvent.PROCESSED]: null,
+  [RecoveryEvent.FAILED]: null,
+}
+
+export function useRecoveryPendingTxs(): PendingRecoveryTransactions {
+  const [pending, setPending] = useState<PendingRecoveryTransactions>({})
+
+  useEffect(() => {
+    const unsubFns = Object.entries(pendingStatuses).map(([event, status]) =>
+      recoverySubscribe(event as RecoveryEvent, (detail) => {
+        const recoveryTxHash = 'recoveryTxHash' in detail && detail.recoveryTxHash
+
+        if (!recoveryTxHash) {
+          return
+        }
+
+        setPending((prev) => {
+          if (status === null) {
+            const { [recoveryTxHash]: _, ...rest } = prev
+            return rest
+          }
+
+          return { ...prev, [recoveryTxHash]: status }
+        })
+      }),
+    )
+
+    return () => {
+      unsubFns.forEach((unsub) => unsub())
+    }
+  }, [])
+
+  return pending
+}

--- a/src/components/recovery/RecoveryStatus/index.tsx
+++ b/src/components/recovery/RecoveryStatus/index.tsx
@@ -1,4 +1,4 @@
-import { SvgIcon, Typography } from '@mui/material'
+import { CircularProgress, SvgIcon, Typography } from '@mui/material'
 import { useContext } from 'react'
 import type { ReactElement } from 'react'
 
@@ -20,29 +20,31 @@ export const RecoveryStatus = ({ recovery }: { recovery: RecoveryQueueItem }): R
   const pendingTxStatus = pending?.[recovery.args.txHash]
 
   const status = pendingTxStatus ? (
-    STATUS_LABELS[pendingTxStatus]
+    <>
+      <CircularProgress size={14} color="inherit" />
+      {STATUS_LABELS[pendingTxStatus]}
+    </>
   ) : isExecutable ? (
     'Awaiting execution'
   ) : isExpired ? (
     'Expired'
   ) : (
     <>
-      <SvgIcon component={ClockIcon} inheritViewBox color="warning" fontSize="inherit" sx={{ mr: 0.5 }} />
+      <SvgIcon component={ClockIcon} inheritViewBox color="warning" fontSize="inherit" />
       Pending
     </>
   )
 
   return (
-    <>
-      <Typography
-        variant="caption"
-        fontWeight="bold"
-        color={isExpired ? 'error.main' : 'warning.main'}
-        display="inline-flex"
-        alignItems="center"
-      >
-        {status}
-      </Typography>
-    </>
+    <Typography
+      variant="caption"
+      fontWeight="bold"
+      color={isExpired ? 'error.main' : 'warning.main'}
+      display="inline-flex"
+      alignItems="center"
+      gap={1}
+    >
+      {status}
+    </Typography>
   )
 }

--- a/src/components/recovery/RecoveryStatus/index.tsx
+++ b/src/components/recovery/RecoveryStatus/index.tsx
@@ -1,12 +1,34 @@
 import { SvgIcon, Typography } from '@mui/material'
+import { useContext } from 'react'
 import type { ReactElement } from 'react'
 
 import ClockIcon from '@/public/images/common/clock.svg'
 import { useRecoveryTxState } from '@/hooks/useRecoveryTxState'
 import type { RecoveryQueueItem } from '@/services/recovery/recovery-state'
+import { PendingStatus } from '@/store/pendingTxsSlice'
+import { RecoveryContext } from '../RecoveryContext'
+
+const STATUS_LABELS: Partial<Record<PendingStatus, string>> = {
+  [PendingStatus.SUBMITTING]: 'Submitting',
+  [PendingStatus.PROCESSING]: 'Processing',
+}
 
 export const RecoveryStatus = ({ recovery }: { recovery: RecoveryQueueItem }): ReactElement => {
-  const { isExecutable, isExpired, isPending } = useRecoveryTxState(recovery)
+  const { isExecutable, isExpired } = useRecoveryTxState(recovery)
+  const { pending } = useContext(RecoveryContext)
+
+  const status = pending?.[recovery.transactionHash] ? (
+    STATUS_LABELS[pending[recovery.transactionHash]]
+  ) : isExecutable ? (
+    'Awaiting execution'
+  ) : isExpired ? (
+    'Expired'
+  ) : (
+    <>
+      <SvgIcon component={ClockIcon} inheritViewBox color="warning" fontSize="inherit" sx={{ mr: 0.5 }} />
+      Pending
+    </>
+  )
 
   return (
     <>
@@ -17,18 +39,7 @@ export const RecoveryStatus = ({ recovery }: { recovery: RecoveryQueueItem }): R
         display="inline-flex"
         alignItems="center"
       >
-        {isPending ? (
-          'Processing...'
-        ) : isExecutable ? (
-          'Awaiting execution'
-        ) : isExpired ? (
-          'Expired'
-        ) : (
-          <>
-            <SvgIcon component={ClockIcon} inheritViewBox color="warning" fontSize="inherit" sx={{ mr: 0.5 }} />
-            Pending
-          </>
-        )}
+        {status}
       </Typography>
     </>
   )

--- a/src/components/recovery/RecoveryStatus/index.tsx
+++ b/src/components/recovery/RecoveryStatus/index.tsx
@@ -17,8 +17,10 @@ export const RecoveryStatus = ({ recovery }: { recovery: RecoveryQueueItem }): R
   const { isExecutable, isExpired } = useRecoveryTxState(recovery)
   const { pending } = useContext(RecoveryContext)
 
-  const status = pending?.[recovery.transactionHash] ? (
-    STATUS_LABELS[pending[recovery.transactionHash]]
+  const pendingTxStatus = pending?.[recovery.args.txHash]
+
+  const status = pendingTxStatus ? (
+    STATUS_LABELS[pendingTxStatus]
   ) : isExecutable ? (
     'Awaiting execution'
   ) : isExpired ? (

--- a/src/components/recovery/RecoveryStatus/index.tsx
+++ b/src/components/recovery/RecoveryStatus/index.tsx
@@ -6,7 +6,7 @@ import { useRecoveryTxState } from '@/hooks/useRecoveryTxState'
 import type { RecoveryQueueItem } from '@/services/recovery/recovery-state'
 
 export const RecoveryStatus = ({ recovery }: { recovery: RecoveryQueueItem }): ReactElement => {
-  const { isExecutable, isExpired } = useRecoveryTxState(recovery)
+  const { isExecutable, isExpired, isPending } = useRecoveryTxState(recovery)
 
   return (
     <>
@@ -17,7 +17,9 @@ export const RecoveryStatus = ({ recovery }: { recovery: RecoveryQueueItem }): R
         display="inline-flex"
         alignItems="center"
       >
-        {isExecutable ? (
+        {isPending ? (
+          'Processing...'
+        ) : isExecutable ? (
           'Awaiting execution'
         ) : isExpired ? (
           'Expired'

--- a/src/components/recovery/RecoverySummary/index.tsx
+++ b/src/components/recovery/RecoverySummary/index.tsx
@@ -33,7 +33,7 @@ export function RecoverySummary({ item }: { item: RecoveryQueueItem }): ReactEle
         </Box>
       )}
 
-      <Box gridArea="status" ml={{ sm: 'auto' }} mr={1} display="flex" alignItems="center" gap={1}>
+      <Box gridArea="status" ml={{ sm: 'auto' }} mr={1} display="flex" alignItems="center">
         <RecoveryStatus recovery={item} />
       </Box>
     </Box>

--- a/src/components/tx-flow/flows/RecoverAccount/RecoverAccountFlowReview.tsx
+++ b/src/components/tx-flow/flows/RecoverAccount/RecoverAccountFlowReview.tsx
@@ -14,7 +14,8 @@ import useDecodeTx from '@/hooks/useDecodeTx'
 import TxCard from '../../common/TxCard'
 import { SafeTxContext } from '../../SafeTxProvider'
 import CheckWallet from '@/components/common/CheckWallet'
-import { createMultiSendCallOnlyTx, createTx, dispatchRecoveryProposal } from '@/services/tx/tx-sender'
+import { dispatchRecoveryProposal } from '@/services/recovery/recovery-sender'
+import { createMultiSendCallOnlyTx, createTx } from '@/services/tx/tx-sender'
 import { RecoverAccountFlowFields } from '.'
 import { OwnerList } from '../../common/OwnerList'
 import { selectDelayModifierByGuardian } from '@/services/recovery/selectors'
@@ -24,7 +25,7 @@ import { TxModalContext } from '../..'
 import { asError } from '@/services/exceptions/utils'
 import { trackError, Errors } from '@/services/exceptions'
 import { getPeriod } from '@/utils/date'
-import { RecoveryContext } from '@/components/recovery/RecoveryContext'
+import { useRecovery } from '@/components/recovery/RecoveryContext'
 import type { RecoverAccountFlowProps } from '.'
 
 import commonCss from '@/components/tx-flow/common/styles.module.css'
@@ -41,10 +42,7 @@ export function RecoverAccountFlowReview({ params }: { params: RecoverAccountFlo
   const { safe } = useSafeInfo()
   const wallet = useWallet()
   const onboard = useOnboard()
-  const {
-    refetch,
-    state: [data],
-  } = useContext(RecoveryContext)
+  const [data] = useRecovery()
   const recovery = data && selectDelayModifierByGuardian(data, wallet?.address ?? '')
 
   // Proposal
@@ -78,7 +76,6 @@ export function RecoverAccountFlowReview({ params }: { params: RecoverAccountFlo
         safe,
         safeTx,
         delayModifierAddress: recovery.address,
-        refetchRecoveryData: refetch,
       })
     } catch (_err) {
       const err = asError(_err)

--- a/src/hooks/__tests__/useRecoveryTxState.test.tsx
+++ b/src/hooks/__tests__/useRecoveryTxState.test.tsx
@@ -50,10 +50,13 @@ describe('useRecoveryTxState', () => {
         ),
       })
 
-      expect(result.current.isExecutable).toBe(false)
-      expect(result.current.remainingSeconds).toBe(1)
-      expect(result.current.isExpired).toBe(false)
-      expect(result.current.isNext).toBe(true)
+      expect(result.current).toStrictEqual({
+        isExecutable: false,
+        remainingSeconds: 1,
+        isExpired: false,
+        isNext: true,
+        isPending: false,
+      })
     })
 
     it('should return correct values when validFrom is in the future and expiresAt is in the future', () => {
@@ -87,10 +90,13 @@ describe('useRecoveryTxState', () => {
         ),
       })
 
-      expect(result.current.isExecutable).toBe(false)
-      expect(result.current.remainingSeconds).toBe(1)
-      expect(result.current.isExpired).toBe(false)
-      expect(result.current.isNext).toBe(true)
+      expect(result.current).toStrictEqual({
+        isExecutable: false,
+        remainingSeconds: 1,
+        isExpired: false,
+        isNext: true,
+        isPending: false,
+      })
     })
 
     it('should return correct values when validFrom is in the past and expiresAt is in the future', () => {
@@ -124,10 +130,13 @@ describe('useRecoveryTxState', () => {
         ),
       })
 
-      expect(result.current.isExecutable).toBe(true)
-      expect(result.current.remainingSeconds).toBe(0)
-      expect(result.current.isExpired).toBe(false)
-      expect(result.current.isNext).toBe(true)
+      expect(result.current).toStrictEqual({
+        isExecutable: true,
+        remainingSeconds: 0,
+        isExpired: false,
+        isNext: true,
+        isPending: false,
+      })
     })
 
     it('should return correct values when validFrom is in the past and expiresAt is in the past', () => {
@@ -161,10 +170,55 @@ describe('useRecoveryTxState', () => {
         ),
       })
 
-      expect(result.current.isExecutable).toBe(false)
-      expect(result.current.remainingSeconds).toBe(0)
-      expect(result.current.isExpired).toBe(true)
-      expect(result.current.isNext).toBe(true)
+      expect(result.current).toStrictEqual({
+        isExecutable: false,
+        remainingSeconds: 0,
+        isExpired: true,
+        isNext: true,
+        isPending: false,
+      })
+    })
+
+    it('should return pending if the transaction hash is set as pending', () => {
+      jest.setSystemTime(0)
+
+      const delayModifierAddress = faker.finance.ethereumAddress()
+      const nextTxHash = faker.string.hexadecimal()
+
+      const validFrom = BigNumber.from(0)
+      const expiresAt = BigNumber.from(1)
+
+      const data = [
+        {
+          address: delayModifierAddress,
+          txNonce: BigNumber.from(0),
+          queue: [
+            {
+              address: delayModifierAddress,
+              transactionHash: nextTxHash,
+              validFrom,
+              expiresAt,
+              args: { queueNonce: BigNumber.from(0) },
+            },
+          ],
+        },
+      ]
+
+      const { result } = renderHook(() => useRecoveryTxState(data[0].queue[0] as any), {
+        wrapper: ({ children }) => (
+          <RecoveryContext.Provider value={{ state: [data], pending: { [nextTxHash]: true } } as any}>
+            {children}
+          </RecoveryContext.Provider>
+        ),
+      })
+
+      expect(result.current).toStrictEqual({
+        isExecutable: true,
+        remainingSeconds: 0,
+        isExpired: false,
+        isNext: true,
+        isPending: true,
+      })
     })
   })
 
@@ -225,10 +279,13 @@ describe('useRecoveryTxState', () => {
         ),
       })
 
-      expect(result.current.isExecutable).toBe(false)
-      expect(result.current.remainingSeconds).toBe(1)
-      expect(result.current.isExpired).toBe(false)
-      expect(result.current.isNext).toBe(false)
+      expect(result.current).toStrictEqual({
+        isExecutable: false,
+        remainingSeconds: 1,
+        isExpired: false,
+        isNext: false,
+        isPending: false,
+      })
     })
 
     it('should return correct values when validFrom is in the future and expiresAt is in the future', () => {
@@ -268,10 +325,13 @@ describe('useRecoveryTxState', () => {
         ),
       })
 
-      expect(result.current.isExecutable).toBe(false)
-      expect(result.current.remainingSeconds).toBe(1)
-      expect(result.current.isExpired).toBe(false)
-      expect(result.current.isNext).toBe(false)
+      expect(result.current).toStrictEqual({
+        isExecutable: false,
+        remainingSeconds: 1,
+        isExpired: false,
+        isNext: false,
+        isPending: false,
+      })
     })
 
     it('should return correct values when validFrom is in the past and expiresAt is in the future', () => {
@@ -311,10 +371,13 @@ describe('useRecoveryTxState', () => {
         ),
       })
 
-      expect(result.current.isExecutable).toBe(false)
-      expect(result.current.remainingSeconds).toBe(0)
-      expect(result.current.isExpired).toBe(false)
-      expect(result.current.isNext).toBe(false)
+      expect(result.current).toStrictEqual({
+        isExecutable: false,
+        remainingSeconds: 0,
+        isExpired: false,
+        isNext: false,
+        isPending: false,
+      })
     })
 
     it('should return correct values when validFrom is in the past and expiresAt is in the past', () => {
@@ -354,10 +417,13 @@ describe('useRecoveryTxState', () => {
         ),
       })
 
-      expect(result.current.isExecutable).toBe(false)
-      expect(result.current.remainingSeconds).toBe(0)
-      expect(result.current.isExpired).toBe(true)
-      expect(result.current.isNext).toBe(false)
+      expect(result.current).toStrictEqual({
+        isExecutable: false,
+        remainingSeconds: 0,
+        isExpired: true,
+        isNext: false,
+        isPending: false,
+      })
     })
   })
 })

--- a/src/hooks/useRecoveryTxState.ts
+++ b/src/hooks/useRecoveryTxState.ts
@@ -1,6 +1,8 @@
+import { useContext } from 'react'
+
 import { useClock } from './useClock'
 import { selectDelayModifierByTxHash } from '@/services/recovery/selectors'
-import { useRecovery } from '@/components/recovery/RecoveryContext'
+import { RecoveryContext } from '@/components/recovery/RecoveryContext'
 import { sameAddress } from '@/utils/addresses'
 import type { RecoveryQueueItem } from '@/services/recovery/recovery-state'
 
@@ -8,9 +10,13 @@ export function useRecoveryTxState({ validFrom, expiresAt, transactionHash, args
   isNext: boolean
   isExecutable: boolean
   isExpired: boolean
+  isPending: boolean
   remainingSeconds: number
 } {
-  const [recovery] = useRecovery()
+  const {
+    state: [recovery],
+    pending,
+  } = useContext(RecoveryContext)
   const delayModifier = recovery && selectDelayModifierByTxHash(recovery, transactionHash)
 
   // We don't display seconds in the interface, so we can use a 60s interval
@@ -24,8 +30,9 @@ export function useRecoveryTxState({ validFrom, expiresAt, transactionHash, args
   const isNext =
     !delayModifier || (sameAddress(delayModifier.address, address) && args.queueNonce.eq(delayModifier.txNonce))
   const isExecutable = isNext && isValid && !isExpired
+  const isPending = !!pending?.[transactionHash]
 
   const remainingSeconds = isValid ? 0 : Math.ceil(remainingMs.div(1_000).toNumber())
 
-  return { isNext, isExecutable, isExpired, remainingSeconds }
+  return { isNext, isExecutable, isExpired, remainingSeconds, isPending }
 }

--- a/src/hooks/useRecoveryTxState.ts
+++ b/src/hooks/useRecoveryTxState.ts
@@ -30,7 +30,7 @@ export function useRecoveryTxState({ validFrom, expiresAt, transactionHash, args
   const isNext =
     !delayModifier || (sameAddress(delayModifier.address, address) && args.queueNonce.eq(delayModifier.txNonce))
   const isExecutable = isNext && isValid && !isExpired
-  const isPending = !!pending?.[transactionHash]
+  const isPending = !!pending?.[args.txHash]
 
   const remainingSeconds = isValid ? 0 : Math.ceil(remainingMs.div(1_000).toNumber())
 

--- a/src/services/recovery/recovery-sender.ts
+++ b/src/services/recovery/recovery-sender.ts
@@ -1,0 +1,188 @@
+import { getModuleInstance, KnownContracts } from '@gnosis.pm/zodiac'
+import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import type { ContractTransaction } from 'ethers'
+import type { OnboardAPI } from '@web3-onboard/core'
+import type { TransactionAddedEvent } from '@gnosis.pm/zodiac/dist/cjs/types/Delay'
+import { createWeb3 } from '@/hooks/wallets/web3'
+
+import { didReprice, didRevert } from '@/utils/ethers-utils'
+import { recoveryDispatch, RecoveryEvent } from './recoveryEvents'
+import { asError } from '@/services/exceptions/utils'
+import { assertWalletChain } from '../tx/tx-sender/sdk'
+
+function waitForRecoveryTx(moduleAddress: string, recoveryTxHash: string, tx: ContractTransaction) {
+  const payload = {
+    moduleAddress,
+    recoveryTxHash,
+  }
+
+  recoveryDispatch(RecoveryEvent.PROCESSING, payload)
+
+  tx.wait()
+    .then((receipt) => {
+      if (didRevert(receipt)) {
+        recoveryDispatch(RecoveryEvent.REVERTED, {
+          ...payload,
+          error: new Error('Transaction reverted by EVM'),
+        })
+      } else {
+        recoveryDispatch(RecoveryEvent.PROCESSED, payload)
+      }
+    })
+    .catch((error) => {
+      if (didReprice(error)) {
+        recoveryDispatch(RecoveryEvent.PROCESSED, payload)
+      } else {
+        recoveryDispatch(RecoveryEvent.FAILED, {
+          ...payload,
+          error: asError(error),
+        })
+      }
+    })
+}
+
+export async function dispatchRecoveryProposal({
+  onboard,
+  safe,
+  safeTx,
+  delayModifierAddress,
+}: {
+  onboard: OnboardAPI
+  safe: SafeInfo
+  safeTx: SafeTransaction
+  delayModifierAddress: string
+}) {
+  const wallet = await assertWalletChain(onboard, safe.chainId)
+  const provider = createWeb3(wallet.provider)
+
+  const delayModifier = getModuleInstance(KnownContracts.DELAY, delayModifierAddress, provider)
+
+  const signer = provider.getSigner()
+
+  let recoveryTxHash: string | undefined
+  let tx: ContractTransaction | undefined
+
+  const contract = delayModifier.connect(signer)
+
+  try {
+    // Get recovery tx hash as a form of ID for event bus
+    recoveryTxHash = await contract.getTransactionHash(
+      safeTx.data.to,
+      safeTx.data.value,
+      safeTx.data.data,
+      safeTx.data.operation,
+    )
+
+    recoveryDispatch(RecoveryEvent.EXECUTING, {
+      moduleAddress: delayModifierAddress,
+      recoveryTxHash: recoveryTxHash,
+    })
+  } catch (error) {
+    recoveryDispatch(RecoveryEvent.FAILED, {
+      moduleAddress: delayModifierAddress,
+      error: asError(error),
+    })
+
+    throw error
+  }
+
+  try {
+    tx = await contract.execTransactionFromModule(
+      safeTx.data.to,
+      safeTx.data.value,
+      safeTx.data.data,
+      safeTx.data.operation,
+    )
+  } catch (error) {
+    recoveryDispatch(RecoveryEvent.FAILED, {
+      moduleAddress: delayModifierAddress,
+      recoveryTxHash,
+      error: asError(error),
+    })
+
+    throw error
+  }
+
+  waitForRecoveryTx(delayModifierAddress, recoveryTxHash, tx)
+}
+
+export async function dispatchRecoveryExecution({
+  onboard,
+  chainId,
+  args,
+  delayModifierAddress,
+}: {
+  onboard: OnboardAPI
+  chainId: string
+  args: TransactionAddedEvent['args']
+  delayModifierAddress: string
+}) {
+  const wallet = await assertWalletChain(onboard, chainId)
+  const provider = createWeb3(wallet.provider)
+
+  const delayModifier = getModuleInstance(KnownContracts.DELAY, delayModifierAddress, provider)
+
+  const signer = provider.getSigner()
+
+  let tx: ContractTransaction | undefined
+
+  try {
+    tx = await delayModifier.connect(signer).executeNextTx(args.to, args.value, args.data, args.operation)
+
+    recoveryDispatch(RecoveryEvent.EXECUTING, {
+      moduleAddress: delayModifierAddress,
+      recoveryTxHash: args.txHash,
+    })
+  } catch (error) {
+    recoveryDispatch(RecoveryEvent.FAILED, {
+      moduleAddress: delayModifierAddress,
+      recoveryTxHash: args.txHash,
+      error: asError(error),
+    })
+
+    throw error
+  }
+
+  waitForRecoveryTx(delayModifierAddress, args.txHash, tx)
+}
+
+export async function dispatchRecoverySkipExpired({
+  onboard,
+  chainId,
+  delayModifierAddress,
+  recoveryTxHash,
+}: {
+  onboard: OnboardAPI
+  chainId: string
+  delayModifierAddress: string
+  recoveryTxHash: string
+}) {
+  const wallet = await assertWalletChain(onboard, chainId)
+  const provider = createWeb3(wallet.provider)
+
+  const delayModifier = getModuleInstance(KnownContracts.DELAY, delayModifierAddress, provider)
+
+  const signer = provider.getSigner()
+
+  let tx: ContractTransaction | undefined
+
+  try {
+    tx = await delayModifier.connect(signer).skipExpired()
+
+    recoveryDispatch(RecoveryEvent.EXECUTING, {
+      moduleAddress: delayModifierAddress,
+      recoveryTxHash,
+    })
+  } catch (error) {
+    recoveryDispatch(RecoveryEvent.FAILED, {
+      moduleAddress: delayModifierAddress,
+      recoveryTxHash,
+      error: asError(error),
+    })
+
+    throw error
+  }
+
+  waitForRecoveryTx(delayModifierAddress, recoveryTxHash, tx)
+}

--- a/src/services/recovery/recoveryEvents.ts
+++ b/src/services/recovery/recoveryEvents.ts
@@ -1,0 +1,30 @@
+import EventBus from '../EventBus'
+
+export enum RecoveryEvent {
+  EXECUTING = 'EXECUTING',
+  PROCESSING = 'PROCESSING',
+  REVERTED = 'REVERTED',
+  PROCESSED = 'PROCESSED',
+  FAILED = 'FAILED',
+}
+
+interface RecoveryEvents {
+  [RecoveryEvent.EXECUTING]: { moduleAddress: string; recoveryTxHash: string }
+  [RecoveryEvent.PROCESSING]: { moduleAddress: string; recoveryTxHash: string }
+  [RecoveryEvent.REVERTED]: { moduleAddress: string; recoveryTxHash: string; error: Error }
+  [RecoveryEvent.PROCESSED]: { moduleAddress: string; recoveryTxHash: string }
+  [RecoveryEvent.FAILED]: { moduleAddress: string; recoveryTxHash?: string; error: Error }
+}
+
+const recoveryEventBus = new EventBus<RecoveryEvents>()
+
+export const recoveryDispatch = recoveryEventBus.dispatch.bind(recoveryEventBus)
+
+export const recoverySubscribe = recoveryEventBus.subscribe.bind(recoveryEventBus)
+
+// Log all events
+Object.values(RecoveryEvent).forEach((event: RecoveryEvent) => {
+  recoverySubscribe<RecoveryEvent>(event, (detail) => {
+    console.info(`Recovery ${event} event received`, detail)
+  })
+})

--- a/src/services/tx/tx-sender/dispatch.ts
+++ b/src/services/tx/tx-sender/dispatch.ts
@@ -22,8 +22,6 @@ import {
 import { createWeb3 } from '@/hooks/wallets/web3'
 import { type OnboardAPI } from '@web3-onboard/core'
 import { asError } from '@/services/exceptions/utils'
-import { getModuleInstance, KnownContracts } from '@gnosis.pm/zodiac'
-import type { TransactionAddedEvent } from '@gnosis.pm/zodiac/dist/cjs/types/Delay'
 
 /**
  * Propose a transaction
@@ -405,102 +403,4 @@ export const dispatchBatchExecutionRelay = async (
     safeAddress,
     groupKey,
   )
-}
-
-function reloadRecoveryDataAfterProcessed(tx: ContractTransaction, refetchRecoveryData: () => void) {
-  tx.wait()
-    .then((receipt) => {
-      if (!didRevert(receipt)) {
-        refetchRecoveryData()
-      }
-    })
-    .catch((error) => {
-      if (didReprice(error)) {
-        refetchRecoveryData()
-      }
-    })
-}
-
-export async function dispatchRecoveryProposal({
-  onboard,
-  safe,
-  safeTx,
-  delayModifierAddress,
-  refetchRecoveryData,
-}: {
-  onboard: OnboardAPI
-  safe: SafeInfo
-  safeTx: SafeTransaction
-  delayModifierAddress: string
-  refetchRecoveryData: () => void
-}) {
-  const wallet = await assertWalletChain(onboard, safe.chainId)
-  const provider = createWeb3(wallet.provider)
-
-  const delayModifier = getModuleInstance(KnownContracts.DELAY, delayModifierAddress, provider)
-
-  const signer = provider.getSigner()
-
-  try {
-    const tx = await delayModifier
-      .connect(signer)
-      .execTransactionFromModule(safeTx.data.to, safeTx.data.value, safeTx.data.data, safeTx.data.operation)
-    reloadRecoveryDataAfterProcessed(tx, refetchRecoveryData)
-  } catch (error) {
-    throw error
-  }
-}
-
-export async function dispatchRecoveryExecution({
-  onboard,
-  chainId,
-  args,
-  delayModifierAddress,
-  refetchRecoveryData,
-}: {
-  onboard: OnboardAPI
-  chainId: string
-  args: TransactionAddedEvent['args']
-  delayModifierAddress: string
-  refetchRecoveryData: () => void
-}) {
-  const wallet = await assertWalletChain(onboard, chainId)
-  const provider = createWeb3(wallet.provider)
-
-  const delayModifier = getModuleInstance(KnownContracts.DELAY, delayModifierAddress, provider)
-
-  const signer = provider.getSigner()
-
-  try {
-    const tx = await delayModifier.connect(signer).executeNextTx(args.to, args.value, args.data, args.operation)
-    reloadRecoveryDataAfterProcessed(tx, refetchRecoveryData)
-  } catch (error) {
-    throw error
-  }
-}
-
-export async function dispatchRecoverySkipExpired({
-  onboard,
-  chainId,
-  delayModifierAddress,
-  refetchRecoveryData,
-}: {
-  onboard: OnboardAPI
-  chainId: string
-  delayModifierAddress: string
-  refetchRecoveryData: () => void
-}) {
-  const wallet = await assertWalletChain(onboard, chainId)
-  const provider = createWeb3(wallet.provider)
-
-  const delayModifier = getModuleInstance(KnownContracts.DELAY, delayModifierAddress, provider)
-
-  const signer = provider.getSigner()
-
-  try {
-    const tx = await delayModifier.connect(signer).skipExpired()
-    reloadRecoveryDataAfterProcessed(tx, refetchRecoveryData)
-  } catch (error) {
-    throw error
-  }
 }


### PR DESCRIPTION
## What it solves

Resolves [missing "Processing..." state for recovery transactions](https://www.notion.so/safe-global/Do-we-have-a-processing-relaying-state-instead-of-awaiting-confirmation-for-the-Account-recovery-5a07f9ed7cde429ba976fe7ad16e5f59)

## How this PR fixes it

A new recovery-focused event bus has been added that matches that of the one for "standard" transactions and messages. Using that, a new pending map is updated according to the dispatched events and parsed for the current status of a recovery attempt.

## How to test it

1. Queue a recovery attempt.
2. Execute/cancel the attempt and observe the new processing status.

Note: data loading should also be tested - recovery state updates when a proposal is executed, cancelled and/or settings are changed.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/c1a15dc7-304f-4524-9499-86602d5b989b)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
