### PR TITLE
fix: adjust description of expired transactions

### DIFF
--- a/src/components/recovery/RecoverySigners/index.tsx
+++ b/src/components/recovery/RecoverySigners/index.tsx
@@ -18,7 +18,22 @@ import txSignersCss from '@/components/transactions/TxSigners/styles.module.css'
 
 export function RecoverySigners({ item }: { item: RecoveryQueueItem }): ReactElement {
   const { submitError } = useContext(RecoveryListItemContext)
-  const { isExecutable, isNext, remainingSeconds } = useRecoveryTxState(item)
+  const { isExecutable, isExpired, isNext, remainingSeconds } = useRecoveryTxState(item)
+
+  const desc = isExecutable ? (
+    item.expiresAt ? (
+      <>
+        The recovery transaction can be executed until{' '}
+        <Typography color="primary.main">until {formatDate(item.expiresAt.toNumber())}.</Typography>
+      </>
+    ) : (
+      'The recovery transaction can be executed now.'
+    )
+  ) : isExpired ? (
+    'The recovery transaction has expired and needs to be cancelled before a new one can be created.'
+  ) : (
+    'The recovery transaction can be executed after the delay period has passed:'
+  )
 
   return (
     <>
@@ -53,20 +68,7 @@ export function RecoverySigners({ item }: { item: RecoveryQueueItem }): ReactEle
       </List>
 
       <Box className={txSignersCss.listFooter}>
-        <Typography sx={({ palette }) => ({ color: palette.border.main, mb: 1 })}>
-          The recovery can be executed{' '}
-          {isExecutable ? (
-            item.expiresAt ? (
-              <Typography color="primary.main">until {formatDate(item.expiresAt.toNumber())}.</Typography>
-            ) : (
-              'now.'
-            )
-          ) : !isNext ? (
-            'after the previous recovery attempts are executed or cancelled and the delay period has passed:'
-          ) : (
-            'after the delay period:'
-          )}
-        </Typography>
+        <Typography sx={({ palette }) => ({ color: palette.border.main, mb: 1 })}>{desc}</Typography>
 
         {isNext && <Countdown seconds={remainingSeconds} />}
       </Box>

--- a/src/components/recovery/RecoverySigners/index.tsx
+++ b/src/components/recovery/RecoverySigners/index.tsx
@@ -23,7 +23,7 @@ export function RecoverySigners({ item }: { item: RecoveryQueueItem }): ReactEle
   const desc = isExecutable ? (
     item.expiresAt ? (
       <>
-        The recovery transaction can be executed until{' '}
+        The recovery transaction can be executed{' '}
         <Typography color="primary.main">until {formatDate(item.expiresAt.toNumber())}.</Typography>
       </>
     ) : (


### PR DESCRIPTION
## What it solves

Resolves [incorrect description of failed attempts](https://www.notion.so/safe-global/Expired-recovery-process-blocks-start-recovery-from-the-dashboard-c9a79955b4eb4592a70d367445ca958b)

## How this PR fixes it

The description of a failed transaction has been added under the recovery signers.

## How to test it

Queue a recovery transaction with a delay and expiration enabled and observe the following lifecycle description under the signers.

1. "The recovery transaction can be executed after the delay period has passed:"
2. "The recovery transaction can be executed until {{date}}." (without expiration: "The recovery transaction can be executed now.")
3. "The recovery transaction has expired and needs to be cancelled before a new one can be created."

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
