### PR TITLE
fix: temporarily reduce delay period

### DIFF
--- a/src/components/tx-flow/flows/UpsertRecovery/useRecoveryPeriods.ts
+++ b/src/components/tx-flow/flows/UpsertRecovery/useRecoveryPeriods.ts
@@ -62,8 +62,11 @@ const TestRecoveryExpirationPeriods: Periods = [
 
 export function useRecoveryPeriods(): { delay: Periods; expiration: Periods } {
   const chain = useCurrentChain()
+  const isTestChain = chain && [chains.gor, chains.sep].includes(chain.chainId)
 
-  if (!chain || [chains.gor, chains.sep].includes(chain.chainId)) {
+  // TODO: Remove constant before release
+  // eslint-disable-next-line no-constant-condition
+  if (true || isTestChain) {
     return {
       delay: TestRecoveryDelayPeriods,
       expiration: TestRecoveryExpirationPeriods,


### PR DESCRIPTION
## What it solves

Reduces delay periods on all networks

## How this PR fixes it

The test network periods have been enabled by default.

## How to test it

Open a non-test network and observe the test periods available during recovery upsertion.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
