### PR TITLE
fix: do not remove invalid address prefix

### DIFF
--- a/src/components/common/AddressInput/index.test.tsx
+++ b/src/components/common/AddressInput/index.test.tsx
@@ -35,7 +35,7 @@ const TestForm = ({ address, validate }: { address: string; validate?: AddressIn
     defaultValues: {
       [name]: address,
     },
-    mode: 'onChange',
+    mode: 'all',
   })
 
   return (
@@ -86,6 +86,17 @@ describe('AddressInput tests', () => {
     act(() => {
       fireEvent.change(input, { target: { value: `eth:${TEST_ADDRESS_A}` } })
       jest.advanceTimersByTime(1000)
+    })
+
+    await waitFor(() =>
+      expect(utils.getByLabelText(`"eth" doesn't match the current chain`, { exact: false })).toBeDefined(),
+    )
+
+    // The validation error should persist on blur
+    await act(async () => {
+      fireEvent.blur(input)
+      jest.advanceTimersByTime(1000)
+      await Promise.resolve()
     })
 
     await waitFor(() =>

--- a/src/components/common/AddressInput/index.tsx
+++ b/src/components/common/AddressInput/index.tsx
@@ -152,16 +152,22 @@ const AddressInput = ({
           required,
 
           setValueAs: (value: string): string => {
+            console.log('setValueAs', value)
             // Clean the input value
             const cleanValue = cleanInputValue(value)
             rawValueRef.current = cleanValue
             // This also checksums the address
-            return parsePrefixedAddress(cleanValue).address
+            if (validatePrefixed(cleanValue) === undefined) {
+              // if the prefix is correct we remove it from the value
+              return parsePrefixedAddress(cleanValue).address
+            } else {
+              // we keep invalid prefixes such that the validation error is persistet
+              return cleanValue
+            }
           },
 
           validate: async () => {
             const value = rawValueRef.current
-
             if (value) {
               return validatePrefixed(value) || (await validate?.(parsePrefixedAddress(value).address))
             }


### PR DESCRIPTION
## What it solves

Resolves #2939 

## How this PR fixes it
Does not remove invalid address prefixes when setting the value.

## How to test it
- Input an address with an invalid chain prefix
- Blur the address input
- Observe that the error persists

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
