### PR TITLE
refactor: improve `isRecoveryQueueItem` strictness

### DIFF
--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -112,7 +112,8 @@ export const isTransactionListItem = (value: TransactionListItem): value is Tran
 }
 
 export function isRecoveryQueueItem(value: TransactionListItem | RecoveryQueueItem): value is RecoveryQueueItem {
-  return 'args' in value
+  const EVENT_SIGNATURE = 'TransactionAdded(uint256,bytes32,address,uint256,bytes,uint8)'
+  return 'eventSignature' in value && value.eventSignature === EVENT_SIGNATURE
 }
 
 // Narrows `Transaction`


### PR DESCRIPTION
## What it solves

Improves the strictness of the `isRecoveryQueueItem` type guard.

## How this PR fixes it

The `eventSignature` uniqueness of the `RecoveryQueueItem` is checked that it is `"TransactionAdded(uint256,bytes32,address,uint256,bytes,uint8)"`.

## How to test it

Queue a recovery proposal and observe that the dashboard and transaction list queues work as expected.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
