### PR TITLE
Fix: disable copying address in AddressBookInput

### DIFF
--- a/src/components/common/AddressBookInput/index.tsx
+++ b/src/components/common/AddressBookInput/index.tsx
@@ -66,7 +66,7 @@ const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canA
         }}
         renderOption={(props, option) => (
           <Typography component="li" variant="body2" {...props}>
-            <EthHashInfo address={option.label} name={option.name} shortAddress={false} />
+            <EthHashInfo address={option.label} name={option.name} shortAddress={false} copyAddress={false} />
           </Typography>
         )}
         renderInput={(params) => (

--- a/src/components/common/AddressInputReadOnly/index.tsx
+++ b/src/components/common/AddressInputReadOnly/index.tsx
@@ -19,7 +19,7 @@ const AddressInputReadOnly = ({ label, address }: { label: string; address: stri
           startAdornment={
             <InputAdornment position="start">
               <Typography variant="body2" component="div">
-                <EthHashInfo address={address} shortAddress={false} />
+                <EthHashInfo address={address} shortAddress={false} copyAddress={false} />
               </Typography>
             </InputAdornment>
           }


### PR DESCRIPTION
## What it solves

Resolves #2931

I've disabled copying address in the AddressBookInput dropdown.