### PR TITLE
fix: adjust recovery execution button tooltip text

### DIFF
--- a/src/components/recovery/ExecuteRecoveryButton/index.tsx
+++ b/src/components/recovery/ExecuteRecoveryButton/index.tsx
@@ -22,7 +22,7 @@ export function ExecuteRecoveryButton({
   compact?: boolean
 }): ReactElement {
   const { setSubmitError } = useContext(RecoveryListItemContext)
-  const { isExecutable, isPending } = useRecoveryTxState(recovery)
+  const { isExecutable, isNext, isPending } = useRecoveryTxState(recovery)
   const onboard = useOnboard()
   const { safe } = useSafeInfo()
 
@@ -55,7 +55,15 @@ export function ExecuteRecoveryButton({
         const isDisabled = !isOk || !isExecutable || isPending
 
         return (
-          <Tooltip title={isDisabled ? 'Previous recovery attempts must be executed or cancelled first' : null}>
+          <Tooltip
+            title={
+              isDisabled
+                ? isNext
+                  ? 'You can execute the recovery after the specified delay'
+                  : 'Previous recovery attempts must be executed or cancelled first'
+                : null
+            }
+          >
             <span>
               {compact ? (
                 <IconButton onClick={onClick} color="primary" disabled={isDisabled} size="small">


### PR DESCRIPTION
## What it solves

Resolves [unclear tooltip text](https://www.notion.so/safe-global/Reword-execute-button-tooltip-22e7a21a1ec743a9904246e595c0bb77)

## How this PR fixes it

The execution button tooltip (shown when no wallet is connected or a recovery transaction is not executable/pending) now reads:

1. "You can execute the recovery after the specified delay" when the transaction is next and awaiting cooldown to pass
2. "Previous recovery attempts must be executed or cancelled first" when the transaction is queued

## How to test it

Queue a recovery transaction with a delay and observe the new tooltip text on hover.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
