### PR TITLE
Fix: [WalletConnect] rm app.optimism.io from blocked bridges

### DIFF
--- a/src/features/walletconnect/constants.ts
+++ b/src/features/walletconnect/constants.ts
@@ -41,7 +41,6 @@ export const BlockedBridges = [
   'cbridge.celer.network',
   'www.orbiter.finance',
   'zksync-era.l2scan.co',
-  'app.optimism.io',
   'www.portalbridge.com',
   'wallet.polygon.technology',
   'app.rhino.fi',


### PR DESCRIPTION
## What it solves

From the Optimism team:

> we recently implemented a code change to block smart contract wallets from using the bridge on [app.optimism.io](http://app.optimism.io/). Can you remove the block on your end for [app.optimism.io](http://app.optimism.io/) that prevents safe wallets from connecting? this will allow safe wallets to be used for the non-bridge features in our app.

I've removed the blocked host accordingly.