### PR TITLE
fix: manually check dirty status

### DIFF
--- a/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowSettings.tsx
+++ b/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowSettings.tsx
@@ -30,15 +30,18 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import InfoIcon from '@/public/images/notifications/info.svg'
 import { RecovererWarning } from './RecovererSmartContractWarning'
 import type { UpsertRecoveryFlowProps } from '.'
+import type { RecoveryStateItem } from '@/services/recovery/recovery-state'
 
 import commonCss from '@/components/tx-flow/common/styles.module.css'
 import css from './styles.module.css'
 
 export function UpsertRecoveryFlowSettings({
   params,
+  delayModifier,
   onSubmit,
 }: {
   params: UpsertRecoveryFlowProps
+  delayModifier?: RecoveryStateItem
   onSubmit: (formData: UpsertRecoveryFlowProps) => void
 }): ReactElement {
   const { safeAddress } = useSafeInfo()
@@ -51,6 +54,19 @@ export function UpsertRecoveryFlowSettings({
     mode: 'onChange',
   })
 
+  const recoverer = formMethods.watch(UpsertRecoveryFlowFields.recoverer)
+  const txCooldown = formMethods.watch(UpsertRecoveryFlowFields.txCooldown)
+  const txExpiration = formMethods.watch(UpsertRecoveryFlowFields.txExpiration)
+
+  // RHF's dirty check is tempermental with our address input dropdown
+  const isDirty = delayModifier
+    ? // Updating settings
+      !sameAddress(recoverer, delayModifier.recoverers[0]) ||
+      !delayModifier.txCooldown.eq(txCooldown) ||
+      !delayModifier.txExpiration.eq(txExpiration)
+    : // Setting up recovery
+      recoverer && txCooldown && txExpiration
+
   const validateRecoverer = (recoverer: string) => {
     if (sameAddress(recoverer, safeAddress)) {
       return 'The Safe Account cannot be a Recoverer of itself'
@@ -62,7 +78,7 @@ export function UpsertRecoveryFlowSettings({
     trackEvent(RECOVERY_EVENTS.SHOW_ADVANCED)
   }
 
-  const isDisabled = !formMethods.formState.isDirty || !understandsRisk
+  const isDisabled = !understandsRisk || !isDirty
 
   return (
     <>

--- a/src/components/tx-flow/flows/UpsertRecovery/index.tsx
+++ b/src/components/tx-flow/flows/UpsertRecovery/index.tsx
@@ -36,7 +36,12 @@ export function UpsertRecoveryFlow({ delayModifier }: { delayModifier?: Recovery
 
   const steps = [
     <UpsertRecoveryFlowIntro key={0} onSubmit={() => nextStep(data)} />,
-    <UpsertRecoveryFlowSettings key={1} params={data} onSubmit={(formData) => nextStep({ ...data, ...formData })} />,
+    <UpsertRecoveryFlowSettings
+      key={1}
+      params={data}
+      delayModifier={delayModifier}
+      onSubmit={(formData) => nextStep({ ...data, ...formData })}
+    />,
     <UpsertRecoveryFlowReview key={2} params={data} moduleAddress={delayModifier?.address} />,
   ]
 


### PR DESCRIPTION
## What it solves

Resolves [disabled next button when selecting address from address book](https://www.notion.so/safe-global/Can-not-edit-recovery-set-up-436b288d55784a0c93e0f428b8cf706d)

## How this PR fixes it

We manually check the "dirty" status of input fields when upserting recovery.

## How to test it

Note: focus on pasting vs. selecting addresses from the address book dropdown.

### Enabling recovery

- Test each input field as dirty _before_ and _after_ confirming consent

### Editing recovery

- Test each input field as dirty _before_ and _after_ confirming consent

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
