### PR TITLE
fix: Add default values for `value` and `data` in AppCommunicator

### DIFF
--- a/src/components/safe-apps/AppFrame/useAppCommunicator.ts
+++ b/src/components/safe-apps/AppFrame/useAppCommunicator.ts
@@ -172,7 +172,7 @@ const useAppCommunicator = (
         return {
           to: getAddress(to),
           value: value ? BigNumber.from(value).toString() : '0',
-          data,
+          data: data || '0x',
         }
       })
 

--- a/src/components/safe-apps/AppFrame/useAppCommunicator.ts
+++ b/src/components/safe-apps/AppFrame/useAppCommunicator.ts
@@ -171,7 +171,7 @@ const useAppCommunicator = (
       const transactions = txs.map(({ to, value, data }) => {
         return {
           to: getAddress(to),
-          value: BigNumber.from(value).toString(),
+          value: value ? BigNumber.from(value).toString() : '0',
           data,
         }
       })


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/safe-apps-sdk/issues/480

This will be a fast hotfix for the issue above. Final fix for the bug was detected in https://github.com/safe-global/safe-apps-sdk/pull/530

Because it may take time to reach all the dependencies where the package is used will publish this as an emergency fix while developers update to the recent version with the fix.

## How this PR fixes it

Set the normalized empty value when undefined is set for `value` or  `data` for a Safe App `sendTransaction` event.

## How to test it

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
