### PR TITLE
Fix: add/replace owner input label

### DIFF
--- a/src/components/common/AddressBookInput/index.tsx
+++ b/src/components/common/AddressBookInput/index.tsx
@@ -48,7 +48,10 @@ const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canA
   if (addressBook[addressValue]) {
     return (
       <Box data-testid="address-book-recipient" onClick={() => setValue(name, '')}>
-        <AddressInputReadOnly address={addressValue} label="Sending to" />
+        <AddressInputReadOnly
+          address={addressValue}
+          label={typeof props.label === 'string' ? props.label : 'Sending to'}
+        />
       </Box>
     )
   }


### PR DESCRIPTION
## What it solves

Resolves #2993

## How this PR fixes it
The label property wasn't propagated properly to the ReadonlyInput.