### PR TITLE
Fix: reconnect MetaMask only if unlocked

### DIFF
--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -10,6 +10,8 @@ import { useAppSelector } from '@/store'
 import { type EnvState, selectRpc } from '@/store/settingsSlice'
 import { E2E_WALLET_NAME } from '@/tests/e2e-wallet'
 import { ONBOARD_MPC_MODULE_LABEL } from '@/services/mpc/SocialLoginModule'
+import { localItem } from '@/services/local-storage/local'
+import { isWalletUnlocked } from '@/utils/wallets'
 
 const WALLETCONNECT = 'WalletConnect'
 
@@ -143,6 +145,25 @@ export const switchWallet = async (onboard: OnboardAPI) => {
   }
 }
 
+const lastWalletStorage = localItem<string>('lastWallet')
+
+const connectLastWallet = async (onboard: OnboardAPI) => {
+  const lastWalletLabel = lastWalletStorage.get()
+  if (lastWalletLabel) {
+    const isUnlocked = await isWalletUnlocked(lastWalletLabel)
+
+    if (isUnlocked === true || isUnlocked === undefined) {
+      connectWallet(onboard, {
+        autoSelect: { label: lastWalletLabel, disableModals: isUnlocked || false },
+      })
+    }
+  }
+}
+
+const saveLastWallet = (walletLabel: string) => {
+  lastWalletStorage.set(walletLabel)
+}
+
 // Disable/enable wallets according to chain
 export const useInitOnboard = () => {
   const { configs } = useChains()
@@ -173,6 +194,9 @@ export const useInitOnboard = () => {
           autoSelect: { label: E2E_WALLET_NAME, disableModals: true },
         })
       }
+
+      // Reconnect last wallet
+      connectLastWallet(onboard)
     })
   }, [chain, onboard])
 
@@ -186,10 +210,12 @@ export const useInitOnboard = () => {
       if (newWallet) {
         if (newWallet.label !== lastConnectedWallet) {
           lastConnectedWallet = newWallet.label
+          saveLastWallet(lastConnectedWallet)
           trackWalletType(newWallet)
         }
-      } else {
+      } else if (lastConnectedWallet) {
         lastConnectedWallet = ''
+        saveLastWallet(lastConnectedWallet)
       }
     })
 

--- a/src/services/onboard.ts
+++ b/src/services/onboard.ts
@@ -57,7 +57,7 @@ export const createOnboard = (
 
     connect: {
       removeWhereIsMyWalletWarning: true,
-      autoConnectLastWallet: true,
+      autoConnectLastWallet: false,
     },
   })
 

--- a/src/utils/wallets.ts
+++ b/src/utils/wallets.ts
@@ -39,3 +39,18 @@ export const isSmartContractWallet = memoize(
   },
   (chainId, address) => chainId + address,
 )
+
+/* Check if the wallet is unlocked. */
+export const isWalletUnlocked = async (walletName: string): Promise<boolean | undefined> => {
+  const METAMASK = 'MetaMask'
+
+  // Only MetaMask exposes a method to check if the wallet is unlocked
+  if (walletName === METAMASK) {
+    if (typeof window === 'undefined' || !window.ethereum?._metamask) return false
+    try {
+      return await window.ethereum?._metamask.isUnlocked()
+    } catch {
+      return false
+    }
+  }
+}


### PR DESCRIPTION
## What it solves

After #2343, the reconnect behavior with MetaMask became extremely annoying. Every time you open the browser and go to the app, it pops up a locked MetaMask window even if you don't need the wallet at that moment.

This PR limits the auto-connect to only when MetaMask is already password-unlocked. The behavior for other wallets is unchanged.

## How to test it

Unlocked MetaMask:

1. Go to the app
2. Connect MetaMask (unlock it if password-locked)
3. Refresh the page
4. MetaMask should seamlessly reconnect w/o showing the onboard modal

Locked MetaMask:
1. Disconnect MetaMask if connected
2. Completely close the browser
3. Open the browser again and go to the app
4. Make sure MetaMask is password-locked
5. Observe that the app didn't auto-connect to MetaMask

Other wallets:
They should reconnect like before.