### PR TITLE
Filter out Redefine incorrectly flagged accounts that use privacy preserving technology.

### DIFF
--- a/src/services/security/modules/RedefineModule/index.ts
+++ b/src/services/security/modules/RedefineModule/index.ts
@@ -145,7 +145,8 @@ export class RedefineModule implements SecurityModule<RedefineModuleRequest, Red
     return {
       severity: result.data ? redefineSeverityMap[result.data.insights.verdict.label] : SecuritySeverity.NONE,
       payload: {
-        issues: result.data?.insights.issues.map((issue) => ({
+        // Redefine incorrectly considers accounts that utilize privacy preserving technology to be a "compliance risk" (despite the law being very clear on this), so we filter those out
+        issues: result.data?.insights.issues.filter(issue => !(issue.category === 'COMPLIANCE' && issue.severity.code === 2)).map((issue) => ({
           ...issue,
           severity: redefineSeverityMap[issue.severity.label],
         })),


### PR DESCRIPTION
```json
{
	"description": {
		"short": "Funds are being transferred to/from an address that has previously received funds from mixer(s) **** times",
		"long": "Funds are being transferred to/from an address 0x**** that has previously received funds from a mixer(s): ['Tornado.Cash: 10 ETH'] last on ****-**-**T**:**:**Z and total of **** times during the past year"
	},
	"category": "COMPLIANCE",
	"severity": {
		"code": 2,
		"label": "MEDIUM"
	}
}
```

Redefine is flagging any account that has used Tornado as a "medium compliance risk".  This is an inappropriate flag and sends a really bad signal to users of Gnosis SAFE as it suggests to them that interacting with such an address is somehow against the law somewhere.  By filtering out this particular issue, we will not continue to spread the unreasonable FUD that these compliance companies make their money on.

Even under the most pessimistic interpretation of the Tornado OFAC sanctions, and assuming that the numerous cases challenging OFAC in court all fail, accounts that used Tornado (or otherwise interacted with a sanctioned address) are not transitively illegal for US persons to interact with.

The entire economy would grind to a halt almost immediately if US sanctions were transitive, which is precisely why they are **NOT** transitive.  While I philosophically disagree with capitulating to the US's sanction program, especially for a product that is used globally (US sanctions only apply to US persons), even if you are forced to follow US sanction laws then you are still free to interact with accounts that interact with sanctioned addresses.

If someone from Türkiye buys a product from someone from Iran, you are still allowed to interact with the Turkish individual even if you are a US person.  The same is true for users of Tornado, who we should be protecting rather than ostracizing.

## What it solves

Gnosis SAFE Web App ovoor-compliance.

## How this PR fixes it

By filtering out at least one instance of ovoor-compliance.

## How to test it

Don't comply, then try to use Gnosis SAFE.

## Screenshots
Before:
![image](https://github.com/safe-global/safe-wallet-web/assets/886059/ff853423-f4a6-4d15-8074-b9d0d17be07a)
After:
![image](https://github.com/safe-global/safe-wallet-web/assets/886059/6e748c98-aaf8-42d0-ab37-a144a529a527)


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
