### PR TITLE
Analytics: key event types

### DIFF
--- a/src/services/analytics/events/createLoadSafe.ts
+++ b/src/services/analytics/events/createLoadSafe.ts
@@ -52,7 +52,7 @@ export const CREATE_SAFE_EVENTS = {
     category: CREATE_SAFE_CATEGORY,
   },
   CREATED_SAFE: {
-    event: EventType.META,
+    event: EventType.SAFE_CREATED,
     action: 'Created Safe',
     category: CREATE_SAFE_CATEGORY,
   },

--- a/src/services/analytics/events/overview.ts
+++ b/src/services/analytics/events/overview.ts
@@ -100,7 +100,7 @@ export const OVERVIEW_EVENTS = {
   },
   // Track actual Safe views
   SAFE_VIEWED: {
-    event: EventType.META,
+    event: EventType.SAFE_OPENED,
     action: 'Safe viewed',
     category: OVERVIEW_CATEGORY,
   },

--- a/src/services/analytics/events/transactions.ts
+++ b/src/services/analytics/events/transactions.ts
@@ -1,3 +1,5 @@
+import { EventType } from '../types'
+
 export enum TX_TYPES {
   // Settings
   owner_add = 'owner_add',
@@ -26,18 +28,18 @@ const TX_CATEGORY = 'transactions'
 
 export const TX_EVENTS = {
   CREATE: {
-    event: 'tx_create',
+    event: EventType.TX_CREATE,
     action: 'Create transaction',
     category: TX_CATEGORY,
     // label: TX_TYPES,
   },
   CONFIRM: {
-    event: 'tx_confirm',
+    event: EventType.TX_CONFIRM,
     action: 'Confirm transaction',
     category: TX_CATEGORY,
   },
   EXECUTE: {
-    event: 'tx_execute',
+    event: EventType.TX_EXECUTE,
     action: 'Execute transaction',
     category: TX_CATEGORY,
   },

--- a/src/services/analytics/events/transactions.ts
+++ b/src/services/analytics/events/transactions.ts
@@ -28,18 +28,18 @@ const TX_CATEGORY = 'transactions'
 
 export const TX_EVENTS = {
   CREATE: {
-    event: EventType.TX_CREATE,
+    event: EventType.TX_CREATED,
     action: 'Create transaction',
     category: TX_CATEGORY,
     // label: TX_TYPES,
   },
   CONFIRM: {
-    event: EventType.TX_CONFIRM,
+    event: EventType.TX_CONFIRMED,
     action: 'Confirm transaction',
     category: TX_CATEGORY,
   },
   EXECUTE: {
-    event: EventType.TX_EXECUTE,
+    event: EventType.TX_EXECUTED,
     action: 'Execute transaction',
     category: TX_CATEGORY,
   },

--- a/src/services/analytics/events/wallet.ts
+++ b/src/services/analytics/events/wallet.ts
@@ -4,7 +4,7 @@ const WALLET_CATEGORY = 'wallet'
 
 export const WALLET_EVENTS = {
   CONNECT: {
-    event: EventType.META,
+    event: EventType.WALLET_CONNECTED,
     action: 'Connect wallet',
     category: WALLET_CATEGORY,
   },

--- a/src/services/analytics/gtm.ts
+++ b/src/services/analytics/gtm.ts
@@ -80,7 +80,7 @@ export const gtmDisableCookies = TagManager.disableCookies
 export const gtmSetUserProperty = TagManager.setUserProperty
 
 type GtmEvent = {
-  event: string
+  event: EventType
   chainId: string
   deviceType: DeviceType
   abTest?: AbTest

--- a/src/services/analytics/types.ts
+++ b/src/services/analytics/types.ts
@@ -9,9 +9,9 @@ export enum EventType {
   SAFE_CREATED = 'safe_created',
   SAFE_OPENED = 'safe_opened',
   WALLET_CONNECTED = 'wallet_connected',
-  TX_CREATE = 'tx_create',
-  TX_CONFIRM = 'tx_confirm',
-  TX_EXECUTE = 'tx_execute',
+  TX_CREATED = 'tx_created',
+  TX_CONFIRMED = 'tx_confirmed',
+  TX_EXECUTED = 'tx_executed',
 }
 
 export type EventLabel = string | number | boolean | null

--- a/src/services/analytics/types.ts
+++ b/src/services/analytics/types.ts
@@ -6,12 +6,18 @@ export enum EventType {
   CLICK = 'customClick',
   META = 'metadata',
   SAFE_APP = 'safeApp',
+  SAFE_CREATED = 'safe_created',
+  SAFE_OPENED = 'safe_opened',
+  WALLET_CONNECTED = 'wallet_connected',
+  TX_CREATE = 'tx_create',
+  TX_CONFIRM = 'tx_confirm',
+  TX_EXECUTE = 'tx_execute',
 }
 
 export type EventLabel = string | number | boolean | null
 
 export type AnalyticsEvent = {
-  event?: string
+  event?: EventType
   category: string
   action: string
   label?: EventLabel


### PR DESCRIPTION
* I've formalized the key event types in an enum
* Renamed tx events to past tense to match the existing events
* Added SAFE_CREATED, SAFE_OPENED and WALLET_CONNECTED. They were previously tracked via GTM by eventAction:

<img width="1106" alt="Screenshot 2024-01-09 at 11 45 37" src="https://github.com/safe-global/safe-wallet-web/assets/381895/dc38526e-c4f1-437b-82f0-6e8c57ea55e7">

When this change is released, we'll need to remove that config on GTM.

## How to test it

* Go to the /welcome page
* Open the console
* Open one of the Safes in the sidebar
* Observe a `[GTM]` event in the console with `eventName: 'safe_opened'`

The same for wallet_connected, safe_created, tx_created, tx_confirmed and tx_executed.
