### PR TITLE
fix: [Spending Limit] estimate gas via readonly provider

### DIFF
--- a/src/hooks/useSpendingLimitGas.ts
+++ b/src/hooks/useSpendingLimitGas.ts
@@ -1,20 +1,23 @@
+import useWallet from '@/hooks/wallets/useWallet'
 import type { BigNumber } from 'ethers'
-import { useWeb3 } from '@/hooks/wallets/web3'
-import { getSpendingLimitContract } from '@/services/contracts/spendingLimitContracts'
+import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
+import { getSpendingLimitContract, getSpendingLimitInterface } from '@/services/contracts/spendingLimitContracts'
 import useAsync from '@/hooks/useAsync'
 import { type SpendingLimitTxParams } from '@/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx'
 import useChainId from '@/hooks/useChainId'
 
 const useSpendingLimitGas = (params: SpendingLimitTxParams) => {
   const chainId = useChainId()
-  const provider = useWeb3()
+  const provider = useWeb3ReadOnly()
+  const wallet = useWallet()
 
   const [gasLimit, gasLimitError, gasLimitLoading] = useAsync<BigNumber>(() => {
-    if (!provider) return
+    if (!provider || !wallet) return
 
-    const contract = getSpendingLimitContract(chainId, provider.getSigner())
+    const contract = getSpendingLimitContract(chainId, provider)
+    const spendingLimitInterface = getSpendingLimitInterface()
 
-    return contract.estimateGas.executeAllowanceTransfer(
+    const data = spendingLimitInterface.encodeFunctionData('executeAllowanceTransfer', [
       params.safeAddress,
       params.token,
       params.to,
@@ -23,8 +26,14 @@ const useSpendingLimitGas = (params: SpendingLimitTxParams) => {
       params.payment,
       params.delegate,
       params.signature,
-    )
-  }, [provider, chainId, params])
+    ])
+
+    return provider.estimateGas({
+      to: contract.address,
+      from: wallet.address,
+      data: data,
+    })
+  }, [provider, wallet, chainId, params])
 
   return { gasLimit, gasLimitError, gasLimitLoading }
 }


### PR DESCRIPTION
## What it solves

Resolves #3086

## How this PR fixes it

Estimates the `gasLimit` for spending limit transactions via the `web3ReadOnly` provider instead of through the connected wallet provider which could be on a different chain and thus make the estimation call fail.

## How to test it

1. Create a spending limit transaction
2. Switch wallet to a different network
3. Observe the gasLimit is still estimated
4. Switch wallet to the correct network
5. Observe the gasLimit is still estimated
6. Make sure the transaction executes

## Screenshots
<img width="701" alt="Screenshot 2024-01-10 at 16 17 43" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/4372ced6-247e-49ae-af45-cfcfa043610d">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
