### PR TITLE
fix: avoid crashing when selecting a 4-letter currency

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,8 +13,9 @@
       {
         "additionalHooks": "useAsync"
       }
-    ]
+    ],
+    "no-only-tests/no-only-tests": "error"
   },
   "ignorePatterns": ["node_modules/", ".next/", ".github/"],
-  "plugins": ["unused-imports", "@typescript-eslint"]
+  "plugins": ["unused-imports", "@typescript-eslint", "no-only-tests"]
 }

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,7 +24,7 @@ jobs:
           # branch should not be protected
           branch: 'main'
           # user names of users allowed to contribute without CLA
-          allowlist: lukasschor,rmeissner,germartinez,Uxio0,dasanra,francovenica,tschubotz,luarx,DaniSomoza,iamacook,yagopv,usame-algan,schmanu,DiogoSoaress,JagoFigueroa,fmrsabino,mike10ca,jmealy,bot*
+          allowlist: lukasschor,rmeissner,germartinez,Uxio0,dasanra,francovenica,tschubotz,luarx,DaniSomoza,iamacook,yagopv,usame-algan,schmanu,DiogoSoaress,JagoFigueroa,fmrsabino,mike10ca,jmealy,compojoom,bot*
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           # enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "eslint": "8.31.0",
     "eslint-config-next": "13.1.1",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-unused-imports": "^2.0.0",
     "fake-indexeddb": "^4.0.2",

--- a/src/components/balances/CurrencySelect/__tests__/useCurrencies.test.ts
+++ b/src/components/balances/CurrencySelect/__tests__/useCurrencies.test.ts
@@ -1,0 +1,56 @@
+import { act, renderHook } from '@testing-library/react'
+import { getFiatCurrencies } from '@safe-global/safe-gateway-typescript-sdk'
+import useCurrencies from '../useCurrencies'
+import { Errors, logError } from '@/services/exceptions'
+
+jest.mock('@safe-global/safe-gateway-typescript-sdk', () => ({
+  getFiatCurrencies: jest.fn(),
+}))
+
+jest.mock('@/services/exceptions', () => {
+  const originalModule = jest.requireActual('@/services/exceptions')
+
+  return {
+    ...originalModule, // this will keep the original exports
+    logError: jest.fn(), // this will override logError with a mock function
+  }
+})
+
+describe('useCurrencies', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should fetch and return the list of ISO 4217 currencies', async () => {
+    const iso4217Currencies = ['USD', 'EUR', 'GBP']
+    const mockCurrencies = [...iso4217Currencies, 'SATS']
+    const getFiatCurrenciesMock = jest.fn(async () => Promise.resolve(mockCurrencies))
+    const myMock = getFiatCurrencies as jest.Mock
+    myMock.mockImplementation(getFiatCurrenciesMock)
+
+    const { result, rerender } = renderHook(() => useCurrencies())
+
+    expect(result.current).toBeUndefined()
+
+    await act(async () => {
+      rerender()
+    })
+
+    expect(result.current).toEqual(iso4217Currencies)
+    expect(getFiatCurrenciesMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('should log an error if fetching currencies fails', async () => {
+    const mockError = new Error('Failed to fetch currencies')
+    const myMock = getFiatCurrencies as jest.Mock
+    myMock.mockRejectedValue(mockError)
+
+    const { rerender } = renderHook(() => useCurrencies())
+
+    await act(async () => {
+      rerender()
+    })
+
+    expect(logError).toHaveBeenCalledWith(Errors._607, mockError.message)
+  })
+})

--- a/src/components/balances/CurrencySelect/useCurrencies.ts
+++ b/src/components/balances/CurrencySelect/useCurrencies.ts
@@ -4,9 +4,20 @@ import { getFiatCurrencies } from '@safe-global/safe-gateway-typescript-sdk'
 import useAsync from '@/hooks/useAsync'
 import { Errors, logError } from '@/services/exceptions'
 
+// The SDK returns a list of currencies, including crypto
+// some of the crypto currencies have a length of 4 characters
+// we filter them out because the frontend only supports ISO 4217 currencies
+// and they have to be exactly 3 characters long
+// if that is not the case Intl.NumberFormat will throw an error and crash the app
+const getISO4217Currencies = async (): Promise<FiatCurrencies> => {
+  const currencies = await getFiatCurrencies()
+
+  return currencies.filter((currency) => currency.length === 3)
+}
+
 const useCurrencies = (): FiatCurrencies | undefined => {
   // Re-fetch assets when the entire SafeInfo updates
-  const [data, error] = useAsync<FiatCurrencies>(getFiatCurrencies, [])
+  const [data, error] = useAsync<FiatCurrencies>(getISO4217Currencies, [])
 
   // Log errors
   useEffect(() => {

--- a/src/components/tx/SignOrExecuteForm/__tests__/ExecuteForm.test.tsx
+++ b/src/components/tx/SignOrExecuteForm/__tests__/ExecuteForm.test.tsx
@@ -21,7 +21,7 @@ jest.mock('@/components/common/CheckWallet', () => ({
   },
 }))
 
-describe.only('ExecuteForm', () => {
+describe('ExecuteForm', () => {
   const safeTransaction = createMockSafeTransaction({
     to: '0x1',
     data: '0x',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8802,6 +8802,11 @@ eslint-plugin-jsx-a11y@^6.5.1:
     object.fromentries "^2.0.6"
     semver "^6.3.0"
 
+eslint-plugin-no-only-tests@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz#f38e4935c6c6c4842bf158b64aaa20c366fe171b"
+  integrity sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==
+
 eslint-plugin-prettier@^4.0.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"


### PR DESCRIPTION
## What it solves
On the assets page if the user was to change the currency to SATS, LINK or BITS the app would crash. It turns out that we rely on Intl.NumberFormat for currency, but it only works with ISO 4217 - which requires the currency length to be exactly 3 characters. With anything else the call will throw. For now we decided to ignore any non ISO 4217 currencies.

Resolves #3045

## How this PR fixes it
@katspaugh and I agreed to remove Currencies that are not 3 characters long (as expected by ISO 4217). The currencies feature is not used much and if it is used it is mainly USD.

## How to test it
The list of currencies will no longer show LINK, BITS or SATS - so running into the crash is no longer possible

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
