### PR TITLE
Tests: Update tx builder and add tx history tests to smoke suite

### DIFF
--- a/cypress/e2e/regression/tx_history.cy.js
+++ b/cypress/e2e/regression/tx_history.cy.js
@@ -54,25 +54,6 @@ describe('Tx history tests 1', () => {
   })
 
   // Token receipt
-  it('Verify summary for token receipt', () => {
-    createTx.verifySummaryByName(
-      typeReceive.summaryTitle,
-      typeReceive.summaryTxInfo,
-      [typeReceive.summaryTxInfo, typeGeneral.statusOk],
-      typeReceive.altTmage,
-    )
-  })
-
-  it('Verify exapanded details for token receipt', () => {
-    createTx.clickOnTransactionItemByName(typeReceive.summaryTitle, typeReceive.summaryTxInfo)
-    createTx.verifyExpandedDetails([
-      typeReceive.title,
-      typeReceive.receivedFrom,
-      typeReceive.senderAddress,
-      typeReceive.transactionHash,
-    ])
-  })
-
   it('Verify copy button copies tx hash', () => {
     createTx.clickOnTransactionItemByName(typeReceive.summaryTitle, typeReceive.summaryTxInfo)
     createTx.verifyNumberOfCopyIcons(2)
@@ -80,15 +61,6 @@ describe('Tx history tests 1', () => {
   })
 
   // Token send
-  it('Verify summary for token send', () => {
-    createTx.verifySummaryByName(
-      typeSend.title,
-      [typeSend.summaryTxInfo, typeGeneral.statusOk],
-      typeSend.altImage,
-      typeSend.altToken,
-    )
-  })
-
   it('Verify exapanded details for token send', () => {
     createTx.clickOnTransactionItemByName(typeSend.title, typeSend.summaryTxInfo)
     createTx.verifyExpandedDetails([typeSend.sentTo, typeSend.recipientAddress, typeSend.transactionHash])
@@ -153,15 +125,6 @@ describe('Tx history tests 1', () => {
   })
 
   // Spending limit deletion
-  it('Verify summary for allowance deletion', () => {
-    createTx.verifySummaryByName(
-      typeDeleteAllowance.title,
-      typeDeleteAllowance.summaryTxInfo,
-      [typeDeleteAllowance.summaryTxInfo, typeGeneral.statusOk],
-      typeDeleteAllowance.altImage,
-    )
-  })
-
   it('Verify exapanded details for allowance deletion', () => {
     createTx.clickOnTransactionItemByName(typeDeleteAllowance.title, typeDeleteAllowance.summaryTxInfo)
     createTx.verifyExpandedDetails([

--- a/cypress/e2e/regression/tx_history_2.cy.js
+++ b/cypress/e2e/regression/tx_history_2.cy.js
@@ -25,10 +25,6 @@ describe('Tx history tests 2', () => {
   })
 
   // On-chain rejection
-  it('Verify summary for on-chain rejection', () => {
-    createTx.verifySummaryByName(typeOnchainRejection.title, [typeGeneral.statusOk], typeOnchainRejection.altImage)
-  })
-
   it('Verify exapanded details for on-chain rejection', () => {
     createTx.clickOnTransactionItemByName(typeOnchainRejection.title)
     createTx.verifyExpandedDetails([
@@ -44,15 +40,6 @@ describe('Tx history tests 2', () => {
   })
 
   // Batch transaction
-  it('Verify summary for batch', () => {
-    createTx.verifySummaryByName(
-      typeBatch.title,
-      typeBatch.summaryTxInfo,
-      [typeBatch.summaryTxInfo, typeGeneral.statusOk],
-      typeBatch.altImage,
-    )
-  })
-
   it('Verify exapanded details for batch', () => {
     createTx.clickOnTransactionItemByName(typeBatch.title, typeBatch.summaryTxInfo)
     createTx.verifyExpandedDetails(

--- a/cypress/e2e/safe-apps/tx-builder.spec.cy.js
+++ b/cypress/e2e/safe-apps/tx-builder.spec.cy.js
@@ -60,7 +60,7 @@ describe('Transaction Builder tests', { defaultCommandTimeout: 20000 }, () => {
       getBody().findByText(safeapps.sendBatchStr).click()
     })
     cy.get('h4').contains(safeapps.transactionBuilderStr).should('be.visible')
-    cy.findAllByText(safeapps.testNativeTransfer).should('have.length', 3)
+    cy.findAllByText(safeapps.testBooleanValue).should('have.length', 3)
     navigation.clickOnModalCloseBtn()
     cy.enter(iframeSelector).then((getBody) => {
       getBody().findAllByText(constants.SEPOLIA_CONTRACT_SHORT).should('have.length', 3)
@@ -179,7 +179,7 @@ describe('Transaction Builder tests', { defaultCommandTimeout: 20000 }, () => {
       getBody().findByText(safeapps.sendBatchStr).click()
     })
     cy.get('h4').contains(safeapps.transactionBuilderStr).should('be.visible')
-    cy.findAllByText(safeapps.testNativeTransfer).should('have.length', 2)
+    cy.findAllByText(safeapps.testAddressValueStr).should('have.length', 2)
     navigation.clickOnModalCloseBtn()
     cy.enter(iframeSelector).then((getBody) => {
       getBody().findAllByText(constants.SEPOLIA_CONTRACT_SHORT).should('have.length', 2)

--- a/cypress/e2e/smoke/tx_history.cy.js
+++ b/cypress/e2e/smoke/tx_history.cy.js
@@ -1,0 +1,70 @@
+import * as constants from '../../support/constants'
+import * as main from '../pages/main.page'
+import * as createTx from '../pages/create_tx.pages'
+import * as data from '../../fixtures/txhistory_data_data.json'
+
+const typeOnchainRejection = data.type.onchainRejection
+const typeBatch = data.type.batchNativeTransfer
+const typeReceive = data.type.receive
+const typeSend = data.type.send
+const typeDeleteAllowance = data.type.deleteSpendingLimit
+const typeGeneral = data.type.general
+
+describe('[SMOKE] Tx history tests', () => {
+  beforeEach(() => {
+    cy.clearLocalStorage()
+    cy.visit(constants.transactionsHistoryUrl + constants.SEPOLIA_TEST_SAFE_8)
+    main.acceptCookies()
+  })
+
+  // Token receipt
+  it('[SMOKE] Verify summary for token receipt', () => {
+    createTx.verifySummaryByName(
+      typeReceive.summaryTitle,
+      typeReceive.summaryTxInfo,
+      [typeReceive.summaryTxInfo, typeGeneral.statusOk],
+      typeReceive.altTmage,
+    )
+  })
+
+  it('[SMOKE] Verify exapanded details for token receipt', () => {
+    createTx.clickOnTransactionItemByName(typeReceive.summaryTitle, typeReceive.summaryTxInfo)
+    createTx.verifyExpandedDetails([
+      typeReceive.title,
+      typeReceive.receivedFrom,
+      typeReceive.senderAddress,
+      typeReceive.transactionHash,
+    ])
+  })
+
+  it('[SMOKE] Verify summary for token send', () => {
+    createTx.verifySummaryByName(
+      typeSend.title,
+      [typeSend.summaryTxInfo, typeGeneral.statusOk],
+      typeSend.altImage,
+      typeSend.altToken,
+    )
+  })
+
+  it('[SMOKE] Verify summary for on-chain rejection', () => {
+    createTx.verifySummaryByName(typeOnchainRejection.title, [typeGeneral.statusOk], typeOnchainRejection.altImage)
+  })
+
+  it('[SMOKE] Verify summary for batch', () => {
+    createTx.verifySummaryByName(
+      typeBatch.title,
+      typeBatch.summaryTxInfo,
+      [typeBatch.summaryTxInfo, typeGeneral.statusOk],
+      typeBatch.altImage,
+    )
+  })
+
+  it('[SMOKE] Verify summary for allowance deletion', () => {
+    createTx.verifySummaryByName(
+      typeDeleteAllowance.title,
+      typeDeleteAllowance.summaryTxInfo,
+      [typeDeleteAllowance.summaryTxInfo, typeGeneral.statusOk],
+      typeDeleteAllowance.altImage,
+    )
+  })
+})


### PR DESCRIPTION
## What it solves

Resolves #3019 

## How this PR fixes it

- As part of our continuous automation test coverage, we are adding some tx history tests to our smoke tests suite.
- Part of this ticket also includes minor update of tx builder test.

## How to test it

- Run E2E tests and observe outcome.
