### PR TITLE
Fix: [Safe Apps] align the share button

### DIFF
--- a/src/components/common/CopyTooltip/index.tsx
+++ b/src/components/common/CopyTooltip/index.tsx
@@ -3,7 +3,7 @@ import React, { type ReactElement, type SyntheticEvent, useCallback, useState } 
 import { Tooltip } from '@mui/material'
 import ConfirmCopyModal from './ConfirmCopyModal'
 
-const spanStyle = { cursor: 'pointer', display: 'inline-block', lineHeight: 0 }
+const spanStyle = { cursor: 'pointer' }
 
 const CopyTooltip = ({
   text,

--- a/src/components/safe-apps/SafeAppActionButtons/index.tsx
+++ b/src/components/safe-apps/SafeAppActionButtons/index.tsx
@@ -37,7 +37,7 @@ const SafeAppActionButtons = ({
   }
 
   return (
-    <Box display="flex" gap={1.5} alignItems="center">
+    <Box display="flex" gap={1} alignItems="center">
       {/* Open the preview drawer */}
       {openPreviewDrawer && (
         <IconButton
@@ -58,7 +58,9 @@ const SafeAppActionButtons = ({
         onCopy={handleCopyShareSafeAppUrl}
         text={shareSafeAppUrl}
       >
-        <SvgIcon component={ShareIcon} inheritViewBox color="border" fontSize="small" />
+        <IconButton size="small">
+          <SvgIcon component={ShareIcon} inheritViewBox color="border" fontSize="small" />
+        </IconButton>
       </CopyButton>
 
       {/* Bookmark Safe App button */}


### PR DESCRIPTION
## What it solves

The Share button now has a hover effect like the other two buttons and is perfectly aligned to the center.

<img width="413" alt="Screenshot 2023-12-20 at 09 57 12" src="https://github.com/safe-global/safe-wallet-web/assets/381895/d553430b-0c75-41b4-b169-8d6994b438d0">
