### PR TITLE
fix: fallback MultiSend version for maliciousness

### DIFF
--- a/src/hooks/__tests__/useRecoveryTxState.test.tsx
+++ b/src/hooks/__tests__/useRecoveryTxState.test.tsx
@@ -15,10 +15,10 @@ describe('useRecoveryTxState', () => {
       jest.setSystemTime(0)
 
       const delayModifierAddress1 = faker.finance.ethereumAddress()
-      const nextTxHash1 = faker.string.hexadecimal()
+      const nextTxHash1 = faker.string.hexadecimal({ length: 10 })
 
       const delayModifierAddress2 = faker.finance.ethereumAddress()
-      const nextTxHash2 = faker.string.hexadecimal()
+      const nextTxHash2 = faker.string.hexadecimal({ length: 10 })
 
       const validFrom = BigNumber.from(1_000)
       const expiresAt = BigNumber.from(1_000)
@@ -63,7 +63,7 @@ describe('useRecoveryTxState', () => {
       jest.setSystemTime(0)
 
       const delayModifierAddress = faker.finance.ethereumAddress()
-      const nextTxHash = faker.string.hexadecimal()
+      const nextTxHash = faker.string.hexadecimal({ length: 10 })
 
       const validFrom = BigNumber.from(1_000)
       const expiresAt = BigNumber.from(1_000)
@@ -103,7 +103,7 @@ describe('useRecoveryTxState', () => {
       jest.setSystemTime(1_000)
 
       const delayModifierAddress = faker.finance.ethereumAddress()
-      const nextTxHash = faker.string.hexadecimal()
+      const nextTxHash = faker.string.hexadecimal({ length: 10 })
 
       const validFrom = BigNumber.from(0)
       const expiresAt = BigNumber.from(2_000)
@@ -143,7 +143,7 @@ describe('useRecoveryTxState', () => {
       jest.setSystemTime(1_000)
 
       const delayModifierAddress = faker.finance.ethereumAddress()
-      const nextTxHash = faker.string.hexadecimal()
+      const nextTxHash = faker.string.hexadecimal({ length: 10 })
 
       const validFrom = BigNumber.from(0)
       const expiresAt = BigNumber.from(0)
@@ -183,9 +183,9 @@ describe('useRecoveryTxState', () => {
       jest.setSystemTime(0)
 
       const delayModifierAddress = faker.finance.ethereumAddress()
-      const nextTxHash = faker.string.hexadecimal()
+      const nextTxHash = faker.string.hexadecimal({ length: 10 })
 
-      const nextRecoveryTxHash = faker.string.hexadecimal()
+      const nextRecoveryTxHash = faker.string.hexadecimal({ length: 10 })
 
       const validFrom = BigNumber.from(0)
       const expiresAt = BigNumber.from(1)
@@ -230,13 +230,13 @@ describe('useRecoveryTxState', () => {
 
       const delayModifierAddress1 = faker.finance.ethereumAddress()
 
-      const nextTxHash1 = faker.string.hexadecimal()
-      const queueTxHash1 = faker.string.hexadecimal()
+      const nextTxHash1 = faker.string.hexadecimal({ length: 10 })
+      const queueTxHash1 = faker.string.hexadecimal({ length: 10 })
 
       const delayModifierAddress2 = faker.finance.ethereumAddress()
 
-      const nextTxHash2 = faker.string.hexadecimal()
-      const queueTxHash2 = faker.string.hexadecimal()
+      const nextTxHash2 = faker.string.hexadecimal({ length: 10 })
+      const queueTxHash2 = faker.string.hexadecimal({ length: 10 })
 
       const validFrom = BigNumber.from(1_000)
       const expiresAt = BigNumber.from(1_000)
@@ -295,8 +295,8 @@ describe('useRecoveryTxState', () => {
 
       const delayModifierAddress = faker.finance.ethereumAddress()
 
-      const nextTxHash = faker.string.hexadecimal()
-      const queueTxHash = faker.string.hexadecimal()
+      const nextTxHash = faker.string.hexadecimal({ length: 10 })
+      const queueTxHash = faker.string.hexadecimal({ length: 10 })
 
       const validFrom = BigNumber.from(1_000)
       const expiresAt = BigNumber.from(1_000)
@@ -341,8 +341,8 @@ describe('useRecoveryTxState', () => {
 
       const delayModifierAddress = faker.finance.ethereumAddress()
 
-      const nextTxHash = faker.string.hexadecimal()
-      const queueTxHash = faker.string.hexadecimal()
+      const nextTxHash = faker.string.hexadecimal({ length: 10 })
+      const queueTxHash = faker.string.hexadecimal({ length: 10 })
 
       const validFrom = BigNumber.from(0)
       const expiresAt = BigNumber.from(2_000)
@@ -387,8 +387,8 @@ describe('useRecoveryTxState', () => {
 
       const delayModifierAddress = faker.finance.ethereumAddress()
 
-      const nextTxHash = faker.string.hexadecimal()
-      const queueTxHash = faker.string.hexadecimal()
+      const nextTxHash = faker.string.hexadecimal({ length: 10 })
+      const queueTxHash = faker.string.hexadecimal({ length: 10 })
 
       const validFrom = BigNumber.from(0)
       const expiresAt = BigNumber.from(0)

--- a/src/services/recovery/__tests__/recovery-state.test.ts
+++ b/src/services/recovery/__tests__/recovery-state.test.ts
@@ -15,10 +15,18 @@ import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { encodeMultiSendData } from '@safe-global/safe-core-sdk/dist/src/utils/transactions/utils'
 import { getMultiSendCallOnlyDeployment, getSafeSingletonDeployment } from '@safe-global/safe-deployments'
 import { Interface } from 'ethers/lib/utils'
+import { LATEST_SAFE_VERSION } from '@/config/constants'
 
 jest.mock('@/hooks/wallets/web3')
 
 const mockUseWeb3ReadOnly = useWeb3ReadOnly as jest.MockedFunction<typeof useWeb3ReadOnly>
+
+const PRE_MULTI_SEND_CALL_ONLY_VERSIONS = ['1.0.0', '1.1.1']
+const SUPPORTED_MULTI_SEND_CALL_ONLY_VERSIONS = [
+  '1.3.0',
+  // '1.4.1', TODO: Uncomment when safe-deployments is updated >1.25.0
+  LATEST_SAFE_VERSION,
+]
 
 describe('recovery-state', () => {
   beforeEach(() => {
@@ -30,7 +38,7 @@ describe('recovery-state', () => {
     describe('non-MultiSend', () => {
       it('should return true if the transaction is not calling the Safe itself', () => {
         const chainId = '5'
-        const version = '1.3.0'
+        const version = LATEST_SAFE_VERSION
         const safeAddress = faker.finance.ethereumAddress()
 
         const transaction = {
@@ -43,7 +51,7 @@ describe('recovery-state', () => {
 
       it('should return false if the transaction is calling the Safe itself', () => {
         const chainId = '5'
-        const version = '1.3.0'
+        const version = LATEST_SAFE_VERSION
         const safeAddress = faker.finance.ethereumAddress()
 
         const transaction = {
@@ -56,109 +64,117 @@ describe('recovery-state', () => {
     })
 
     describe('MultiSend', () => {
-      it('should return true if the transaction is a not and official MultiSend address', () => {
-        const chainId = '5'
-        const version = '1.3.0'
-        const safeAddress = faker.finance.ethereumAddress()
+      ;[...PRE_MULTI_SEND_CALL_ONLY_VERSIONS, ...SUPPORTED_MULTI_SEND_CALL_ONLY_VERSIONS].forEach((version) => {
+        it(`should return true if the transaction is not an official MultiSend address for Safe version ${version}`, () => {
+          const chainId = '5'
+          const safeAddress = faker.finance.ethereumAddress()
 
-        const safeAbi = getSafeSingletonDeployment({ network: chainId, version })!.abi
-        const safeInterface = new Interface(safeAbi)
+          const safeAbi = getSafeSingletonDeployment({ network: chainId, version })!.abi
+          const safeInterface = new Interface(safeAbi)
 
-        const multiSendAbi = getMultiSendCallOnlyDeployment({ network: chainId, version })!.abi
-        const multiSendInterface = new Interface(multiSendAbi)
+          const multiSendAbi =
+            getMultiSendCallOnlyDeployment({ network: chainId, version }) ??
+            getMultiSendCallOnlyDeployment({ network: chainId, version: '1.3.0' })
+          const multiSendInterface = new Interface(multiSendAbi!.abi)
 
-        const multiSendData = encodeMultiSendData([
-          {
-            to: safeAddress,
-            value: '0',
-            data: safeInterface.encodeFunctionData('addOwnerWithThreshold', [faker.finance.ethereumAddress(), 1]),
-            operation: 0,
-          },
-          {
-            to: safeAddress,
-            value: '0',
-            data: safeInterface.encodeFunctionData('addOwnerWithThreshold', [faker.finance.ethereumAddress(), 2]),
-            operation: 0,
-          },
-        ])
+          const multiSendData = encodeMultiSendData([
+            {
+              to: safeAddress,
+              value: '0',
+              data: safeInterface.encodeFunctionData('addOwnerWithThreshold', [faker.finance.ethereumAddress(), 1]),
+              operation: 0,
+            },
+            {
+              to: safeAddress,
+              value: '0',
+              data: safeInterface.encodeFunctionData('addOwnerWithThreshold', [faker.finance.ethereumAddress(), 2]),
+              operation: 0,
+            },
+          ])
 
-        const transaction = {
-          to: faker.finance.ethereumAddress(), // Not official MultiSend
-          data: multiSendInterface.encodeFunctionData('multiSend', [multiSendData]),
-        }
+          const transaction = {
+            to: faker.finance.ethereumAddress(), // Not official MultiSend
+            data: multiSendInterface.encodeFunctionData('multiSend', [multiSendData]),
+          }
 
-        expect(_isMaliciousRecovery({ chainId, version, safeAddress, transaction })).toBe(true)
+          expect(_isMaliciousRecovery({ chainId, version, safeAddress, transaction })).toBe(true)
+        })
+      })
+      ;[...PRE_MULTI_SEND_CALL_ONLY_VERSIONS, ...SUPPORTED_MULTI_SEND_CALL_ONLY_VERSIONS].forEach((version) => {
+        it(`should return true if the transaction is an official MultiSend call and not every transaction in the batch calls the Safe itself for Safe version ${version}`, () => {
+          const chainId = '5'
+          const version = LATEST_SAFE_VERSION
+          const safeAddress = faker.finance.ethereumAddress()
+
+          const safeAbi = getSafeSingletonDeployment({ network: chainId, version })!.abi
+          const safeInterface = new Interface(safeAbi)
+
+          const multiSendDeployment =
+            getMultiSendCallOnlyDeployment({ network: chainId, version }) ??
+            getMultiSendCallOnlyDeployment({ network: chainId, version: '1.3.0' })
+          const multiSendInterface = new Interface(multiSendDeployment!.abi)
+
+          const multiSendData = encodeMultiSendData([
+            {
+              to: faker.finance.ethereumAddress(), // Not Safe
+              value: '0',
+              data: safeInterface.encodeFunctionData('addOwnerWithThreshold', [faker.finance.ethereumAddress(), 1]),
+              operation: 0,
+            },
+            {
+              to: faker.finance.ethereumAddress(), // Not Safe
+              value: '0',
+              data: safeInterface.encodeFunctionData('addOwnerWithThreshold', [faker.finance.ethereumAddress(), 2]),
+              operation: 0,
+            },
+          ])
+
+          const transaction = {
+            to: multiSendDeployment!.networkAddresses[chainId],
+            data: multiSendInterface.encodeFunctionData('multiSend', [multiSendData]),
+          }
+
+          expect(_isMaliciousRecovery({ chainId, version, safeAddress, transaction })).toBe(true)
+        })
       })
 
-      it('should return true if the transaction is an official MultiSend call and not every transaction in the batch calls the Safe itself', () => {
-        const chainId = '5'
-        const version = '1.3.0'
-        const safeAddress = faker.finance.ethereumAddress()
+      SUPPORTED_MULTI_SEND_CALL_ONLY_VERSIONS.forEach((version) => {
+        it(`should return false if the transaction is an official MultiSend call and every transaction in the batch calls the Safe itself for Safe version ${version}`, () => {
+          const chainId = '5'
+          const safeAddress = faker.finance.ethereumAddress()
 
-        const safeAbi = getSafeSingletonDeployment({ network: chainId, version })!.abi
-        const safeInterface = new Interface(safeAbi)
+          const safeAbi = getSafeSingletonDeployment({ network: chainId, version })!.abi
+          const safeInterface = new Interface(safeAbi)
 
-        const multiSendDeployment = getMultiSendCallOnlyDeployment({ network: chainId, version })!
-        const multiSendInterface = new Interface(multiSendDeployment.abi)
+          const multiSendDeployment = getMultiSendCallOnlyDeployment({ network: chainId, version })!
+          const multiSendInterface = new Interface(multiSendDeployment.abi)
 
-        const multiSendData = encodeMultiSendData([
-          {
-            to: faker.finance.ethereumAddress(), // Not Safe
-            value: '0',
-            data: safeInterface.encodeFunctionData('addOwnerWithThreshold', [faker.finance.ethereumAddress(), 1]),
-            operation: 0,
-          },
-          {
-            to: faker.finance.ethereumAddress(), // Not Safe
-            value: '0',
-            data: safeInterface.encodeFunctionData('addOwnerWithThreshold', [faker.finance.ethereumAddress(), 2]),
-            operation: 0,
-          },
-        ])
+          const multiSendData = encodeMultiSendData([
+            {
+              to: safeAddress,
+              value: '0',
+              data: safeInterface.encodeFunctionData('addOwnerWithThreshold', [faker.finance.ethereumAddress(), 1]),
+              operation: 0,
+            },
+            {
+              to: safeAddress,
+              value: '0',
+              data: safeInterface.encodeFunctionData('addOwnerWithThreshold', [faker.finance.ethereumAddress(), 2]),
+              operation: 0,
+            },
+          ])
 
-        const transaction = {
-          to: multiSendDeployment.networkAddresses[chainId],
-          data: multiSendInterface.encodeFunctionData('multiSend', [multiSendData]),
-        }
+          const transaction = {
+            to: multiSendDeployment.networkAddresses[chainId],
+            data: multiSendInterface.encodeFunctionData('multiSend', [multiSendData]),
+          }
 
-        expect(_isMaliciousRecovery({ chainId, version, safeAddress, transaction })).toBe(true)
+          expect(_isMaliciousRecovery({ chainId, version, safeAddress, transaction })).toBe(false)
+        })
       })
 
-      it('should return false if the transaction is an official MultiSend call and every transaction in the batch calls the Safe itself', () => {
-        const chainId = '5'
-        const version = '1.3.0'
-        const safeAddress = faker.finance.ethereumAddress()
-
-        const safeAbi = getSafeSingletonDeployment({ network: chainId, version })!.abi
-        const safeInterface = new Interface(safeAbi)
-
-        const multiSendDeployment = getMultiSendCallOnlyDeployment({ network: chainId, version })!
-        const multiSendInterface = new Interface(multiSendDeployment.abi)
-
-        const multiSendData = encodeMultiSendData([
-          {
-            to: safeAddress,
-            value: '0',
-            data: safeInterface.encodeFunctionData('addOwnerWithThreshold', [faker.finance.ethereumAddress(), 1]),
-            operation: 0,
-          },
-          {
-            to: safeAddress,
-            value: '0',
-            data: safeInterface.encodeFunctionData('addOwnerWithThreshold', [faker.finance.ethereumAddress(), 2]),
-            operation: 0,
-          },
-        ])
-
-        const transaction = {
-          to: multiSendDeployment.networkAddresses[chainId],
-          data: multiSendInterface.encodeFunctionData('multiSend', [multiSendData]),
-        }
-
-        expect(_isMaliciousRecovery({ chainId, version, safeAddress, transaction })).toBe(false)
-      })
-      ;['1.0.0', '1.1.1'].forEach((version) => {
-        it(`should return false if the transaction is an official MultiSend call on Safe version ${version} (below the initial MultiSend contract version)`, () => {
+      PRE_MULTI_SEND_CALL_ONLY_VERSIONS.forEach((version) => {
+        it(`should return false if the transaction is an official MultiSend call for Safe version ${version} (below the initial MultiSend contract version)`, () => {
           const chainId = '5'
           const safeAddress = faker.finance.ethereumAddress()
 

--- a/src/services/recovery/recovery-state.ts
+++ b/src/services/recovery/recovery-state.ts
@@ -47,6 +47,8 @@ export function _isMaliciousRecovery({
   safeAddress: string
   transaction: Pick<TransactionAddedEvent['args'], 'to' | 'data'>
 }) {
+  const BASE_MULTI_SEND_CALL_ONLY_VERSION = '1.3.0'
+
   const isMultiSend = isMultiSendCalldata(transaction.data)
   const transactions = isMultiSend ? decodeMultiSendTxs(transaction.data) : [transaction]
 
@@ -55,7 +57,9 @@ export function _isMaliciousRecovery({
     return !sameAddress(transaction.to, safeAddress)
   }
 
-  const multiSendDeployment = getMultiSendCallOnlyDeployment({ network: chainId, version: version ?? undefined })
+  const multiSendDeployment =
+    getMultiSendCallOnlyDeployment({ network: chainId, version: version ?? undefined }) ??
+    getMultiSendCallOnlyDeployment({ network: chainId, version: BASE_MULTI_SEND_CALL_ONLY_VERSION })
 
   if (!multiSendDeployment) {
     return true


### PR DESCRIPTION
## What it solves

Resolves [recovery of <1.3.0 Safes showing as malicious](https://www.notion.so/safe-global/1-1-1-Recovery-tx-is-displayed-as-Malicious-Transaction-16f6beb12675450cbcd1d75df906d856)

## How this PR fixes it

The initial deployment version of the MultiSendCallOnly contract is used as a fallback when checking for maliciousness of a recovery attempt.

## How to test it

Propose a recovery attempt on a <1.3.0 Safe and observe that it is not marked as malicious in the queue.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
