### PR TITLE
Analytics: track successfull QR scans

### DIFF
--- a/src/components/common/ScanQRModal/ScanQRButton.tsx
+++ b/src/components/common/ScanQRModal/ScanQRButton.tsx
@@ -1,8 +1,7 @@
 import React, { lazy, useState, Suspense, type ReactElement } from 'react'
 import QrCodeIcon from '@/public/images/common/qr.svg'
 import { IconButton, SvgIcon } from '@mui/material'
-import Track from '../Track'
-import { MODALS_EVENTS } from '@/services/analytics'
+import { MODALS_EVENTS, trackEvent } from '@/services/analytics'
 
 const ScanQRModal = lazy(() => import('.'))
 
@@ -15,6 +14,7 @@ const ScanQRButton = ({ onScan }: Props): ReactElement => {
 
   const openQrModal = () => {
     setOpen(true)
+    trackEvent(MODALS_EVENTS.SCAN_QR)
   }
 
   const closeQrModal = () => {
@@ -24,15 +24,14 @@ const ScanQRButton = ({ onScan }: Props): ReactElement => {
   const onScanFinished = (value: string) => {
     onScan(value)
     closeQrModal()
+    trackEvent(MODALS_EVENTS.SCAN_QR_FINISHED)
   }
 
   return (
     <>
-      <Track {...MODALS_EVENTS.SCAN_QR}>
-        <IconButton data-testid="address-qr-scan" onClick={openQrModal}>
-          <SvgIcon component={QrCodeIcon} inheritViewBox color="primary" fontSize="small" />
-        </IconButton>
-      </Track>
+      <IconButton data-testid="address-qr-scan" onClick={openQrModal}>
+        <SvgIcon component={QrCodeIcon} inheritViewBox color="primary" fontSize="small" />
+      </IconButton>
 
       {open && (
         <Suspense>

--- a/src/services/analytics/events/modals.ts
+++ b/src/services/analytics/events/modals.ts
@@ -19,6 +19,10 @@ export const MODALS_EVENTS = {
     action: 'Scan QR',
     category: MODALS_CATEGORY,
   },
+  SCAN_QR_FINISHED: {
+    action: 'Scan QR finished',
+    category: MODALS_CATEGORY,
+  },
   TX_DETAILS: {
     action: 'Transaction details',
     category: MODALS_CATEGORY,


### PR DESCRIPTION
## What it solves

Adds a new analytics event emitted after a successfull QR code scan.

## How this PR fixes it
I've made a [GA exploration](https://analytics.google.com/analytics/web/#/analysis/p308247657/edit/QUA2dWwnRmyWKbKZDz1H8w
) for the "Scan QR" event. It shows an average of 100-150 events a day. I'd like to test the hypothesis that many of those clicks don't result in an actual scan.

<img width="875" alt="Screenshot 2023-12-15 at 09 37 50" src="https://github.com/safe-global/safe-wallet-web/assets/381895/2a0b02aa-6287-46a9-a868-633ce12b7f42">