### PR TITLE
Refactor: update safe-apps-sdk to v9 with ESM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@mui/material": "^5.14.20",
     "@mui/x-date-pickers": "^5.0.20",
     "@reduxjs/toolkit": "^1.9.5",
-    "@safe-global/safe-apps-sdk": "^8.1.0",
+    "@safe-global/safe-apps-sdk": "^9.0.0-next.0",
     "@safe-global/safe-core-sdk": "^3.3.5",
     "@safe-global/safe-core-sdk-utils": "^1.7.4",
     "@safe-global/safe-deployments": "1.25.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@mui/material": "^5.14.20",
     "@mui/x-date-pickers": "^5.0.20",
     "@reduxjs/toolkit": "^1.9.5",
-    "@safe-global/safe-apps-sdk": "^9.0.0-next.0",
+    "@safe-global/safe-apps-sdk": "^9.0.0-next.1",
     "@safe-global/safe-core-sdk": "^3.3.5",
     "@safe-global/safe-core-sdk-utils": "^1.7.4",
     "@safe-global/safe-deployments": "1.25.0",

--- a/src/components/safe-apps/AppFrame/useAppCommunicator.ts
+++ b/src/components/safe-apps/AppFrame/useAppCommunicator.ts
@@ -24,9 +24,8 @@ import type {
   ChainInfo,
   SafeBalances,
 } from '@safe-global/safe-apps-sdk'
-import { Methods } from '@safe-global/safe-apps-sdk'
+import { Methods, RPC_CALLS } from '@safe-global/safe-apps-sdk'
 import type { Permission, PermissionRequest } from '@safe-global/safe-apps-sdk/dist/types/types/permissions'
-import type { RPC_CALLS } from '@safe-global/safe-apps-sdk/dist/types/eth/constants'
 import type { SafeSettings } from '@safe-global/safe-apps-sdk'
 import AppCommunicator from '@/services/safe-apps/AppCommunicator'
 import { Errors, logError } from '@/services/exceptions'
@@ -35,22 +34,6 @@ import type { SafePermissionsRequest } from '@/hooks/safe-apps/permissions'
 import { SAFE_APPS_EVENTS, trackSafeAppEvent } from '@/services/analytics'
 import { useAppSelector } from '@/store'
 import { selectRpc } from '@/store/settingsSlice'
-
-const SDK_RPC_CALLS: typeof RPC_CALLS = {
-  eth_call: 'eth_call',
-  eth_gasPrice: 'eth_gasPrice',
-  eth_getLogs: 'eth_getLogs',
-  eth_getBalance: 'eth_getBalance',
-  eth_getCode: 'eth_getCode',
-  eth_getBlockByHash: 'eth_getBlockByHash',
-  eth_getBlockByNumber: 'eth_getBlockByNumber',
-  eth_getStorageAt: 'eth_getStorageAt',
-  eth_getTransactionByHash: 'eth_getTransactionByHash',
-  eth_getTransactionReceipt: 'eth_getTransactionReceipt',
-  eth_getTransactionCount: 'eth_getTransactionCount',
-  eth_estimateGas: 'eth_estimateGas',
-  safe_setSettings: 'safe_setSettings',
-}
 
 export enum CommunicatorMessages {
   REJECT_TRANSACTION_MESSAGE = 'Transaction was rejected',
@@ -165,7 +148,7 @@ const useAppCommunicator = (
     communicator?.on(Methods.rpcCall, async (msg) => {
       const params = msg.data.params as RPCPayload
 
-      if (params.call === SDK_RPC_CALLS.safe_setSettings) {
+      if (params.call === RPC_CALLS.safe_setSettings) {
         const settings = params.params[0] as SafeSettings
         return handlers.onSetSafeSettings(settings)
       }

--- a/src/components/safe-apps/AppFrame/useAppCommunicator.ts
+++ b/src/components/safe-apps/AppFrame/useAppCommunicator.ts
@@ -7,7 +7,6 @@ import type {
   ChainInfo as WebCoreChainInfo,
   TransactionDetails,
 } from '@safe-global/safe-gateway-typescript-sdk'
-import type { Permission, PermissionRequest } from '@safe-global/safe-apps-sdk/dist/src/types/permissions'
 import type {
   AddressBookItem,
   BaseTransaction,
@@ -26,7 +25,8 @@ import type {
   SafeBalances,
 } from '@safe-global/safe-apps-sdk'
 import { Methods } from '@safe-global/safe-apps-sdk'
-import { RPC_CALLS } from '@safe-global/safe-apps-sdk/dist/src/eth/constants'
+import type { Permission, PermissionRequest } from '@safe-global/safe-apps-sdk/dist/types/types/permissions'
+import type { RPC_CALLS } from '@safe-global/safe-apps-sdk/dist/types/eth/constants'
 import type { SafeSettings } from '@safe-global/safe-apps-sdk'
 import AppCommunicator from '@/services/safe-apps/AppCommunicator'
 import { Errors, logError } from '@/services/exceptions'
@@ -35,6 +35,22 @@ import type { SafePermissionsRequest } from '@/hooks/safe-apps/permissions'
 import { SAFE_APPS_EVENTS, trackSafeAppEvent } from '@/services/analytics'
 import { useAppSelector } from '@/store'
 import { selectRpc } from '@/store/settingsSlice'
+
+const SDK_RPC_CALLS: typeof RPC_CALLS = {
+  eth_call: 'eth_call',
+  eth_gasPrice: 'eth_gasPrice',
+  eth_getLogs: 'eth_getLogs',
+  eth_getBalance: 'eth_getBalance',
+  eth_getCode: 'eth_getCode',
+  eth_getBlockByHash: 'eth_getBlockByHash',
+  eth_getBlockByNumber: 'eth_getBlockByNumber',
+  eth_getStorageAt: 'eth_getStorageAt',
+  eth_getTransactionByHash: 'eth_getTransactionByHash',
+  eth_getTransactionReceipt: 'eth_getTransactionReceipt',
+  eth_getTransactionCount: 'eth_getTransactionCount',
+  eth_estimateGas: 'eth_estimateGas',
+  safe_setSettings: 'safe_setSettings',
+}
 
 export enum CommunicatorMessages {
   REJECT_TRANSACTION_MESSAGE = 'Transaction was rejected',
@@ -149,7 +165,7 @@ const useAppCommunicator = (
     communicator?.on(Methods.rpcCall, async (msg) => {
       const params = msg.data.params as RPCPayload
 
-      if (params.call === RPC_CALLS.safe_setSettings) {
+      if (params.call === SDK_RPC_CALLS.safe_setSettings) {
         const settings = params.params[0] as SafeSettings
         return handlers.onSetSafeSettings(settings)
       }

--- a/src/components/safe-apps/PermissionsPrompt.tsx
+++ b/src/components/safe-apps/PermissionsPrompt.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react'
-import type { PermissionRequest } from '@safe-global/safe-apps-sdk/dist/src/types/permissions'
+import type { PermissionRequest } from '@safe-global/safe-apps-sdk/dist/types/types/permissions'
 import { Button, Dialog, DialogActions, DialogContent, Divider, Typography } from '@mui/material'
 
 import { ModalDialogTitle } from '@/components/common/ModalDialog'

--- a/src/hooks/safe-apps/permissions/useSafePermissions.ts
+++ b/src/hooks/safe-apps/permissions/useSafePermissions.ts
@@ -4,7 +4,7 @@ import type {
   Permission,
   PermissionCaveat,
   PermissionRequest,
-} from '@safe-global/safe-apps-sdk/dist/src/types/permissions'
+} from '@safe-global/safe-apps-sdk/dist/types/types/permissions'
 
 import { PermissionStatus } from '@/components/safe-apps/types'
 import useLocalStorage from '@/services/local-storage/useLocalStorage'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3882,10 +3882,10 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.5.1.tgz#5f1b518ec5fa54437c0b7c4a821546c64fed6922"
   integrity sha512-6i/8UoL0P5y4leBIGzvkZdS85RDMG9y1ihZzmTZQ5LdHUYmZ7pKFoj8X0236s3lusPs1Fa5HTQUpwI+UfTcmeA==
 
-"@safe-global/safe-apps-sdk@^9.0.0-next.0":
-  version "9.0.0-next.0"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-apps-sdk/-/safe-apps-sdk-9.0.0-next.0.tgz#a9fa2d9aa211675435d7d848dfd65a5983d68138"
-  integrity sha512-PeTIkAKGLB5jZ0mlsvNhpt6Ryz+XM9A2sdrqt3DlsOHe0/sN1vTO8nQ5hpulaNDBBbDkpVNjdBzEmkep1Xn/nA==
+"@safe-global/safe-apps-sdk@^9.0.0-next.1":
+  version "9.0.0-next.1"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-apps-sdk/-/safe-apps-sdk-9.0.0-next.1.tgz#762186e36a3580c93e7efe7f49259c75043c5b7b"
+  integrity sha512-0XsgPXCOXx0wKhumKX/b65alRgd3umfNhsCq/S0K/hhMD/Uh6BTOzHRNFCosbnGvWQT75Hp3Y11LVS7ZD49t/w==
   dependencies:
     "@safe-global/safe-gateway-typescript-sdk" "^3.5.3"
     viem "^1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,10 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.1.tgz#abfccb8ca78075a2b6187345c26243c1a0842f28"
   integrity sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==
 
-"@adraffy/ens-normalize@1.9.4":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.9.4.tgz#aae21cb858bbb0411949d5b7b3051f4209043f62"
-  integrity sha512-UK0bHA7hh9cR39V+4gl2/NnBBjoXIxkuWAPCaY4X7fbH4L/azIi7ilWOCjMUYfpJgraLUAqkRi2BqrjME8Rynw==
+"@adraffy/ens-normalize@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz#d2a39395c587e092d77cbbc80acf956a54f38bf7"
+  integrity sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==
 
 "@ampproject/remapping@^2.2.0":
   version "2.2.1"
@@ -3882,13 +3882,13 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.5.1.tgz#5f1b518ec5fa54437c0b7c4a821546c64fed6922"
   integrity sha512-6i/8UoL0P5y4leBIGzvkZdS85RDMG9y1ihZzmTZQ5LdHUYmZ7pKFoj8X0236s3lusPs1Fa5HTQUpwI+UfTcmeA==
 
-"@safe-global/safe-apps-sdk@^8.1.0":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-apps-sdk/-/safe-apps-sdk-8.1.0.tgz#d1d0c69cd2bf4eef8a79c5d677d16971926aa64a"
-  integrity sha512-XJbEPuaVc7b9n23MqlF6c+ToYIS3f7P2Sel8f3cSBQ9WORE4xrSuvhMpK9fDSFqJ7by/brc+rmJR/5HViRr0/w==
+"@safe-global/safe-apps-sdk@^9.0.0-next.0":
+  version "9.0.0-next.0"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-apps-sdk/-/safe-apps-sdk-9.0.0-next.0.tgz#a9fa2d9aa211675435d7d848dfd65a5983d68138"
+  integrity sha512-PeTIkAKGLB5jZ0mlsvNhpt6Ryz+XM9A2sdrqt3DlsOHe0/sN1vTO8nQ5hpulaNDBBbDkpVNjdBzEmkep1Xn/nA==
   dependencies:
     "@safe-global/safe-gateway-typescript-sdk" "^3.5.3"
-    viem "^1.0.0"
+    viem "^1.6.0"
 
 "@safe-global/safe-core-sdk-types@^1.9.1", "@safe-global/safe-core-sdk-types@^1.9.2":
   version "1.10.1"
@@ -15724,12 +15724,12 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-viem@^1.0.0:
-  version "1.16.5"
-  resolved "https://registry.yarnpkg.com/viem/-/viem-1.16.5.tgz#99bac3bd6a2ccdff4a097438a8ef23a91f01d414"
-  integrity sha512-D8aE6cp/5w6PDtOOkJjkN+FtLyfsNWkfE78N4yTgCt4BG7KsBsePp4O68r1IaTVTVa41anebiZAy9kNEIwAXiw==
+viem@^1.6.0:
+  version "1.20.3"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-1.20.3.tgz#8b8360daee622295f5385949c02c86d943d14e0f"
+  integrity sha512-7CrmeCb2KYkeCgUmUyb1hsf+IX/PLwi+Np+Vm4YUTPeG82y3HRSgGHSaCOp3d0YtR2kXD3nv9y5kE7LBFE+wWw==
   dependencies:
-    "@adraffy/ens-normalize" "1.9.4"
+    "@adraffy/ens-normalize" "1.10.0"
     "@noble/curves" "1.2.0"
     "@noble/hashes" "1.3.2"
     "@scure/bip32" "1.3.2"


### PR DESCRIPTION
## What it solves

The new safe-apps-sdk exports ESM modules which allows tree-shaking. It reduces the 500-kb Viem dependency significantly.

## Todo

* [x] Remove the copied RPC_CALLS (they are exported only as a type from the SDK atm)
* [ ] Update the package version once it's fully released
