### PR TITLE
Fix: speed up popups

### DIFF
--- a/src/components/batch/BatchSidebar/index.tsx
+++ b/src/components/batch/BatchSidebar/index.tsx
@@ -61,7 +61,7 @@ const BatchSidebar = ({ isOpen, onToggle }: { isOpen: boolean; onToggle: (open: 
   }, [txFlow, closeSidebar])
 
   return (
-    <Drawer variant="temporary" anchor="right" open={isOpen} onClose={closeSidebar}>
+    <Drawer variant="temporary" anchor="right" open={isOpen} onClose={closeSidebar} transitionDuration={100}>
       <aside className={css.aside}>
         <Typography variant="h4" fontWeight={700} mb={1}>
           Batched transactions

--- a/src/components/common/ConnectWallet/AccountCenter.tsx
+++ b/src/components/common/ConnectWallet/AccountCenter.tsx
@@ -60,6 +60,7 @@ export const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
             top: 'var(--header-height) !important',
           },
         }}
+        transitionDuration={0}
       >
         <Paper className={css.popoverContainer}>
           <WalletInfo wallet={wallet} handleClose={closeWalletInfo} />

--- a/src/components/notification-center/NotificationCenter/index.tsx
+++ b/src/components/notification-center/NotificationCenter/index.tsx
@@ -120,6 +120,7 @@ const NotificationCenter = (): ReactElement => {
             top: 'var(--header-height) !important',
           },
         }}
+        transitionDuration={0}
       >
         <Paper className={css.popoverContainer}>
           <div className={css.popoverHeader}>

--- a/src/components/walletconnect/WcHeaderWidget/index.tsx
+++ b/src/components/walletconnect/WcHeaderWidget/index.tsx
@@ -26,7 +26,7 @@ const WcHeaderWidget = ({ sessions, ...props }: WcHeaderWidgetProps) => {
         />
       </div>
 
-      <Popup keepMounted anchorEl={iconRef.current} open={props.isOpen} onClose={props.onClose}>
+      <Popup keepMounted anchorEl={iconRef.current} open={props.isOpen} onClose={props.onClose} transitionDuration={0}>
         {props.children}
       </Popup>
     </>


### PR DESCRIPTION
## What it solves

MUI has a default animation when a dropdown or a popup opens. It makes them feel slow.
This PR sets the animation duration to 0 for the dropdowns in the header. It makes the UI much snappier.