### PR TITLE
fix: show "Unknown NFT" on transactions when token symbol value is null

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,7 +24,7 @@ jobs:
           # branch should not be protected
           branch: 'main'
           # user names of users allowed to contribute without CLA
-          allowlist: lukasschor,rmeissner,germartinez,Uxio0,dasanra,francovenica,tschubotz,luarx,DaniSomoza,iamacook,yagopv,usame-algan,schmanu,DiogoSoaress,JagoFigueroa,fmrsabino,mike10ca,bot*
+          allowlist: lukasschor,rmeissner,germartinez,Uxio0,dasanra,francovenica,tschubotz,luarx,DaniSomoza,iamacook,yagopv,usame-algan,schmanu,DiogoSoaress,JagoFigueroa,fmrsabino,mike10ca,jmealy,bot*
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           # enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)

--- a/src/components/transactions/TxInfo/index.tsx
+++ b/src/components/transactions/TxInfo/index.tsx
@@ -56,7 +56,11 @@ export const TransferTx = ({
     return (
       <TokenAmount
         {...transfer}
-        tokenSymbol={transfer.tokenSymbol ? ellipsis(`${transfer.tokenSymbol} #${transfer.tokenId}`, withLogo ? 16 : 100) : "Unknown Token"}
+        tokenSymbol={
+          transfer.tokenSymbol
+            ? ellipsis(`${transfer.tokenSymbol} #${transfer.tokenId}`, withLogo ? 16 : 100)
+            : 'Unknown Token'
+        }
         value="1"
         direction={undefined}
         logoUri={withLogo ? transfer?.logoUri : undefined}

--- a/src/components/transactions/TxInfo/index.tsx
+++ b/src/components/transactions/TxInfo/index.tsx
@@ -56,11 +56,10 @@ export const TransferTx = ({
     return (
       <TokenAmount
         {...transfer}
-        tokenSymbol={
-          transfer.tokenSymbol
-            ? ellipsis(`${transfer.tokenSymbol} #${transfer.tokenId}`, withLogo ? 16 : 100)
-            : 'Unknown Token'
-        }
+        tokenSymbol={ellipsis(
+          `${transfer.tokenSymbol ? transfer.tokenSymbol : 'Unknown NFT'} #${transfer.tokenId}`,
+          withLogo ? 16 : 100,
+        )}
         value="1"
         direction={undefined}
         logoUri={withLogo ? transfer?.logoUri : undefined}

--- a/src/components/transactions/TxInfo/index.tsx
+++ b/src/components/transactions/TxInfo/index.tsx
@@ -56,7 +56,7 @@ export const TransferTx = ({
     return (
       <TokenAmount
         {...transfer}
-        tokenSymbol={ellipsis(`${transfer.tokenSymbol} #${transfer.tokenId}`, withLogo ? 16 : 100)}
+        tokenSymbol={transfer.tokenSymbol ? ellipsis(`${transfer.tokenSymbol} #${transfer.tokenId}`, withLogo ? 16 : 100) : "Unknown Token"}
         value="1"
         direction={undefined}
         logoUri={withLogo ? transfer?.logoUri : undefined}


### PR DESCRIPTION
## What it solves

Resolves #3007

## How this PR fixes it
- [x] Shows the string `Unknown NFT` when token symbol value is null, instead of displaying `null`.

## How to test it

1. Open a transaction where the Token Symbol value is null. Example: https://app.safe.global/transactions/tx?safe=eth:0x220866b1a2219f40e72f5c628b65d54268ca3a9d&id=transfer_0x220866B1A2219f40e72f5c628B65D54268cA3A9D_ed95a5741db35c4a8478b9cad5c196784687106180afb92ab7f0e3157c45f4fd0344
2. Observe that "Unknown NFT" is shown where the token symbol would usually be.

## Screenshots
Before: 
<img width="726" alt="Screenshot 2024-01-04 at 14 55 08" src="https://github.com/safe-global/safe-wallet-web/assets/17801424/748f8ea9-6ac9-43a5-8775-7b0d93c4d353">
After:
<img width="759" alt="Screenshot 2024-01-04 at 15 26 20" src="https://github.com/safe-global/safe-wallet-web/assets/17801424/bfd82a25-0cf6-4ac7-b950-5734557fcd23">



## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
