### PR TITLE
feat: add export button to owner list

### DIFF
--- a/src/components/common/EnhancedTable/index.tsx
+++ b/src/components/common/EnhancedTable/index.tsx
@@ -35,7 +35,6 @@ type EnhancedHeadCell = {
   label: ReactNode
   width?: string
   sticky?: boolean
-  hideSort?: boolean
 }
 
 function descendingComparator(a: EnhancedRow, b: EnhancedRow, orderBy: string) {
@@ -79,25 +78,22 @@ function EnhancedTableHead(props: EnhancedTableHeadProps) {
             sx={headCell.width ? { width: headCell.width } : undefined}
             className={classNames({ sticky: headCell.sticky })}
           >
-            {headCell.label &&
-              (headCell.hideSort ? (
-                headCell.label
-              ) : (
-                <>
-                  <TableSortLabel
-                    active={orderBy === headCell.id}
-                    direction={orderBy === headCell.id ? order : 'asc'}
-                    onClick={createSortHandler(headCell.id)}
-                  >
-                    {headCell.label}
-                    {orderBy === headCell.id ? (
-                      <Box component="span" sx={visuallyHidden}>
-                        {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
-                      </Box>
-                    ) : null}
-                  </TableSortLabel>
-                </>
-              ))}
+            {headCell.label && (
+              <>
+                <TableSortLabel
+                  active={orderBy === headCell.id}
+                  direction={orderBy === headCell.id ? order : 'asc'}
+                  onClick={createSortHandler(headCell.id)}
+                >
+                  {headCell.label}
+                  {orderBy === headCell.id ? (
+                    <Box component="span" sx={visuallyHidden}>
+                      {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
+                    </Box>
+                  ) : null}
+                </TableSortLabel>
+              </>
+            )}
           </TableCell>
         ))}
       </TableRow>

--- a/src/components/common/EnhancedTable/index.tsx
+++ b/src/components/common/EnhancedTable/index.tsx
@@ -35,6 +35,7 @@ type EnhancedHeadCell = {
   label: ReactNode
   width?: string
   sticky?: boolean
+  hideSort?: boolean
 }
 
 function descendingComparator(a: EnhancedRow, b: EnhancedRow, orderBy: string) {
@@ -78,22 +79,25 @@ function EnhancedTableHead(props: EnhancedTableHeadProps) {
             sx={headCell.width ? { width: headCell.width } : undefined}
             className={classNames({ sticky: headCell.sticky })}
           >
-            {headCell.label && (
-              <>
-                <TableSortLabel
-                  active={orderBy === headCell.id}
-                  direction={orderBy === headCell.id ? order : 'asc'}
-                  onClick={createSortHandler(headCell.id)}
-                >
-                  {headCell.label}
-                  {orderBy === headCell.id ? (
-                    <Box component="span" sx={visuallyHidden}>
-                      {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
-                    </Box>
-                  ) : null}
-                </TableSortLabel>
-              </>
-            )}
+            {headCell.label &&
+              (headCell.hideSort ? (
+                headCell.label
+              ) : (
+                <>
+                  <TableSortLabel
+                    active={orderBy === headCell.id}
+                    direction={orderBy === headCell.id ? order : 'asc'}
+                    onClick={createSortHandler(headCell.id)}
+                  >
+                    {headCell.label}
+                    {orderBy === headCell.id ? (
+                      <Box component="span" sx={visuallyHidden}>
+                        {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
+                      </Box>
+                    ) : null}
+                  </TableSortLabel>
+                </>
+              ))}
           </TableCell>
         ))}
       </TableRow>

--- a/src/components/settings/owner/OwnerList/index.tsx
+++ b/src/components/settings/owner/OwnerList/index.tsx
@@ -17,18 +17,13 @@ import CheckWallet from '@/components/common/CheckWallet'
 import { TxModalContext } from '@/components/tx-flow'
 import ReplaceOwnerIcon from '@/public/images/settings/setup/replace-owner.svg'
 import DeleteIcon from '@/public/images/common/delete.svg'
-import ExportIcon from '@/public/images/common/export.svg'
+import type { AddressBook } from '@/store/addressBookSlice'
 
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
 
 const headCells = [
   { id: 'owner', label: 'Name' },
-  {
-    id: 'actions',
-    label: <ExportButton />,
-    sticky: true,
-    hideSort: true,
-  },
+  { id: 'actions', label: '', sticky: true },
 ]
 
 export const OwnerList = () => {
@@ -118,7 +113,7 @@ export const OwnerList = () => {
 
           <EnhancedTable rows={rows} headCells={headCells} />
 
-          <Box pt={2}>
+          <Box pt={2} display="flex" justifyContent="space-between">
             <CheckWallet>
               {(isOk) => (
                 <Track {...SETTINGS_EVENTS.SETUP.ADD_OWNER}>
@@ -134,6 +129,10 @@ export const OwnerList = () => {
                 </Track>
               )}
             </CheckWallet>
+
+            <Button variant="text" onClick={() => exportOwners(safe, addressBook)}>
+              Export as CSV
+            </Button>
           </Box>
         </Grid>
       </Grid>
@@ -141,8 +140,14 @@ export const OwnerList = () => {
   )
 }
 
-function exportOwners({ chainId, address, owners }: SafeInfo) {
-  const csv = jsonToCSV(owners.map((owner) => [owner.value]))
+function exportOwners({ chainId, address, owners }: SafeInfo, addressBook: AddressBook) {
+  const json = owners.map((owner) => {
+    const address = owner.value
+    const name = addressBook[address] || owner.name
+    return [address, name]
+  })
+
+  const csv = jsonToCSV(json)
   const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
   const link = document.createElement('a')
 
@@ -152,18 +157,4 @@ function exportOwners({ chainId, address, owners }: SafeInfo) {
   })
 
   link.click()
-}
-
-function ExportButton() {
-  const { safe } = useSafeInfo()
-
-  return (
-    <Box textAlign="right">
-      <Tooltip title="Export owners">
-        <Button variant="contained" onClick={() => exportOwners(safe)} sx={{ p: 1, minWidth: 'unset' }}>
-          <SvgIcon component={ExportIcon} inheritViewBox fontSize="small" />
-        </Button>
-      </Tooltip>
-    </Box>
-  )
 }

--- a/src/components/settings/owner/OwnerList/index.tsx
+++ b/src/components/settings/owner/OwnerList/index.tsx
@@ -1,3 +1,5 @@
+import { jsonToCSV } from 'react-papaparse'
+import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import AddOwnerFlow from '@/components/tx-flow/flows/AddOwner'
 import useAddressBook from '@/hooks/useAddressBook'
@@ -15,12 +17,18 @@ import CheckWallet from '@/components/common/CheckWallet'
 import { TxModalContext } from '@/components/tx-flow'
 import ReplaceOwnerIcon from '@/public/images/settings/setup/replace-owner.svg'
 import DeleteIcon from '@/public/images/common/delete.svg'
+import ExportIcon from '@/public/images/common/export.svg'
 
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
 
 const headCells = [
   { id: 'owner', label: 'Name' },
-  { id: 'actions', label: '', sticky: true },
+  {
+    id: 'actions',
+    label: <ExportButton />,
+    sticky: true,
+    hideSort: true,
+  },
 ]
 
 export const OwnerList = () => {
@@ -129,6 +137,33 @@ export const OwnerList = () => {
           </Box>
         </Grid>
       </Grid>
+    </Box>
+  )
+}
+
+function exportOwners({ chainId, address, owners }: SafeInfo) {
+  const csv = jsonToCSV(owners.map((owner) => [owner.value]))
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const link = document.createElement('a')
+
+  Object.assign(link, {
+    download: `${chainId}-${address.value}-owners.csv`,
+    href: window.URL.createObjectURL(blob),
+  })
+
+  link.click()
+}
+
+function ExportButton() {
+  const { safe } = useSafeInfo()
+
+  return (
+    <Box textAlign="right">
+      <Tooltip title="Export owners">
+        <Button variant="contained" onClick={() => exportOwners(safe)} sx={{ p: 1, minWidth: 'unset' }}>
+          <SvgIcon component={ExportIcon} inheritViewBox fontSize="small" />
+        </Button>
+      </Tooltip>
     </Box>
   )
 }


### PR DESCRIPTION
## What it solves

Resolves inability to export owner list

## How this PR fixes it

This adds an export button below the owner list that, when clicked, creates as CSV file listing the current owners of the Safe Account and their name prioritised by address book then "known address".

## How to test it

Open the owner list and click the new export button. Observe that the downloaded CSV lists all the owners.

## Screenshots

![image](https://github.com/safe-global/safe-wallet-web/assets/20442784/38f37c6f-fd24-4193-a1ad-586598621f11)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
