### PR TITLE
Fix: Hide nonce input if its a spending limit transaction

### DIFF
--- a/src/components/common/AddressBookInput/index.tsx
+++ b/src/components/common/AddressBookInput/index.tsx
@@ -1,6 +1,7 @@
+import AddressInputReadOnly from '@/components/common/AddressInputReadOnly'
 import { type ReactElement, useState, useMemo } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
-import { SvgIcon, Typography } from '@mui/material'
+import { Box, SvgIcon, Typography } from '@mui/material'
 import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete'
 import useAddressBook from '@/hooks/useAddressBook'
 import AddressInput, { type AddressInputProps } from '../AddressInput'
@@ -44,6 +45,14 @@ const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canA
       }
     : undefined
 
+  if (addressBook[addressValue]) {
+    return (
+      <Box data-testid="address-book-recipient" onClick={() => setValue(name, '')}>
+        <AddressInputReadOnly address={addressValue} label="Sending to" />
+      </Box>
+    )
+  }
+
   return (
     <>
       <Autocomplete
@@ -73,6 +82,7 @@ const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canA
           <AddressInput
             {...params}
             {...props}
+            focused={props.focused || !addressValue}
             name={name}
             onOpenListClick={hasVisibleOptions ? handleOpenAutocomplete : undefined}
             isAutocompleteOpen={open}

--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -18,7 +18,12 @@ import classnames from 'classnames'
 
 const TOKEN_DECIMALS = 18
 
-export const getSafeTokenAddress = (chainId: string): string => {
+export const useSafeTokenAddress = () => {
+  const chainId = useChainId()
+  return getSafeTokenAddress(chainId)
+}
+
+export const getSafeTokenAddress = (chainId: string): string | undefined => {
   return SAFE_TOKEN_ADDRESSES[chainId]
 }
 

--- a/src/components/common/TokenAmountInput/index.tsx
+++ b/src/components/common/TokenAmountInput/index.tsx
@@ -1,3 +1,4 @@
+import { safeFormatUnits } from '@/utils/formatters'
 import { Button, Divider, FormControl, InputLabel, MenuItem, TextField } from '@mui/material'
 import { type SafeBalanceResponse } from '@safe-global/safe-gateway-typescript-sdk'
 import css from './styles.module.css'
@@ -17,13 +18,11 @@ export enum TokenAmountFields {
 const TokenAmountInput = ({
   balances,
   selectedToken,
-  onMaxAmountClick,
   maxAmount,
   validate,
 }: {
   balances: SafeBalanceResponse['items']
   selectedToken: SafeBalanceResponse['items'][number] | undefined
-  onMaxAmountClick?: () => void
   maxAmount?: BigNumber
   validate?: (value: string) => string | undefined
 }) => {
@@ -32,6 +31,7 @@ const TokenAmountInput = ({
     register,
     resetField,
     watch,
+    setValue,
   } = useFormContext<{ [TokenAmountFields.tokenAddress]: string; [TokenAmountFields.amount]: string }>()
 
   const tokenAddress = watch(TokenAmountFields.tokenAddress)
@@ -45,6 +45,14 @@ const TokenAmountInput = ({
     [maxAmount, selectedToken?.tokenInfo.decimals],
   )
 
+  const onMaxAmountClick = useCallback(() => {
+    if (!selectedToken || !maxAmount) return
+
+    setValue(TokenAmountFields.amount, safeFormatUnits(maxAmount.toString(), selectedToken.tokenInfo.decimals), {
+      shouldValidate: true,
+    })
+  }, [maxAmount, selectedToken, setValue])
+
   return (
     <FormControl className={classNames(css.outline, { [css.error]: isAmountError })} fullWidth>
       <InputLabel shrink required className={css.label}>
@@ -55,7 +63,7 @@ const TokenAmountInput = ({
           variant="standard"
           InputProps={{
             disableUnderline: true,
-            endAdornment: onMaxAmountClick && (
+            endAdornment: maxAmount && (
               <Button className={css.max} onClick={onMaxAmountClick}>
                 Max
               </Button>

--- a/src/components/tx-flow/flows/NewSpendingLimit/CreateSpendingLimit.tsx
+++ b/src/components/tx-flow/flows/NewSpendingLimit/CreateSpendingLimit.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import { Controller, FormProvider, useForm } from 'react-hook-form'
-import { Box, Button, CardActions, FormControl, InputLabel, MenuItem, Select, Typography } from '@mui/material'
+import { Button, CardActions, FormControl, InputLabel, MenuItem, Select, Typography } from '@mui/material'
 import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded'
 import { defaultAbiCoder, parseUnits } from 'ethers/lib/utils'
 
@@ -14,8 +14,6 @@ import css from '@/components/tx/ExecuteCheckbox/styles.module.css'
 import TokenAmountInput from '@/components/common/TokenAmountInput'
 import { SpendingLimitFields } from '.'
 import { validateAmount, validateDecimalLength } from '@/utils/validation'
-import AddressInputReadOnly from '@/components/common/AddressInputReadOnly'
-import useAddressBook from '@/hooks/useAddressBook'
 
 export const _validateSpendingLimit = (val: string, decimals?: number) => {
   // Allowance amount is uint96 https://github.com/safe-global/safe-modules/blob/master/allowances/contracts/AlowanceModule.sol#L52
@@ -34,10 +32,8 @@ export const CreateSpendingLimit = ({
   params: NewSpendingLimitFlowProps
   onSubmit: (data: NewSpendingLimitFlowProps) => void
 }) => {
-  const [recipientFocus, setRecipientFocus] = useState(!params.beneficiary)
   const chainId = useChainId()
   const { balances } = useVisibleBalances()
-  const addressBook = useAddressBook()
 
   const resetTimeOptions = useMemo(() => getResetTimeOptions(chainId), [chainId])
 
@@ -46,9 +42,8 @@ export const CreateSpendingLimit = ({
     mode: 'onChange',
   })
 
-  const { handleSubmit, setValue, watch, control } = formMethods
+  const { handleSubmit, watch, control } = formMethods
 
-  const beneficiary = watch(SpendingLimitFields.beneficiary)
   const tokenAddress = watch(SpendingLimitFields.tokenAddress)
   const selectedToken = tokenAddress
     ? balances.items.find((item) => item.tokenInfo.address === tokenAddress)
@@ -70,18 +65,7 @@ export const CreateSpendingLimit = ({
       <FormProvider {...formMethods}>
         <form onSubmit={handleSubmit(onSubmit)}>
           <FormControl fullWidth sx={{ mb: 3 }}>
-            {addressBook[beneficiary] ? (
-              <Box
-                onClick={() => {
-                  setValue(SpendingLimitFields.beneficiary, '')
-                  setRecipientFocus(true)
-                }}
-              >
-                <AddressInputReadOnly label="Sending to" address={beneficiary} />
-              </Box>
-            ) : (
-              <AddressBookInput name={SpendingLimitFields.beneficiary} label="Beneficiary" focused={recipientFocus} />
-            )}
+            <AddressBookInput name={SpendingLimitFields.beneficiary} label="Beneficiary" />
           </FormControl>
 
           <TokenAmountInput balances={balances.items} selectedToken={selectedToken} validate={validateSpendingLimit} />

--- a/src/components/tx-flow/flows/NftTransfer/SendNftBatch.tsx
+++ b/src/components/tx-flow/flows/NftTransfer/SendNftBatch.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Box, Button, CardActions, Divider, FormControl, Grid, SvgIcon, Typography } from '@mui/material'
 import { type SafeCollectibleResponse } from '@safe-global/safe-gateway-typescript-sdk'
 import { FormProvider, useForm } from 'react-hook-form'
@@ -6,9 +5,7 @@ import NftIcon from '@/public/images/common/nft.svg'
 import AddressBookInput from '@/components/common/AddressBookInput'
 import type { NftTransferParams } from '.'
 import ImageFallback from '@/components/common/ImageFallback'
-import useAddressBook from '@/hooks/useAddressBook'
 import TxCard from '../../common/TxCard'
-import AddressInputReadOnly from '@/components/common/AddressInputReadOnly'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
 
 enum Field {
@@ -88,8 +85,6 @@ export const NftItems = ({ tokens }: { tokens: SafeCollectibleResponse[] }) => {
 }
 
 const SendNftBatch = ({ params, onSubmit }: SendNftBatchProps) => {
-  const [recipientFocus, setRecipientFocus] = useState(false)
-  const addressBook = useAddressBook()
   const { tokens } = params
 
   const formMethods = useForm<FormData>({
@@ -100,7 +95,6 @@ const SendNftBatch = ({ params, onSubmit }: SendNftBatchProps) => {
   const {
     handleSubmit,
     watch,
-    setValue,
     formState: { errors },
   } = formMethods
 
@@ -119,24 +113,7 @@ const SendNftBatch = ({ params, onSubmit }: SendNftBatchProps) => {
       <FormProvider {...formMethods}>
         <form onSubmit={handleSubmit(onFormSubmit)}>
           <FormControl fullWidth sx={{ mb: 3, mt: 1 }}>
-            {/* TODO: Extract this */}
-            {addressBook[recipient] ? (
-              <Box
-                onClick={() => {
-                  setValue(Field.recipient, '')
-                  setRecipientFocus(true)
-                }}
-              >
-                <AddressInputReadOnly label="Sending to" address={recipient} />
-              </Box>
-            ) : (
-              <AddressBookInput
-                name={Field.recipient}
-                label="Recipient address or ENS"
-                canAdd={isAddressValid}
-                focused={recipientFocus}
-              />
-            )}
+            <AddressBookInput name={Field.recipient} label="Recipient address or ENS" canAdd={isAddressValid} />
           </FormControl>
 
           <Typography data-testid="selected-nfts" variant="body2" color="text.secondary" mb={2}>

--- a/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
@@ -67,6 +67,16 @@ const CreateTokenTransfer = ({
     }
   }, [setNonce, txNonce])
 
+  const balancesItems = useMemo(() => {
+    return isOnlySpendingLimitBeneficiary
+      ? balances.items.filter(({ tokenInfo }) => {
+          return spendingLimits?.some(({ beneficiary, token }) => {
+            return sameAddress(beneficiary, wallet?.address || '') && sameAddress(tokenInfo.address, token.address)
+          })
+        })
+      : balances.items
+  }, [balances.items, isOnlySpendingLimitBeneficiary, spendingLimits, wallet?.address])
+
   const formMethods = useForm<TokenTransferParams>({
     defaultValues: {
       ...params,
@@ -75,6 +85,9 @@ const CreateTokenTransfer = ({
         : isOnlySpendingLimitBeneficiary
         ? TokenTransferType.spendingLimit
         : params.type,
+      [TokenTransferFields.tokenAddress]: isOnlySpendingLimitBeneficiary
+        ? balancesItems[0]?.tokenInfo.address
+        : params.tokenAddress,
     },
     mode: 'onChange',
     delayError: 500,
@@ -91,9 +104,7 @@ const CreateTokenTransfer = ({
 
   // Selected token
   const tokenAddress = watch(TokenAmountFields.tokenAddress)
-  const selectedToken = tokenAddress
-    ? balances.items.find((item) => item.tokenInfo.address === tokenAddress)
-    : undefined
+  const selectedToken = tokenAddress ? balancesItems.find((item) => item.tokenInfo.address === tokenAddress) : undefined
 
   const type = watch(TokenTransferFields.type)
   const spendingLimit = useSpendingLimit(selectedToken?.tokenInfo)
@@ -105,16 +116,6 @@ const CreateTokenTransfer = ({
       ? spendingLimitAmount
       : totalAmount
     : totalAmount
-
-  const balancesItems = useMemo(() => {
-    return isOnlySpendingLimitBeneficiary
-      ? balances.items.filter(({ tokenInfo }) => {
-          return spendingLimits?.some(({ beneficiary, token }) => {
-            return sameAddress(beneficiary, wallet?.address || '') && sameAddress(tokenInfo.address, token.address)
-          })
-        })
-      : balances.items
-  }, [balances.items, isOnlySpendingLimitBeneficiary, spendingLimits, wallet?.address])
 
   const onMaxAmountClick = useCallback(() => {
     if (!selectedToken) return

--- a/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
@@ -58,7 +58,7 @@ const CreateTokenTransfer = ({
   const isOnlySpendingLimitBeneficiary = useIsOnlySpendingLimitBeneficiary()
   const spendingLimits = useAppSelector(selectSpendingLimits)
   const wallet = useWallet()
-  const { setNonce } = useContext(SafeTxContext)
+  const { setNonce, setNonceNeeded } = useContext(SafeTxContext)
   const [recipientFocus, setRecipientFocus] = useState(!params.recipient)
 
   useEffect(() => {
@@ -133,6 +133,12 @@ const CreateTokenTransfer = ({
   const isSafeTokenSelected = sameAddress(safeTokenAddress, tokenAddress)
   const isDisabled = isSafeTokenSelected && isSafeTokenPaused
   const isAddressValid = !!recipient && !errors[TokenTransferFields.recipient]
+
+  useEffect(() => {
+    if (!spendingLimit) {
+      setNonceNeeded(true)
+    }
+  }, [setNonceNeeded, spendingLimit])
 
   return (
     <TxCard>

--- a/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
@@ -135,10 +135,8 @@ const CreateTokenTransfer = ({
   const isAddressValid = !!recipient && !errors[TokenTransferFields.recipient]
 
   useEffect(() => {
-    if (!spendingLimit) {
-      setNonceNeeded(true)
-    }
-  }, [setNonceNeeded, spendingLimit])
+    setNonceNeeded(!isSpendingLimitType || !spendingLimit)
+  }, [setNonceNeeded, isSpendingLimitType, spendingLimit])
 
   return (
     <TxCard>

--- a/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
@@ -16,7 +16,7 @@ import { TokenTransferFields, type TokenTransferParams, TokenTransferType } from
 import TxCard from '../../common/TxCard'
 import { formatVisualAmount } from '@/utils/formatters'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
-import TokenAmountInput, { TokenAmountFields } from '@/components/common/TokenAmountInput'
+import TokenAmountInput from '@/components/common/TokenAmountInput'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 
 export const AutocompleteItem = (item: { tokenInfo: TokenInfo; balance: string }): ReactElement => (
@@ -80,7 +80,7 @@ export const CreateTokenTransfer = ({
   } = formMethods
 
   const recipient = watch(TokenTransferFields.recipient)
-  const tokenAddress = watch(TokenAmountFields.tokenAddress)
+  const tokenAddress = watch(TokenTransferFields.tokenAddress)
   const type = watch(TokenTransferFields.type)
 
   const selectedToken = balancesItems.find((item) => item.tokenInfo.address === tokenAddress)
@@ -88,17 +88,14 @@ export const CreateTokenTransfer = ({
 
   const isSpendingLimitType = type === TokenTransferType.spendingLimit
 
-  const maxAmount =
-    isSpendingLimitType && spendingLimitAmount && totalAmount.gt(spendingLimitAmount)
-      ? spendingLimitAmount
-      : totalAmount
+  const maxAmount = isSpendingLimitType && totalAmount.gt(spendingLimitAmount) ? spendingLimitAmount : totalAmount
 
   const isSafeTokenSelected = sameAddress(safeTokenAddress, tokenAddress)
   const isDisabled = isSafeTokenSelected && isSafeTokenPaused
   const isAddressValid = !!recipient && !errors[TokenTransferFields.recipient]
 
   useEffect(() => {
-    setNonceNeeded(!isSpendingLimitType || !spendingLimitAmount)
+    setNonceNeeded(!isSpendingLimitType || spendingLimitAmount.eq(0))
   }, [setNonceNeeded, isSpendingLimitType, spendingLimitAmount])
 
   return (
@@ -124,7 +121,7 @@ export const CreateTokenTransfer = ({
             </Box>
           )}
 
-          {!disableSpendingLimit && !!spendingLimitAmount && (
+          {!disableSpendingLimit && spendingLimitAmount.gt(0) && (
             <FormControl fullWidth sx={{ mt: 3 }}>
               <SpendingLimitRow availableAmount={spendingLimitAmount} selectedToken={selectedToken?.tokenInfo} />
             </FormControl>

--- a/src/components/tx-flow/flows/TokenTransfer/__tests__/CreateTokenTransfer.test.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/__tests__/CreateTokenTransfer.test.tsx
@@ -1,0 +1,79 @@
+import { TokenTransferType } from '@/components/tx-flow/flows/TokenTransfer'
+import { CreateTokenTransfer } from '@/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer'
+import { render } from '@/tests/test-utils'
+import { faker } from '@faker-js/faker'
+import { ZERO_ADDRESS } from '@safe-global/safe-core-sdk/dist/src/utils/constants'
+import { fireEvent, waitFor } from '@testing-library/react'
+
+describe('CreateTokenTransfer', () => {
+  const mockParams = {
+    recipient: '',
+    tokenAddress: ZERO_ADDRESS,
+    amount: '',
+    type: TokenTransferType.multiSig,
+  }
+
+  it('should display a token amount input', () => {
+    const { getByText } = render(
+      <CreateTokenTransfer params={mockParams} onSubmit={jest.fn()} addressBook={{}} isSafeTokenPaused={true} />,
+    )
+
+    expect(getByText('Amount')).toBeInTheDocument()
+  })
+
+  it('should display a read-only field if recipient is in address book', () => {
+    const mockAddress = faker.finance.ethereumAddress()
+    const mockAddressBook = { [mockAddress]: 'Test address' }
+
+    const { getAllByText } = render(
+      <CreateTokenTransfer
+        params={{ ...mockParams, recipient: mockAddress }}
+        onSubmit={jest.fn()}
+        addressBook={mockAddressBook}
+        isSafeTokenPaused={true}
+      />,
+    )
+
+    expect(getAllByText('Sending to')[0]).toBeInTheDocument()
+  })
+
+  it('should display an input field if the read-only field was clicked', () => {
+    const mockAddress = faker.finance.ethereumAddress()
+    const mockAddressBook = { [mockAddress]: 'Test address' }
+
+    const { getByTestId, getAllByText } = render(
+      <CreateTokenTransfer
+        params={{ ...mockParams, recipient: mockAddress }}
+        onSubmit={jest.fn()}
+        addressBook={mockAddressBook}
+        isSafeTokenPaused={true}
+      />,
+    )
+
+    expect(getAllByText('Sending to')[0]).toBeInTheDocument()
+
+    fireEvent.click(getByTestId('address-book-recipient'))
+
+    expect(getAllByText('Recipient address or ENS')[0]).toBeInTheDocument()
+  })
+
+  it('should disable the submit button and display a warning if $SAFE token is selected and not transferable', () => {
+    const { getByText } = render(
+      <CreateTokenTransfer
+        params={{ ...mockParams, tokenAddress: '0x2' }}
+        onSubmit={jest.fn()}
+        addressBook={{}}
+        safeTokenAddress="0x2"
+        isSafeTokenPaused={true}
+      />,
+    )
+
+    const button = getByText('Next')
+
+    expect(getByText('$SAFE is currently non-transferable.')).toBeInTheDocument()
+    expect(button).toBeDisabled()
+  })
+
+  it.todo('should display a type selection if a spending limit token is selected')
+  it.todo('should not display a type selection if there is a txNonce')
+})

--- a/src/components/tx-flow/flows/TokenTransfer/__tests__/CreateTokenTransfer.test.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/__tests__/CreateTokenTransfer.test.tsx
@@ -13,6 +13,10 @@ describe('CreateTokenTransfer', () => {
     type: TokenTransferType.multiSig,
   }
 
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('should display a token amount input', () => {
     const { getByText } = render(
       <CreateTokenTransfer params={mockParams} onSubmit={jest.fn()} isSafeTokenPaused={true} />,

--- a/src/components/tx-flow/flows/TokenTransfer/__tests__/utils.test.ts
+++ b/src/components/tx-flow/flows/TokenTransfer/__tests__/utils.test.ts
@@ -1,0 +1,165 @@
+import { connectedWalletBuilder } from '@/tests/builders/wallet'
+import { type SafeBalanceResponse, type TokenInfo, TokenType } from '@safe-global/safe-gateway-typescript-sdk'
+import { BigNumber } from 'ethers'
+import { useTokenAmount, useVisibleTokens } from '@/components/tx-flow/flows/TokenTransfer/utils'
+import { renderHook } from '@/tests/test-utils'
+import * as spendingLimit from '@/hooks/useSpendingLimit'
+import * as spendingLimitBeneficiary from '@/hooks/useIsOnlySpendingLimitBeneficiary'
+import * as visibleBalances from '@/hooks/useVisibleBalances'
+import * as wallet from '@/hooks/wallets/useWallet'
+
+describe('TokenTransfer utils', () => {
+  describe('useTokenAmount', () => {
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should return a totalAmount of 0 if there is no token', () => {
+      const { result } = renderHook(() => useTokenAmount(undefined))
+
+      expect(result.current.totalAmount).toStrictEqual(BigNumber.from(0))
+    })
+
+    it('should return the totalAmount if there is a token', () => {
+      const mockToken = {
+        tokenInfo: { address: '0x2', symbol: 'TST', decimals: 16 } as TokenInfo,
+        balance: '100',
+        fiatBalance: '100',
+        fiatConversion: '1',
+      }
+      const { result } = renderHook(() => useTokenAmount(mockToken))
+
+      expect(result.current.totalAmount).toStrictEqual(BigNumber.from(mockToken.balance))
+    })
+
+    it('should return a spendingLimitAmount of 0 if there is no spending limit token', () => {
+      jest.spyOn(spendingLimit, 'default').mockReturnValue(undefined)
+
+      const { result } = renderHook(() => useTokenAmount(undefined))
+
+      expect(result.current.spendingLimitAmount).toStrictEqual(BigNumber.from(0))
+    })
+
+    it('should return the remaining spending limit amount for a token', () => {
+      const mockSpendingLimitToken = {
+        beneficiary: '0x1',
+        token: { address: '0x2', symbol: 'TST', decimals: 16 },
+        amount: '100',
+        nonce: '',
+        resetTimeMin: '',
+        lastResetMin: '',
+        spent: '30',
+      }
+
+      jest.spyOn(spendingLimit, 'default').mockReturnValue(mockSpendingLimitToken)
+
+      const { result } = renderHook(() => useTokenAmount(undefined))
+
+      expect(result.current.spendingLimitAmount).toStrictEqual(BigNumber.from('70'))
+    })
+  })
+
+  describe('useVisibleTokens', () => {
+    it('returns balance items if its not a spending limit beneficiary', () => {
+      const mockToken = {
+        balance: '100',
+        fiatBalance: '100',
+        fiatConversion: '1',
+        tokenInfo: {
+          address: '0x1',
+          decimals: 18,
+          logoUri: '',
+          name: 'Test Token',
+          symbol: 'TST',
+          type: TokenType.ERC20,
+        },
+      }
+
+      const mockToken1 = {
+        balance: '60',
+        fiatBalance: '60',
+        fiatConversion: '1',
+        tokenInfo: {
+          address: '0x2',
+          decimals: 18,
+          logoUri: '',
+          name: 'Test Token 1',
+          symbol: 'TST1',
+          type: TokenType.ERC20,
+        },
+      }
+      const balance: SafeBalanceResponse = {
+        fiatTotal: '200',
+        items: [mockToken, mockToken1],
+      }
+
+      jest.spyOn(spendingLimitBeneficiary, 'default').mockReturnValue(false)
+      jest.spyOn(visibleBalances, 'useVisibleBalances').mockReturnValue({
+        balances: balance,
+        loading: false,
+      })
+
+      const { result } = renderHook(() => useVisibleTokens())
+
+      expect(result.current).toStrictEqual(balance.items)
+    })
+
+    it('only returns spending limit tokens if its a spending limit beneficiary', () => {
+      const mockSpendingLimitToken = {
+        beneficiary: '0x3',
+        token: { address: '0x1', symbol: 'TST', decimals: 16 },
+        amount: '100',
+        nonce: '',
+        resetTimeMin: '',
+        lastResetMin: '',
+        spent: '30',
+      }
+
+      const mockToken = {
+        balance: '100',
+        fiatBalance: '100',
+        fiatConversion: '1',
+        tokenInfo: {
+          address: '0x1',
+          decimals: 18,
+          logoUri: '',
+          name: 'Test Token',
+          symbol: 'TST',
+          type: TokenType.ERC20,
+        },
+      }
+
+      const mockToken1 = {
+        balance: '60',
+        fiatBalance: '60',
+        fiatConversion: '1',
+        tokenInfo: {
+          address: '0x2',
+          decimals: 18,
+          logoUri: '',
+          name: 'Test Token 1',
+          symbol: 'TST1',
+          type: TokenType.ERC20,
+        },
+      }
+      const balance: SafeBalanceResponse = {
+        fiatTotal: '200',
+        items: [mockToken, mockToken1],
+      }
+
+      jest.spyOn(spendingLimitBeneficiary, 'default').mockReturnValue(true)
+      jest.spyOn(visibleBalances, 'useVisibleBalances').mockReturnValue({
+        balances: balance,
+        loading: false,
+      })
+
+      jest.spyOn(wallet, 'default').mockReturnValue(connectedWalletBuilder().with({ address: '0x3' }).build())
+
+      const { result } = renderHook(() => useVisibleTokens(), {
+        initialReduxState: { spendingLimits: { data: [mockSpendingLimitToken], loading: false } },
+      })
+
+      expect(result.current).toStrictEqual([mockToken])
+    })
+  })
+})

--- a/src/components/tx-flow/flows/TokenTransfer/utils.ts
+++ b/src/components/tx-flow/flows/TokenTransfer/utils.ts
@@ -11,7 +11,7 @@ import { type SafeBalanceResponse } from '@safe-global/safe-gateway-typescript-s
 export const useTokenAmount = (selectedToken: SafeBalanceResponse['items'][0] | undefined) => {
   const spendingLimit = useSpendingLimit(selectedToken?.tokenInfo)
 
-  const spendingLimitAmount = spendingLimit ? BigNumber.from(spendingLimit.amount).sub(spendingLimit.spent) : undefined
+  const spendingLimitAmount = BigNumber.from(spendingLimit?.amount || 0).sub(spendingLimit?.spent || 0)
   const totalAmount = BigNumber.from(selectedToken?.balance || 0)
 
   return { totalAmount, spendingLimitAmount }
@@ -23,11 +23,13 @@ export const useVisibleTokens = () => {
   const spendingLimits = useAppSelector(selectSpendingLimits)
   const wallet = useWallet()
 
-  return isOnlySpendingLimitBeneficiary
-    ? balances.items.filter(({ tokenInfo }) => {
-        return spendingLimits?.some(({ beneficiary, token }) => {
-          return sameAddress(beneficiary, wallet?.address || '') && sameAddress(tokenInfo.address, token.address)
-        })
+  if (isOnlySpendingLimitBeneficiary) {
+    return balances.items.filter(({ tokenInfo }) => {
+      return spendingLimits?.some(({ beneficiary, token }) => {
+        return sameAddress(beneficiary, wallet?.address) && sameAddress(tokenInfo.address, token.address)
       })
-    : balances.items
+    })
+  }
+
+  return balances.items
 }

--- a/src/components/tx-flow/flows/TokenTransfer/utils.ts
+++ b/src/components/tx-flow/flows/TokenTransfer/utils.ts
@@ -1,0 +1,33 @@
+import useIsOnlySpendingLimitBeneficiary from '@/hooks/useIsOnlySpendingLimitBeneficiary'
+import useSpendingLimit from '@/hooks/useSpendingLimit'
+import { useVisibleBalances } from '@/hooks/useVisibleBalances'
+import useWallet from '@/hooks/wallets/useWallet'
+import { useAppSelector } from '@/store'
+import { selectSpendingLimits } from '@/store/spendingLimitsSlice'
+import { sameAddress } from '@/utils/addresses'
+import { BigNumber } from '@ethersproject/bignumber'
+import { type SafeBalanceResponse } from '@safe-global/safe-gateway-typescript-sdk'
+
+export const useTokenAmount = (selectedToken: SafeBalanceResponse['items'][0] | undefined) => {
+  const spendingLimit = useSpendingLimit(selectedToken?.tokenInfo)
+
+  const spendingLimitAmount = spendingLimit ? BigNumber.from(spendingLimit.amount).sub(spendingLimit.spent) : undefined
+  const totalAmount = BigNumber.from(selectedToken?.balance || 0)
+
+  return { totalAmount, spendingLimitAmount }
+}
+
+export const useVisibleTokens = () => {
+  const isOnlySpendingLimitBeneficiary = useIsOnlySpendingLimitBeneficiary()
+  const { balances } = useVisibleBalances()
+  const spendingLimits = useAppSelector(selectSpendingLimits)
+  const wallet = useWallet()
+
+  return isOnlySpendingLimitBeneficiary
+    ? balances.items.filter(({ tokenInfo }) => {
+        return spendingLimits?.some(({ beneficiary, token }) => {
+          return sameAddress(beneficiary, wallet?.address || '') && sameAddress(tokenInfo.address, token.address)
+        })
+      })
+    : balances.items
+}

--- a/src/components/tx/SpendingLimitRow/index.tsx
+++ b/src/components/tx/SpendingLimitRow/index.tsx
@@ -12,7 +12,7 @@ import { HelpCenterArticle } from '@/config/constants'
 
 import css from './styles.module.css'
 import { TokenAmountFields } from '@/components/common/TokenAmountInput'
-import { useContext } from 'react'
+import { useContext, useEffect } from 'react'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 
 const SpendingLimitRow = ({
@@ -27,6 +27,12 @@ const SpendingLimitRow = ({
   const { setNonceNeeded } = useContext(SafeTxContext)
 
   const formattedAmount = safeFormatUnits(availableAmount, selectedToken?.decimals)
+
+  useEffect(() => {
+    if (isOnlySpendLimitBeneficiary) {
+      setNonceNeeded(false)
+    }
+  }, [isOnlySpendLimitBeneficiary, setNonceNeeded])
 
   return (
     <FormControl>

--- a/src/components/tx/SpendingLimitRow/index.tsx
+++ b/src/components/tx/SpendingLimitRow/index.tsx
@@ -12,7 +12,7 @@ import { HelpCenterArticle } from '@/config/constants'
 
 import css from './styles.module.css'
 import { TokenAmountFields } from '@/components/common/TokenAmountInput'
-import { useContext, useEffect } from 'react'
+import { useContext } from 'react'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 
 const SpendingLimitRow = ({
@@ -27,12 +27,6 @@ const SpendingLimitRow = ({
   const { setNonceNeeded } = useContext(SafeTxContext)
 
   const formattedAmount = safeFormatUnits(availableAmount, selectedToken?.decimals)
-
-  useEffect(() => {
-    if (isOnlySpendLimitBeneficiary) {
-      setNonceNeeded(false)
-    }
-  }, [isOnlySpendLimitBeneficiary, setNonceNeeded])
 
   return (
     <FormControl>

--- a/src/components/tx/SpendingLimitRow/styles.module.css
+++ b/src/components/tx/SpendingLimitRow/styles.module.css
@@ -1,13 +1,13 @@
 .group {
   border: 1px solid var(--color-border-main);
   border-radius: 4px;
-  display: grid;
-  grid-template-columns: 50% 50%;
+  display: flex;
 }
 
 .label {
   margin: 0;
   padding: 12px 3px;
+  flex: 1;
 }
 
 .spendingLimit {

--- a/src/hooks/useIsSafeTokenPaused.ts
+++ b/src/hooks/useIsSafeTokenPaused.ts
@@ -15,6 +15,8 @@ const useIsSafeTokenPaused = () => {
   const [isSafeTokenPaused] = useAsync<boolean>(async () => {
     const safeTokenAddress = getSafeTokenAddress(chainId)
 
+    if (!safeTokenAddress) return false
+
     const safeTokenContract = new Contract(safeTokenAddress, new Interface([PAUSED_ABI]), provider)
 
     let isPaused: boolean


### PR DESCRIPTION
## What it solves

Resolves #2880 

## How this PR fixes it

- Hides the nonce input field if a non-owner tries to create a spending limit transaction
- Pre-selects the first available token when a non-owner tries to create a spending limit transaction
- Displays the nonce input again if an owner switches from a spending limit token to a non-spending limit token

## How to test it

1. Open a safe with a spending limit as a non-owner
2. Create a transaction and observe the nonce input is hidden
3. Observe a token is pre-selected in the form

---

1. Open a safe as an owner that also has a spending limit
2. Create a transaction
3. Observe the nonce input being visible
5. Select the spending limit token and select spending limit in the radio group
6. Observe the nonce input is hidden
7. Switch to a different token
8. Observe the nonce input is visible

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
