### PR TITLE
refactor: simplify `RecoveryEvent.SUCCESS` event dispatch

### DIFF
--- a/src/components/recovery/RecoveryContext/useRecoverySuccessEvents.ts
+++ b/src/components/recovery/RecoveryContext/useRecoverySuccessEvents.ts
@@ -23,21 +23,15 @@ export function useRecoverySuccessEvents(
 
       const isQueued = recoveryState.some(({ queue }) => queue.some(({ args }) => args.txHash === recoveryTxHash))
 
-      if (isQueued) {
-        // Only proposals should appear in the queue
-        if (txType === RecoveryTxType.PROPOSAL) {
-          recoveryDispatch(RecoveryEvent.SUCCESS, {
-            recoveryTxHash,
-            txType,
-          })
-        }
-      } else {
-        // Executions/cancellations are removed from the queue
-        recoveryDispatch(RecoveryEvent.SUCCESS, {
-          recoveryTxHash,
-          txType,
-        })
+      // Only queued proposals or executions/cancellations removed from the queue
+      if (isQueued && txType !== RecoveryTxType.PROPOSAL) {
+        return
       }
+
+      recoveryDispatch(RecoveryEvent.SUCCESS, {
+        recoveryTxHash,
+        txType,
+      })
     })
   }, [pending, recoveryState])
 }


### PR DESCRIPTION
## What it solves

Refactors dispatching of `RecoveryEvent.SUCCESS` events

## How this PR fixes it

The code responsible for dispatchinn `RecoveryEvent.SUCCESS` events has been simplified.

## How to test it

Queue a recovery attempt or execute/cancel one (as owner/Recoverers) and observe a final success notification for each.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
