### PR TITLE
Analytics: include query params in the pageview event

### DIFF
--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -239,7 +239,7 @@ const AppFrame = ({ appUrl, allowedFeaturesList, safeAppFromManifest }: AppFrame
     }
 
     setAppIsLoading(false)
-    gtmTrackPageview(`${router.pathname}?appUrl=${router.query.appUrl}`)
+    gtmTrackPageview(`${router.pathname}?appUrl=${router.query.appUrl}`, router.asPath)
   }, [appUrl, iframeRef, setAppIsLoading, router])
 
   useEffect(() => {

--- a/src/hooks/useTxQueue.ts
+++ b/src/hooks/useTxQueue.ts
@@ -43,7 +43,6 @@ const useTxQueue = (
 export const useQueuedTxsLength = (): string => {
   const queue = useAppSelector(selectTxQueue)
   const { length } = queue.data?.results.filter(isTransactionListItem) ?? []
-  console.log(queue)
   const recoveryQueueSize = useRecoveryQueue().length
   const totalSize = length + recoveryQueueSize
   if (!totalSize) return ''

--- a/src/services/analytics/gtm.ts
+++ b/src/services/analytics/gtm.ts
@@ -138,11 +138,11 @@ export const gtmTrack = (eventData: AnalyticsEvent): void => {
   gtmSend(gtmEvent)
 }
 
-export const gtmTrackPageview = (pagePath: string): void => {
+export const gtmTrackPageview = (pagePath: string, pathWithQuery: string): void => {
   const gtmEvent: PageviewGtmEvent = {
     ...commonEventParams,
     event: EventType.PAGEVIEW,
-    pageLocation: `${location.origin}${pagePath}`,
+    pageLocation: `${location.origin}${pathWithQuery}`,
     pagePath,
   }
 

--- a/src/services/analytics/useGtm.ts
+++ b/src/services/analytics/useGtm.ts
@@ -85,8 +85,8 @@ const useGtm = () => {
     // Don't track 404 because it's not a real page, it immediately does a client-side redirect
     if (router.pathname === AppRoutes['404']) return
 
-    gtmTrackPageview(router.pathname)
-  }, [router.pathname])
+    gtmTrackPageview(router.pathname, router.asPath)
+  }, [router.asPath, router.pathname])
 
   useEffect(() => {
     if (wallet?.label) {


### PR DESCRIPTION
## What it solves

We need to track the query params to pass UTM-params to GA.