### PR TITLE
Fix: don't treat user rejections as errors

### DIFF
--- a/src/components/tx-flow/flows/ExecuteBatch/ReviewBatch.tsx
+++ b/src/components/tx-flow/flows/ExecuteBatch/ReviewBatch.tsx
@@ -33,10 +33,13 @@ import { hasFeature } from '@/utils/chains'
 import type { PayableOverrides } from 'ethers'
 import { trackEvent } from '@/services/analytics'
 import { TX_EVENTS, TX_TYPES } from '@/services/analytics/events/transactions'
+import { isWalletRejection } from '@/utils/wallets'
+import WalletRejectionError from '@/components/tx/SignOrExecuteForm/WalletRejectionError'
 
 export const ReviewBatch = ({ params }: { params: ExecuteBatchFlowProps }) => {
   const [isSubmittable, setIsSubmittable] = useState<boolean>(true)
   const [submitError, setSubmitError] = useState<Error | undefined>()
+  const [isRejectedByUser, setIsRejectedByUser] = useState<Boolean>(false)
   const [executionMethod, setExecutionMethod] = useState(ExecutionMethod.RELAY)
   const chain = useCurrentChain()
   const { safe } = useSafeInfo()
@@ -108,15 +111,21 @@ export const ReviewBatch = ({ params }: { params: ExecuteBatchFlowProps }) => {
     e.preventDefault()
     setIsSubmittable(false)
     setSubmitError(undefined)
+    setIsRejectedByUser(false)
 
     try {
       await (willRelay ? onRelay() : onExecute())
       setTxFlow(undefined)
     } catch (_err) {
       const err = asError(_err)
-      logError(Errors._804, err)
+      if (isWalletRejection(err)) {
+        setIsRejectedByUser(true)
+      } else {
+        logError(Errors._804, err)
+        setSubmitError(err)
+      }
+
       setIsSubmittable(true)
-      setSubmitError(err)
       return
     }
 
@@ -189,6 +198,8 @@ export const ReviewBatch = ({ params }: { params: ExecuteBatchFlowProps }) => {
         {submitError && (
           <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
         )}
+
+        {isRejectedByUser && <WalletRejectionError />}
 
         <div>
           <Divider className={commonCss.nestedDivider} sx={{ pt: 2 }} />

--- a/src/components/tx-flow/flows/RecoverAccount/RecoverAccountFlowReview.tsx
+++ b/src/components/tx-flow/flows/RecoverAccount/RecoverAccountFlowReview.tsx
@@ -169,11 +169,7 @@ export function RecoverAccountFlowReview({ params }: { params: RecoverAccountFlo
           </ErrorMessage>
         )}
 
-        {isRejectedByUser && (
-          <Box mt={1}>
-            <WalletRejectionError />
-          </Box>
-        )}
+        {isRejectedByUser && <WalletRejectionError />}
 
         <Divider className={commonCss.nestedDivider} />
 

--- a/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
+++ b/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
@@ -100,12 +100,12 @@ const MessageDialogError = ({ isOwner, submitError }: { isOwner: boolean; submit
     !wallet || !onboard
       ? 'No wallet is connected.'
       : !isOwner
-        ? "You are currently not an owner of this Safe Account and won't be able to confirm this message."
-        : submitError && 'code' in submitError && submitError.code === ErrorCode.ACTION_REJECTED
-          ? "You've rejected the transaction."
-          : submitError
-            ? 'Error confirming the message. Please try again.'
-            : null
+      ? "You are currently not an owner of this Safe Account and won't be able to confirm this message."
+      : submitError && 'code' in submitError && submitError.code === ErrorCode.ACTION_REJECTED
+      ? "You've rejected the transaction."
+      : submitError
+      ? 'Error confirming the message. Please try again.'
+      : null
 
   if (errorMessage) {
     return <ErrorMessage>{errorMessage}</ErrorMessage>

--- a/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
+++ b/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
@@ -44,6 +44,7 @@ import { SafeTxContext } from '../../SafeTxProvider'
 import RiskConfirmationError from '@/components/tx/SignOrExecuteForm/RiskConfirmationError'
 import { Redefine } from '@/components/tx/security/redefine'
 import { TxSecurityContext } from '@/components/tx/security/shared/TxSecurityContext'
+import { ErrorCode } from '@ethersproject/logger'
 
 const createSkeletonMessage = (confirmationsRequired: number): SafeMessage => {
   return {
@@ -99,10 +100,12 @@ const MessageDialogError = ({ isOwner, submitError }: { isOwner: boolean; submit
     !wallet || !onboard
       ? 'No wallet is connected.'
       : !isOwner
-      ? "You are currently not an owner of this Safe Account and won't be able to confirm this message."
-      : submitError
-      ? 'Error confirming the message. Please try again.'
-      : null
+        ? "You are currently not an owner of this Safe Account and won't be able to confirm this message."
+        : submitError && 'code' in submitError && submitError.code === ErrorCode.ACTION_REJECTED
+          ? "You've rejected the transaction."
+          : submitError
+            ? 'Error confirming the message. Please try again.'
+            : null
 
   if (errorMessage) {
     return <ErrorMessage>{errorMessage}</ErrorMessage>

--- a/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
+++ b/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
@@ -45,6 +45,7 @@ import RiskConfirmationError from '@/components/tx/SignOrExecuteForm/RiskConfirm
 import { Redefine } from '@/components/tx/security/redefine'
 import { TxSecurityContext } from '@/components/tx/security/shared/TxSecurityContext'
 import { ErrorCode } from '@ethersproject/logger'
+import { isWalletRejection } from '@/utils/wallets'
 
 const createSkeletonMessage = (confirmationsRequired: number): SafeMessage => {
   return {
@@ -101,7 +102,7 @@ const MessageDialogError = ({ isOwner, submitError }: { isOwner: boolean; submit
       ? 'No wallet is connected.'
       : !isOwner
       ? "You are currently not an owner of this Safe Account and won't be able to confirm this message."
-      : submitError && 'code' in submitError && submitError.code === ErrorCode.ACTION_REJECTED
+      : submitError && isWalletRejection(submitError)
       ? "You've rejected the transaction."
       : submitError
       ? 'Error confirming the message. Please try again.'

--- a/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
+++ b/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
@@ -44,7 +44,6 @@ import { SafeTxContext } from '../../SafeTxProvider'
 import RiskConfirmationError from '@/components/tx/SignOrExecuteForm/RiskConfirmationError'
 import { Redefine } from '@/components/tx/security/redefine'
 import { TxSecurityContext } from '@/components/tx/security/shared/TxSecurityContext'
-import { ErrorCode } from '@ethersproject/logger'
 import { isWalletRejection } from '@/utils/wallets'
 
 const createSkeletonMessage = (confirmationsRequired: number): SafeMessage => {

--- a/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
+++ b/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
@@ -102,7 +102,7 @@ const MessageDialogError = ({ isOwner, submitError }: { isOwner: boolean; submit
       : !isOwner
       ? "You are currently not an owner of this Safe Account and won't be able to confirm this message."
       : submitError && isWalletRejection(submitError)
-      ? "You've rejected the transaction."
+      ? 'User rejected signing.'
       : submitError
       ? 'Error confirming the message. Please try again.'
       : null

--- a/src/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx.tsx
@@ -102,13 +102,12 @@ const ReviewSpendingLimitTx = ({
     } catch (_err) {
       const err = asError(_err)
       if (isWalletRejection(err)) {
-        setIsSubmittable(true)
         setIsRejectedByUser(true)
       } else {
         logError(Errors._801, err)
-        setIsSubmittable(true)
         setSubmitError(err)
       }
+      setIsSubmittable(true)
     }
 
     trackEvent({ ...TX_EVENTS.CREATE, label: TX_TYPES.transfer_token })

--- a/src/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx.tsx
@@ -26,7 +26,6 @@ import TxCard from '@/components/tx-flow/common/TxCard'
 import { TxModalContext } from '@/components/tx-flow'
 import { type SubmitCallback } from '@/components/tx/SignOrExecuteForm'
 import { TX_EVENTS, TX_TYPES } from '@/services/analytics/events/transactions'
-import { ErrorCode } from '@ethersproject/logger'
 import { isWalletRejection } from '@/utils/wallets'
 
 export type SpendingLimitTxParams = {

--- a/src/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx.tsx
@@ -20,7 +20,6 @@ import { getTxOptions } from '@/utils/transactions'
 import { MODALS_EVENTS, trackEvent } from '@/services/analytics'
 import useOnboard from '@/hooks/wallets/useOnboard'
 import { WrongChainWarning } from '@/components/tx/WrongChainWarning'
-import { asError } from '@/services/exceptions/utils'
 import TxCard from '@/components/tx-flow/common/TxCard'
 import { TxModalContext } from '@/components/tx-flow'
 import { type SubmitCallback } from '@/components/tx/SignOrExecuteForm'
@@ -137,9 +136,7 @@ const ReviewSpendingLimitTx = ({
           <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
         )}
 
-        {isRejectedByUser && (
-          <ErrorMessage>You've rejected the transaction.</ErrorMessage>
-        )}
+        {isRejectedByUser && <ErrorMessage>{`You've rejected the transaction.`}</ErrorMessage>}
 
         <Typography variant="body2" color="primary.light" textAlign="center">
           You&apos;re about to create a transaction and will need to confirm it with your currently connected wallet.

--- a/src/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx.tsx
@@ -20,11 +20,11 @@ import { getTxOptions } from '@/utils/transactions'
 import { MODALS_EVENTS, trackEvent } from '@/services/analytics'
 import useOnboard from '@/hooks/wallets/useOnboard'
 import { WrongChainWarning } from '@/components/tx/WrongChainWarning'
+import { asError } from '@/services/exceptions/utils'
 import TxCard from '@/components/tx-flow/common/TxCard'
 import { TxModalContext } from '@/components/tx-flow'
 import { type SubmitCallback } from '@/components/tx/SignOrExecuteForm'
 import { TX_EVENTS, TX_TYPES } from '@/services/analytics/events/transactions'
-import { type EthersError } from '@/utils/ethers-utils'
 import { ErrorCode } from '@ethersproject/logger'
 
 export type SpendingLimitTxParams = {
@@ -98,8 +98,8 @@ const ReviewSpendingLimitTx = ({
       onSubmit('', true)
       setTxFlow(undefined)
     } catch (_err) {
-      const err = _err as EthersError
-      if (err.code === ErrorCode.ACTION_REJECTED) {
+      const err = asError(_err)
+      if ('code' in err && err.code === ErrorCode.ACTION_REJECTED) {
         setIsSubmittable(true)
         setIsRejectedByUser(true)
       } else {

--- a/src/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx.tsx
@@ -14,6 +14,7 @@ import { EMPTY_DATA, ZERO_ADDRESS } from '@safe-global/safe-core-sdk/dist/src/ut
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { Errors, logError } from '@/services/exceptions'
 import ErrorMessage from '@/components/tx/ErrorMessage'
+import WalletRejectionError from '@/components/tx/SignOrExecuteForm/WalletRejectionError'
 import { useCurrentChain } from '@/hooks/useChains'
 import { dispatchSpendingLimitTxExecution } from '@/services/tx/tx-sender'
 import { getTxOptions } from '@/utils/transactions'
@@ -26,6 +27,7 @@ import { TxModalContext } from '@/components/tx-flow'
 import { type SubmitCallback } from '@/components/tx/SignOrExecuteForm'
 import { TX_EVENTS, TX_TYPES } from '@/services/analytics/events/transactions'
 import { ErrorCode } from '@ethersproject/logger'
+import { isWalletRejection } from '@/utils/wallets'
 
 export type SpendingLimitTxParams = {
   safeAddress: string
@@ -99,7 +101,7 @@ const ReviewSpendingLimitTx = ({
       setTxFlow(undefined)
     } catch (_err) {
       const err = asError(_err)
-      if ('code' in err && err.code === ErrorCode.ACTION_REJECTED) {
+      if (isWalletRejection(err)) {
         setIsSubmittable(true)
         setIsRejectedByUser(true)
       } else {
@@ -136,7 +138,7 @@ const ReviewSpendingLimitTx = ({
           <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
         )}
 
-        {isRejectedByUser && <ErrorMessage>{`You've rejected the transaction.`}</ErrorMessage>}
+        {isRejectedByUser && <WalletRejectionError />}
 
         <Typography variant="body2" color="primary.light" textAlign="center">
           You&apos;re about to create a transaction and will need to confirm it with your currently connected wallet.

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -21,13 +21,13 @@ import { TxModalContext } from '@/components/tx-flow'
 import { SuccessScreenFlow } from '@/components/tx-flow/flows'
 import useGasLimit from '@/hooks/useGasLimit'
 import AdvancedParams, { useAdvancedParams } from '../AdvancedParams'
+import { asError } from '@/services/exceptions/utils'
 
 import css from './styles.module.css'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
 import { TxSecurityContext } from '../security/shared/TxSecurityContext'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import NonOwnerError from '@/components/tx/SignOrExecuteForm/NonOwnerError'
-import { type EthersError } from '@/utils/ethers-utils'
 import { ErrorCode } from '@ethersproject/logger'
 
 export const ExecuteForm = ({
@@ -98,8 +98,8 @@ export const ExecuteForm = ({
     try {
       executedTxId = await executeTx(txOptions, safeTx, txId, origin, willRelay)
     } catch (_err) {
-      const err = _err as EthersError
-      if (err.code === ErrorCode.ACTION_REJECTED) {
+      const err = asError(_err)
+      if ('code' in err && err.code === ErrorCode.ACTION_REJECTED) {
         setIsSubmittable(true)
         setIsRejectedByUser(true)
       } else {

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -180,7 +180,7 @@ export const ExecuteForm = ({
 
         {isRejectedByUser && (
           <Box mt={1}>
-            <ErrorMessage>The transaction was rejected by the user.</ErrorMessage>
+            <ErrorMessage>You've rejected the transaction.</ErrorMessage>
           </Box>
         )}
 

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -30,7 +30,6 @@ import { TxSecurityContext } from '../security/shared/TxSecurityContext'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import NonOwnerError from '@/components/tx/SignOrExecuteForm/NonOwnerError'
 import WalletRejectionError from '@/components/tx/SignOrExecuteForm/WalletRejectionError'
-import { ErrorCode } from '@ethersproject/logger'
 
 export const ExecuteForm = ({
   safeTx,

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -21,7 +21,6 @@ import { TxModalContext } from '@/components/tx-flow'
 import { SuccessScreenFlow } from '@/components/tx-flow/flows'
 import useGasLimit from '@/hooks/useGasLimit'
 import AdvancedParams, { useAdvancedParams } from '../AdvancedParams'
-import { asError } from '@/services/exceptions/utils'
 
 import css from './styles.module.css'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
@@ -103,7 +102,7 @@ export const ExecuteForm = ({
       const err = _err as EthersError
       if (err.code === ErrorCode.ACTION_REJECTED) {
         setIsSubmittable(true)
-        setIsRejectedByUser(true);
+        setIsRejectedByUser(true)
       } else {
         trackError(Errors._804, err)
         setIsSubmittable(true)

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -22,12 +22,14 @@ import { SuccessScreenFlow } from '@/components/tx-flow/flows'
 import useGasLimit from '@/hooks/useGasLimit'
 import AdvancedParams, { useAdvancedParams } from '../AdvancedParams'
 import { asError } from '@/services/exceptions/utils'
+import { isWalletRejection } from '@/utils/wallets'
 
 import css from './styles.module.css'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
 import { TxSecurityContext } from '../security/shared/TxSecurityContext'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import NonOwnerError from '@/components/tx/SignOrExecuteForm/NonOwnerError'
+import WalletRejectionError from '@/components/tx/SignOrExecuteForm/WalletRejectionError'
 import { ErrorCode } from '@ethersproject/logger'
 
 export const ExecuteForm = ({
@@ -99,7 +101,7 @@ export const ExecuteForm = ({
       executedTxId = await executeTx(txOptions, safeTx, txId, origin, willRelay)
     } catch (_err) {
       const err = asError(_err)
-      if ('code' in err && err.code === ErrorCode.ACTION_REJECTED) {
+      if (isWalletRejection(err)) {
         setIsSubmittable(true)
         setIsRejectedByUser(true)
       } else {
@@ -180,7 +182,7 @@ export const ExecuteForm = ({
 
         {isRejectedByUser && (
           <Box mt={1}>
-            <ErrorMessage>{`You've rejected the transaction.`}</ErrorMessage>
+            <WalletRejectionError />
           </Box>
         )}
 

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -30,7 +30,6 @@ import NonOwnerError from '@/components/tx/SignOrExecuteForm/NonOwnerError'
 import { type EthersError } from '@/utils/ethers-utils'
 import { ErrorCode } from '@ethersproject/logger'
 
-
 export const ExecuteForm = ({
   safeTx,
   txId,
@@ -108,7 +107,6 @@ export const ExecuteForm = ({
         setIsSubmittable(true)
         setSubmitError(err)
       }
-
       return
     }
 

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -102,13 +102,12 @@ export const ExecuteForm = ({
     } catch (_err) {
       const err = asError(_err)
       if (isWalletRejection(err)) {
-        setIsSubmittable(true)
         setIsRejectedByUser(true)
       } else {
         trackError(Errors._804, err)
-        setIsSubmittable(true)
         setSubmitError(err)
       }
+      setIsSubmittable(true)
       return
     }
 

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -180,7 +180,7 @@ export const ExecuteForm = ({
 
         {isRejectedByUser && (
           <Box mt={1}>
-            <ErrorMessage>You've rejected the transaction.</ErrorMessage>
+            <ErrorMessage>{`You've rejected the transaction.`}</ErrorMessage>
           </Box>
         )}
 

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -107,7 +107,7 @@ export const SignForm = ({
 
       {isRejectedByUser && (
         <Box mt={1}>
-          <ErrorMessage>You've rejected the transaction.</ErrorMessage>
+          <ErrorMessage>{`You've rejected the transaction.`}</ErrorMessage>
         </Box>
       )}
 

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -10,7 +10,6 @@ import { useAlreadySigned, useTxActions } from './hooks'
 import type { SignOrExecuteProps } from '.'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { TxModalContext } from '@/components/tx-flow'
-import { asError } from '@/services/exceptions/utils'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
 import { TxSecurityContext } from '../security/shared/TxSecurityContext'
 import NonOwnerError from '@/components/tx/SignOrExecuteForm/NonOwnerError'
@@ -61,7 +60,6 @@ export const SignForm = ({
     setIsSubmittable(false)
     setSubmitError(undefined)
     setIsRejectedByUser(false)
-
 
     let resultTxId: string
     try {

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -13,8 +13,10 @@ import { TxModalContext } from '@/components/tx-flow'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
 import { TxSecurityContext } from '../security/shared/TxSecurityContext'
 import NonOwnerError from '@/components/tx/SignOrExecuteForm/NonOwnerError'
+import WalletRejectionError from '@/components/tx/SignOrExecuteForm/WalletRejectionError'
 import BatchButton from './BatchButton'
 import { asError } from '@/services/exceptions/utils'
+import { isWalletRejection } from '@/utils/wallets'
 import { ErrorCode } from '@ethersproject/logger'
 
 export const SignForm = ({
@@ -66,7 +68,7 @@ export const SignForm = ({
       resultTxId = await (isAddingToBatch ? addToBatch(safeTx, origin) : signTx(safeTx, txId, origin))
     } catch (_err) {
       const err = asError(_err)
-      if ('code' in err && err.code === ErrorCode.ACTION_REJECTED) {
+      if (isWalletRejection(err)) {
         setIsSubmittable(true)
         setIsRejectedByUser(true)
       } else {
@@ -107,7 +109,7 @@ export const SignForm = ({
 
       {isRejectedByUser && (
         <Box mt={1}>
-          <ErrorMessage>{`You've rejected the transaction.`}</ErrorMessage>
+          <WalletRejectionError />
         </Box>
       )}
 

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -69,13 +69,12 @@ export const SignForm = ({
     } catch (_err) {
       const err = asError(_err)
       if (isWalletRejection(err)) {
-        setIsSubmittable(true)
         setIsRejectedByUser(true)
       } else {
         trackError(Errors._804, err)
-        setIsSubmittable(true)
         setSubmitError(err)
       }
+      setIsSubmittable(true)
       return
     }
 

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -17,7 +17,6 @@ import WalletRejectionError from '@/components/tx/SignOrExecuteForm/WalletReject
 import BatchButton from './BatchButton'
 import { asError } from '@/services/exceptions/utils'
 import { isWalletRejection } from '@/utils/wallets'
-import { ErrorCode } from '@ethersproject/logger'
 
 export const SignForm = ({
   safeTx,

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -14,7 +14,7 @@ import commonCss from '@/components/tx-flow/common/styles.module.css'
 import { TxSecurityContext } from '../security/shared/TxSecurityContext'
 import NonOwnerError from '@/components/tx/SignOrExecuteForm/NonOwnerError'
 import BatchButton from './BatchButton'
-import { type EthersError } from '@/utils/ethers-utils'
+import { asError } from '@/services/exceptions/utils'
 import { ErrorCode } from '@ethersproject/logger'
 
 export const SignForm = ({
@@ -65,8 +65,8 @@ export const SignForm = ({
     try {
       resultTxId = await (isAddingToBatch ? addToBatch(safeTx, origin) : signTx(safeTx, txId, origin))
     } catch (_err) {
-      const err = _err as EthersError
-      if (err.code === ErrorCode.ACTION_REJECTED) {
+      const err = asError(_err)
+      if ('code' in err && err.code === ErrorCode.ACTION_REJECTED) {
         setIsSubmittable(true)
         setIsRejectedByUser(true)
       } else {

--- a/src/components/tx/SignOrExecuteForm/WalletRejectionError.tsx
+++ b/src/components/tx/SignOrExecuteForm/WalletRejectionError.tsx
@@ -1,7 +1,7 @@
 import ErrorMessage from '@/components/tx/ErrorMessage'
 
 const WalletRejectionError = () => {
-  return <ErrorMessage>You&apos;ve rejected the transaction.</ErrorMessage>
+  return <ErrorMessage>User rejected signing.</ErrorMessage>
 }
 
 export default WalletRejectionError

--- a/src/components/tx/SignOrExecuteForm/WalletRejectionError.tsx
+++ b/src/components/tx/SignOrExecuteForm/WalletRejectionError.tsx
@@ -1,0 +1,7 @@
+import ErrorMessage from '@/components/tx/ErrorMessage'
+
+const WalletRejectionError = () => {
+  return <ErrorMessage>You&apos;ve rejected the transaction.</ErrorMessage>
+}
+
+export default WalletRejectionError

--- a/src/features/recovery/hooks/useRecoveryTxNotification.ts
+++ b/src/features/recovery/hooks/useRecoveryTxNotification.ts
@@ -7,6 +7,7 @@ import useSafeAddress from '../../../hooks/useSafeAddress'
 import { RecoveryEvent, RecoveryTxType, recoverySubscribe } from '@/features/recovery/services/recoveryEvents'
 import { getExplorerLink } from '@/utils/gateway'
 import { useCurrentChain } from '../../../hooks/useChains'
+import { isWalletRejection } from '@/utils/wallets'
 
 const SUCCESS_EVENTS = [
   RecoveryEvent.PROCESSING_BY_SMART_CONTRACT_WALLET,
@@ -49,6 +50,7 @@ export function useRecoveryTxNotifications(): void {
       recoverySubscribe(event, async (detail) => {
         const isSuccess = SUCCESS_EVENTS.includes(event)
         const isError = 'error' in detail
+        if (isError && isWalletRejection(detail.error)) return
 
         const txHash = 'txHash' in detail ? detail.txHash : undefined
         const recoveryTxHash = 'recoveryTxHash' in detail ? detail.recoveryTxHash : undefined

--- a/src/hooks/messages/useSafeMessageNotifications.ts
+++ b/src/hooks/messages/useSafeMessageNotifications.ts
@@ -15,7 +15,6 @@ import useWallet from '@/hooks/wallets/useWallet'
 import { useCurrentChain } from '@/hooks/useChains'
 import useSafeAddress from '@/hooks/useSafeAddress'
 import type { PendingSafeMessagesState } from '@/store/pendingSafeMessagesSlice'
-import { ErrorCode } from '@ethersproject/logger'
 import { isWalletRejection } from '@/utils/wallets'
 
 const SafeMessageNotifications: Partial<Record<SafeMsgEvent, string>> = {
@@ -25,7 +24,6 @@ const SafeMessageNotifications: Partial<Record<SafeMsgEvent, string>> = {
   [SafeMsgEvent.CONFIRM_PROPOSE_FAILED]: 'Confirming the message failed. Please try again.',
   [SafeMsgEvent.SIGNATURE_PREPARED]: 'The message was successfully confirmed.',
 }
-
 
 export const _getSafeMessagesAwaitingConfirmations = (
   items: SafeMessageListItem[],

--- a/src/hooks/messages/useSafeMessageNotifications.ts
+++ b/src/hooks/messages/useSafeMessageNotifications.ts
@@ -16,6 +16,7 @@ import { useCurrentChain } from '@/hooks/useChains'
 import useSafeAddress from '@/hooks/useSafeAddress'
 import type { PendingSafeMessagesState } from '@/store/pendingSafeMessagesSlice'
 import { ErrorCode } from '@ethersproject/logger'
+import { isWalletRejection } from '@/utils/wallets'
 
 const SafeMessageNotifications: Partial<Record<SafeMsgEvent, string>> = {
   [SafeMsgEvent.PROPOSE]: 'You successfully signed the message.',
@@ -25,9 +26,6 @@ const SafeMessageNotifications: Partial<Record<SafeMsgEvent, string>> = {
   [SafeMsgEvent.SIGNATURE_PREPARED]: 'The message was successfully confirmed.',
 }
 
-const isUserRejection = (error: Error) => {
-  return 'code' in error && error.code === ErrorCode.ACTION_REJECTED
-}
 
 export const _getSafeMessagesAwaitingConfirmations = (
   items: SafeMessageListItem[],
@@ -55,7 +53,7 @@ const useSafeMessageNotifications = () => {
     const unsubFns = entries.map(([event, baseMessage]) =>
       safeMsgSubscribe(event, (detail) => {
         const isError = 'error' in detail
-        if (isError && isUserRejection(detail.error)) return
+        if (isError && isWalletRejection(detail.error)) return
         const isSuccess = event === SafeMsgEvent.PROPOSE || event === SafeMsgEvent.SIGNATURE_PREPARED
         const message = isError ? `${baseMessage}${formatError(detail.error)}` : baseMessage
 

--- a/src/hooks/useTxNotifications.ts
+++ b/src/hooks/useTxNotifications.ts
@@ -15,7 +15,6 @@ import useWallet from './wallets/useWallet'
 import useSafeAddress from './useSafeAddress'
 import { getExplorerLink } from '@/utils/gateway'
 import { getTxDetails } from '@/services/tx/txDetails'
-import { ErrorCode } from '@ethersproject/logger'
 import { isWalletRejection } from '@/utils/wallets'
 
 const TxNotifications = {

--- a/src/hooks/useTxNotifications.ts
+++ b/src/hooks/useTxNotifications.ts
@@ -16,6 +16,7 @@ import useSafeAddress from './useSafeAddress'
 import { getExplorerLink } from '@/utils/gateway'
 import { getTxDetails } from '@/services/tx/txDetails'
 import { ErrorCode } from '@ethersproject/logger'
+import { isWalletRejection } from '@/utils/wallets'
 
 const TxNotifications = {
   [TxEvent.SIGN_FAILED]: 'Failed to sign. Please try again.',
@@ -41,10 +42,6 @@ enum Variant {
 }
 
 const successEvents = [TxEvent.PROPOSED, TxEvent.SIGNATURE_PROPOSED, TxEvent.ONCHAIN_SIGNATURE_SUCCESS, TxEvent.SUCCESS]
-
-const isUserRejection = (error: Error) => {
-  return 'code' in error && error.code === ErrorCode.ACTION_REJECTED
-}
 
 export const getTxLink = (
   txId: string,
@@ -77,7 +74,7 @@ const useTxNotifications = (): void => {
     const unsubFns = entries.map(([event, baseMessage]) =>
       txSubscribe(event, async (detail) => {
         const isError = 'error' in detail
-        if (isError && isUserRejection(detail.error)) return
+        if (isError && isWalletRejection(detail.error)) return
         const isSuccess = successEvents.includes(event)
         const message = isError ? `${baseMessage} ${formatError(detail.error)}` : baseMessage
         const txId = 'txId' in detail ? detail.txId : undefined

--- a/src/hooks/useTxNotifications.ts
+++ b/src/hooks/useTxNotifications.ts
@@ -17,7 +17,6 @@ import { getExplorerLink } from '@/utils/gateway'
 import { getTxDetails } from '@/services/tx/txDetails'
 import { ErrorCode } from '@ethersproject/logger'
 
-
 const TxNotifications = {
   [TxEvent.SIGN_FAILED]: 'Failed to sign. Please try again.',
   [TxEvent.PROPOSED]: 'Successfully added to queue.',
@@ -91,7 +90,7 @@ const useTxNotifications = (): void => {
           try {
             const txDetails = await getTxDetails(chain.chainId, id)
             humanDescription = txDetails.txInfo.humanDescription || humanDescription
-          } catch { }
+          } catch {}
         }
 
         dispatch(
@@ -104,8 +103,8 @@ const useTxNotifications = (): void => {
             link: txId
               ? getTxLink(txId, chain, safeAddress)
               : txHash
-                ? getExplorerLink(txHash, chain.blockExplorerUriTemplate)
-                : undefined,
+              ? getExplorerLink(txHash, chain.blockExplorerUriTemplate)
+              : undefined,
           }),
         )
       }),

--- a/src/hooks/useTxNotifications.ts
+++ b/src/hooks/useTxNotifications.ts
@@ -41,11 +41,11 @@ enum Variant {
   ERROR = 'error',
 }
 
+const successEvents = [TxEvent.PROPOSED, TxEvent.SIGNATURE_PROPOSED, TxEvent.ONCHAIN_SIGNATURE_SUCCESS, TxEvent.SUCCESS]
+
 const isUserRejection = (error: Error) => {
   return 'code' in error && error.code === ErrorCode.ACTION_REJECTED
 }
-
-const successEvents = [TxEvent.PROPOSED, TxEvent.SIGNATURE_PROPOSED, TxEvent.ONCHAIN_SIGNATURE_SUCCESS, TxEvent.SUCCESS]
 
 export const getTxLink = (
   txId: string,
@@ -78,9 +78,7 @@ const useTxNotifications = (): void => {
     const unsubFns = entries.map(([event, baseMessage]) =>
       txSubscribe(event, async (detail) => {
         const isError = 'error' in detail
-        if (isError && isUserRejection(detail.error)) {
-          return
-        }
+        if (isError && isUserRejection(detail.error)) return
         const isSuccess = successEvents.includes(event)
         const message = isError ? `${baseMessage} ${formatError(detail.error)}` : baseMessage
         const txId = 'txId' in detail ? detail.txId : undefined

--- a/src/services/tx/tx-sender/dispatch.ts
+++ b/src/services/tx/tx-sender/dispatch.ts
@@ -1,5 +1,6 @@
 import type { SafeInfo, TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 import type { SafeTransaction, TransactionOptions, TransactionResult } from '@safe-global/safe-core-sdk-types'
+import type { EthersError } from '@/utils/ethers-utils'
 import { didReprice, didRevert } from '@/utils/ethers-utils'
 import type MultiSendCallOnlyEthersContract from '@safe-global/safe-ethers-lib/dist/src/contracts/MultiSendCallOnly/MultiSendCallOnlyEthersContract'
 import { type SpendingLimitTxParams } from '@/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx'
@@ -162,7 +163,9 @@ export const dispatchTxExecution = async (
       }
     })
     .catch((err) => {
-      if (didReprice(err)) {
+      const error = err as EthersError
+
+      if (didReprice(error)) {
         txDispatch(TxEvent.PROCESSED, { ...eventParams, safeAddress })
       } else {
         txDispatch(TxEvent.FAILED, { ...eventParams, error: asError(error) })
@@ -227,8 +230,9 @@ export const dispatchBatchExecution = async (
       }
     })
     .catch((err) => {
+      const error = err as EthersError
 
-      if (didReprice(err)) {
+      if (didReprice(error)) {
         txs.forEach(({ txId }) => {
           txDispatch(TxEvent.PROCESSED, {
             txId,

--- a/src/services/tx/tx-sender/dispatch.ts
+++ b/src/services/tx/tx-sender/dispatch.ts
@@ -22,6 +22,7 @@ import {
 import { createWeb3 } from '@/hooks/wallets/web3'
 import { type OnboardAPI } from '@web3-onboard/core'
 import { asError } from '@/services/exceptions/utils'
+import { ErrorCode } from '@ethersproject/logger'
 
 /**
  * Propose a transaction
@@ -85,10 +86,12 @@ export const dispatchTxSigning = async (
   try {
     signedTx = await tryOffChainTxSigning(safeTx, safeVersion, sdk)
   } catch (error) {
-    txDispatch(TxEvent.SIGN_FAILED, {
-      txId,
-      error: asError(error),
-    })
+    if ((error as EthersError).code !== ErrorCode.ACTION_REJECTED) {
+      txDispatch(TxEvent.SIGN_FAILED, {
+        txId,
+        error: asError(error),
+      })
+    }
     throw error
   }
 


### PR DESCRIPTION
## What it solves

Resolves #2701

## How this PR fixes it
When a user rejects a transaction through their connected wallet:
- do not log it as an error to sentry.
- do not send the user an error notification.
- Show `The transaction was rejected by the user.` in the tx execution box instead of a generic error message.

## How to test it
- Create a new transaction.
- When you are prompted to accept the transaction in Metamask, click reject.
- There should not be an error logged to sentry.
- There should be no error notification.
- The Execution box should say `The transaction was rejected by the user.`
- This will effect anywhere the user is prompted to accept or reject a transaction, including:
    - signing a tx
    - executing a tx
    - signing a message
    - batch txs
    - tx with spending limits
    - relayed txs
    - bulk txs
    - account recovery

## Screenshots
Before: 
<img width="1278" alt="Screenshot 2024-01-10 at 09 51 20" src="https://github.com/safe-global/safe-wallet-web/assets/17801424/c0d18f24-8cfb-46b2-9820-1a2ad7c7567a">

After:
<img width="1278" alt="Screenshot 2024-01-10 at 15 36 39" src="https://github.com/safe-global/safe-wallet-web/assets/17801424/e84b530d-9525-45e1-9627-4ed09368ed0a">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
