### PR TITLE
fix: use unchecked for smart contract recoverers

### DIFF
--- a/src/components/dashboard/RecoveryHeader/index.test.tsx
+++ b/src/components/dashboard/RecoveryHeader/index.test.tsx
@@ -62,32 +62,28 @@ describe('RecoveryHeader', () => {
 })
 
 describe('useIsProposalInProgress', () => {
-  ;[
-    RecoveryEvent.EXECUTING,
-    RecoveryEvent.PROCESSING,
-    RecoveryEvent.REVERTED,
-    RecoveryEvent.PROCESSED,
-    RecoveryEvent.FAILED,
-  ].forEach((event) => {
-    it('should return true if there is a proposal in progress', async () => {
-      mockUseRecoveryQueue.mockReturnValue([] as any)
+  ;[RecoveryEvent.PROCESSING, RecoveryEvent.REVERTED, RecoveryEvent.PROCESSED, RecoveryEvent.FAILED].forEach(
+    (event) => {
+      it('should return true if there is a proposal in progress', async () => {
+        mockUseRecoveryQueue.mockReturnValue([] as any)
 
-      const { result } = renderHook(() => _useIsProposalInProgress())
+        const { result } = renderHook(() => _useIsProposalInProgress())
 
-      expect(result.current).toBe(false)
+        expect(result.current).toBe(false)
 
-      recoveryDispatch(event, {
-        moduleAddress: faker.finance.ethereumAddress(),
-        txHash: faker.string.hexadecimal(),
-        recoveryTxHash: faker.string.hexadecimal(),
-        eventType: RecoveryEventType.PROPOSAL,
+        recoveryDispatch(event, {
+          moduleAddress: faker.finance.ethereumAddress(),
+          txHash: faker.string.hexadecimal(),
+          recoveryTxHash: faker.string.hexadecimal(),
+          eventType: RecoveryEventType.PROPOSAL,
+        })
+
+        await waitFor(() => {
+          expect(result.current).toBe(true)
+        })
       })
-
-      await waitFor(() => {
-        expect(result.current).toBe(true)
-      })
-    })
-  })
+    },
+  )
   ;[RecoveryEvent.REVERTED, RecoveryEvent.PROCESSED, RecoveryEvent.FAILED].forEach((event) => {
     it('should return false if there is not a proposal in progress and it is not in the queue', async () => {
       const payload = {
@@ -104,7 +100,7 @@ describe('useIsProposalInProgress', () => {
       expect(result.current).toBe(false)
 
       // Trigger pending
-      recoveryDispatch(RecoveryEvent.EXECUTING, payload)
+      recoveryDispatch(RecoveryEvent.PROCESSING, payload)
 
       await waitFor(() => {
         expect(result.current).toBe(true)

--- a/src/components/dashboard/RecoveryHeader/index.tsx
+++ b/src/components/dashboard/RecoveryHeader/index.tsx
@@ -56,10 +56,10 @@ export function _useIsProposalInProgress(): boolean {
     const unsubFns = Object.values(RecoveryEvent).map((event) =>
       recoverySubscribe(event, (detail) => {
         const isProposal = 'eventType' in detail && detail.eventType === RecoveryEventType.PROPOSAL
-        const isValidating = event === RecoveryEvent.EXECUTING || event === RecoveryEvent.PROCESSING
+        const isProcessing = event === RecoveryEvent.PROCESSING
         const isLoaded = queue.some((item) => item.args.txHash === detail?.recoveryTxHash)
 
-        setIsProposalSubmitting(isProposal && (isValidating || !isLoaded))
+        setIsProposalSubmitting(isProposal && (isProcessing || !isLoaded))
       }),
     )
 

--- a/src/components/recovery/RecoveryContext/__tests__/useRecoveryPendingTxs.test.ts
+++ b/src/components/recovery/RecoveryContext/__tests__/useRecoveryPendingTxs.test.ts
@@ -6,29 +6,7 @@ import { act, renderHook } from '@/tests/test-utils'
 import { useRecoveryPendingTxs } from '../useRecoveryPendingTxs'
 
 describe('useRecoveryPendingTxs', () => {
-  it('should set pending status to SUBMITTING when EXECUTING event is emitted', () => {
-    const delayModifierAddress = faker.finance.ethereumAddress()
-    const txHash = faker.string.hexadecimal()
-    const recoveryTxHash = faker.string.hexadecimal()
-    const { result } = renderHook(() => useRecoveryPendingTxs())
-
-    expect(result.current).toStrictEqual({})
-
-    act(() => {
-      recoveryDispatch(RecoveryEvent.EXECUTING, {
-        moduleAddress: delayModifierAddress,
-        txHash,
-        recoveryTxHash,
-        eventType: faker.helpers.enumValue(RecoveryEventType),
-      })
-    })
-
-    expect(result.current).toStrictEqual({
-      [recoveryTxHash]: PendingStatus.SUBMITTING,
-    })
-  })
-
-  it('should set pending status to PROCESSING when PROCESSING event is emitted', () => {
+  it('should set pending status to SUBMITTING when PROCESSING event is emitted', () => {
     const delayModifierAddress = faker.finance.ethereumAddress()
     const txHash = faker.string.hexadecimal()
     const recoveryTxHash = faker.string.hexadecimal()
@@ -46,7 +24,7 @@ describe('useRecoveryPendingTxs', () => {
     })
 
     expect(result.current).toStrictEqual({
-      [recoveryTxHash]: PendingStatus.PROCESSING,
+      [recoveryTxHash]: PendingStatus.SUBMITTING,
     })
   })
 
@@ -60,7 +38,7 @@ describe('useRecoveryPendingTxs', () => {
     expect(result.current).toStrictEqual({})
 
     act(() => {
-      recoveryDispatch(RecoveryEvent.EXECUTING, {
+      recoveryDispatch(RecoveryEvent.PROCESSING, {
         moduleAddress: delayModifierAddress,
         txHash,
         recoveryTxHash,
@@ -88,7 +66,7 @@ describe('useRecoveryPendingTxs', () => {
     expect(result.current).toStrictEqual({})
 
     act(() => {
-      recoveryDispatch(RecoveryEvent.EXECUTING, {
+      recoveryDispatch(RecoveryEvent.PROCESSING, {
         moduleAddress: delayModifierAddress,
         txHash,
         recoveryTxHash,

--- a/src/components/recovery/RecoveryContext/useRecoveryPendingTxs.ts
+++ b/src/components/recovery/RecoveryContext/useRecoveryPendingTxs.ts
@@ -6,7 +6,7 @@ import { PendingStatus } from '@/store/pendingTxsSlice'
 export type PendingRecoveryTransactions = { [recoveryTxHash: string]: PendingStatus }
 
 const pendingStatuses: { [key in RecoveryEvent]: PendingStatus | null } = {
-  [RecoveryEvent.EXECUTING]: PendingStatus.SUBMITTING,
+  [RecoveryEvent.PROCESSING_BY_SMART_CONTRACT_WALLET]: null,
   [RecoveryEvent.PROCESSING]: PendingStatus.PROCESSING,
   [RecoveryEvent.PROCESSED]: PendingStatus.INDEXING,
   [RecoveryEvent.REVERTED]: null,

--- a/src/hooks/useRecoveryTxNotification.ts
+++ b/src/hooks/useRecoveryTxNotification.ts
@@ -1,16 +1,14 @@
 import { useEffect } from 'react'
 
 import { formatError } from '@/utils/formatters'
-import { selectNotifications, showNotification } from '@/store/notificationsSlice'
+import { showNotification } from '@/store/notificationsSlice'
 import { useAppDispatch } from '@/store'
 import useSafeAddress from './useSafeAddress'
 import { RecoveryEvent, RecoveryEventType, recoverySubscribe } from '@/services/recovery/recoveryEvents'
 import { getExplorerLink } from '@/utils/gateway'
 import { useCurrentChain } from './useChains'
-import { useSelector } from 'react-redux'
 
 const RecoveryTxNotifications = {
-  [RecoveryEvent.EXECUTING]: 'Confirm the execution in your wallet.',
   [RecoveryEvent.PROCESSING]: 'Validating...',
   [RecoveryEvent.PROCESSED]: 'Successfully validated. Loading...',
   [RecoveryEvent.REVERTED]: 'Reverted. Please check your gas settings.',
@@ -30,8 +28,6 @@ export function useRecoveryTxNotifications(): void {
   const chain = useCurrentChain()
   const safeAddress = useSafeAddress()
 
-  const notifications = useSelector(selectNotifications)
-
   /**
    * Show notifications of a recovery transaction's lifecycle
    */
@@ -50,11 +46,7 @@ export function useRecoveryTxNotifications(): void {
         const recoveryTxHash = 'recoveryTxHash' in detail ? detail.recoveryTxHash : undefined
         const groupKey = txHash || recoveryTxHash || ''
 
-        const title =
-          'eventType' in detail
-            ? RecoveryTxNotificationTitles[detail.eventType]
-            : notifications.find((notification) => notification.groupKey === groupKey)?.title ||
-              RecoveryTxNotificationTitles[RecoveryEventType.EXECUTION]
+        const title = RecoveryTxNotificationTitles[detail.eventType]
         const message = isError ? `${notification} ${formatError(detail.error)}` : notification
 
         const link = txHash ? getExplorerLink(txHash, chain.blockExplorerUriTemplate) : undefined
@@ -75,5 +67,5 @@ export function useRecoveryTxNotifications(): void {
     return () => {
       unsubFns.forEach((unsub) => unsub())
     }
-  }, [dispatch, safeAddress, chain?.blockExplorerUriTemplate, notifications])
+  }, [dispatch, safeAddress, chain?.blockExplorerUriTemplate])
 }

--- a/src/services/recovery/recoveryEvents.ts
+++ b/src/services/recovery/recoveryEvents.ts
@@ -1,7 +1,7 @@
 import EventBus from '../EventBus'
 
 export enum RecoveryEvent {
-  EXECUTING = 'EXECUTING',
+  PROCESSING_BY_SMART_CONTRACT_WALLET = 'PROCESSING_BY_SMART_CONTRACT_WALLET',
   PROCESSING = 'PROCESSING',
   REVERTED = 'REVERTED',
   PROCESSED = 'PROCESSED',
@@ -15,7 +15,7 @@ export enum RecoveryEventType {
 }
 
 export interface RecoveryEvents {
-  [RecoveryEvent.EXECUTING]: {
+  [RecoveryEvent.PROCESSING_BY_SMART_CONTRACT_WALLET]: {
     moduleAddress: string
     txHash: string
     recoveryTxHash: string


### PR DESCRIPTION
## What it solves

Resolves [smart contract Recoverers not working](https://www.notion.so/safe-global/Safe-as-an-Recoverer-create-recovery-tx-form-is-not-updated-and-manual-closing-is-required-53071d129364467aa1b18bfd2a2a368e)

## How this PR fixes it

An unchecked signer is now used when interfacing with the Delay Modifier if the connected provider is a smart contract.

## How to test it

1. Enable a Safe as a Recoverer.
2. Propose a recovery and observe that the proposal modal closes and loads after the proposal is executed.
3. Executing/skipping recovery proposals should work in the same way.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
