### PR TITLE
fix: show fieldErrors in readonly input

### DIFF
--- a/src/components/common/AddressBookInput/index.tsx
+++ b/src/components/common/AddressBookInput/index.tsx
@@ -1,6 +1,6 @@
 import AddressInputReadOnly from '@/components/common/AddressInputReadOnly'
 import { type ReactElement, useState, useMemo } from 'react'
-import { useFormContext, useWatch } from 'react-hook-form'
+import { get, useFormContext, useWatch } from 'react-hook-form'
 import { Box, SvgIcon, Typography } from '@mui/material'
 import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete'
 import useAddressBook from '@/hooks/useAddressBook'
@@ -20,7 +20,7 @@ const abFilterOptions = createFilterOptions({
  */
 const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canAdd?: boolean }): ReactElement => {
   const addressBook = useAddressBook()
-  const { setValue, control } = useFormContext()
+  const { setValue, control, formState } = useFormContext()
   const addressValue = useWatch({ name, control })
   const [open, setOpen] = useState(false)
   const [openAddressBook, setOpenAddressBook] = useState<boolean>(false)
@@ -46,11 +46,14 @@ const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canA
     : undefined
 
   if (addressBook[addressValue]) {
+    const fieldError = get(formState.errors, name)
+
     return (
       <Box data-testid="address-book-recipient" onClick={() => setValue(name, '')}>
         <AddressInputReadOnly
           address={addressValue}
-          label={typeof props.label === 'string' ? props.label : 'Sending to'}
+          label={fieldError?.message || (typeof props.label === 'string' ? props.label : 'Sending to')}
+          error={!!fieldError}
         />
       </Box>
     )

--- a/src/components/common/AddressInputReadOnly/index.tsx
+++ b/src/components/common/AddressInputReadOnly/index.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from 'react'
+import { type ReactNode, useState, type ReactElement } from 'react'
 import { IconButton, InputAdornment, InputLabel, OutlinedInput, SvgIcon, Typography } from '@mui/material'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import SaveAddressIcon from '@/public/images/common/save-address.svg'
@@ -6,16 +6,27 @@ import css from './styles.module.css'
 import EntryDialog from '@/components/address-book/EntryDialog'
 import useAddressBook from '@/hooks/useAddressBook'
 
-const AddressInputReadOnly = ({ label, address }: { label: string; address: string }): ReactElement => {
+const AddressInputReadOnly = ({
+  label,
+  address,
+  error,
+}: {
+  label: ReactNode
+  address: string
+  error?: boolean
+}): ReactElement => {
   const addressBook = useAddressBook()
   const [open, setOpen] = useState(false)
 
   return (
     <>
       <div className={css.wrapper}>
-        <InputLabel shrink>{label}</InputLabel>
+        <InputLabel shrink error={error}>
+          {label}
+        </InputLabel>
         <OutlinedInput
           className={css.input}
+          error={error}
           startAdornment={
             <InputAdornment position="start">
               <Typography variant="body2" component="div">

--- a/src/components/common/AddressInputReadOnly/styles.module.css
+++ b/src/components/common/AddressInputReadOnly/styles.module.css
@@ -1,11 +1,19 @@
 .wrapper :global .MuiInputBase-root:hover .MuiOutlinedInput-notchedOutline,
 .wrapper :global .MuiInputBase-root .MuiOutlinedInput-notchedOutline {
-  border-color: var(--color-text-secondary);
+  border-color: var(--color-border-light) !important;
   border-width: 1px;
+}
+
+.wrapper :global .MuiInputBase-root.Mui-error .MuiOutlinedInput-notchedOutline {
+  border-color: var(--color-error-main) !important;
 }
 
 .wrapper :global .MuiInputLabel-root {
   color: var(--color-text-secondary);
+}
+
+.wrapper :global .MuiInputLabel-root.Mui-error {
+  color: var(--color-error-main);
 }
 
 .wrapper :global .MuiInputBase-root {
@@ -33,8 +41,4 @@
 .input [title] {
   font-weight: bold;
   color: var(--color-text-primary);
-}
-
-.input fieldset {
-  border-color: var(--color-border-light) !important;
 }


### PR DESCRIPTION
## What it solves

Resolves #3058 

## How this PR fixes it
- [x] Shows `fieldErrors` in readonly component
- [ ] Validates when selecting from the dropdown

## How to test it
1. Paste the Safe's address into the address input when adding an owner
2. Observe that the error is correctly shown

1. Select the Safe from the Address book input
2. Observe that the error is correctly shown

## Screenshots

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
