### PR TITLE
fix: (Recovery) change validation `mode` for QR modal

### DIFF
--- a/src/components/tx-flow/flows/RecoverAccount/RecoverAccountFlowSetup.tsx
+++ b/src/components/tx-flow/flows/RecoverAccount/RecoverAccountFlowSetup.tsx
@@ -64,7 +64,7 @@ export function RecoverAccountFlowSetup({
 
   const formMethods = useForm<RecoverAccountFlowProps>({
     defaultValues: params,
-    mode: 'all',
+    mode: 'onChange',
   })
 
   const newOwners = formMethods.watch(RecoverAccountFlowFields.owners)


### PR DESCRIPTION
## What it solves

Resolves [QR modal not opening in proposal flow](https://www.notion.so/safe-global/The-QR-code-icon-in-the-recovery-form-doesn-t-work-28b73698d4a340b284f9168b448c4158)

## How this PR fixes it

The validation `mode` of the proposal flow has been changed from `all` to `onChange` (matching that of the other recovery flows. The modal was otherwise closing immediately due to error focusing.

## How to test it

Open the recovery proposal flow and click the address input QR, observing that it opens.

## Screenshots

![proposal-qr](https://github.com/safe-global/safe-wallet-web/assets/20442784/523c4323-24d7-4e14-86f7-7d63f02f76b3)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
