### PR TITLE
Fix: [WalletConnect] - user reject session reason

### DIFF
--- a/src/services/walletconnect/WalletConnectWallet.ts
+++ b/src/services/walletconnect/WalletConnectWallet.ts
@@ -185,7 +185,7 @@ class WalletConnectWallet {
 
     await this.web3Wallet.rejectSession({
       id: proposal.id,
-      reason: getSdkError('UNSUPPORTED_CHAINS'),
+      reason: getSdkError('USER_REJECTED'),
     })
 
     // Workaround: WalletConnect doesn't have a session_reject event


### PR DESCRIPTION
## What it solves
The wrong error was thrown on user-initiated session rejection.