### PR TITLE
Refactor: poll messages based on messagesTag

### DIFF
--- a/src/hooks/loadables/useLoadSafeMessages.ts
+++ b/src/hooks/loadables/useLoadSafeMessages.ts
@@ -5,20 +5,10 @@ import type { SafeMessageListPage } from '@safe-global/safe-gateway-typescript-s
 import useAsync from '@/hooks/useAsync'
 import { logError, Errors } from '@/services/exceptions'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import { POLLING_INTERVAL } from '@/config/constants'
-import useIntervalCounter from '@/hooks/useIntervalCounter'
 import type { AsyncResult } from '@/hooks/useAsync'
 
 export const useLoadSafeMessages = (): AsyncResult<SafeMessageListPage> => {
   const { safe, safeAddress, safeLoaded } = useSafeInfo()
-
-  // TODO: Remove manual polling when messagesTag is no longer cached on the backend
-  const [pollCount, resetPolling] = useIntervalCounter(POLLING_INTERVAL)
-
-  // Reset the counter when safe address/chainId changes
-  useEffect(() => {
-    resetPolling()
-  }, [resetPolling, safeAddress, safe.chainId])
 
   const [data, error, loading] = useAsync<SafeMessageListPage>(
     () => {
@@ -28,13 +18,7 @@ export const useLoadSafeMessages = (): AsyncResult<SafeMessageListPage> => {
       return getSafeMessages(safe.chainId, safeAddress)
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      safeLoaded,
-      safe.chainId,
-      safeAddress,
-      // safe.messagesTag,
-      pollCount,
-    ],
+    [safeLoaded, safe.chainId, safeAddress, safe.messagesTag],
     false,
   )
 


### PR DESCRIPTION
## What it solves

Resolves #1403

## How this PR fixes it

Removes a polling timer and listens to the `messagesTag` from the backend instead.

## How to test it

* Open the Messages tab
* In another browser window, create a new message (e.g. OpenSea login)
* Observe that the new message appeared on the Messages tab within 15 seconds