### PR TITLE
Fix: safe apps search performance

### DIFF
--- a/src/hooks/safe-apps/useSafeAppsFilters.ts
+++ b/src/hooks/safe-apps/useSafeAppsFilters.ts
@@ -20,18 +20,14 @@ type ReturnType = {
 
 const useSafeAppsFilters = (safeAppsList: SafeAppData[]): ReturnType => {
   const [query, setQuery] = useState<string>('')
-  const debouncedQuery = useDebounce(query, 400)
   const [selectedCategories, setSelectedCategories] = useState<string[]>([])
   const [optimizedWithBatchFilter, setOptimizedWithBatchFilter] = useState<boolean>(false)
 
-  const filteredAppsByQuery = useAppsSearch(safeAppsList, debouncedQuery)
-
+  const filteredAppsByQuery = useAppsSearch(safeAppsList, query)
   const filteredAppsByQueryAndCategories = useAppsFilterByCategory(filteredAppsByQuery, selectedCategories)
-
   const filteredApps = useAppsFilterByOptimizedForBatch(filteredAppsByQueryAndCategories, optimizedWithBatchFilter)
 
   const debouncedSearchQuery = useDebounce(query, 2000)
-
   useEffect(() => {
     if (debouncedSearchQuery) {
       trackSafeAppEvent({ ...SAFE_APPS_EVENTS.SEARCH, label: debouncedSearchQuery })

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -24,7 +24,8 @@ const SafeApps: NextPage = () => {
     [remoteSafeApps, pinnedSafeAppIds],
   )
 
-  const onChangeQuery = useCallback(debounce(setQuery, 300), [setQuery])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const onChangeQuery = useCallback(debounce(setQuery, 300), [])
 
   // Redirect to an individual safe app page if the appUrl is in the query params
   useEffect(() => {

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -1,7 +1,8 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
-import { useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
+import debounce from 'lodash/debounce'
 
 import { useSafeApps } from '@/hooks/safe-apps/useSafeApps'
 import SafeAppsSDKLink from '@/components/safe-apps/SafeAppsSDKLink'
@@ -22,6 +23,8 @@ const SafeApps: NextPage = () => {
     () => remoteSafeApps.filter((app) => !pinnedSafeAppIds.has(app.id)),
     [remoteSafeApps, pinnedSafeAppIds],
   )
+
+  const onChangeQuery = useCallback(debounce(setQuery, 300), [setQuery])
 
   // Redirect to an individual safe app page if the appUrl is in the query params
   useEffect(() => {
@@ -44,7 +47,7 @@ const SafeApps: NextPage = () => {
       <main>
         {/* Safe Apps Filters */}
         <SafeAppsFilters
-          onChangeQuery={setQuery}
+          onChangeQuery={onChangeQuery}
           onChangeFilterCategory={setSelectedCategories}
           onChangeOptimizedWithBatch={setOptimizedWithBatchFilter}
           selectedCategories={selectedCategories}


### PR DESCRIPTION
## What it solves

The search input in the Safe Apps list was painfully slow to type. Instead of debouncing using a hook, I've added a debounce directly to the onchange listener and it's much faster. Still far from ideal but much faster.

## How to test it

Type something in the Safe Apps search filter.