### PR TITLE
fix: Persist timeout for pending transactions

### DIFF
--- a/src/hooks/useTxPendingStatuses.ts
+++ b/src/hooks/useTxPendingStatuses.ts
@@ -36,7 +36,7 @@ const useTxMonitor = (): void => {
       return
     }
 
-    for (const [txId, { txHash, status, taskId, safeAddress }] of pendingTxEntriesOnChain) {
+    for (const [txId, { txHash, status, taskId, safeAddress, submittedAt }] of pendingTxEntriesOnChain) {
       const isProcessing = status === PendingStatus.PROCESSING && txHash !== undefined
       const isMonitored = monitoredTxs.current[txId]
       const isRelaying = status === PendingStatus.RELAYING && taskId !== undefined
@@ -48,7 +48,7 @@ const useTxMonitor = (): void => {
       monitoredTxs.current[txId] = true
 
       if (isProcessing) {
-        waitForTx(provider, txId, txHash)
+        waitForTx(provider, txId, txHash, submittedAt)
         continue
       }
 
@@ -103,6 +103,7 @@ const useTxPendingStatuses = (): void => {
               groupKey: 'groupKey' in detail ? detail.groupKey : undefined,
               signerAddress: `signerAddress` in detail ? detail.signerAddress : undefined,
               taskId: 'taskId' in detail ? detail.taskId : undefined,
+              submittedAt: status === PendingStatus.PROCESSING ? Date.now() : undefined,
             }),
           )
         }

--- a/src/services/tx/__tests__/txMonitor.test.ts
+++ b/src/services/tx/__tests__/txMonitor.test.ts
@@ -1,3 +1,4 @@
+import { _getRemainingTimeout } from '@/services/tx/txMonitor'
 import { JsonRpcProvider } from '@ethersproject/providers'
 import * as txEvents from '@/services/tx/txEvents'
 import * as txMonitor from '@/services/tx/txMonitor'
@@ -402,5 +403,28 @@ describe('txMonitor', () => {
       expect(mockFetch).toHaveBeenCalled()
       expect(setStatusSpy).toHaveBeenCalledWith(SafeCreationStatus.ERROR)
     })
+  })
+})
+
+describe('getRemainingTimeout', () => {
+  const DefaultTimeout = 6.5
+
+  it('returns 1 if submission is older than 6.5 minutes', () => {
+    const result = _getRemainingTimeout(DefaultTimeout, Date.now() - DefaultTimeout * 60_000)
+
+    expect(result).toBe(1)
+  })
+
+  it('returns default timeout in milliseconds if no submission time was passed', () => {
+    const result = _getRemainingTimeout(DefaultTimeout)
+
+    expect(result).toBe(DefaultTimeout * 60_000)
+  })
+
+  it('returns remaining timeout', () => {
+    const passedMinutes = 3
+    const result = _getRemainingTimeout(DefaultTimeout, Date.now() - passedMinutes * 60_000)
+
+    expect(result).toBe((DefaultTimeout - passedMinutes) * 60_000)
   })
 })

--- a/src/store/pendingTxsSlice.ts
+++ b/src/store/pendingTxsSlice.ts
@@ -19,6 +19,7 @@ export type PendingTx = {
   groupKey?: string
   signerAddress?: string
   taskId?: string
+  submittedAt?: number
 }
 
 export type PendingTxsState = {


### PR DESCRIPTION
## What it solves

Resolves #2878 

## How this PR fixes it

Stores a `submittedAt` time for pending transactions and checks for that time in `waitForTx` instead of always falling back to the default timeout of 6.5 minutes.

Additionally, we can call `waitForTx` when dispatching an execution as the `.wait()` call doesn't accept a timeout and can be stuck for > 30 minutes if the user doesn't reload the app or reconnect their wallet (to start the `txMonitor`).

## ToDos

- [ ] Add a `Promise.race` and call `waitForTx` when dispatching an execution

## How to test it

1. Execute a transaction and cancel in your wallet
2. Close the app or reload after a few minutes (< 6.5 minutes)
3. Reopen the app after 6.5 minutes
4. Observe a timeout error for the pending transaction
5. Observe the transaction can be executed again

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
