### PR TITLE
Fix: [Welcome page] don't show name in Continue with

### DIFF
--- a/src/components/welcome/WelcomeLogin/WalletLogin.tsx
+++ b/src/components/welcome/WelcomeLogin/WalletLogin.tsx
@@ -29,7 +29,9 @@ const WalletLogin = ({ onLogin }: { onLogin: () => void }) => {
                 <Typography variant="subtitle2" fontWeight={700}>
                   Continue with {wallet.label}
                 </Typography>
-                {wallet.address && <EthHashInfo address={wallet.address} shortAddress avatarSize={16} />}
+                {wallet.address && (
+                  <EthHashInfo address={wallet.address} shortAddress avatarSize={16} showName={false} />
+                )}
               </Box>
               {wallet.icon && (
                 <img


### PR DESCRIPTION
## What it solves

Resolves #3073

## How this PR fixes it

Always show just the address w/o an address book/ENS name.