### PR TITLE
refactor: Use custom recovery events instead of create tx events

### DIFF
--- a/src/components/tx-flow/flows/CancelRecovery/CancelRecoveryFlowReview.tsx
+++ b/src/components/tx-flow/flows/CancelRecovery/CancelRecoveryFlowReview.tsx
@@ -1,5 +1,5 @@
 import { trackEvent } from '@/services/analytics'
-import { TX_EVENTS, TX_TYPES } from '@/services/analytics/events/transactions'
+import { RECOVERY_EVENTS } from '@/services/analytics/events/recovery'
 import { Typography } from '@mui/material'
 import { useContext, useEffect } from 'react'
 import type { ReactElement } from 'react'
@@ -13,7 +13,7 @@ import ErrorMessage from '@/components/tx/ErrorMessage'
 import type { RecoveryQueueItem } from '@/services/recovery/recovery-state'
 
 const onSubmit = () => {
-  trackEvent({ ...TX_EVENTS.CREATE, label: TX_TYPES.recovery_cancel })
+  trackEvent({ ...RECOVERY_EVENTS.SUBMIT_RECOVERY_CANCEL })
 }
 
 export function CancelRecoveryFlowReview({ recovery }: { recovery: RecoveryQueueItem }): ReactElement {

--- a/src/components/tx-flow/flows/RecoverAccount/RecoverAccountFlowReview.tsx
+++ b/src/components/tx-flow/flows/RecoverAccount/RecoverAccountFlowReview.tsx
@@ -1,5 +1,5 @@
 import { trackEvent } from '@/services/analytics'
-import { TX_EVENTS, TX_TYPES } from '@/services/analytics/events/transactions'
+import { RECOVERY_EVENTS } from '@/services/analytics/events/recovery'
 import { CardActions, Button, Typography, Divider, Box, CircularProgress } from '@mui/material'
 import { useContext, useEffect, useState } from 'react'
 import type { ReactElement } from 'react'
@@ -81,7 +81,7 @@ export function RecoverAccountFlowReview({ params }: { params: RecoverAccountFlo
         safeTx,
         delayModifierAddress: recovery.address,
       })
-      trackEvent({ ...TX_EVENTS.CREATE, label: TX_TYPES.recovery_attempt })
+      trackEvent({ ...RECOVERY_EVENTS.SUBMIT_RECOVERY_ATTEMPT })
     } catch (_err) {
       const err = asError(_err)
       trackError(Errors._810, err)

--- a/src/components/tx-flow/flows/RemoveRecovery/RemoveRecoveryFlowReview.tsx
+++ b/src/components/tx-flow/flows/RemoveRecovery/RemoveRecoveryFlowReview.tsx
@@ -1,5 +1,5 @@
 import { trackEvent } from '@/services/analytics'
-import { TX_EVENTS, TX_TYPES } from '@/services/analytics/events/transactions'
+import { RECOVERY_EVENTS } from '@/services/analytics/events/recovery'
 import { Typography } from '@mui/material'
 import { useContext, useEffect } from 'react'
 import type { ReactElement } from 'react'
@@ -11,7 +11,7 @@ import { SafeTxContext } from '../../SafeTxProvider'
 import type { RecoveryFlowProps } from '.'
 
 const onSubmit = () => {
-  trackEvent({ ...TX_EVENTS.CREATE, label: TX_TYPES.recovery_remove })
+  trackEvent({ ...RECOVERY_EVENTS.SUBMIT_RECOVERY_REMOVE })
 }
 
 export function RemoveRecoveryFlowReview({ delayModifier }: RecoveryFlowProps): ReactElement {

--- a/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowReview.tsx
+++ b/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowReview.tsx
@@ -11,7 +11,6 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import InfoIcon from '@/public/images/notifications/info.svg'
 import { trackEvent } from '@/services/analytics'
 import { RECOVERY_EVENTS } from '@/services/analytics/events/recovery'
-import { TX_EVENTS, TX_TYPES } from '@/services/analytics/events/transactions'
 import { Errors, logError } from '@/services/exceptions'
 import { getRecoveryUpsertTransactions } from '@/services/recovery/setup'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
@@ -40,10 +39,10 @@ const getAddressType = async (address: string, chainId: string) => {
 
 const onSubmit = async (isEdit: boolean, params: UpsertRecoveryFlowProps, chainId: string) => {
   const addressType = await getAddressType(params.recoverer, chainId)
-  const creationType = isEdit ? TX_TYPES.recovery_edit : TX_TYPES.recovery_setup
-  const settings = `${creationType},delay_${params.delay},expiry_${params.expiry},type_${addressType}`
+  const creationEvent = isEdit ? RECOVERY_EVENTS.SUBMIT_RECOVERY_EDIT : RECOVERY_EVENTS.SUBMIT_RECOVERY_CREATE
+  const settings = `delay_${params.delay},expiry_${params.expiry},type_${addressType}`
 
-  trackEvent({ ...TX_EVENTS.CREATE, label: creationType })
+  trackEvent({ ...creationEvent })
   trackEvent({ ...RECOVERY_EVENTS.RECOVERY_SETTINGS, label: settings })
 }
 

--- a/src/services/analytics/events/recovery.ts
+++ b/src/services/analytics/events/recovery.ts
@@ -10,7 +10,7 @@ const RECOVERY_CATEGORY = 'recovery'
 
 export const RECOVERY_EVENTS = {
   SETUP_RECOVERY: {
-    action: 'Start recovery set-up',
+    action: 'Start recovery setup',
     category: RECOVERY_CATEGORY,
     event: EventType.CLICK,
   },
@@ -83,5 +83,30 @@ export const RECOVERY_EVENTS = {
     action: 'Check recovery proposal',
     category: RECOVERY_CATEGORY,
     event: EventType.CLICK,
+  },
+  SUBMIT_RECOVERY_CREATE: {
+    action: 'Submit recovery setup',
+    category: RECOVERY_CATEGORY,
+    event: EventType.META,
+  },
+  SUBMIT_RECOVERY_EDIT: {
+    action: 'Submit recovery edit',
+    category: RECOVERY_CATEGORY,
+    event: EventType.META,
+  },
+  SUBMIT_RECOVERY_REMOVE: {
+    action: 'Submit recovery remove',
+    category: RECOVERY_CATEGORY,
+    event: EventType.META,
+  },
+  SUBMIT_RECOVERY_ATTEMPT: {
+    action: 'Submit recovery attempt',
+    category: RECOVERY_CATEGORY,
+    event: EventType.META,
+  },
+  SUBMIT_RECOVERY_CANCEL: {
+    action: 'Submit recovery cancel',
+    category: RECOVERY_CATEGORY,
+    event: EventType.META,
   },
 }

--- a/src/services/analytics/events/transactions.ts
+++ b/src/services/analytics/events/transactions.ts
@@ -26,13 +26,6 @@ export enum TX_TYPES {
   typed_message = 'typed_message',
   safeapps = 'safeapps',
   walletconnect = 'walletconnect',
-
-  // Recovery
-  recovery_setup = 'recovery_setup',
-  recovery_edit = 'recovery_edit',
-  recovery_remove = 'recovery_remove',
-  recovery_attempt = 'recovery_attempt',
-  recovery_cancel = 'recovery_cancel',
 }
 
 const TX_CATEGORY = 'transactions'


### PR DESCRIPTION
## What it solves

Part of Recovery EPIC

## How this PR fixes it

- Emits custom recovery events instead of using `TX_EVENTS.CREATE` since with #2914 they would be tracked twice in some cases

## How to test it

Create, edit, remove a recovery setup and observe the new events
Create and cancel a recovery attempt and observe the new events

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
