### PR TITLE
Fix: use wallet balance from onboard

### DIFF
--- a/src/components/common/ConnectWallet/AccountCenter.tsx
+++ b/src/components/common/ConnectWallet/AccountCenter.tsx
@@ -10,6 +10,7 @@ import WalletInfo from '@/components/common/WalletInfo'
 
 export const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
+  const { balance } = wallet
 
   const openWalletInfo = (event: MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget)
@@ -32,7 +33,7 @@ export const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
         data-testid="open-account-center"
       >
         <Box className={css.buttonContainer}>
-          <WalletOverview wallet={wallet} />
+          <WalletOverview wallet={wallet} balance={balance} showBalance />
 
           <Box display="flex" alignItems="center" justifyContent="flex-end" marginLeft="auto">
             {open ? <ExpandLessIcon color="border" /> : <ExpandMoreIcon color="border" />}
@@ -61,7 +62,7 @@ export const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
         transitionDuration={0}
       >
         <Paper className={css.popoverContainer}>
-          <WalletInfo wallet={wallet} handleClose={closeWalletInfo} />
+          <WalletInfo wallet={wallet} handleClose={closeWalletInfo} balance={balance} />
         </Paper>
       </Popover>
     </>

--- a/src/components/common/SocialLoginInfo/index.tsx
+++ b/src/components/common/SocialLoginInfo/index.tsx
@@ -1,6 +1,5 @@
 import WalletBalance from '@/components/common/WalletBalance'
 import { Badge, Box, Typography } from '@mui/material'
-import { type BigNumber } from 'ethers'
 import css from './styles.module.css'
 import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { type ConnectedWallet } from '@/hooks/wallets/useOnboard'
@@ -23,7 +22,7 @@ const SocialLoginInfo = ({
   chainInfo?: ChainInfo
   hideActions?: boolean
   size?: number
-  balance?: BigNumber | undefined
+  balance?: string
   showBalance?: boolean
 }) => {
   const socialWalletService = useSocialWallet()

--- a/src/components/common/WalletBalance/index.tsx
+++ b/src/components/common/WalletBalance/index.tsx
@@ -3,11 +3,15 @@ import { Skeleton } from '@mui/material'
 import { type BigNumber } from 'ethers'
 import { useCurrentChain } from '@/hooks/useChains'
 
-const WalletBalance = ({ balance }: { balance: BigNumber | undefined }) => {
+const WalletBalance = ({ balance }: { balance: string | BigNumber | undefined }) => {
   const currentChain = useCurrentChain()
 
   if (!balance) {
     return <Skeleton width={30} variant="text" sx={{ display: 'inline-block' }} />
+  }
+
+  if (typeof balance === 'string') {
+    return <>{balance}</>
   }
 
   return (

--- a/src/components/common/WalletInfo/index.test.tsx
+++ b/src/components/common/WalletInfo/index.test.tsx
@@ -46,6 +46,7 @@ describe('WalletInfo', () => {
         addressBook={{}}
         handleClose={jest.fn()}
         balance={undefined}
+        currentChainId="1"
       />,
     )
 
@@ -62,6 +63,7 @@ describe('WalletInfo', () => {
         addressBook={{}}
         handleClose={jest.fn()}
         balance={undefined}
+        currentChainId="1"
       />,
     )
 
@@ -78,6 +80,7 @@ describe('WalletInfo', () => {
         addressBook={{}}
         handleClose={jest.fn()}
         balance={undefined}
+        currentChainId="1"
       />,
     )
 
@@ -105,6 +108,7 @@ describe('WalletInfo', () => {
         addressBook={{}}
         handleClose={jest.fn()}
         balance={undefined}
+        currentChainId="1"
       />,
     )
 
@@ -124,6 +128,7 @@ describe('WalletInfo', () => {
         addressBook={{}}
         handleClose={jest.fn()}
         balance={undefined}
+        currentChainId="1"
       />,
     )
 
@@ -143,6 +148,7 @@ describe('WalletInfo', () => {
         addressBook={{}}
         handleClose={jest.fn()}
         balance={undefined}
+        currentChainId="1"
       />,
     )
 
@@ -161,6 +167,7 @@ describe('WalletInfo', () => {
         addressBook={{}}
         handleClose={jest.fn()}
         balance={undefined}
+        currentChainId="1"
       />,
     )
 
@@ -182,6 +189,7 @@ describe('WalletInfo', () => {
         addressBook={{}}
         handleClose={jest.fn()}
         balance={undefined}
+        currentChainId="1"
       />,
     )
 

--- a/src/components/common/WalletInfo/index.tsx
+++ b/src/components/common/WalletInfo/index.tsx
@@ -19,10 +19,12 @@ import { selectChainById } from '@/store/chainsSlice'
 import madProps from '@/utils/mad-props'
 import useSocialWallet from '@/hooks/wallets/mpc/useSocialWallet'
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew'
+import useChainId from '@/hooks/useChainId'
 
 type WalletInfoProps = {
   wallet: ConnectedWallet
-  balance?: BigNumber
+  balance?: string | BigNumber
+  currentChainId: ReturnType<typeof useChainId>
   socialWalletService: ReturnType<typeof useSocialWallet>
   router: ReturnType<typeof useRouter>
   onboard: ReturnType<typeof useOnboard>
@@ -33,6 +35,7 @@ type WalletInfoProps = {
 export const WalletInfo = ({
   wallet,
   balance,
+  currentChainId,
   socialWalletService,
   router,
   onboard,
@@ -106,17 +109,6 @@ export const WalletInfo = ({
       </Box>
 
       <Box className={css.rowContainer}>
-        {balance && (
-          <Box className={css.row}>
-            <Typography variant="body2" color="primary.light">
-              Balance
-            </Typography>
-            <Typography variant="body2">
-              <WalletBalance balance={balance} />
-            </Typography>
-          </Box>
-        )}
-
         <Box className={css.row}>
           <Typography variant="body2" color="primary.light">
             Wallet
@@ -126,13 +118,23 @@ export const WalletInfo = ({
 
         <Box className={css.row}>
           <Typography variant="body2" color="primary.light">
-            Network
+            Balance
           </Typography>
-          <Typography variant="body2">{chainInfo?.chainName}</Typography>
+          <Typography variant="body2">
+            <WalletBalance balance={balance} />
+
+            {currentChainId !== chainInfo?.chainId && (
+              <>
+                <Typography variant="body2" color="primary.light" textAlign="right">
+                  ({chainInfo?.chainName || 'Unknown chain'})
+                </Typography>
+              </>
+            )}
+          </Typography>
         </Box>
       </Box>
 
-      <Box display="flex" flexDirection="column" gap={1} width={1}>
+      <Box display="flex" flexDirection="column" gap={2} width={1}>
         <ChainSwitcher fullWidth />
 
         <Button variant="contained" size="small" onClick={handleSwitchWallet} fullWidth>
@@ -165,4 +167,5 @@ export default madProps(WalletInfo, {
   router: useRouter,
   onboard: useOnboard,
   addressBook: useAddressBook,
+  currentChainId: useChainId,
 })

--- a/src/components/common/WalletInfo/index.tsx
+++ b/src/components/common/WalletInfo/index.tsx
@@ -120,12 +120,12 @@ export const WalletInfo = ({
           <Typography variant="body2" color="primary.light">
             Balance
           </Typography>
-          <Typography variant="body2">
+          <Typography variant="body2" textAlign="right">
             <WalletBalance balance={balance} />
 
             {currentChainId !== chainInfo?.chainId && (
               <>
-                <Typography variant="body2" color="primary.light" textAlign="right">
+                <Typography variant="body2" color="primary.light">
                   ({chainInfo?.chainName || 'Unknown chain'})
                 </Typography>
               </>

--- a/src/components/common/WalletInfo/styles.module.css
+++ b/src/components/common/WalletInfo/styles.module.css
@@ -48,6 +48,7 @@
 
 .row {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   border-top: 1px solid var(--color-border-light);

--- a/src/components/common/WalletOverview/index.tsx
+++ b/src/components/common/WalletOverview/index.tsx
@@ -1,6 +1,5 @@
 import Identicon from '@/components/common/Identicon'
 import { Box, Typography } from '@mui/material'
-import { type BigNumber } from 'ethers'
 import { Suspense } from 'react'
 import type { ReactElement } from 'react'
 
@@ -34,7 +33,7 @@ const WalletOverview = ({
   showBalance,
 }: {
   wallet: ConnectedWallet
-  balance?: BigNumber | undefined
+  balance?: string
   showBalance?: boolean
 }): ReactElement => {
   const walletChain = useAppSelector((state) => selectChainById(state, wallet.chainId))

--- a/src/components/tx/SignOrExecuteForm/__tests__/SignOrExecute.test.tsx
+++ b/src/components/tx/SignOrExecuteForm/__tests__/SignOrExecute.test.tsx
@@ -11,6 +11,7 @@ describe('SignOrExecute', () => {
         onSubmit={jest.fn()}
         safeTxError={new Error('Safe transaction error')}
         safeTx={safeTxBuilder().build()}
+        chainId="1"
       />,
     )
 
@@ -29,6 +30,7 @@ describe('SignOrExecute', () => {
           onSubmit={jest.fn()}
           safeTxError={undefined}
           isExecutable={true}
+          chainId="1"
         />,
       )
 
@@ -48,6 +50,7 @@ describe('SignOrExecute', () => {
           safeTxError={undefined}
           txId={undefined}
           isExecutable={true}
+          chainId="1"
         />,
       )
 
@@ -63,6 +66,7 @@ describe('SignOrExecute', () => {
         safeTxError={undefined}
         txId={undefined}
         onlyExecute={true}
+        chainId="1"
       />,
     )
 
@@ -79,6 +83,7 @@ describe('SignOrExecute', () => {
         safeTxError={undefined}
         txId={'someid'}
         isExecutable={true}
+        chainId="1"
       />,
     )
 

--- a/src/hooks/wallets/__tests__/useOnboard.test.ts
+++ b/src/hooks/wallets/__tests__/useOnboard.test.ts
@@ -21,8 +21,12 @@ describe('useOnboard', () => {
           accounts: [
             {
               address: '0x1234567890123456789012345678901234567890',
-              ens: null,
-              balance: null,
+              ens: {
+                name: 'test.eth',
+              },
+              balance: {
+                ETH: '0.002346456767547',
+              },
             },
           ],
         },
@@ -47,6 +51,8 @@ describe('useOnboard', () => {
         address: '0x1234567890123456789012345678901234567890',
         provider: wallets[0].provider,
         chainId: '4',
+        ens: 'test.eth',
+        balance: '0.00235 ETH',
       })
     })
 

--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -10,6 +10,7 @@ import { useAppSelector } from '@/store'
 import { type EnvState, selectRpc } from '@/store/settingsSlice'
 import { E2E_WALLET_NAME } from '@/tests/e2e-wallet'
 import { ONBOARD_MPC_MODULE_LABEL } from '@/services/mpc/SocialLoginModule'
+import { formatAmount } from '@/utils/formatNumber'
 
 const WALLETCONNECT = 'WalletConnect'
 
@@ -20,6 +21,7 @@ export type ConnectedWallet = {
   ens?: string
   provider: EIP1193Provider
   icon?: string
+  balance?: string
 }
 
 const { getStore, setStore, useStore } = new ExternalStore<OnboardAPI>()
@@ -45,6 +47,18 @@ export const getConnectedWallet = (wallets: WalletState[]): ConnectedWallet | nu
   const account = primaryWallet.accounts[0]
   if (!account) return null
 
+  let balance = ''
+  if (account.balance) {
+    const tokenBalance = Object.entries(account.balance)[0]
+    const token = tokenBalance[0]
+    const balanceString = tokenBalance[1]
+    const balanceNumber = parseFloat(balanceString)
+    if (!Number.isNaN(balanceNumber)) {
+      const balanceFormatted = formatAmount(balanceNumber)
+      balance = `${balanceFormatted} ${token}`
+    }
+  }
+
   try {
     const address = getAddress(account.address)
     return {
@@ -54,6 +68,7 @@ export const getConnectedWallet = (wallets: WalletState[]): ConnectedWallet | nu
       chainId: Number(primaryWallet.chains[0].id).toString(10),
       provider: primaryWallet.provider,
       icon: primaryWallet.icon,
+      balance,
     }
   } catch (e) {
     logError(Errors._106, e)

--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -50,8 +50,8 @@ export const getConnectedWallet = (wallets: WalletState[]): ConnectedWallet | nu
   let balance = ''
   if (account.balance) {
     const tokenBalance = Object.entries(account.balance)[0]
-    const token = tokenBalance[0]
-    const balanceString = tokenBalance[1]
+    const token = tokenBalance?.[0] || ''
+    const balanceString = tokenBalance?.[1] || ''
     const balanceNumber = parseFloat(balanceString)
     if (!Number.isNaN(balanceNumber)) {
       const balanceFormatted = formatAmount(balanceNumber)

--- a/src/hooks/wallets/useWalletBalance.ts
+++ b/src/hooks/wallets/useWalletBalance.ts
@@ -1,19 +1,19 @@
 import useAsync, { type AsyncResult } from '../useAsync'
 import useWallet from './useWallet'
-import { useWeb3 } from '@/hooks/wallets/web3'
+import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { type BigNumber } from 'ethers'
 
 const useWalletBalance = (): AsyncResult<BigNumber | undefined> => {
-  const web3 = useWeb3()
+  const web3ReadOnly = useWeb3ReadOnly()
   const wallet = useWallet()
 
   return useAsync<BigNumber | undefined>(() => {
-    if (!wallet || !web3) {
+    if (!wallet || !web3ReadOnly) {
       return undefined
     }
 
-    return web3.getBalance(wallet.address, 'latest')
-  }, [wallet, web3])
+    return web3ReadOnly.getBalance(wallet.address, 'latest')
+  }, [wallet, web3ReadOnly])
 }
 
 export default useWalletBalance

--- a/src/hooks/wallets/useWalletBalance.ts
+++ b/src/hooks/wallets/useWalletBalance.ts
@@ -1,19 +1,19 @@
 import useAsync, { type AsyncResult } from '../useAsync'
 import useWallet from './useWallet'
-import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
+import { useWeb3 } from '@/hooks/wallets/web3'
 import { type BigNumber } from 'ethers'
 
 const useWalletBalance = (): AsyncResult<BigNumber | undefined> => {
-  const web3ReadOnly = useWeb3ReadOnly()
+  const web3 = useWeb3()
   const wallet = useWallet()
 
   return useAsync<BigNumber | undefined>(() => {
-    if (!wallet || !web3ReadOnly) {
+    if (!wallet || !web3) {
       return undefined
     }
 
-    return web3ReadOnly.getBalance(wallet.address, 'latest')
-  }, [wallet, web3ReadOnly])
+    return web3.getBalance(wallet.address, 'latest')
+  }, [wallet, web3])
 }
 
 export default useWalletBalance


### PR DESCRIPTION
## What it solves

For the header widget, use the balance string returned by web3-onboard as it fetches it from the wallet RPC anyway.
The returned balance always matches the wallet chain, not the Safe chain, so I made it clearer in the header widget:

<img width="435" alt="Screenshot 2023-12-18 at 13 58 14" src="https://github.com/safe-global/safe-wallet-web/assets/381895/0d85a173-cc87-4c19-826e-505330f4bbf8">

---

In the tx-flow, it will still get an updated wallet balance directly from the readonly RCP like before:

<img width="1110" alt="Screenshot 2023-12-18 at 13 57 53" src="https://github.com/safe-global/safe-wallet-web/assets/381895/5ce6fe1e-7e64-485e-8756-b1c6a8d34fc1">
