### PR TITLE
changing order of evaluations

### DIFF
--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -132,12 +132,12 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
   useEffect(() => {
     let message = ''
     // Warnings
-    if (Number(nonce) >= safe.nonce + MAX_NONCE_DIFFERENCE) {
-      message = ErrorMessages.NONCE_TOO_FAR
-    }
-
     if (Number(nonce) > Number(recommendedNonce)) {
       message = ErrorMessages.NONCE_GT_RECOMMENDED
+    }
+
+    if (Number(nonce) >= safe.nonce + MAX_NONCE_DIFFERENCE) {
+      message = ErrorMessages.NONCE_TOO_FAR
     }
 
     setWarning(message)


### PR DESCRIPTION
## What it solves

Resolves #
In the Nonce input, if you set a nonce that is 100 numbers higher than the recomended nonce it should display a specific message. That message wasn't showing up because of the order of the "if". The 2nd "if" was always overwriting the first one so the message that should show for 100+ values would never show up

## How this PR fixes it
Change the order of "if"

## How to test it
Go to a send funds tx
Change the nonce to a value slightly higher than the recomended nonce and check the tooltip message
Change the nonce to a value 100+ higher than the recomended nonce and check the tooltip message

## Screenshots
![image](https://github.com/safe-global/safe-wallet-web/assets/4503659/3f8b3b30-e059-4ecb-8e81-e0e45e5c7962)
![image](https://github.com/safe-global/safe-wallet-web/assets/4503659/33478f36-afc0-4b16-9c27-8dec39c4551c)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
