### PR TITLE
Fix: rm human-readable leftovers

### DIFF
--- a/src/components/batch/BatchSidebar/BatchTxItem.tsx
+++ b/src/components/batch/BatchSidebar/BatchTxItem.tsx
@@ -12,7 +12,6 @@ import { MethodDetails } from '@/components/transactions/TxDetails/TxData/Decode
 import { TxDataRow } from '@/components/transactions/TxDetails/Summary/TxDataRow'
 import { dateString } from '@/utils/formatters'
 import { BATCH_EVENTS, trackEvent } from '@/services/analytics'
-import { TransactionInfoType } from '@safe-global/safe-gateway-typescript-sdk'
 
 type BatchTxItemProps = DraftBatchItem & {
   id: string
@@ -56,7 +55,6 @@ const BatchTxItem = ({
   const handleExpand = () => {
     trackEvent(BATCH_EVENTS.BATCH_EXPAND_TX)
   }
-  const displayInfo = !txDetails.txInfo.richDecodedInfo && txDetails.txInfo.type !== TransactionInfoType.TRANSFER
 
   return (
     <ListItem disablePadding sx={{ gap: 2, alignItems: 'flex-start' }}>
@@ -77,7 +75,9 @@ const BatchTxItem = ({
 
             <TxType tx={txSummary} />
 
-            <Box flex={1}>{displayInfo && <TxInfo info={txDetails.txInfo} />}</Box>
+            <Box flex={1}>
+              <TxInfo info={txDetails.txInfo} />
+            </Box>
 
             {onDelete && (
               <>

--- a/src/components/transactions/TxSummary/index.tsx
+++ b/src/components/transactions/TxSummary/index.tsx
@@ -1,7 +1,7 @@
 import type { Palette } from '@mui/material'
 import { Box, CircularProgress, Typography } from '@mui/material'
 import type { ReactElement } from 'react'
-import { type Transaction, TransactionInfoType, TransactionStatus } from '@safe-global/safe-gateway-typescript-sdk'
+import { type Transaction, TransactionStatus } from '@safe-global/safe-gateway-typescript-sdk'
 
 import DateTime from '@/components/common/DateTime'
 import TxInfo from '@/components/transactions/TxInfo'
@@ -52,20 +52,11 @@ const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
     : undefined
 
   const displayConfirmations = isQueue && !!submittedConfirmations && !!requiredConfirmations
-  const displayInfo = !tx.txInfo.richDecodedInfo && tx.txInfo.type !== TransactionInfoType.TRANSFER
 
   return (
     <Box
       data-testid="transaction-item"
-      className={`${css.gridContainer} ${
-        isQueue
-          ? displayInfo
-            ? css.columnTemplate
-            : css.columnTemplateShort
-          : displayInfo
-          ? css.columnTemplateTxHistory
-          : css.columnTemplateTxHistoryShort
-      }`}
+      className={`${css.gridContainer} ${isQueue ? css.columnTemplate : css.columnTemplateTxHistory}`}
       id={tx.id}
     >
       {nonce && !isGrouped && <Box gridArea="nonce">{nonce}</Box>}
@@ -74,11 +65,9 @@ const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
         <TxType tx={tx} />
       </Box>
 
-      {displayInfo && (
-        <Box gridArea="info" className={css.columnWrap}>
-          <TxInfo info={tx.txInfo} />
-        </Box>
-      )}
+      <Box gridArea="info" className={css.columnWrap}>
+        <TxInfo info={tx.txInfo} />
+      </Box>
 
       <Box gridArea="date">
         <DateTime value={tx.timestamp} />

--- a/src/components/transactions/TxSummary/styles.module.css
+++ b/src/components/transactions/TxSummary/styles.module.css
@@ -13,22 +13,9 @@
   grid-template-areas: 'nonce type info date confirmations actions status';
 }
 
-.columnTemplateShort {
-  grid-template-columns: minmax(50px, 0.25fr) minmax(150px, 4fr) 0fr minmax(200px, 2fr) 1fr minmax(60px, 0.5fr) minmax(
-      170px,
-      1fr
-    );
-  grid-template-areas: 'nonce type empty date confirmations actions status';
-}
-
 .columnTemplateTxHistory {
   grid-template-columns: minmax(50px, 0.25fr) minmax(150px, 3fr) minmax(150px, 3fr) 0.75fr 0.5fr;
   grid-template-areas: 'nonce type info date status';
-}
-
-.columnTemplateTxHistoryShort {
-  grid-template-columns: minmax(50px, 0.25fr) 6fr 0fr 0.75fr 0.5fr;
-  grid-template-areas: 'nonce type empty date status';
 }
 
 .columnWrap {
@@ -44,8 +31,7 @@
     gap: var(--space-1);
   }
 
-  .columnTemplate,
-  .columnTemplateShort {
+  .columnTemplate {
     grid-template-columns: repeat(12, auto);
     grid-template-areas:
       'nonce type type type type type type type type type type type'
@@ -56,8 +42,7 @@
       'empty actions actions actions actions actions actions actions actions actions actions actions';
   }
 
-  .columnTemplateTxHistory,
-  .columnTemplateTxHistoryShort {
+  .columnTemplateTxHistory {
     grid-template-columns: repeat(12, 1fr);
     grid-template-areas:
       'nonce type type type type type type type type type type type'


### PR DESCRIPTION
## What it solves

The human-readable A/B test was removed in #2900 but some leftovers remained. This PR cleans that up which fixes the missing tx summary.