### PR TITLE
fix: allow localhost URLs with subdomains when adding custom safe apps

### DIFF
--- a/src/utils/__tests__/validation.test.ts
+++ b/src/utils/__tests__/validation.test.ts
@@ -5,6 +5,7 @@ import {
   validatePrefixedAddress,
   validateDecimalLength,
   isValidAddress,
+  isValidURL,
 } from '@/utils/validation'
 
 describe('validation', () => {
@@ -127,6 +128,24 @@ describe('validation', () => {
 
       const result3 = validateDecimalLength('1', 0)
       expect(result3).toBeUndefined()
+    })
+  })
+
+  describe('URL validation', () => {
+    it.only('returns true for localhost URLs', () => {
+      const result1 = isValidURL('http://localhost:3000')
+      expect(result1).toBe(true)
+
+      const result2 = isValidURL('http://subdomain.localhost:3000')
+      expect(result2).toBe(true)
+    })
+
+    it.only('returns false for non https domains ', () => {
+      const result1 = isValidURL('https://example.com')
+      expect(result1).toBe(true)
+
+      const result2 = isValidURL('http://example.com')
+      expect(result2).toBe(false)
     })
   })
 })

--- a/src/utils/__tests__/validation.test.ts
+++ b/src/utils/__tests__/validation.test.ts
@@ -132,7 +132,7 @@ describe('validation', () => {
   })
 
   describe('URL validation', () => {
-    it.only('returns true for localhost URLs', () => {
+    it('returns true for localhost URLs', () => {
       const result1 = isValidURL('http://localhost:3000')
       expect(result1).toBe(true)
 
@@ -140,7 +140,7 @@ describe('validation', () => {
       expect(result2).toBe(true)
     })
 
-    it.only('returns false for non https domains ', () => {
+    it('returns false for non https domains ', () => {
       const result1 = isValidURL('https://example.com')
       expect(result1).toBe(true)
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -17,32 +17,32 @@ export const isValidAddress = (address: string): boolean => validateAddress(addr
 
 export const validatePrefixedAddress =
   (chainShortName?: string) =>
-    (value: string): string | undefined => {
-      const { prefix, address } = parsePrefixedAddress(value)
+  (value: string): string | undefined => {
+    const { prefix, address } = parsePrefixedAddress(value)
 
-      if (prefix) {
-        if (prefix !== chainShortName) {
-          return `"${prefix}" doesn't match the current chain`
-        }
+    if (prefix) {
+      if (prefix !== chainShortName) {
+        return `"${prefix}" doesn't match the current chain`
       }
-
-      return validateAddress(address)
     }
+
+    return validateAddress(address)
+  }
 
 export const uniqueAddress =
   (addresses: string[] = []) =>
-    (address: string): string | undefined => {
-      const ADDRESS_REPEATED_ERROR = 'Address already added'
-      const addressExists = addresses.some((addressFromList) => sameAddress(addressFromList, address))
-      return addressExists ? ADDRESS_REPEATED_ERROR : undefined
-    }
+  (address: string): string | undefined => {
+    const ADDRESS_REPEATED_ERROR = 'Address already added'
+    const addressExists = addresses.some((addressFromList) => sameAddress(addressFromList, address))
+    return addressExists ? ADDRESS_REPEATED_ERROR : undefined
+  }
 
 export const addressIsNotCurrentSafe =
   (safeAddress: string) =>
-    (address: string): string | undefined => {
-      const OWNER_ADDRESS_IS_SAFE_ADDRESS_ERROR = 'Cannot use Safe Account itself as owner.'
-      return sameAddress(safeAddress, address) ? OWNER_ADDRESS_IS_SAFE_ADDRESS_ERROR : undefined
-    }
+  (address: string): string | undefined => {
+    const OWNER_ADDRESS_IS_SAFE_ADDRESS_ERROR = 'Cannot use Safe Account itself as owner.'
+    return sameAddress(safeAddress, address) ? OWNER_ADDRESS_IS_SAFE_ADDRESS_ERROR : undefined
+  }
 
 export const FLOAT_REGEX = /^[0-9]+([,.][0-9]+)?$/
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -17,32 +17,32 @@ export const isValidAddress = (address: string): boolean => validateAddress(addr
 
 export const validatePrefixedAddress =
   (chainShortName?: string) =>
-  (value: string): string | undefined => {
-    const { prefix, address } = parsePrefixedAddress(value)
+    (value: string): string | undefined => {
+      const { prefix, address } = parsePrefixedAddress(value)
 
-    if (prefix) {
-      if (prefix !== chainShortName) {
-        return `"${prefix}" doesn't match the current chain`
+      if (prefix) {
+        if (prefix !== chainShortName) {
+          return `"${prefix}" doesn't match the current chain`
+        }
       }
-    }
 
-    return validateAddress(address)
-  }
+      return validateAddress(address)
+    }
 
 export const uniqueAddress =
   (addresses: string[] = []) =>
-  (address: string): string | undefined => {
-    const ADDRESS_REPEATED_ERROR = 'Address already added'
-    const addressExists = addresses.some((addressFromList) => sameAddress(addressFromList, address))
-    return addressExists ? ADDRESS_REPEATED_ERROR : undefined
-  }
+    (address: string): string | undefined => {
+      const ADDRESS_REPEATED_ERROR = 'Address already added'
+      const addressExists = addresses.some((addressFromList) => sameAddress(addressFromList, address))
+      return addressExists ? ADDRESS_REPEATED_ERROR : undefined
+    }
 
 export const addressIsNotCurrentSafe =
   (safeAddress: string) =>
-  (address: string): string | undefined => {
-    const OWNER_ADDRESS_IS_SAFE_ADDRESS_ERROR = 'Cannot use Safe Account itself as owner.'
-    return sameAddress(safeAddress, address) ? OWNER_ADDRESS_IS_SAFE_ADDRESS_ERROR : undefined
-  }
+    (address: string): string | undefined => {
+      const OWNER_ADDRESS_IS_SAFE_ADDRESS_ERROR = 'Cannot use Safe Account itself as owner.'
+      return sameAddress(safeAddress, address) ? OWNER_ADDRESS_IS_SAFE_ADDRESS_ERROR : undefined
+    }
 
 export const FLOAT_REGEX = /^[0-9]+([,.][0-9]+)?$/
 
@@ -89,7 +89,7 @@ export const isValidURL = (url: string, protocolsAllowed = ['https:']): boolean 
   try {
     const urlInfo = new URL(url)
 
-    return protocolsAllowed.includes(urlInfo.protocol) || urlInfo.hostname === 'localhost'
+    return protocolsAllowed.includes(urlInfo.protocol) || urlInfo.hostname.split('.').pop() === 'localhost'
   } catch (error) {
     return false
   }


### PR DESCRIPTION
## What it solves

When adding a custom safe app, if a localhost URL includes subdomains, it will fail the validation. For example `http://localhost:3001/` will be allowed, but `http://foobar.localhost:3000/` will fail.

Resolves #1108 

## How this PR fixes it
- allows localhost domains which include subdomains when adding a custom safe app.
- both `http://localhost:3000` and `http://foobar.localhost:3000` will be allowed.

## How to test it
- Open the `Add a custom safe app` modal.
- Enter a localhost URL with subdomains. The example from the ticket is http://bafybeiasatviqudql65qxx66ois3dr7vxmhkk7zawn2vhdeax6q6pn4lsa.ipfs.localhost:8080/  
- To be able to add the url you will need to run the IPFS desktop app: https://docs.ipfs.tech/install/ipfs-desktop/ 
Although this fix is only to do with the form validation so it isn't necessary.
- There should be no `The url is invalid` error shown. If you are running the safe app locally you will be able to add it to your custom safe apps. If you are not running it locally you will see the error: `The app doesn't support Safe App functionality`


## Screenshots
Before:
![](https://user-images.githubusercontent.com/886059/200769221-1a84fc22-2ce7-4ec2-9a9e-39d7604bf58b.png)
After:
<img width="605" alt="Screenshot 2024-01-08 at 13 41 59" src="https://github.com/safe-global/safe-wallet-web/assets/17801424/838324b8-df21-4fb7-bfd5-ea8d1315ecdf">


## Checklist

* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
