### PR TITLE
Chore: optimize the Zodiac dependency

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -32,7 +32,7 @@ const nextConfig = {
     dirs: ['src'],
   },
   experimental: {
-    optimizePackageImports: ['@mui/material', '@mui/icons-material', 'lodash', 'date-fns', '@sentry/react'],
+    optimizePackageImports: ['@mui/material', '@mui/icons-material', 'lodash', 'date-fns', '@sentry/react', '@gnosis.pm/zodiac'],
   },
   webpack(config) {
     config.module.rules.push({


### PR DESCRIPTION
## What it solves

Resolves #3050

## How this PR fixes it

Simply adding the Zodiac module to `optimizePackageImports` drastically reduced its size.
It doesn't affect the bundle analyzer report because it's in its own code chunk. But the difference is visible in the `yarn analyze` report.