### PR TITLE
fix: Dont reload balance when popup is closed

### DIFF
--- a/src/components/common/ConnectWallet/AccountCenter.tsx
+++ b/src/components/common/ConnectWallet/AccountCenter.tsx
@@ -62,7 +62,7 @@ export const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
         }}
       >
         <Paper className={css.popoverContainer}>
-          <WalletInfo wallet={wallet} handleClose={closeWalletInfo} />
+          <WalletInfo wallet={wallet} balance={balance} handleClose={closeWalletInfo} />
         </Paper>
       </Popover>
     </>

--- a/src/components/common/WalletInfo/index.tsx
+++ b/src/components/common/WalletInfo/index.tsx
@@ -1,6 +1,6 @@
 import WalletBalance from '@/components/common/WalletBalance'
 import { WalletIdenticon } from '@/components/common/WalletOverview'
-import useWalletBalance from '@/hooks/wallets/useWalletBalance'
+import { type BigNumber } from 'ethers'
 import { Box, Button, Typography } from '@mui/material'
 import css from './styles.module.css'
 import SocialLoginInfo from '@/components/common/SocialLoginInfo'
@@ -22,6 +22,7 @@ import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew'
 
 type WalletInfoProps = {
   wallet: ConnectedWallet
+  balance: BigNumber | undefined
   socialWalletService: ReturnType<typeof useSocialWallet>
   router: ReturnType<typeof useRouter>
   onboard: ReturnType<typeof useOnboard>
@@ -31,6 +32,7 @@ type WalletInfoProps = {
 
 export const WalletInfo = ({
   wallet,
+  balance,
   socialWalletService,
   router,
   onboard,
@@ -39,7 +41,6 @@ export const WalletInfo = ({
 }: WalletInfoProps) => {
   const chainInfo = useAppSelector((state) => selectChainById(state, wallet.chainId))
   const prefix = chainInfo?.shortName
-  const [balance] = useWalletBalance()
 
   const handleSwitchWallet = () => {
     if (onboard) {


### PR DESCRIPTION
## What it solves

The balance doesn't reload anymore whenever the header popup is opened and closed

## How this PR fixes it

Pass the balance from the header to the child component instead of using the same hook twice

## How to test it

1. Connect a wallet
2. Open the account center through the header
3. Observe the balance being visible
4. Close the popup and open it again
5. Observe no loading state

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
