### PR TITLE
Tests: e2e - select connected wallet (patch)

### DIFF
--- a/cypress/e2e/smoke/create_tx.cy.js
+++ b/cypress/e2e/smoke/create_tx.cy.js
@@ -29,6 +29,7 @@ describe('[SMOKE] Create transactions tests', () => {
     createtx.verifyNativeTokenTransfer()
     createtx.changeNonce(currentNonce)
     createtx.verifyConfirmTransactionData()
+    cy.contains('Connected wallet').click()
     createtx.openExecutionParamsModal()
     createtx.verifyAndSubmitExecutionParams()
     createtx.clickOnNoLaterOption()


### PR DESCRIPTION
## What it solves

There is an issue with the Create-tx test. Now that in Sepolia the Relayer is enabled you need to select the connected wallet option in the test. 
This is just a quick patch while I finish with the full refactor of the e2e-test, so the test doesn't fail in other PR's

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
