### PR TITLE
fix: smart contract warning style

### DIFF
--- a/src/components/tx-flow/flows/UpsertRecovery/RecovererSmartContractWarning.tsx
+++ b/src/components/tx-flow/flows/UpsertRecovery/RecovererSmartContractWarning.tsx
@@ -1,15 +1,18 @@
-import { Alert } from '@mui/material'
+import { SvgIcon, Typography } from '@mui/material'
 import { getSafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { useState, useEffect } from 'react'
 import { useWatch } from 'react-hook-form'
 import { isAddress } from 'ethers/lib/utils'
 import type { ReactElement } from 'react'
 
+import InfoIcon from '@/public/images/notifications/info.svg'
 import { isSmartContractWallet } from '@/utils/wallets'
 import useDebounce from '@/hooks/useDebounce'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { UpsertRecoveryFlowFields } from '.'
 import { sameAddress } from '@/utils/addresses'
+
+import addressBookInputCss from '@/components/common/AddressBookInput/styles.module.css'
 
 export function RecovererWarning(): ReactElement | null {
   const { safe, safeAddress } = useSafeInfo()
@@ -52,8 +55,16 @@ export function RecovererWarning(): ReactElement | null {
   }
 
   return (
-    <Alert severity="warning" sx={{ border: 'unset' }}>
+    <Typography
+      variant="body2"
+      className={addressBookInputCss.unknownAddress}
+      sx={({ palette }) => ({
+        bgcolor: `${palette.warning.background} !important`,
+        color: `${palette.warning.light} !important`,
+      })}
+    >
+      <SvgIcon component={InfoIcon} fontSize="small" />
       {warning}
-    </Alert>
+    </Typography>
   )
 }

--- a/src/components/tx-flow/flows/UpsertRecovery/RecovererSmartContractWarning.tsx
+++ b/src/components/tx-flow/flows/UpsertRecovery/RecovererSmartContractWarning.tsx
@@ -60,7 +60,7 @@ export function RecovererWarning(): ReactElement | null {
       className={addressBookInputCss.unknownAddress}
       sx={({ palette }) => ({
         bgcolor: `${palette.warning.background} !important`,
-        color: `${palette.warning.light} !important`,
+        color: `${palette.warning.main} !important`,
       })}
     >
       <SvgIcon component={InfoIcon} fontSize="small" />

--- a/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowSettings.tsx
+++ b/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowSettings.tsx
@@ -73,15 +73,16 @@ export function UpsertRecoveryFlowSettings({
               </Typography>
             </div>
 
-            <AddressBookInput
-              label="Recoverer address"
-              name={UpsertRecoveryFlowFields.recoverer}
-              required
-              fullWidth
-              validate={validateRecoverer}
-            />
-
-            <RecovererWarning />
+            <div>
+              <AddressBookInput
+                label="Recoverer address"
+                name={UpsertRecoveryFlowFields.recoverer}
+                required
+                fullWidth
+                validate={validateRecoverer}
+              />
+              <RecovererWarning />
+            </div>
 
             <Alert severity="info" sx={{ border: 'unset' }}>
               Your Recoverer will be able to modify your Account setup. Only select an address that you trust.


### PR DESCRIPTION
## What it solves

Resolves [style inconsistencies of smart contract validation](https://www.notion.so/safe-global/Validate-EOA-and-Safes-in-the-guardian-input-f93b1340c71c424ea191dfc5adfb835f)

## How this PR fixes it

The style of the smart contract validation has been adjusted to match that of the address add functionality below an address input (see screenshots).

## How to test it

Upsert the recovery Recoverer and enter a non-Safe smart contract, observing the correctly styled message.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/116f002f-150e-427e-892b-c81af9ac4313)

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/55599458-c32c-4535-b226-f2dd0a4d183e)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
