### PR TITLE
Fix: tx details - show loader only when no data

### DIFF
--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -134,16 +134,18 @@ const TxDetails = ({
 
   return (
     <div className={css.container}>
-      {txDetailsData && <TxDetailsBlock txSummary={txSummary} txDetails={txDetailsData} />}
-      {loading && (
+      {txDetailsData ? (
+        <TxDetailsBlock txSummary={txSummary} txDetails={txDetailsData} />
+      ) : loading ? (
         <div className={css.loading}>
           <CircularProgress />
         </div>
-      )}
-      {error && (
-        <div className={css.error}>
-          <ErrorMessage error={error}>Couldn&apos;t load the transaction details</ErrorMessage>
-        </div>
+      ) : (
+        error && (
+          <div className={css.error}>
+            <ErrorMessage error={error}>Couldn&apos;t load the transaction details</ErrorMessage>
+          </div>
+        )
       )}
     </div>
   )


### PR DESCRIPTION
## What it solves

Tx details showed a loader every 15 seconds which made the whole tx jump in the History/Queue.
