### PR TITLE
Add untrustedtoken const to the history_2 test in regression

### DIFF
--- a/cypress/e2e/regression/tx_history_2.cy.js
+++ b/cypress/e2e/regression/tx_history_2.cy.js
@@ -12,6 +12,7 @@ const typeDisableOwner = data.type.disableModule
 const typeChangeThreshold = data.type.changeThreshold
 const typeSideActions = data.type.sideActions
 const typeGeneral = data.type.general
+const typeUntrustedToken = data.type.untrustedReceivedToken
 
 describe('Tx history tests 2', () => {
   beforeEach(() => {


### PR DESCRIPTION
## What it solves
The regression run on dev is failing because of typeUntrustedToken is undefined

Resolves #

## How this PR fixes it
typeUntrustedToken is defined as const 
const typeUntrustedToken = data.type.untrustedReceivedToken
## How to test it
run the regression suite and make sure that the test " 
Verify that sender address of untrusted token will not be copied until agreed in warning popup" is passed
## Screenshots
<img width="824" alt="image" src="https://github.com/safe-global/safe-wallet-web/assets/338622/b726291a-e478-4e9b-a68d-a01fd857d879">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
