### PR TITLE
Feat: queue counter in the sidebar menu

### DIFF
--- a/src/components/sidebar/SidebarList/index.tsx
+++ b/src/components/sidebar/SidebarList/index.tsx
@@ -68,3 +68,6 @@ export const SidebarListItemText = ({
     {children}
   </ListItemText>
 )
+
+export const SidebarListItemCounter = ({ count }: { count?: number }): ReactElement | null =>
+  count ? <Badge color="secondary" variant="standard" badgeContent={count} sx={{ ml: 2 }} /> : null

--- a/src/components/sidebar/SidebarList/styles.module.css
+++ b/src/components/sidebar/SidebarList/styles.module.css
@@ -24,6 +24,10 @@
   background-color: var(--color-border-light);
 }
 
+[data-theme='dark'] .list :global .MuiBadge-standard {
+  background-color: var(--color-primary-main);
+}
+
 .list :global .MuiListItemButton-root:hover {
   border-radius: 6px;
   background-color: var(--color-background-light);

--- a/src/components/sidebar/SidebarNavigation/config.tsx
+++ b/src/components/sidebar/SidebarNavigation/config.tsx
@@ -13,7 +13,6 @@ export type NavItem = {
   label: string
   icon?: ReactElement
   href: string
-  badge?: boolean
 }
 
 export const navItems: NavItem[] = [


### PR DESCRIPTION
## What it solves

A badge with a queued transaction count in the sidebar menu.

## How to test it
Open a Safe with queued txs, look at the sidebar

## Screenshots
![Screenshot 2023-12-06 at 14 31 42](https://github.com/safe-global/safe-wallet-web/assets/381895/88ab32fd-daab-47b0-a36a-b47a9b8a7a30)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
