### PR TITLE
chore: Download latest bundle analysis artifact from base branch

### DIFF
--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -38,12 +38,11 @@ jobs:
           path: .next/analyze/__bundle_analysis.json
 
       - name: Download base branch bundle stats
-        uses: dawidd6/action-download-artifact@v2
         if: success() && github.event.number
-        with:
-          workflow: nextjs_bundle_analysis.yml
-          branch: ${{ github.event.pull_request.base.ref }}
-          path: .next/analyze/base
+        run: bash ./scripts/github/download_bundle_analyser_artifact.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
 
       - name: Compare with base branch bundle
         if: success() && github.event.number

--- a/scripts/github/download_bundle_analyser_artifact.sh
+++ b/scripts/github/download_bundle_analyser_artifact.sh
@@ -1,0 +1,31 @@
+# We use this instead of action-download-artifact. See discussion on
+# https://github.com/dawidd6/action-download-artifact/issues/240
+set -xe
+ORG="safe-global"
+REPO="safe-wallet-web"
+WORKFLOW="nextjs-bundle-analysis.yml"
+ARTIFACT_NAME="bundle"
+DESTINATION=".next/analyze/base"
+BASE_BRANCH="dev"
+
+ARTIFACTS_URL=$(
+  gh api \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/${ORG}/${REPO}/actions/workflows/${WORKFLOW}/runs?event=push&branch=${BASE_BRANCH}&status=success&per_page=1" \
+    --jq ".workflow_runs[0].artifacts_url"
+)
+
+DOWNLOAD_URL=$(
+  gh api \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "${ARTIFACTS_URL}" \
+    --jq '.artifacts[] | select(.name == "'"${ARTIFACT_NAME}"'") | .archive_download_url'
+)
+
+set +x
+curl -H "Accept: application/vnd.github+json" -H "Authorization: token $GH_TOKEN" -L -o "${DESTINATION}.zip" "$DOWNLOAD_URL"
+set -x
+unzip "${DESTINATION}.zip" -d "${DESTINATION}" && mkdir -p "${DESTINATION}/bundle" && mv "${DESTINATION}/__bundle_analysis.json" "${DESTINATION}/bundle/"
+rm "${DESTINATION}.zip"


### PR DESCRIPTION
## What it solves

Follow up for #2803 

The download-artifact action we use downloads artifacts in chronological order so it always compares with the oldest dev bundle instead of the newest. There is an open issue on the board but no fix so far ([see discussion](https://github.com/dawidd6/action-download-artifact/issues/240)). We switch to a custom bash script that is also linked in the discussion to download and unzip the bundle from dev.

## Screenshots
<img width="924" alt="Screenshot 2023-12-11 at 15 55 05" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/f65b809d-50ce-4f93-8a02-9d9c1d71ee80">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
