### PR TITLE
Fix: don't show balance in header

### DIFF
--- a/src/components/common/ConnectWallet/AccountCenter.tsx
+++ b/src/components/common/ConnectWallet/AccountCenter.tsx
@@ -1,4 +1,3 @@
-import useWalletBalance from '@/hooks/wallets/useWalletBalance'
 import type { MouseEvent } from 'react'
 import { useState } from 'react'
 import { Box, ButtonBase, Paper, Popover } from '@mui/material'
@@ -11,7 +10,6 @@ import WalletInfo from '@/components/common/WalletInfo'
 
 export const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
-  const [balance] = useWalletBalance()
 
   const openWalletInfo = (event: MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget)
@@ -34,7 +32,7 @@ export const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
         data-testid="open-account-center"
       >
         <Box className={css.buttonContainer}>
-          <WalletOverview wallet={wallet} balance={balance} showBalance />
+          <WalletOverview wallet={wallet} />
 
           <Box display="flex" alignItems="center" justifyContent="flex-end" marginLeft="auto">
             {open ? <ExpandLessIcon color="border" /> : <ExpandMoreIcon color="border" />}
@@ -63,7 +61,7 @@ export const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
         transitionDuration={0}
       >
         <Paper className={css.popoverContainer}>
-          <WalletInfo wallet={wallet} balance={balance} handleClose={closeWalletInfo} />
+          <WalletInfo wallet={wallet} handleClose={closeWalletInfo} />
         </Paper>
       </Popover>
     </>

--- a/src/components/common/WalletInfo/index.tsx
+++ b/src/components/common/WalletInfo/index.tsx
@@ -22,7 +22,7 @@ import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew'
 
 type WalletInfoProps = {
   wallet: ConnectedWallet
-  balance: BigNumber | undefined
+  balance?: BigNumber
   socialWalletService: ReturnType<typeof useSocialWallet>
   router: ReturnType<typeof useRouter>
   onboard: ReturnType<typeof useOnboard>
@@ -106,20 +106,24 @@ export const WalletInfo = ({
       </Box>
 
       <Box className={css.rowContainer}>
-        <Box className={css.row}>
-          <Typography variant="body2" color="primary.light">
-            Balance
-          </Typography>
-          <Typography variant="body2">
-            <WalletBalance balance={balance} />
-          </Typography>
-        </Box>
+        {balance && (
+          <Box className={css.row}>
+            <Typography variant="body2" color="primary.light">
+              Balance
+            </Typography>
+            <Typography variant="body2">
+              <WalletBalance balance={balance} />
+            </Typography>
+          </Box>
+        )}
+
         <Box className={css.row}>
           <Typography variant="body2" color="primary.light">
             Wallet
           </Typography>
           <Typography variant="body2">{wallet.label}</Typography>
         </Box>
+
         <Box className={css.row}>
           <Typography variant="body2" color="primary.light">
             Network


### PR DESCRIPTION
## What it solves

Fetching the wallet balance to display in the header using the "readonly" RPC provider drastically increased the number of RPC requests.

Reverting until we figure out how to get this data w/o extra load.

## Possible alternatives
* Fetch the balance via the connected wallet RPC provider
* Use the balance that web3-onboard provides (has to be parsed from a string)