### PR TITLE
Refactor: lazy-load BatchSidebar + remove animations in Safe Apps list

### DIFF
--- a/src/components/batch/BatchSidebar/BatchReorder.tsx
+++ b/src/components/batch/BatchSidebar/BatchReorder.tsx
@@ -1,0 +1,33 @@
+import { Reorder } from 'framer-motion'
+import type { DraftBatchItem } from '@/store/batchSlice'
+import BatchTxItem from './BatchTxItem'
+import { useState } from 'react'
+
+const BatchReorder = ({
+  txItems,
+  onDelete,
+  onReorder,
+}: {
+  txItems: DraftBatchItem[]
+  onDelete?: (id: string) => void
+  onReorder: (items: DraftBatchItem[]) => void
+}) => {
+  const [dragging, setDragging] = useState(false)
+
+  return (
+    <Reorder.Group axis="y" values={txItems} onReorder={onReorder}>
+      {txItems.map((item, index) => (
+        <Reorder.Item
+          key={item.id}
+          value={item}
+          onDragStart={() => setDragging(true)}
+          onDragEnd={() => setDragging(false)}
+        >
+          <BatchTxItem count={index + 1} {...item} onDelete={onDelete} draggable dragging={dragging} />
+        </Reorder.Item>
+      ))}
+    </Reorder.Group>
+  )
+}
+
+export default BatchReorder

--- a/src/components/batch/BatchSidebar/BatchTxList.tsx
+++ b/src/components/batch/BatchSidebar/BatchTxList.tsx
@@ -1,7 +1,5 @@
-import { Reorder } from 'framer-motion'
 import type { DraftBatchItem } from '@/store/batchSlice'
 import BatchTxItem from './BatchTxItem'
-import { useState } from 'react'
 import { List } from '@mui/material'
 
 const BatchTxList = ({ txItems, onDelete }: { txItems: DraftBatchItem[]; onDelete?: (id: string) => void }) => {
@@ -13,33 +11,6 @@ const BatchTxList = ({ txItems, onDelete }: { txItems: DraftBatchItem[]; onDelet
         ))}
       </List>
     </>
-  )
-}
-
-export const BatchReorder = ({
-  txItems,
-  onDelete,
-  onReorder,
-}: {
-  txItems: DraftBatchItem[]
-  onDelete?: (id: string) => void
-  onReorder: (items: DraftBatchItem[]) => void
-}) => {
-  const [dragging, setDragging] = useState(false)
-
-  return (
-    <Reorder.Group axis="y" values={txItems} onReorder={onReorder}>
-      {txItems.map((item, index) => (
-        <Reorder.Item
-          key={item.id}
-          value={item}
-          onDragStart={() => setDragging(true)}
-          onDragEnd={() => setDragging(false)}
-        >
-          <BatchTxItem count={index + 1} {...item} onDelete={onDelete} draggable dragging={dragging} />
-        </Reorder.Item>
-      ))}
-    </Reorder.Group>
   )
 }
 

--- a/src/components/batch/BatchSidebar/index.tsx
+++ b/src/components/batch/BatchSidebar/index.tsx
@@ -9,7 +9,7 @@ import { TxModalContext } from '@/components/tx-flow'
 import { ConfirmBatchFlow } from '@/components/tx-flow/flows'
 import Track from '@/components/common/Track'
 import { BATCH_EVENTS } from '@/services/analytics'
-import { BatchReorder } from './BatchTxList'
+import BatchReorder from './BatchReorder'
 import CheckWallet from '@/components/common/CheckWallet'
 
 import PlusIcon from '@/public/images/common/plus.svg'

--- a/src/components/batch/BatchSidebar/index.tsx
+++ b/src/components/batch/BatchSidebar/index.tsx
@@ -1,5 +1,6 @@
 import { type SyntheticEvent, useEffect } from 'react'
 import { useCallback, useContext } from 'react'
+import dynamic from 'next/dynamic'
 import { Button, Divider, Drawer, IconButton, SvgIcon, Typography } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 import { useDraftBatch, useUpdateBatch } from '@/hooks/useDraftBatch'
@@ -9,11 +10,11 @@ import { TxModalContext } from '@/components/tx-flow'
 import { ConfirmBatchFlow } from '@/components/tx-flow/flows'
 import Track from '@/components/common/Track'
 import { BATCH_EVENTS } from '@/services/analytics'
-import BatchReorder from './BatchReorder'
 import CheckWallet from '@/components/common/CheckWallet'
-
 import PlusIcon from '@/public/images/common/plus.svg'
 import EmptyBatch from './EmptyBatch'
+
+const BatchReorder = dynamic(() => import('./BatchReorder'))
 
 const BatchSidebar = ({ isOpen, onToggle }: { isOpen: boolean; onToggle: (open: boolean) => void }) => {
   const { txFlow, setTxFlow } = useContext(TxModalContext)

--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -1,6 +1,5 @@
 import { useContext, useEffect, useState, type ReactElement } from 'react'
 import classnames from 'classnames'
-import dynamic from 'next/dynamic'
 
 import Header from '@/components/common/Header'
 import css from './styles.module.css'
@@ -11,8 +10,7 @@ import { useIsSidebarRoute } from '@/hooks/useIsSidebarRoute'
 import useDebounce from '@/hooks/useDebounce'
 import { useRouter } from 'next/router'
 import { TxModalContext } from '@/components/tx-flow'
-
-const BatchSidebar = dynamic(() => import('@/components/batch/BatchSidebar'))
+import BatchSidebar from '@/components/batch/BatchSidebar'
 
 const PageLayout = ({ pathname, children }: { pathname: string; children: ReactElement }): ReactElement => {
   const router = useRouter()

--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -1,5 +1,6 @@
 import { useContext, useEffect, useState, type ReactElement } from 'react'
 import classnames from 'classnames'
+import dynamic from 'next/dynamic'
 
 import Header from '@/components/common/Header'
 import css from './styles.module.css'
@@ -10,7 +11,8 @@ import { useIsSidebarRoute } from '@/hooks/useIsSidebarRoute'
 import useDebounce from '@/hooks/useDebounce'
 import { useRouter } from 'next/router'
 import { TxModalContext } from '@/components/tx-flow'
-import BatchSidebar from '@/components/batch/BatchSidebar'
+
+const BatchSidebar = dynamic(() => import('@/components/batch/BatchSidebar'))
 
 const PageLayout = ({ pathname, children }: { pathname: string; children: ReactElement }): ReactElement => {
   const router = useRouter()

--- a/src/components/safe-apps/SafeAppList/index.tsx
+++ b/src/components/safe-apps/SafeAppList/index.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from 'react'
 import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
-import { motion, AnimatePresence } from 'framer-motion'
 
 import SafeAppCard from '@/components/safe-apps/SafeAppCard'
 import AddCustomSafeAppCard from '@/components/safe-apps/AddCustomSafeAppCard'
@@ -70,27 +69,19 @@ const SafeAppList = ({
             </li>
           ))}
 
-        <AnimatePresence>
-          {/* Flat list filtered by search query */}
-          {safeAppsList.map((safeApp) => (
-            <motion.li
-              key={safeApp.id}
-              layout
-              animate={{ scale: 1, opacity: 1 }}
-              exit={{ scale: 0.8, opacity: 0 }}
-              transition={{ duration: 0.2 }}
-            >
-              <SafeAppCard
-                safeApp={safeApp}
-                isBookmarked={bookmarkedSafeAppsId?.has(safeApp.id)}
-                onBookmarkSafeApp={onBookmarkSafeApp}
-                removeCustomApp={removeCustomApp}
-                onClickSafeApp={handleSafeAppClick(safeApp)}
-                openPreviewDrawer={openPreviewDrawer}
-              />
-            </motion.li>
-          ))}
-        </AnimatePresence>
+        {/* Flat list filtered by search query */}
+        {safeAppsList.map((safeApp) => (
+          <li key={safeApp.id}>
+            <SafeAppCard
+              safeApp={safeApp}
+              isBookmarked={bookmarkedSafeAppsId?.has(safeApp.id)}
+              onBookmarkSafeApp={onBookmarkSafeApp}
+              removeCustomApp={removeCustomApp}
+              onClickSafeApp={handleSafeAppClick(safeApp)}
+              openPreviewDrawer={openPreviewDrawer}
+            />
+          </li>
+        ))}
       </ul>
 
       {/* Zero results placeholder */}


### PR DESCRIPTION
## What it solves

We had two places where `framer-motion` was used:
* Batch sidebar (for reordering)
* Safe Apps list (animation was added in #2699)

I've made the Batch sidebar lazy-loaded, and removed the animation completely from Safe Apps as it was very slow and not particularly better for UX.