### PR TITLE
Fix: don't auto-reconnect social login

### DIFF
--- a/src/utils/wallets.ts
+++ b/src/utils/wallets.ts
@@ -4,6 +4,7 @@ import { type ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import { getWeb3ReadOnly, isSmartContract } from '@/hooks/wallets/web3'
 import { WALLET_KEYS } from '@/hooks/wallets/consts'
 import { memoize } from 'lodash'
+import { ONBOARD_MPC_MODULE_LABEL } from '@/services/mpc/SocialLoginModule'
 
 const isWCRejection = (err: Error): boolean => {
   return /rejected/.test(err?.message)
@@ -52,5 +53,10 @@ export const isWalletUnlocked = async (walletName: string): Promise<boolean | un
     } catch {
       return false
     }
+  }
+
+  // Don't reconnect to MPC wallet because it's not initialized right away
+  if (walletName === ONBOARD_MPC_MODULE_LABEL) {
+    return false
   }
 }


### PR DESCRIPTION
![Untitled](https://github.com/safe-global/safe-wallet-web/assets/381895/a562074c-fb45-4702-94b0-b803dc80bd60)

As per @schmanu's comment:

> After rehydrating the Web3Auth session we automatically call connectWallet we have to avoid calling connectWallet on page load as the MPC connection is not ready yet then and the connectWallet call on rehydration get’s blocked somehow.

I've disable auto-reconnect for the social login.