### PR TITLE
fix: hide recovery widget if feature enabled

### DIFF
--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -12,10 +12,17 @@ import { FEATURES } from '@/utils/chains'
 import { useHasFeature } from '@/hooks/useChains'
 import { CREATION_MODAL_QUERY_PARM } from '../new-safe/create/logic'
 import { RecoveryHeader } from './RecoveryHeader'
+import { useRecovery } from '../recovery/RecoveryContext'
+
+function _useShouldShowRecovery(): boolean {
+  const supportsRecovery = useHasFeature(FEATURES.RECOVERY)
+  const [recovery] = useRecovery()
+  return supportsRecovery && !recovery
+}
 
 const Dashboard = (): ReactElement => {
   const router = useRouter()
-  const supportsRecovery = useHasFeature(FEATURES.RECOVERY)
+  const showRecoveryWidget = _useShouldShowRecovery()
   const { [CREATION_MODAL_QUERY_PARM]: showCreationModal = '' } = router.query
 
   return (
@@ -31,11 +38,11 @@ const Dashboard = (): ReactElement => {
           <PendingTxsList />
         </Grid>
 
-        <Grid item xs={12} lg={supportsRecovery ? 6 : undefined}>
-          <FeaturedApps stackedLayout={!!supportsRecovery} />
+        <Grid item xs={12} lg={showRecoveryWidget ? 6 : undefined}>
+          <FeaturedApps stackedLayout={!!showRecoveryWidget} />
         </Grid>
 
-        {supportsRecovery ? (
+        {showRecoveryWidget ? (
           <Grid item xs={12} lg={6}>
             <Recovery />
           </Grid>


### PR DESCRIPTION
## What it solves

Resolves [recovery feature widget not hiding after being enabled](https://www.notion.so/safe-global/Remove-the-Edit-recovery-banner-from-the-Dashboard-after-the-recovery-is-set-up-cc6336c7391f4faf8cf587f5680ca70f)

## How this PR fixes it

The dashboard widget featuring recovery is now not only hidden if the chain doesn't support it but also if the feature is enabled on the current Safe.

## How to test it

Switch between Safes that have recovery enabled/disabled and observe the dashboard widget hidden accordingly.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
