### PR TITLE
fix: recovery expiry label

### DIFF
--- a/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowReview.tsx
+++ b/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowReview.tsx
@@ -61,7 +61,7 @@ export function UpsertRecoveryFlowReview({
   const periods = useRecoveryPeriods()
   const recoverer = params[UpsertRecoveryFlowFields.recoverer]
   const delay = periods.delay.find(({ value }) => value === params[UpsertRecoveryFlowFields.delay])!.label
-  const expiry = periods.expiration.find(({ value }) => value === params[UpsertRecoveryFlowFields.expiry])!.value
+  const expiry = periods.expiration.find(({ value }) => value === params[UpsertRecoveryFlowFields.expiry])!.label
 
   useEffect(() => {
     if (!web3ReadOnly) {

--- a/src/components/tx-flow/flows/UpsertRecovery/useRecoveryPeriods.ts
+++ b/src/components/tx-flow/flows/UpsertRecovery/useRecoveryPeriods.ts
@@ -47,7 +47,7 @@ const TestRecoveryDelayPeriods: Periods = [
   },
   {
     label: '1 hour',
-    value: `${60 * 60 * 60}`,
+    value: `${60 * 60}`,
   },
   ...DefaultRecoveryDelayPeriods,
 ]

--- a/src/components/tx-flow/flows/UpsertRecovery/useRecoveryPeriods.ts
+++ b/src/components/tx-flow/flows/UpsertRecovery/useRecoveryPeriods.ts
@@ -47,7 +47,7 @@ const TestRecoveryDelayPeriods: Periods = [
   },
   {
     label: '1 hour',
-    value: `${DAY_IN_SECONDS}`,
+    value: `${60 * 60 * 60}`,
   },
   ...DefaultRecoveryDelayPeriods,
 ]


### PR DESCRIPTION
## What it solves

Resolves [expiry time displayed in seconds](https://www.notion.so/Proposal-expire-time-is-in-seconds-instead-of-human-readable-time-format-5e4f039fd65d41ba86ea1adc791a64ef)

## How this PR fixes it

The expiry time on the upsertion review screen is now displayed by it's label, e.g. "1 minute" instead of "60".

Note: this also includes a small fix for [the test period of "1 hour" which was incorrectly set to have a value of 1 day](https://www.notion.so/safe-global/Setting-the-recovery-in-1-hour-actually-sets-its-for-1-day-64d8bc3a5f4f4528b40e4bc062901046).

## How to test it

Open the recovery upsertion flow and set an expiration period and delay period of 1 hour. Observe the correctly labelled expiration period and delay period setting to 1 hour.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
