### PR TITLE
Fix: logo centering on welcome page

### DIFF
--- a/src/components/welcome/WelcomeLogin/index.tsx
+++ b/src/components/welcome/WelcomeLogin/index.tsx
@@ -27,10 +27,12 @@ const WelcomeLogin = () => {
   return (
     <Paper className={css.loginCard} data-testid="welcome-login">
       <Box className={css.loginContent}>
-        <SvgIcon component={SafeLogo} inheritViewBox sx={{ height: '24px', width: '80px' }} />
+        <SvgIcon component={SafeLogo} inheritViewBox sx={{ height: '24px', width: '80px', ml: '-12px' }} />
+
         <Typography variant="h6" mt={6} fontWeight={700}>
           Create Account
         </Typography>
+
         <Typography mb={2} textAlign="center">
           Choose how you would like to create your Safe Account
         </Typography>

--- a/src/components/welcome/WelcomeLogin/index.tsx
+++ b/src/components/welcome/WelcomeLogin/index.tsx
@@ -27,7 +27,7 @@ const WelcomeLogin = () => {
   return (
     <Paper className={css.loginCard} data-testid="welcome-login">
       <Box className={css.loginContent}>
-        <SvgIcon component={SafeLogo} inheritViewBox sx={{ height: '24px', width: '80px', ml: '-12px' }} />
+        <SvgIcon component={SafeLogo} inheritViewBox sx={{ height: '24px', width: '80px', ml: '-8px' }} />
 
         <Typography variant="h6" mt={6} fontWeight={700}>
           Create Account


### PR DESCRIPTION
## What it solves

The position of the Safe logo on the Welcome page, although perfectly in the middle of the block mathematically, looked unbalanced because of the graphical and textual parts of the logo. I've shifted it a bit to the left and it looks more centered now.

Before:
<img width="442" alt="Screenshot 2023-11-29 at 09 34 03" src="https://github.com/safe-global/safe-wallet-web/assets/381895/0bacdd44-5a0f-4ecc-af63-9148941ce693">

After:
<img width="445" alt="Screenshot 2023-11-29 at 09 33 46" src="https://github.com/safe-global/safe-wallet-web/assets/381895/273eeb9a-425a-46f8-88a5-d52d9f8eddca">