### PR TITLE
feat: Update Safe Apps header

### DIFF
--- a/src/components/safe-apps/SafeAppsHeader/index.tsx
+++ b/src/components/safe-apps/SafeAppsHeader/index.tsx
@@ -1,18 +1,20 @@
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import type { ReactElement } from 'react'
+import { useCurrentChain } from '@/hooks/useChains'
 
 import NavTabs from '@/components/common/NavTabs'
 import { safeAppsNavItems } from '@/components/sidebar/SidebarNavigation/config'
 import css from './styles.module.css'
 
 const SafeAppsHeader = (): ReactElement => {
+  const chain = useCurrentChain()
   return (
     <>
       <Box className={css.container}>
         {/* Safe Apps Title */}
         <Typography className={css.title} variant="h3">
-          Explore the Safe Apps ecosystem
+          Explore the Safe {chain?.chainName} ecosystem
         </Typography>
 
         {/* Safe Apps Subtitle */}

--- a/src/components/safe-apps/SafeAppsHeader/styles.module.css
+++ b/src/components/safe-apps/SafeAppsHeader/styles.module.css
@@ -11,7 +11,7 @@
 }
 
 .subtitle {
-  max-width: 650px;
+  max-width: 700px;
   letter-spacing: 0.15px;
 }
 


### PR DESCRIPTION
## What it solves

Resolves #3075 

## How this PR fixes it

This pull request updates the Safe Apps header by dynamically adding the connected network name into the title. The new title format is "Explore the Safe {networkName} ecosystem". Additionally, the subtitle tag length has been adjusted to ensure it fits in a single line.

## How to test it

## Screenshots
![PR-1](https://github.com/safe-global/safe-wallet-web/assets/92922580/9496c956-722a-4a68-9d36-7ae338773b26)
![PR-2](https://github.com/safe-global/safe-wallet-web/assets/92922580/003fae15-2536-4f6f-a1bb-d509fdda4b21)

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
