### PR TITLE
fix: wallet connect namespace without requiredNamespace

### DIFF
--- a/src/services/walletconnect/WalletConnectWallet.ts
+++ b/src/services/walletconnect/WalletConnectWallet.ts
@@ -8,7 +8,7 @@ import { type JsonRpcResponse } from '@walletconnect/jsonrpc-utils'
 import uniq from 'lodash/uniq'
 
 import { IS_PRODUCTION, LS_NAMESPACE, WC_PROJECT_ID } from '@/config/constants'
-import { EIP155, SAFE_COMPATIBLE_METHODS, SAFE_WALLET_METADATA } from './constants'
+import { EIP155, SAFE_COMPATIBLE_EVENTS, SAFE_COMPATIBLE_METHODS, SAFE_WALLET_METADATA } from './constants'
 import { invariant } from '@/utils/helpers'
 import { getEip155ChainId, stripEip155Prefix } from './utils'
 
@@ -97,7 +97,7 @@ class WalletConnectWallet {
 
     // Don't include optionalNamespaces methods/events
     const methods = uniq((proposal.params.requiredNamespaces[EIP155]?.methods || []).concat(SAFE_COMPATIBLE_METHODS))
-    const events = proposal.params.requiredNamespaces[EIP155]?.events || []
+    const events = uniq((proposal.params.requiredNamespaces[EIP155]?.events || []).concat(SAFE_COMPATIBLE_EVENTS))
 
     return buildApprovedNamespaces({
       proposal: proposal.params,

--- a/src/services/walletconnect/constants.ts
+++ b/src/services/walletconnect/constants.ts
@@ -24,6 +24,8 @@ export const SAFE_COMPATIBLE_METHODS = [
   'safe_setSettings',
 ]
 
+export const SAFE_COMPATIBLE_EVENTS = ['chainChanged', 'accountsChanged']
+
 export const SAFE_WALLET_METADATA = {
   name: 'Safe{Wallet}',
   url: 'https://app.safe.global',


### PR DESCRIPTION
## What it solves

Resolves #2946 

## How this PR fixes it
Adds required events to namespace on approveSession.

## How to test it
- Find a dapp without requiredNamesapce
- Observe no error about a unavailble emit event.

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
