### PR TITLE
Refactor: [WalletConnect] lazy-load based on feature toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   },
   "resolutions": {
     "@ethereumjs/common": "^3.2.0",
+    "@walletconnect/core": "^2.10.6",
+    "@walletconnect/ethereum-provider": "^2.10.6",
+    "@walletconnect/utils": "^2.10.6",
     "@web3-onboard/trezor/**/protobufjs": "^7.2.4"
   },
   "dependencies": {
@@ -59,15 +62,15 @@
     "@spindl-xyz/attribution-lite": "^1.4.0",
     "@tkey-mpc/common-types": "^8.2.2",
     "@truffle/hdwallet-provider": "^2.1.4",
-    "@walletconnect/utils": "^2.10.2",
-    "@walletconnect/web3wallet": "^1.9.2",
+    "@walletconnect/utils": "^2.10.6",
+    "@walletconnect/web3wallet": "^1.9.5",
     "@web3-onboard/coinbase": "^2.2.6",
     "@web3-onboard/core": "^2.21.2",
     "@web3-onboard/injected-wallets": "^2.10.7",
     "@web3-onboard/keystone": "^2.3.7",
     "@web3-onboard/ledger": "2.3.2",
     "@web3-onboard/trezor": "^2.4.2",
-    "@web3-onboard/walletconnect": "^2.5.0",
+    "@web3-onboard/walletconnect": "^2.5.2",
     "@web3auth/mpc-core-kit": "^1.1.3",
     "blo": "^1.1.1",
     "bn.js": "^5.2.1",

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -15,10 +15,10 @@ import SafeLogo from '@/public/images/logo.svg'
 import Link from 'next/link'
 import useSafeAddress from '@/hooks/useSafeAddress'
 import BatchIndicator from '@/components/batch/BatchIndicator'
-import WalletConnectUi from '@/components/walletconnect'
+import WalletConnect from '@/components/walletconnect'
 import { PushNotificationsBanner } from '@/components/settings/PushNotifications/PushNotificationsBanner'
-import { useCurrentChain } from '@/hooks/useChains'
-import { hasFeature, FEATURES } from '@/utils/chains'
+import { FEATURES } from '@/utils/chains'
+import { useHasFeature } from '@/hooks/useChains'
 
 type HeaderProps = {
   onMenuToggle?: Dispatch<SetStateAction<boolean>>
@@ -30,8 +30,7 @@ const Header = ({ onMenuToggle, onBatchToggle }: HeaderProps): ReactElement => {
   const safeAddress = useSafeAddress()
   const showSafeToken = safeAddress && !!getSafeTokenAddress(chainId)
   const router = useRouter()
-  const chain = useCurrentChain()
-  const enableWc = !!chain && hasFeature(chain, FEATURES.NATIVE_WALLETCONNECT)
+  const enableWc = useHasFeature(FEATURES.NATIVE_WALLETCONNECT)
 
   // Logo link: if on Dashboard, link to Welcome, otherwise to the root (which redirects to either Dashboard or Welcome)
   const logoHref = router.pathname === AppRoutes.home ? AppRoutes.welcome.index : AppRoutes.index
@@ -84,7 +83,7 @@ const Header = ({ onMenuToggle, onBatchToggle }: HeaderProps): ReactElement => {
 
       {enableWc && (
         <div className={classnames(css.element, css.hideMobile)}>
-          <WalletConnectUi />
+          <WalletConnect />
         </div>
       )}
 

--- a/src/components/walletconnect/WalletConnectUi/index.tsx
+++ b/src/components/walletconnect/WalletConnectUi/index.tsx
@@ -1,0 +1,51 @@
+import { useCallback, useContext, useEffect } from 'react'
+import { ErrorBoundary } from '@sentry/react'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import useWalletConnectSessions from '@/services/walletconnect/useWalletConnectSessions'
+import { WalletConnectContext, WalletConnectProvider } from '@/services/walletconnect/WalletConnectContext'
+import useWcUri from '../useWcUri'
+import WcHeaderWidget from '../WcHeaderWidget'
+import WcSessionManager from '../WcSessionMananger'
+
+const WalletConnectWidget = () => {
+  const { walletConnect, error, open, setOpen } = useContext(WalletConnectContext)
+  const [uri, clearUri] = useWcUri()
+  const sessions = useWalletConnectSessions()
+  const { safeLoaded } = useSafeInfo()
+
+  const onOpen = useCallback(() => {
+    setOpen(true)
+  }, [setOpen])
+
+  const onClose = useCallback(() => {
+    setOpen(false)
+  }, [setOpen])
+
+  // Open the popup if there is a pairing code in the URL or clipboard
+  useEffect(() => {
+    if (safeLoaded && uri) {
+      onOpen()
+    }
+  }, [safeLoaded, uri, onOpen])
+
+  // Clear the pairing code when connected
+  useEffect(() => {
+    return walletConnect?.onSessionPropose(clearUri)
+  }, [walletConnect, clearUri])
+
+  return (
+    <WcHeaderWidget isError={!!error} isOpen={open} onOpen={onOpen} onClose={onClose} sessions={sessions}>
+      <WcSessionManager sessions={sessions} uri={uri} />
+    </WcHeaderWidget>
+  )
+}
+
+const WalletConnectUi = () => (
+  <ErrorBoundary>
+    <WalletConnectProvider>
+      <WalletConnectWidget />
+    </WalletConnectProvider>
+  </ErrorBoundary>
+)
+
+export default WalletConnectUi

--- a/src/components/walletconnect/index.tsx
+++ b/src/components/walletconnect/index.tsx
@@ -1,45 +1,13 @@
-import useSafeInfo from '@/hooks/useSafeInfo'
-import useWalletConnectSessions from '@/services/walletconnect/useWalletConnectSessions'
-import { WalletConnectContext } from '@/services/walletconnect/WalletConnectContext'
-import { ErrorBoundary } from '@sentry/react'
-import { useCallback, useContext, useEffect } from 'react'
-import useWcUri from './useWcUri'
-import WcHeaderWidget from './WcHeaderWidget'
-import WcSessionManager from './WcSessionMananger'
+import dynamic from 'next/dynamic'
+import ExternalStore from '@/services/ExternalStore'
 
-const WalletConnectUi = () => {
-  const { walletConnect, error, open, setOpen } = useContext(WalletConnectContext)
-  const [uri, clearUri] = useWcUri()
-  const sessions = useWalletConnectSessions()
-  const { safeLoaded } = useSafeInfo()
-
-  const onOpen = useCallback(() => {
-    setOpen(true)
-  }, [setOpen])
-
-  const onClose = useCallback(() => {
-    setOpen(false)
-  }, [setOpen])
-
-  // Open the popup if there is a pairing code in the URL or clipboard
-  useEffect(() => {
-    if (safeLoaded && uri) {
-      onOpen()
-    }
-  }, [safeLoaded, uri, onOpen])
-
-  // Clear the pairing code when connected
-  useEffect(() => {
-    return walletConnect?.onSessionPropose(clearUri)
-  }, [walletConnect, clearUri])
-
-  return (
-    <ErrorBoundary>
-      <WcHeaderWidget isError={!!error} isOpen={open} onOpen={onOpen} onClose={onClose} sessions={sessions}>
-        <WcSessionManager sessions={sessions} uri={uri} />
-      </WcHeaderWidget>
-    </ErrorBoundary>
-  )
-}
+const WalletConnectUi = dynamic(() => import('./WalletConnectUi'))
 
 export default WalletConnectUi
+
+// Open/close WC popup externally
+export const wcPopupStore = new ExternalStore<boolean>(false)
+
+export function openWalletConnect() {
+  wcPopupStore.setStore(true)
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -39,7 +39,6 @@ import useSafeMessageNotifications from '@/hooks/messages/useSafeMessageNotifica
 import useSafeMessagePendingStatuses from '@/hooks/messages/useSafeMessagePendingStatuses'
 import useChangedValue from '@/hooks/useChangedValue'
 import { TxModalProvider } from '@/components/tx-flow'
-import { WalletConnectProvider } from '@/services/walletconnect/WalletConnectContext'
 import { useNotificationTracking } from '@/components/settings/PushNotifications/hooks/useNotificationTracking'
 import { RecoveryProvider } from '@/features/recovery/components/RecoveryContext'
 import { RecoveryModal } from '@/features/recovery/components/RecoveryModal'
@@ -86,9 +85,7 @@ export const AppProviders = ({ children }: { children: ReactNode | ReactNode[] }
           <Sentry.ErrorBoundary showDialog fallback={ErrorBoundary}>
             <WalletProvider>
               <RecoveryProvider>
-                <TxModalProvider>
-                  <WalletConnectProvider>{children}</WalletConnectProvider>
-                </TxModalProvider>
+                <TxModalProvider>{children}</TxModalProvider>
               </RecoveryProvider>
             </WalletProvider>
           </Sentry.ErrorBoundary>

--- a/src/pages/apps/open.tsx
+++ b/src/pages/apps/open.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
-import { useCallback, useContext } from 'react'
+import { useCallback } from 'react'
 import { Box, CircularProgress } from '@mui/material'
 
 import { useSafeAppUrl } from '@/hooks/safe-apps/useSafeAppUrl'
@@ -15,9 +15,9 @@ import { useBrowserPermissions } from '@/hooks/safe-apps/permissions'
 import useChainId from '@/hooks/useChainId'
 import { AppRoutes } from '@/config/routes'
 import { getOrigin } from '@/components/safe-apps/utils'
-import { WalletConnectContext } from '@/services/walletconnect/WalletConnectContext'
 import { useHasFeature } from '@/hooks/useChains'
 import { FEATURES } from '@/utils/chains'
+import { openWalletConnect } from '@/components/walletconnect'
 
 // TODO: Remove this once we properly deprecate the WC app
 const WC_SAFE_APP = /wallet-connect/
@@ -28,6 +28,7 @@ const SafeApps: NextPage = () => {
   const appUrl = useSafeAppUrl()
   const { safeApp, isLoading } = useSafeAppFromManifest(appUrl || '', chainId)
   const isSafeAppsEnabled = useHasFeature(FEATURES.SAFE_APPS)
+  const isWalletConnectEnabled = useHasFeature(FEATURES.NATIVE_WALLETCONNECT)
 
   const { remoteSafeApps, remoteSafeAppsLoading } = useSafeApps()
 
@@ -49,8 +50,6 @@ const SafeApps: NextPage = () => {
     remoteSafeAppsLoading,
   })
 
-  const { setOpen } = useContext(WalletConnectContext)
-
   const goToList = useCallback(() => {
     router.push({
       pathname: AppRoutes.apps.index,
@@ -61,8 +60,8 @@ const SafeApps: NextPage = () => {
   // appUrl is required to be present
   if (!isSafeAppsEnabled || !appUrl || !router.isReady) return null
 
-  if (WC_SAFE_APP.test(appUrl)) {
-    setOpen(true)
+  if (isWalletConnectEnabled && WC_SAFE_APP.test(appUrl)) {
+    openWalletConnect()
     goToList()
     return null
   }

--- a/src/services/analytics/tx-tracking.ts
+++ b/src/services/analytics/tx-tracking.ts
@@ -1,6 +1,6 @@
 import { TX_TYPES } from '@/services/analytics/events/transactions'
 import { getTxDetails } from '@/services/tx/txDetails'
-import { isWalletConnectSafeApp } from '@/services/walletconnect/utils'
+import { isWalletConnectSafeApp } from '@/utils/gateway'
 import { SettingsInfoType, type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 import {
   isERC721Transfer,

--- a/src/services/walletconnect/WalletConnectContext.tsx
+++ b/src/services/walletconnect/WalletConnectContext.tsx
@@ -11,6 +11,7 @@ import { IS_PRODUCTION } from '@/config/constants'
 import { SafeAppsTag } from '@/config/constants'
 import { useRemoteSafeApps } from '@/hooks/safe-apps/useRemoteSafeApps'
 import { trackRequest } from './tracking'
+import { wcPopupStore } from '@/components/walletconnect'
 
 enum Errors {
   WRONG_CHAIN = '%%dappName%% made a request on a different chain than the one you are connected to',
@@ -48,7 +49,8 @@ export const WalletConnectProvider = ({ children }: { children: ReactNode }) => 
     safeAddress,
   } = useSafeInfo()
   const [walletConnect, setWalletConnect] = useState<WalletConnectWallet | null>(null)
-  const [open, setOpen] = useState(false)
+  const open = wcPopupStore.useStore() ?? false
+  const setOpen = wcPopupStore.setStore
   const [error, setError] = useState<Error | null>(null)
   const safeWalletProvider = useSafeWalletProvider()
   const wcApp = useWalletConnectApp()

--- a/src/services/walletconnect/utils.ts
+++ b/src/services/walletconnect/utils.ts
@@ -62,8 +62,3 @@ export const getPeerName = (peer: SessionTypes.Struct['peer'] | ProposalTypes.St
 export const splitError = (message: string): string[] => {
   return message.split(/: (.+)/).slice(0, 2)
 }
-
-export const isWalletConnectSafeApp = (url: string): boolean => {
-  const WALLET_CONNECT = /wallet-connect/
-  return WALLET_CONNECT.test(url)
-}

--- a/src/utils/gateway.ts
+++ b/src/utils/gateway.ts
@@ -26,3 +26,8 @@ export const getExplorerLink = (
 
   return { href, title }
 }
+
+export const isWalletConnectSafeApp = (url: string): boolean => {
+  const WALLET_CONNECT = /wallet-connect/
+  return WALLET_CONNECT.test(url)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5668,32 +5668,10 @@
     events "^3.3.0"
     isomorphic-unfetch "^3.1.0"
 
-"@walletconnect/core@2.10.2", "@walletconnect/core@^2.10.1":
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-2.10.2.tgz#a1bf6e3e87b33f9df795ce0970d8ddd400fdc8a3"
-  integrity sha512-JQz/xp3SLEpTeRQctdck2ugSBVEpMxoSE+lFi2voJkZop1hv6P+uqr6E4PzjFluAjeAnKlT1xvra0aFWjPWVcw==
-  dependencies:
-    "@walletconnect/heartbeat" "1.2.1"
-    "@walletconnect/jsonrpc-provider" "1.0.13"
-    "@walletconnect/jsonrpc-types" "1.0.3"
-    "@walletconnect/jsonrpc-utils" "1.0.8"
-    "@walletconnect/jsonrpc-ws-connection" "1.0.13"
-    "@walletconnect/keyvaluestorage" "^1.0.2"
-    "@walletconnect/logger" "^2.0.1"
-    "@walletconnect/relay-api" "^1.0.9"
-    "@walletconnect/relay-auth" "^1.0.4"
-    "@walletconnect/safe-json" "^1.0.2"
-    "@walletconnect/time" "^1.0.2"
-    "@walletconnect/types" "2.10.2"
-    "@walletconnect/utils" "2.10.2"
-    events "^3.3.0"
-    lodash.isequal "4.5.0"
-    uint8arrays "^3.1.0"
-
-"@walletconnect/core@2.10.5":
-  version "2.10.5"
-  resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-2.10.5.tgz#d61706c6459d9baaef05e83907df8cab82a03251"
-  integrity sha512-QnGHkA05KzJrtqExPqXm/TsstM1uTDI8tQT0x86/DuR6LdiYEntzSpVjnv7kKK6Mo9UxlXfud431dNRfOW5uJg==
+"@walletconnect/core@2.10.6", "@walletconnect/core@^2.10.1", "@walletconnect/core@^2.10.6":
+  version "2.10.6"
+  resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-2.10.6.tgz#786b0d2e2045c210c917e29bfa0498bbc210be20"
+  integrity sha512-Z4vh4ZdfcoQjgPEOxeuF9HUZCVLtV3MgRbS/awLIj/omDrFnOwlBhxi5Syr4Y8muVGC0ocRetQYHae0/gX5crQ==
   dependencies:
     "@walletconnect/heartbeat" "1.2.1"
     "@walletconnect/jsonrpc-provider" "1.0.13"
@@ -5706,8 +5684,8 @@
     "@walletconnect/relay-auth" "^1.0.4"
     "@walletconnect/safe-json" "^1.0.2"
     "@walletconnect/time" "^1.0.2"
-    "@walletconnect/types" "2.10.5"
-    "@walletconnect/utils" "2.10.5"
+    "@walletconnect/types" "2.10.6"
+    "@walletconnect/utils" "2.10.6"
     events "^3.3.0"
     lodash.isequal "4.5.0"
     uint8arrays "^3.1.0"
@@ -5719,20 +5697,20 @@
   dependencies:
     tslib "1.14.1"
 
-"@walletconnect/ethereum-provider@^2.10.2":
-  version "2.10.5"
-  resolved "https://registry.yarnpkg.com/@walletconnect/ethereum-provider/-/ethereum-provider-2.10.5.tgz#a14ede16a751f115f8a0d050736155c8654835d5"
-  integrity sha512-Pihi2M03cRkWEiGetRUiO2A506YTj/Bbbxp+Ct7t5N5SccoeuhrzsEt30pA7I0XAiOnAeKp79OKmXHRhXfRmhg==
+"@walletconnect/ethereum-provider@^2.10.6":
+  version "2.10.6"
+  resolved "https://registry.yarnpkg.com/@walletconnect/ethereum-provider/-/ethereum-provider-2.10.6.tgz#53720771cc2d6accd452916a853ac927f26acbaa"
+  integrity sha512-bBQ+yUfxLv8VxNttgNKY7nED35gSVayO/BnLHbNKvyV1gpvSCla5mWB9MsXuQs70MK0g+/qtgRVSrOtdSubaNQ==
   dependencies:
     "@walletconnect/jsonrpc-http-connection" "^1.0.7"
     "@walletconnect/jsonrpc-provider" "^1.0.13"
     "@walletconnect/jsonrpc-types" "^1.0.3"
     "@walletconnect/jsonrpc-utils" "^1.0.8"
     "@walletconnect/modal" "^2.4.3"
-    "@walletconnect/sign-client" "2.10.5"
-    "@walletconnect/types" "2.10.5"
-    "@walletconnect/universal-provider" "2.10.5"
-    "@walletconnect/utils" "2.10.5"
+    "@walletconnect/sign-client" "2.10.6"
+    "@walletconnect/types" "2.10.6"
+    "@walletconnect/universal-provider" "2.10.6"
+    "@walletconnect/utils" "2.10.6"
     events "^3.3.0"
 
 "@walletconnect/events@^1.0.1":
@@ -5788,17 +5766,6 @@
     "@walletconnect/jsonrpc-types" "^1.0.3"
     tslib "1.14.1"
 
-"@walletconnect/jsonrpc-ws-connection@1.0.13":
-  version "1.0.13"
-  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.13.tgz#23b0cdd899801bfbb44a6556936ec2b93ef2adf4"
-  integrity sha512-mfOM7uFH4lGtQxG+XklYuFBj6dwVvseTt5/ahOkkmpcAEgz2umuzu7fTR+h5EmjQBdrmYyEBOWADbeaFNxdySg==
-  dependencies:
-    "@walletconnect/jsonrpc-utils" "^1.0.6"
-    "@walletconnect/safe-json" "^1.0.2"
-    events "^3.3.0"
-    tslib "1.14.1"
-    ws "^7.5.1"
-
 "@walletconnect/jsonrpc-ws-connection@1.0.14":
   version "1.0.14"
   resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.14.tgz#eec700e74766c7887de2bd76c91a0206628732aa"
@@ -5851,7 +5818,7 @@
     motion "10.16.2"
     qrcode "1.5.3"
 
-"@walletconnect/modal@2.6.2", "@walletconnect/modal@^2.4.3":
+"@walletconnect/modal@^2.4.3":
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/@walletconnect/modal/-/modal-2.6.2.tgz#4b534a836f5039eeb3268b80be7217a94dd12651"
   integrity sha512-eFopgKi8AjKf/0U4SemvcYw9zlLpx9njVN8sf6DAkowC2Md0gPU/UNEbH1Wwj407pEKnEds98pKWib1NN1ACoA==
@@ -5886,34 +5853,19 @@
   dependencies:
     tslib "1.14.1"
 
-"@walletconnect/sign-client@2.10.2":
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/@walletconnect/sign-client/-/sign-client-2.10.2.tgz#33300a9cfe42487473f66b73c99535f6b26f8c54"
-  integrity sha512-vviSLV3f92I0bReX+OLr1HmbH0uIzYEQQFd1MzIfDk9PkfFT/LLAHhUnDaIAMkIdippqDcJia+5QEtT4JihL3Q==
+"@walletconnect/sign-client@2.10.6":
+  version "2.10.6"
+  resolved "https://registry.yarnpkg.com/@walletconnect/sign-client/-/sign-client-2.10.6.tgz#722d2c2844565e2826dce6a6d3a36c9b3ca1ea91"
+  integrity sha512-EvUWjaZBQu2yKnH5/5F2qzbuiIuUN9ZgrNKgvXkw5z1Dq5RJCks0S9/MFlKH/ZSGqXnLl7uAzBXtoX4sMgbCMA==
   dependencies:
-    "@walletconnect/core" "2.10.2"
+    "@walletconnect/core" "2.10.6"
     "@walletconnect/events" "^1.0.1"
     "@walletconnect/heartbeat" "1.2.1"
     "@walletconnect/jsonrpc-utils" "1.0.8"
     "@walletconnect/logger" "^2.0.1"
     "@walletconnect/time" "^1.0.2"
-    "@walletconnect/types" "2.10.2"
-    "@walletconnect/utils" "2.10.2"
-    events "^3.3.0"
-
-"@walletconnect/sign-client@2.10.5":
-  version "2.10.5"
-  resolved "https://registry.yarnpkg.com/@walletconnect/sign-client/-/sign-client-2.10.5.tgz#f97f0fed544179a3303941f3bebd13ede3a736ed"
-  integrity sha512-HEYsoeGC6fGplQy0NIZSRNHgOwZwQ892UWG1Ahkcasf2R35QaBgnTVQkSCisl1PAAOKXZG7yB1YDoAAZBF+g5Q==
-  dependencies:
-    "@walletconnect/core" "2.10.5"
-    "@walletconnect/events" "^1.0.1"
-    "@walletconnect/heartbeat" "1.2.1"
-    "@walletconnect/jsonrpc-utils" "1.0.8"
-    "@walletconnect/logger" "^2.0.1"
-    "@walletconnect/time" "^1.0.2"
-    "@walletconnect/types" "2.10.5"
-    "@walletconnect/utils" "2.10.5"
+    "@walletconnect/types" "2.10.6"
+    "@walletconnect/utils" "2.10.6"
     events "^3.3.0"
 
 "@walletconnect/time@^1.0.2":
@@ -5923,7 +5875,19 @@
   dependencies:
     tslib "1.14.1"
 
-"@walletconnect/types@2.10.2", "@walletconnect/types@^2.10.1":
+"@walletconnect/types@2.10.6":
+  version "2.10.6"
+  resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-2.10.6.tgz#d9920ed4fd0113e0addbda8e7e73a5176a3163fd"
+  integrity sha512-WgHfiTG1yakmxheaBRiXhUdEmgxwrvsAdOIWaMf/spvrzVKYh6sHI3oyEEky5qj5jjiMiyQBeB57QamzCotbcQ==
+  dependencies:
+    "@walletconnect/events" "^1.0.1"
+    "@walletconnect/heartbeat" "1.2.1"
+    "@walletconnect/jsonrpc-types" "1.0.3"
+    "@walletconnect/keyvaluestorage" "^1.1.1"
+    "@walletconnect/logger" "^2.0.1"
+    events "^3.3.0"
+
+"@walletconnect/types@^2.10.1":
   version "2.10.2"
   resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-2.10.2.tgz#68e433a29ec2cf42d79d8b50c77bd5c1d91db721"
   integrity sha512-luNV+07Wdla4STi9AejseCQY31tzWKQ5a7C3zZZaRK/di+rFaAAb7YW04OP4klE7tw/mJRGPTlekZElmHxO8kQ==
@@ -5935,42 +5899,30 @@
     "@walletconnect/logger" "^2.0.1"
     events "^3.3.0"
 
-"@walletconnect/types@2.10.5":
-  version "2.10.5"
-  resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-2.10.5.tgz#bf4e692cf736b6e71423f96a106d7a96089245de"
-  integrity sha512-N8xaN7/Kob93rKxKDaT6oy6symgIkAwyLqq0/dLJEhXfv7S/gyNvDka4SosjVVTc4oTvE1+OmxNIR8pB1DuwJw==
-  dependencies:
-    "@walletconnect/events" "^1.0.1"
-    "@walletconnect/heartbeat" "1.2.1"
-    "@walletconnect/jsonrpc-types" "1.0.3"
-    "@walletconnect/keyvaluestorage" "^1.1.1"
-    "@walletconnect/logger" "^2.0.1"
-    events "^3.3.0"
-
 "@walletconnect/types@~1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-1.8.0.tgz#3f5e85b2d6b149337f727ab8a71b8471d8d9a195"
   integrity sha512-Cn+3I0V0vT9ghMuzh1KzZvCkiAxTq+1TR2eSqw5E5AVWfmCtECFkVZBP6uUJZ8YjwLqXheI+rnjqPy7sVM4Fyg==
 
-"@walletconnect/universal-provider@2.10.5":
-  version "2.10.5"
-  resolved "https://registry.yarnpkg.com/@walletconnect/universal-provider/-/universal-provider-2.10.5.tgz#b08965a9306a30775796cc0cc384f2dfc9fde512"
-  integrity sha512-sQOvjrGF6za7+6zv7KI9eQz2gzRbS19j7U1z+JwIWdn4VBJmriaTjVHDz/R1liwKcS4sUiUthDC6WmQvjukjZQ==
+"@walletconnect/universal-provider@2.10.6":
+  version "2.10.6"
+  resolved "https://registry.yarnpkg.com/@walletconnect/universal-provider/-/universal-provider-2.10.6.tgz#1a6c42517581f11ce275474bc70d0eb4f1044525"
+  integrity sha512-CEivusqqoD31BhCTKp08DnrccfGjwD9MFjZs5BNRorDteRFE8zVm9LmP6DSiNJCw82ZajGlZThggLQ/BAATfwA==
   dependencies:
     "@walletconnect/jsonrpc-http-connection" "^1.0.7"
     "@walletconnect/jsonrpc-provider" "1.0.13"
     "@walletconnect/jsonrpc-types" "^1.0.2"
     "@walletconnect/jsonrpc-utils" "^1.0.7"
     "@walletconnect/logger" "^2.0.1"
-    "@walletconnect/sign-client" "2.10.5"
-    "@walletconnect/types" "2.10.5"
-    "@walletconnect/utils" "2.10.5"
+    "@walletconnect/sign-client" "2.10.6"
+    "@walletconnect/types" "2.10.6"
+    "@walletconnect/utils" "2.10.6"
     events "^3.3.0"
 
-"@walletconnect/utils@2.10.2", "@walletconnect/utils@^2.10.1", "@walletconnect/utils@^2.10.2":
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/@walletconnect/utils/-/utils-2.10.2.tgz#1f2c6a2f1bb95bcc4517b1e94aa7164c9286eb46"
-  integrity sha512-syxXRpc2yhSknMu3IfiBGobxOY7fLfLTJuw+ppKaeO6WUdZpIit3wfuGOcc0Ms3ZPFCrGfyGOoZsCvgdXtptRg==
+"@walletconnect/utils@2.10.6", "@walletconnect/utils@^2.10.1", "@walletconnect/utils@^2.10.6":
+  version "2.10.6"
+  resolved "https://registry.yarnpkg.com/@walletconnect/utils/-/utils-2.10.6.tgz#749b37d14e291e346862e7027ec7548463350226"
+  integrity sha512-oRsWWhN2+hi3aiDXrQEOfysz6FHQJGXLsNQPVt+WIBJplO6Szmdau9dbleD88u1iiT4GKPqE0R9FOYvvPm1H/w==
   dependencies:
     "@stablelib/chacha20poly1305" "1.0.1"
     "@stablelib/hkdf" "1.0.1"
@@ -5980,46 +5932,26 @@
     "@walletconnect/relay-api" "^1.0.9"
     "@walletconnect/safe-json" "^1.0.2"
     "@walletconnect/time" "^1.0.2"
-    "@walletconnect/types" "2.10.2"
+    "@walletconnect/types" "2.10.6"
     "@walletconnect/window-getters" "^1.0.1"
     "@walletconnect/window-metadata" "^1.0.1"
     detect-browser "5.3.0"
     query-string "7.1.3"
     uint8arrays "^3.1.0"
 
-"@walletconnect/utils@2.10.5":
-  version "2.10.5"
-  resolved "https://registry.yarnpkg.com/@walletconnect/utils/-/utils-2.10.5.tgz#8c8ef90c9e2b59886aae002ab8cbbdb35da1df9a"
-  integrity sha512-3yeclD9/AlPEIHBqBVzrHUO/KRAEIXVK0ViIQ5oUH+zT3TpdsDGDiW1Z0TsAQ1EiYoiiz8dOQzd80a3eZVwnrg==
-  dependencies:
-    "@stablelib/chacha20poly1305" "1.0.1"
-    "@stablelib/hkdf" "1.0.1"
-    "@stablelib/random" "^1.0.2"
-    "@stablelib/sha256" "1.0.1"
-    "@stablelib/x25519" "^1.0.3"
-    "@walletconnect/relay-api" "^1.0.9"
-    "@walletconnect/safe-json" "^1.0.2"
-    "@walletconnect/time" "^1.0.2"
-    "@walletconnect/types" "2.10.5"
-    "@walletconnect/window-getters" "^1.0.1"
-    "@walletconnect/window-metadata" "^1.0.1"
-    detect-browser "5.3.0"
-    query-string "7.1.3"
-    uint8arrays "^3.1.0"
-
-"@walletconnect/web3wallet@^1.9.2":
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/@walletconnect/web3wallet/-/web3wallet-1.9.2.tgz#f648fa267cc4c9416e9d3c06cb1d7ab93793559d"
-  integrity sha512-IUEmUWKNErWSIMxyvHmFm8NYinsSybaw2Q2Z+7AJdlP+bTA7jg2eeyOGrJsFmBRrfXD3QT/rS/fRDr/LRIvCGg==
+"@walletconnect/web3wallet@^1.9.5":
+  version "1.9.5"
+  resolved "https://registry.yarnpkg.com/@walletconnect/web3wallet/-/web3wallet-1.9.5.tgz#abb87a2fbe7ada506d1550e9c7c5ce2a3a7e8555"
+  integrity sha512-98ymdQ1QuNaC0krsyalzSBpMX6iYmBG2pvUMeStqnI4bas30dt4LaVqGXcklmnxZd2nFJsHLIFqN9jHAg39hhw==
   dependencies:
     "@walletconnect/auth-client" "2.1.2"
-    "@walletconnect/core" "2.10.2"
+    "@walletconnect/core" "2.10.6"
     "@walletconnect/jsonrpc-provider" "1.0.13"
     "@walletconnect/jsonrpc-utils" "1.0.8"
     "@walletconnect/logger" "2.0.1"
-    "@walletconnect/sign-client" "2.10.2"
-    "@walletconnect/types" "2.10.2"
-    "@walletconnect/utils" "2.10.2"
+    "@walletconnect/sign-client" "2.10.6"
+    "@walletconnect/types" "2.10.6"
+    "@walletconnect/utils" "2.10.6"
 
 "@walletconnect/window-getters@^1.0.1":
   version "1.0.1"
@@ -6134,13 +6066,12 @@
     ethereumjs-util "^7.1.3"
     hdkey "^2.0.1"
 
-"@web3-onboard/walletconnect@^2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@web3-onboard/walletconnect/-/walletconnect-2.5.0.tgz#3370079a1366c196d5d089d754e54bb6f2c04a01"
-  integrity sha512-cD5OZYPCg1tvG/mevsEnBauhPK/TJQALru7S6fCB4IpML8tcIf3bk0S+0caZdOlqK+UfOT2P/iiQrIh8OKZ01g==
+"@web3-onboard/walletconnect@^2.5.2":
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/walletconnect/-/walletconnect-2.5.2.tgz#799eb4bcbe9ec0abcb088392a02c32eeb1117a7e"
+  integrity sha512-BoRAaMzkgUzSRRH0YSeCJHdUybNsKydKCocgt/6PY8NZVvJBV3CDasYgVIeIwj+bYB6pWm9IIyFE6VN5/Gzxtg==
   dependencies:
-    "@walletconnect/ethereum-provider" "^2.10.2"
-    "@walletconnect/modal" "2.6.2"
+    "@walletconnect/ethereum-provider" "^2.10.6"
     "@web3-onboard/common" "^2.3.3"
     joi "17.9.1"
     rxjs "^7.5.2"


### PR DESCRIPTION
## What it solves

WalletConnect code is now dynamically imported only if the feature is enabled.

Unfortunately, the large `@walletconnect/ethereum-provider` package still gets bundled with the main chunk because of the web3-onboard module that imports it statically.