### PR TITLE
Tests: add tests for spending limits

### DIFF
--- a/cypress/e2e/pages/create_tx.pages.js
+++ b/cypress/e2e/pages/create_tx.pages.js
@@ -26,8 +26,12 @@ const advancedDetails = '[data-testid="tx-advanced-details"]'
 const baseGas = '[data-testid="tx-bas-gas"]'
 const requiredConfirmation = '[data-testid="required-confirmations"]'
 const txDate = '[data-testid="tx-date"]'
+<<<<<<< HEAD
 const spamTokenWarningIcon = '[data-testid="warning"]'
 const untrustedTokenWarningModal = '[data-testid="untrusted-token-warning"]'
+=======
+const sendTokensBtn = '[data-testid="send-tokens-btn"]'
+>>>>>>> 0558d7e3 (tests: add tests for spending limits)
 
 const viewTransactionBtn = 'View transaction'
 const transactionDetailsTitle = 'Transaction details'
@@ -48,6 +52,9 @@ const signBtnStr = 'Sign'
 const expandAllBtnStr = 'Expand all'
 const collapseAllBtnStr = 'Collapse all'
 
+export function clickOnSendTokensBtn() {
+  cy.get(sendTokensBtn).click()
+}
 export function verifyNumberOfTransactions(count) {
   cy.get(txDate).should('have.length.at.least', count)
   cy.get(transactionItem).should('have.length.at.least', count)
@@ -234,10 +241,6 @@ export function verifyENSResolves(fullAddress) {
   let split = fullAddress.split(':')
   let noPrefixAddress = split[1]
   cy.get(recepientInput).should('have.value', noPrefixAddress)
-}
-
-export function clickOnSendTokensBtn() {
-  cy.contains(sendTokensBtnStr).click()
 }
 
 export function verifyRandomStringAddress(randomAddressString) {

--- a/cypress/e2e/pages/create_tx.pages.js
+++ b/cypress/e2e/pages/create_tx.pages.js
@@ -26,12 +26,9 @@ const advancedDetails = '[data-testid="tx-advanced-details"]'
 const baseGas = '[data-testid="tx-bas-gas"]'
 const requiredConfirmation = '[data-testid="required-confirmations"]'
 const txDate = '[data-testid="tx-date"]'
-<<<<<<< HEAD
 const spamTokenWarningIcon = '[data-testid="warning"]'
 const untrustedTokenWarningModal = '[data-testid="untrusted-token-warning"]'
-=======
 const sendTokensBtn = '[data-testid="send-tokens-btn"]'
->>>>>>> 0558d7e3 (tests: add tests for spending limits)
 
 const viewTransactionBtn = 'View transaction'
 const transactionDetailsTitle = 'Transaction details'

--- a/cypress/e2e/pages/load_safe.pages.js
+++ b/cypress/e2e/pages/load_safe.pages.js
@@ -2,7 +2,7 @@ import * as constants from '../../support/constants'
 
 const addExistingAccountBtnStr = 'Add existing one'
 const contactStr = 'Name, address & network'
-const invalidAddressFormatErrorMsg = 'Invalid address format'
+export const invalidAddressFormatErrorMsg = 'Invalid address format'
 const invalidAddressNameLengthErrorMsg = 'Maximum 50 symbols'
 
 const safeDataForm = '[data-testid=load-safe-form]'

--- a/cypress/e2e/pages/main.page.js
+++ b/cypress/e2e/pages/main.page.js
@@ -59,6 +59,13 @@ export function checkTextsExistWithinElement(element, texts) {
   })
 }
 
+export function checkRadioButtonState(selector, state) {
+  if (state === constants.checkboxStates.checked) {
+    cy.get(selector).should('be.checked')
+  } else state === constants.checkboxStates.unchecked
+  cy.get(selector).should('not.be.checked')
+}
+
 export function verifyCheckboxeState(element, index, state) {
   cy.get(element).eq(index).should(state)
 }
@@ -150,5 +157,12 @@ export function addToLocalStorage(key, jsonValue) {
     } catch (error) {
       reject('Error adding item to local storage: ' + error)
     }
+  })
+}
+
+export function checkTextOrder(selector, expectedTextArray) {
+  cy.get(selector).each((element, index) => {
+    const text = Cypress.$(element).text().trim()
+    expect(text).to.eq(expectedTextArray[index])
   })
 }

--- a/cypress/e2e/pages/navigation.page.js
+++ b/cypress/e2e/pages/navigation.page.js
@@ -2,6 +2,7 @@ export const sideNavSettingsIcon = '[data-testid="settings-nav-icon"]'
 export const setupSection = '[data-testid="setup-section"]'
 export const modalBackBtn = '[data-testid="modal-back-btn"]'
 const modalCloseIcon = '[data-testid="CloseIcon"]'
+const newTxBtn = '[data-testid="new-tx-btn"]'
 
 export function clickOnSideNavigation(option) {
   cy.get(option).should('exist').click()
@@ -9,4 +10,8 @@ export function clickOnSideNavigation(option) {
 
 export function clickOnModalCloseBtn() {
   cy.get(modalCloseIcon).eq(0).trigger('click')
+}
+
+export function clickOnNewTxBtn() {
+  cy.get(newTxBtn).click()
 }

--- a/cypress/e2e/pages/spending_limits.pages.js
+++ b/cypress/e2e/pages/spending_limits.pages.js
@@ -1,0 +1,135 @@
+import * as constants from '../../support/constants'
+import * as main from './main.page'
+import { invalidAddressFormatErrorMsg } from '../pages/load_safe.pages'
+import 'cypress-file-upload'
+
+export const spendingLimitsSection = '[data-testid="spending-limit-section"]'
+export const newSpendingLimitBtn = '[data-testid="new-spending-limit"]'
+const beneficiarySection = '[data-testid="beneficiary-section"]'
+const tokenAmountFld = '[data-testid="token-amount-field"]'
+const tokenAmountSection = '[data-testid="token-amount-section"]'
+const modalTitle = '[data-testid="modal-title"]'
+const timePeriodSection = '[data-testid="time-period-section"]'
+const timePeriodItem = '[data-testid="time-period-item"]'
+const nextBtn = '[data-testid="next-btn"]'
+const reviewTokenAmountFld = '[data-testid="token-amount"]'
+const reviewBeneficiaryAddressFld = '[data-testid="beneficiary-address"]'
+const reviewSpendingLimit = '[data-testid="spending-limit-label"]'
+const deleteBtn = '[data-testid="delete-btn"]'
+const resetTimeInfo = '[data-testid="reset-time"]'
+const spentAmountInfo = '[data-testid="spent-amount"]'
+const spendingLimitTxOption = '[data-testid="spending-limit-tx"]'
+const standartTxOption = '[data-testid="standard-tx"]'
+const tokenBalance = '[data-testid="token-balance"]'
+const maxBtn = '[data-testid="max-btn"]'
+const nonceFld = '[data-testid="nonce-fld"]'
+
+export const timePeriodOptions = {
+  oneTime: 'One time',
+  fiveMin: '5 minutes',
+  thirtyMin: '30 minutes',
+  oneHr: '1 hour',
+}
+
+const expectedSpendOptions = ['0 of 0.17 ETH', '0 of 0.05 ETH', '0 of 0.01 ETH']
+const expectedResetOptions = new Array(3).fill('One-time')
+
+const newTransactionStr = 'New transaction'
+const confirmTxStr = 'Confirm transaction'
+const invalidNumberErrorStr = 'The value must be greater than 0'
+const invalidCharErrorStr = 'The value must be a number'
+
+export function verifyNonceState(state) {
+  if (state === constants.elementExistanceStates.exist) {
+    cy.get(nonceFld).should(constants.elementExistanceStates.exist)
+  }
+  cy.get(nonceFld).should(constants.elementExistanceStates.not_exist)
+}
+
+export function clickOnMaxBtn() {
+  cy.get(maxBtn).click()
+}
+
+export function selectSpendingLimitOption() {
+  const input = () => {
+    return cy.get(spendingLimitTxOption).find('input')
+  }
+
+  cy.get(spendingLimitTxOption).click()
+  main.checkRadioButtonState(input, constants.checkboxStates.checked)
+}
+
+export function verifySpendingOptionExists() {
+  cy.get(spendingLimitTxOption).should('exist').and('be.visible')
+}
+
+export function verifySpendingOptionShowsBalance(balance) {
+  main.verifyValuesExist(spendingLimitTxOption, [balance])
+}
+
+export function verifyBeneficiaryTable() {
+  main.checkTextOrder(spentAmountInfo, expectedSpendOptions)
+  main.checkTextOrder(resetTimeInfo, expectedResetOptions)
+  main.verifyElementsCount(deleteBtn, 3)
+}
+export function checkReviewData(tokenAmount, address, spendingLimit) {
+  cy.get(reviewTokenAmountFld).should('have.text', tokenAmount)
+  cy.get(reviewBeneficiaryAddressFld).should('contain', address)
+  cy.get(reviewSpendingLimit).should('contain', spendingLimit)
+}
+export function clickOnNextBtn() {
+  cy.get(nextBtn).click()
+  cy.get(modalTitle).should('have.text', confirmTxStr)
+}
+export function clickOnTimePeriodDropdown() {
+  cy.get(timePeriodSection).click()
+}
+
+export function checkTimeDropdownOptions() {
+  cy.get(timePeriodItem).then(($lis) => {
+    const displayedOptions = Array.from($lis, (li) => li.textContent.trim())
+
+    const expectedOptions = Object.values(timePeriodOptions).every((option) => displayedOptions.includes(option))
+    expect(expectedOptions).to.be.true
+  })
+}
+
+export function verifyDefaultTimeIsSet() {
+  cy.get(timePeriodSection).find('div').contains(timePeriodOptions.oneTime).should('be.visible')
+}
+
+export function clickOnNewSpendingLimitBtn() {
+  cy.get(newSpendingLimitBtn).click()
+  cy.get(modalTitle).should('have.text', newTransactionStr)
+}
+
+export function enterSpendingLimitAmount(amount) {
+  cy.get(tokenAmountFld).find('input').clear().type(amount)
+}
+
+export function enterBeneficiaryAddress(address) {
+  cy.get(beneficiarySection).find('input').clear().type(address)
+}
+
+export function checkBeneficiaryInputValue(value) {
+  cy.get(beneficiarySection).find('input').invoke('val').should('contain', value)
+}
+
+export function checkBeneficiaryENS(ens) {
+  cy.get(beneficiarySection).find('input').invoke('val').should('contain', ens.substring(4))
+}
+
+export function verifyValidAddressShowsNoErrors() {
+  cy.get(beneficiarySection)
+    .find('label')
+    .should('not.contain', invalidAddressFormatErrorMsg)
+    .and('not.contain', invalidCharErrorStr)
+}
+
+export function verifyNumberErrorValidation() {
+  cy.get(tokenAmountSection).find('label').should('contain', invalidNumberErrorStr)
+}
+
+export function verifyCharErrorValidation() {
+  cy.get(tokenAmountSection).find('label').should('contain', invalidCharErrorStr)
+}

--- a/cypress/e2e/regression/spending_limits.cy.js
+++ b/cypress/e2e/regression/spending_limits.cy.js
@@ -9,7 +9,7 @@ const tokenAmount = 0.1
 const spendingLimitBalance = '(0.17 ETH)'
 
 describe('Spending limits tests', () => {
-  before(() => {
+  beforeEach(() => {
     cy.visit(constants.securityUrl + constants.SEPOLIA_TEST_SAFE_12)
     cy.clearLocalStorage()
     main.acceptCookies()

--- a/cypress/e2e/regression/spending_limits.cy.js
+++ b/cypress/e2e/regression/spending_limits.cy.js
@@ -1,0 +1,55 @@
+import * as constants from '../../support/constants'
+import * as main from '../pages/main.page'
+import * as spendinglimit from '../pages/spending_limits.pages'
+import * as owner from '../pages/owners.pages'
+import * as navigation from '../pages/navigation.page'
+import * as tx from '../pages/create_tx.pages'
+
+const tokenAmount = 0.1
+const spendingLimitBalance = '(0.17 ETH)'
+
+describe('Spending limits tests', () => {
+  before(() => {
+    cy.visit(constants.securityUrl + constants.SEPOLIA_TEST_SAFE_12)
+    cy.clearLocalStorage()
+    main.acceptCookies()
+    owner.waitForConnectionStatus()
+    cy.get(spendinglimit.spendingLimitsSection).should('be.visible')
+  })
+
+  it('Verify that the Review step shows beneficiary, amount allowed, reset time', () => {
+    //Assume that default reset time is set to One time
+    spendinglimit.clickOnNewSpendingLimitBtn()
+    spendinglimit.enterBeneficiaryAddress(constants.SEPOLIA_TEST_SAFE_7)
+    spendinglimit.enterSpendingLimitAmount(0.1)
+    spendinglimit.clickOnNextBtn()
+    spendinglimit.checkReviewData(
+      tokenAmount,
+      constants.SEPOLIA_TEST_SAFE_7,
+      spendinglimit.timePeriodOptions.oneTime.split(' ').join('-'),
+    )
+  })
+
+  it('Verify values and trash icons are displayed in Beneficiary table', () => {
+    spendinglimit.verifyBeneficiaryTable()
+  })
+
+  it('Verify Spending limit option is available when selecting the corresponding token', () => {
+    navigation.clickOnNewTxBtn()
+    tx.clickOnSendTokensBtn()
+    spendinglimit.verifySpendingOptionExists()
+  })
+
+  it('Verify spending limit option shows available amount', () => {
+    navigation.clickOnNewTxBtn()
+    tx.clickOnSendTokensBtn()
+    spendinglimit.verifySpendingOptionShowsBalance([spendingLimitBalance])
+  })
+
+  it('Verify when spending limit is selected the nonce field is removed', () => {
+    navigation.clickOnNewTxBtn()
+    tx.clickOnSendTokensBtn()
+    spendinglimit.selectSpendingLimitOption()
+    spendinglimit.verifyNonceState(constants.elementExistanceStates.not_exist)
+  })
+})

--- a/cypress/e2e/smoke/spending_limits.cy.js
+++ b/cypress/e2e/smoke/spending_limits.cy.js
@@ -1,0 +1,65 @@
+import * as constants from '../../support/constants'
+import * as main from '../pages/main.page'
+import * as spendinglimit from '../pages/spending_limits.pages'
+import * as owner from '../pages/owners.pages'
+import * as safe from '../pages/load_safe.pages'
+
+describe('[SMOKE] Spending limits tests', () => {
+  before(() => {
+    cy.visit(constants.securityUrl + constants.SEPOLIA_TEST_SAFE_12)
+    cy.clearLocalStorage()
+    main.acceptCookies()
+    owner.waitForConnectionStatus()
+    cy.get(spendinglimit.spendingLimitsSection).should('be.visible')
+    spendinglimit.clickOnNewSpendingLimitBtn()
+  })
+
+  it('Verify A valid ENS name is resolved successfully', () => {
+    spendinglimit.enterBeneficiaryAddress(constants.ENS_TEST_SEPOLIA)
+    spendinglimit.checkBeneficiaryENS(constants.SEPOLIA_TEST_SAFE_7)
+  })
+
+  it('Verify writing a valid address shows no errors', () => {
+    spendinglimit.enterBeneficiaryAddress(constants.SEPOLIA_TEST_SAFE_7)
+    spendinglimit.verifyValidAddressShowsNoErrors()
+  })
+
+  it('Verify Fill by QR code with a valid address', () => {
+    safe.scanQRCode(constants.VALID_QR_CODE_PATH)
+    spendinglimit.checkBeneficiaryENS(constants.SEPOLIA_TEST_SAFE_6)
+  })
+
+  it('Verify Amount input cannot be 0', () => {
+    spendinglimit.enterSpendingLimitAmount('0')
+    spendinglimit.verifyNumberErrorValidation()
+  })
+
+  it('Verify Amount input cannot be a negative number', () => {
+    spendinglimit.enterSpendingLimitAmount('-1')
+    spendinglimit.verifyNumberErrorValidation()
+  })
+
+  it('Verify Amount input cannot be characters', () => {
+    spendinglimit.enterSpendingLimitAmount('abc')
+    spendinglimit.verifyCharErrorValidation()
+  })
+
+  it('Verify any positive number can be set in the amount input', () => {
+    spendinglimit.enterSpendingLimitAmount(1)
+    spendinglimit.verifyValidAddressShowsNoErrors()
+  })
+
+  it('Verify any positive number can be set in the amount input', () => {
+    spendinglimit.enterSpendingLimitAmount(1)
+    spendinglimit.verifyValidAddressShowsNoErrors()
+  })
+
+  it('Verify the reset time is "One time" by default', () => {
+    spendinglimit.verifyDefaultTimeIsSet()
+  })
+
+  it('Validate Reset values present in dropdown: One time, 1 day, 1 week, 1 month', () => {
+    spendinglimit.clickOnTimePeriodDropdown()
+    spendinglimit.checkTimeDropdownOptions()
+  })
+})

--- a/cypress/e2e/smoke/spending_limits.cy.js
+++ b/cypress/e2e/smoke/spending_limits.cy.js
@@ -49,16 +49,11 @@ describe('[SMOKE] Spending limits tests', () => {
     spendinglimit.verifyValidAddressShowsNoErrors()
   })
 
-  it('Verify any positive number can be set in the amount input', () => {
-    spendinglimit.enterSpendingLimitAmount(1)
-    spendinglimit.verifyValidAddressShowsNoErrors()
-  })
-
   it('Verify the reset time is "One time" by default', () => {
     spendinglimit.verifyDefaultTimeIsSet()
   })
 
-  it('Validate Reset values present in dropdown: One time, 1 day, 1 week, 1 month', () => {
+  it('Validate Reset values present in dropdown: One time, 5 minutes, 30 minutes, 1 hr', () => {
     spendinglimit.clickOnTimePeriodDropdown()
     spendinglimit.checkTimeDropdownOptions()
   })

--- a/cypress/e2e/smoke/spending_limits.cy.js
+++ b/cypress/e2e/smoke/spending_limits.cy.js
@@ -5,7 +5,7 @@ import * as owner from '../pages/owners.pages'
 import * as safe from '../pages/load_safe.pages'
 
 describe('[SMOKE] Spending limits tests', () => {
-  before(() => {
+  beforeEach(() => {
     cy.visit(constants.securityUrl + constants.SEPOLIA_TEST_SAFE_12)
     cy.clearLocalStorage()
     main.acceptCookies()

--- a/cypress/support/constants.js
+++ b/cypress/support/constants.js
@@ -17,6 +17,8 @@ export const SEPOLIA_TEST_SAFE_8 = 'sep:0x5912f6616c84024cD1aff0D5b55bb36F5180fF
 // SAFE 9 & 10 are used for safe apps tests
 export const SEPOLIA_TEST_SAFE_9 = 'sep:0xD1571E8Cc4438aFef2836DD9a0E5D09fb63EDE9a'
 export const SEPOLIA_TEST_SAFE_10 = 'sep:0x4DD4cB2299E491E1B469245DB589ccB2B16d7bde'
+// SAFE 12 is used for spending limits
+export const SEPOLIA_TEST_SAFE_12 = 'sep:0x9190cc22D592dDcf396Fa616ce84a9978fD96Fc9'
 export const SEPOLIA_CONTRACT_SHORT = '0x11AB...34aF'
 export const SEPOLIA_RECIPIENT_ADDR_SHORT = '0x4DD4...7bde'
 export const GNO_TEST_SAFE = 'gno:0xB8d760a90a5ed54D3c2b3EFC231277e99188642A'
@@ -30,6 +32,7 @@ export const DEFAULT_OWNER_ADDRESS = '0xC16Db0251654C0a72E91B190d81eAD367d2C6fED
 export const SEPOLIA_OWNER_2 = '0x96D4c6fFC338912322813a77655fCC926b9A5aC5'
 export const TEST_SAFE_2 = 'gor:0xE96C43C54B08eC528e9e815fC3D02Ea94A320505'
 export const SIDEBAR_ADDRESS = '0x04f8...1a91'
+//ENS_TEST_SEPOLIA resolves to 0xBf30F749FC027a5d79c4710D988F0D3C8e217A4F
 export const ENS_TEST_SEPOLIA = 'e2etestsafe.eth'
 export const ENS_TEST_GOERLI = 'goerli-safe-test.eth'
 export const ENS_TEST_SEPOLIA_INVALID = 'ivladitestenssepolia.eth'
@@ -65,6 +68,7 @@ export const getPermissionsUrl = '/get-permissions'
 export const appSettingsUrl = '/settings/safe-apps'
 export const setupUrl = '/settings/setup?safe='
 export const dataSettingsUrl = '/settings/data?safe='
+export const securityUrl = '/settings/security-login?safe='
 export const invalidAppUrl = 'https://my-invalid-custom-app.com/manifest.json'
 export const validAppUrlJson = 'https://my-valid-custom-app.com/manifest.json'
 export const validAppUrl = 'https://my-valid-custom-app.com'
@@ -126,6 +130,11 @@ export const testAppData = {
 export const checkboxStates = {
   unchecked: 'not.be.checked',
   checked: 'be.checked',
+}
+
+export const elementExistanceStates = {
+  exist: 'exist',
+  not_exist: 'not.exist',
 }
 
 export const transactionStatus = {

--- a/src/components/common/TokenAmountInput/index.tsx
+++ b/src/components/common/TokenAmountInput/index.tsx
@@ -54,17 +54,18 @@ const TokenAmountInput = ({
   }, [maxAmount, selectedToken, setValue])
 
   return (
-    <FormControl className={classNames(css.outline, { [css.error]: isAmountError })} fullWidth>
+    <FormControl data-testid="token-amount-section" className={classNames(css.outline, { [css.error]: isAmountError })} fullWidth>
       <InputLabel shrink required className={css.label}>
         {errors[TokenAmountFields.tokenAddress]?.message || errors[TokenAmountFields.amount]?.message || 'Amount'}
       </InputLabel>
       <div className={css.inputs}>
-        <NumberField
+        <NumberField 
+          data-testid="token-amount-field"
           variant="standard"
           InputProps={{
             disableUnderline: true,
             endAdornment: maxAmount && (
-              <Button className={css.max} onClick={onMaxAmountClick}>
+              <Button data-testid="max-btn" className={css.max} onClick={onMaxAmountClick}>
                 Max
               </Button>
             ),
@@ -78,7 +79,7 @@ const TokenAmountInput = ({
           })}
         />
         <Divider orientation="vertical" flexItem />
-        <TextField
+        <TextField data-testid="token-balance"
           select
           variant="standard"
           InputProps={{

--- a/src/components/common/TokenAmountInput/index.tsx
+++ b/src/components/common/TokenAmountInput/index.tsx
@@ -54,12 +54,15 @@ const TokenAmountInput = ({
   }, [maxAmount, selectedToken, setValue])
 
   return (
-    <FormControl data-testid="token-amount-section" className={classNames(css.outline, { [css.error]: isAmountError })} fullWidth>
+    <FormControl 
+      data-testid="token-amount-section" 
+      className={classNames(css.outline, { [css.error]: isAmountError })} 
+      fullWidth>
       <InputLabel shrink required className={css.label}>
         {errors[TokenAmountFields.tokenAddress]?.message || errors[TokenAmountFields.amount]?.message || 'Amount'}
       </InputLabel>
       <div className={css.inputs}>
-        <NumberField 
+        <NumberField
           data-testid="token-amount-field"
           variant="standard"
           InputProps={{
@@ -79,7 +82,8 @@ const TokenAmountInput = ({
           })}
         />
         <Divider orientation="vertical" flexItem />
-        <TextField data-testid="token-balance"
+        <TextField 
+          data-testid="token-balance"
           select
           variant="standard"
           InputProps={{

--- a/src/components/common/TokenAmountInput/index.tsx
+++ b/src/components/common/TokenAmountInput/index.tsx
@@ -54,10 +54,11 @@ const TokenAmountInput = ({
   }, [maxAmount, selectedToken, setValue])
 
   return (
-    <FormControl 
-      data-testid="token-amount-section" 
-      className={classNames(css.outline, { [css.error]: isAmountError })} 
-      fullWidth>
+    <FormControl
+      data-testid="token-amount-section"
+      className={classNames(css.outline, { [css.error]: isAmountError })}
+      fullWidth
+    >
       <InputLabel shrink required className={css.label}>
         {errors[TokenAmountFields.tokenAddress]?.message || errors[TokenAmountFields.amount]?.message || 'Amount'}
       </InputLabel>
@@ -82,7 +83,7 @@ const TokenAmountInput = ({
           })}
         />
         <Divider orientation="vertical" flexItem />
-        <TextField 
+        <TextField
           data-testid="token-balance"
           select
           variant="standard"

--- a/src/components/settings/SpendingLimits/SpendingLimitsTable.tsx
+++ b/src/components/settings/SpendingLimits/SpendingLimitsTable.tsx
@@ -98,7 +98,7 @@ export const SpendingLimitsTable = ({
                 spent: {
                   rawValue: spendingLimit.spent,
                   content: (
-                    <Box display="flex" alignItems="center" gap={1}>
+                    <Box data-testid="spent-amount" display="flex" alignItems="center" gap={1}>
                       <TokenIcon logoUri={spendingLimit.token.logoUri} tokenSymbol={spendingLimit.token.symbol} />
                       {`${formattedSpent} of ${formattedAmount} ${spendingLimit.token.symbol}`}
                     </Box>
@@ -108,6 +108,7 @@ export const SpendingLimitsTable = ({
                   rawValue: spendingLimit.resetTimeMin,
                   content: (
                     <SpendingLimitLabel
+                      data-testid="reset-time"
                       label={relativeTime(spendingLimit.lastResetMin, spendingLimit.resetTimeMin)}
                       isOneTime={spendingLimit.resetTimeMin === '0'}
                     />
@@ -121,6 +122,7 @@ export const SpendingLimitsTable = ({
                       {(isOk) => (
                         <Track {...SETTINGS_EVENTS.SPENDING_LIMIT.REMOVE_LIMIT}>
                           <IconButton
+                            data-testid="delete-btn"
                             onClick={() => setTxFlow(<RemoveSpendingLimitFlow spendingLimit={spendingLimit} />)}
                             color="error"
                             size="small"

--- a/src/components/settings/SpendingLimits/index.tsx
+++ b/src/components/settings/SpendingLimits/index.tsx
@@ -19,7 +19,7 @@ const SpendingLimits = () => {
   const isEnabled = useHasFeature(FEATURES.SPENDING_LIMIT)
 
   return (
-    <Paper sx={{ padding: 4 }}>
+    <Paper data-testid="spending-limit-section" sx={{ padding: 4 }}>
       <Grid container direction="row" justifyContent="space-between" spacing={3} mb={2}>
         <Grid item lg={4} xs={12}>
           <Typography variant="h4" fontWeight={700}>
@@ -38,7 +38,8 @@ const SpendingLimits = () => {
               <CheckWallet>
                 {(isOk) => (
                   <Track {...SETTINGS_EVENTS.SPENDING_LIMIT.NEW_LIMIT}>
-                    <Button
+                    <Button 
+                      data-testid="new-spending-limit"
                       onClick={() => setTxFlow(<NewSpendingLimitFlow />)}
                       sx={{ mt: 2 }}
                       variant="contained"

--- a/src/components/settings/SpendingLimits/index.tsx
+++ b/src/components/settings/SpendingLimits/index.tsx
@@ -38,7 +38,7 @@ const SpendingLimits = () => {
               <CheckWallet>
                 {(isOk) => (
                   <Track {...SETTINGS_EVENTS.SPENDING_LIMIT.NEW_LIMIT}>
-                    <Button 
+                    <Button
                       data-testid="new-spending-limit"
                       onClick={() => setTxFlow(<NewSpendingLimitFlow />)}
                       sx={{ mt: 2 }}

--- a/src/components/sidebar/NewTxButton/index.tsx
+++ b/src/components/sidebar/NewTxButton/index.tsx
@@ -18,6 +18,7 @@ const NewTxButton = (): ReactElement => {
     <CheckWallet allowSpendingLimit>
       {(isOk) => (
         <Button
+          data-testid="new-tx-btn"
           onClick={onClick}
           variant="contained"
           size="small"

--- a/src/components/tx-flow/common/TxButton.tsx
+++ b/src/components/tx-flow/common/TxButton.tsx
@@ -17,7 +17,7 @@ const buttonSx = {
 export const SendTokensButton = ({ onClick, sx }: { onClick: () => void; sx?: ButtonProps['sx'] }) => {
   return (
     <Track {...MODALS_EVENTS.SEND_FUNDS}>
-      <Button onClick={onClick} variant="contained" sx={sx ?? buttonSx} fullWidth>
+      <Button data-testid="send-tokens-btn" onClick={onClick} variant="contained" sx={sx ?? buttonSx} fullWidth>
         Send tokens
       </Button>
     </Track>

--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -273,7 +273,7 @@ const TxNonce = () => {
   const { nonce, recommendedNonce } = useContext(SafeTxContext)
 
   return (
-    <Box display="flex" alignItems="center" gap={1}>
+    <Box data-testid="nonce-fld"  display="flex" alignItems="center" gap={1}>
       Nonce{' '}
       <Typography component="span" fontWeight={700}>
         #

--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -273,7 +273,7 @@ const TxNonce = () => {
   const { nonce, recommendedNonce } = useContext(SafeTxContext)
 
   return (
-    <Box data-testid="nonce-fld"  display="flex" alignItems="center" gap={1}>
+    <Box data-testid="nonce-fld" display="flex" alignItems="center" gap={1}>
       Nonce{' '}
       <Typography component="span" fontWeight={700}>
         #

--- a/src/components/tx-flow/flows/NewSpendingLimit/CreateSpendingLimit.tsx
+++ b/src/components/tx-flow/flows/NewSpendingLimit/CreateSpendingLimit.tsx
@@ -65,7 +65,7 @@ export const CreateSpendingLimit = ({
       <FormProvider {...formMethods}>
         <form onSubmit={handleSubmit(onSubmit)}>
           <FormControl fullWidth sx={{ mb: 3 }}>
-            <AddressBookInput name={SpendingLimitFields.beneficiary} label="Beneficiary" />
+            <AddressBookInput data-testid="beneficiary-section" name={SpendingLimitFields.beneficiary} label="Beneficiary" />
           </FormControl>
 
           <TokenAmountInput balances={balances.items} selectedToken={selectedToken} validate={validateSpendingLimit} />
@@ -83,9 +83,9 @@ export const CreateSpendingLimit = ({
               control={control}
               name={SpendingLimitFields.resetTime}
               render={({ field }) => (
-                <Select {...field} sx={{ textAlign: 'right', fontWeight: 700 }} IconComponent={ExpandMoreRoundedIcon}>
+                <Select data-testid="time-period-section" {...field} sx={{ textAlign: 'right', fontWeight: 700 }} IconComponent={ExpandMoreRoundedIcon}>
                   {resetTimeOptions.map((resetTime) => (
-                    <MenuItem key={resetTime.value} value={resetTime.value} sx={{ overflow: 'hidden' }}>
+                    <MenuItem data-testid="time-period-item" key={resetTime.value} value={resetTime.value} sx={{ overflow: 'hidden' }}>
                       {resetTime.label}
                     </MenuItem>
                   ))}
@@ -95,7 +95,7 @@ export const CreateSpendingLimit = ({
           </FormControl>
 
           <CardActions>
-            <Button variant="contained" type="submit">
+            <Button data-testid="next-btn" variant="contained" type="submit">
               Next
             </Button>
           </CardActions>

--- a/src/components/tx-flow/flows/NewSpendingLimit/CreateSpendingLimit.tsx
+++ b/src/components/tx-flow/flows/NewSpendingLimit/CreateSpendingLimit.tsx
@@ -65,10 +65,11 @@ export const CreateSpendingLimit = ({
       <FormProvider {...formMethods}>
         <form onSubmit={handleSubmit(onSubmit)}>
           <FormControl fullWidth sx={{ mb: 3 }}>
-            <AddressBookInput 
-              data-testid="beneficiary-section" 
-              name={SpendingLimitFields.beneficiary} 
-              label="Beneficiary" />
+            <AddressBookInput
+              data-testid="beneficiary-section"
+              name={SpendingLimitFields.beneficiary}
+              label="Beneficiary"
+            />
           </FormControl>
 
           <TokenAmountInput balances={balances.items} selectedToken={selectedToken} validate={validateSpendingLimit} />
@@ -86,16 +87,19 @@ export const CreateSpendingLimit = ({
               control={control}
               name={SpendingLimitFields.resetTime}
               render={({ field }) => (
-                <Select 
-                  data-testid="time-period-section" 
-                  {...field} sx={{ textAlign: 'right', fontWeight: 700 }} 
-                  IconComponent={ExpandMoreRoundedIcon}>
+                <Select
+                  data-testid="time-period-section"
+                  {...field}
+                  sx={{ textAlign: 'right', fontWeight: 700 }}
+                  IconComponent={ExpandMoreRoundedIcon}
+                >
                   {resetTimeOptions.map((resetTime) => (
-                    <MenuItem 
-                      data-testid="time-period-item" 
-                      key={resetTime.value} 
-                      value={resetTime.value} 
-                      sx={{ overflow: 'hidden' }}>
+                    <MenuItem
+                      data-testid="time-period-item"
+                      key={resetTime.value}
+                      value={resetTime.value}
+                      sx={{ overflow: 'hidden' }}
+                    >
                       {resetTime.label}
                     </MenuItem>
                   ))}

--- a/src/components/tx-flow/flows/NewSpendingLimit/CreateSpendingLimit.tsx
+++ b/src/components/tx-flow/flows/NewSpendingLimit/CreateSpendingLimit.tsx
@@ -65,7 +65,10 @@ export const CreateSpendingLimit = ({
       <FormProvider {...formMethods}>
         <form onSubmit={handleSubmit(onSubmit)}>
           <FormControl fullWidth sx={{ mb: 3 }}>
-            <AddressBookInput data-testid="beneficiary-section" name={SpendingLimitFields.beneficiary} label="Beneficiary" />
+            <AddressBookInput 
+              data-testid="beneficiary-section" 
+              name={SpendingLimitFields.beneficiary} 
+              label="Beneficiary" />
           </FormControl>
 
           <TokenAmountInput balances={balances.items} selectedToken={selectedToken} validate={validateSpendingLimit} />
@@ -83,9 +86,16 @@ export const CreateSpendingLimit = ({
               control={control}
               name={SpendingLimitFields.resetTime}
               render={({ field }) => (
-                <Select data-testid="time-period-section" {...field} sx={{ textAlign: 'right', fontWeight: 700 }} IconComponent={ExpandMoreRoundedIcon}>
+                <Select 
+                  data-testid="time-period-section" 
+                  {...field} sx={{ textAlign: 'right', fontWeight: 700 }} 
+                  IconComponent={ExpandMoreRoundedIcon}>
                   {resetTimeOptions.map((resetTime) => (
-                    <MenuItem data-testid="time-period-item" key={resetTime.value} value={resetTime.value} sx={{ overflow: 'hidden' }}>
+                    <MenuItem 
+                      data-testid="time-period-item" 
+                      key={resetTime.value} 
+                      value={resetTime.value} 
+                      sx={{ overflow: 'hidden' }}>
                       {resetTime.label}
                     </MenuItem>
                   ))}

--- a/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
+++ b/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
@@ -130,10 +130,11 @@ export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowPr
               />
             </>
           ) : (
-            <SpendingLimitLabel 
-              data-testid= "spending-limit-label" 
-              label={resetTime || 'One-time spending limit'} 
-              isOneTime={!!resetTime && isOneTime} />
+            <SpendingLimitLabel
+              data-testid="spending-limit-label"
+              label={resetTime || 'One-time spending limit'}
+              isOneTime={!!resetTime && isOneTime}
+            />
           )}
         </Grid>
       </Grid>

--- a/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
+++ b/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
@@ -85,7 +85,7 @@ export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowPr
           </Typography>
         </Grid>
 
-        <Grid item md={10}>
+        <Grid data-testid="beneficiary-address" item md={10}>
           <EthHashInfo
             address={params.beneficiary}
             shortAddress={false}
@@ -130,7 +130,7 @@ export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowPr
               />
             </>
           ) : (
-            <SpendingLimitLabel label={resetTime || 'One-time spending limit'} isOneTime={!!resetTime && isOneTime} />
+            <SpendingLimitLabel data-testid= "spending-limit-label" label={resetTime || 'One-time spending limit'} isOneTime={!!resetTime && isOneTime} />
           )}
         </Grid>
       </Grid>

--- a/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
+++ b/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
@@ -130,7 +130,10 @@ export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowPr
               />
             </>
           ) : (
-            <SpendingLimitLabel data-testid= "spending-limit-label" label={resetTime || 'One-time spending limit'} isOneTime={!!resetTime && isOneTime} />
+            <SpendingLimitLabel 
+              data-testid= "spending-limit-label" 
+              label={resetTime || 'One-time spending limit'} 
+              isOneTime={!!resetTime && isOneTime} />
           )}
         </Grid>
       </Grid>

--- a/src/components/tx-flow/flows/TokenTransfer/SendAmountBlock.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/SendAmountBlock.tsx
@@ -4,7 +4,29 @@ import { Box, Typography } from '@mui/material'
 import TokenIcon from '@/components/common/TokenIcon'
 import { formatAmountPrecise } from '@/utils/formatNumber'
 import { PSEUDO_APPROVAL_VALUES } from '@/components/tx/ApprovalEditor/utils/approvals'
-import FieldsGrid from '@/components/tx/FieldsGrid'
+
+const AmountBlock = ({
+  amount,
+  tokenInfo,
+  children,
+}: {
+  amount: number | string
+  tokenInfo: Omit<TokenInfo, 'name' | 'logoUri'> & { logoUri?: string }
+  children?: ReactNode
+}) => {
+  return (
+    <Grid item md={10} className={css.token}>
+      <TokenIcon logoUri={tokenInfo.logoUri} tokenSymbol={tokenInfo.symbol} />
+      <Typography fontWeight="bold">{tokenInfo.symbol}</Typography>
+      {children}
+      {amount === PSEUDO_APPROVAL_VALUES.UNLIMITED ? (
+        <Typography>{PSEUDO_APPROVAL_VALUES.UNLIMITED}</Typography>
+      ) : (
+        <Typography data-testid="token-amount">{formatAmountPrecise(amount, tokenInfo.decimals)}</Typography>
+      )}
+    </Grid>
+  )
+}
 
 const SendAmountBlock = ({
   amount,

--- a/src/components/tx-flow/flows/TokenTransfer/SendAmountBlock.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/SendAmountBlock.tsx
@@ -4,29 +4,7 @@ import { Box, Typography } from '@mui/material'
 import TokenIcon from '@/components/common/TokenIcon'
 import { formatAmountPrecise } from '@/utils/formatNumber'
 import { PSEUDO_APPROVAL_VALUES } from '@/components/tx/ApprovalEditor/utils/approvals'
-
-const AmountBlock = ({
-  amount,
-  tokenInfo,
-  children,
-}: {
-  amount: number | string
-  tokenInfo: Omit<TokenInfo, 'name' | 'logoUri'> & { logoUri?: string }
-  children?: ReactNode
-}) => {
-  return (
-    <Grid item md={10} className={css.token}>
-      <TokenIcon logoUri={tokenInfo.logoUri} tokenSymbol={tokenInfo.symbol} />
-      <Typography fontWeight="bold">{tokenInfo.symbol}</Typography>
-      {children}
-      {amount === PSEUDO_APPROVAL_VALUES.UNLIMITED ? (
-        <Typography>{PSEUDO_APPROVAL_VALUES.UNLIMITED}</Typography>
-      ) : (
-        <Typography data-testid="token-amount">{formatAmountPrecise(amount, tokenInfo.decimals)}</Typography>
-      )}
-    </Grid>
-  )
-}
+import FieldsGrid from '@/components/tx/FieldsGrid'
 
 const SendAmountBlock = ({
   amount,
@@ -51,7 +29,7 @@ const SendAmountBlock = ({
         {amount === PSEUDO_APPROVAL_VALUES.UNLIMITED ? (
           <Typography>{PSEUDO_APPROVAL_VALUES.UNLIMITED}</Typography>
         ) : (
-          <Typography>{formatAmountPrecise(amount, tokenInfo.decimals)}</Typography>
+          <Typography data-testid="token-amount">{formatAmountPrecise(amount, tokenInfo.decimals)}</Typography>
         )}
       </Box>
     </FieldsGrid>

--- a/src/components/tx-flow/flows/TokenTransfer/SpendingLimitRow/index.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/SpendingLimitRow/index.tsx
@@ -55,7 +55,7 @@ const SpendingLimitRow = ({
             className={css.group}
           >
             {!isOnlySpendLimitBeneficiary && (
-              <FormControlLabel
+              <FormControlLabel data-testid="standard-tx"
                 value={TokenTransferType.multiSig}
                 label={
                   <>
@@ -97,7 +97,7 @@ const SpendingLimitRow = ({
                 className={css.label}
               />
             )}
-            <FormControlLabel
+            <FormControlLabel data-testid="spending-limit-tx"
               value={TokenTransferType.spendingLimit}
               label={
                 <>

--- a/src/components/tx-flow/flows/TokenTransfer/SpendingLimitRow/index.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/SpendingLimitRow/index.tsx
@@ -55,7 +55,8 @@ const SpendingLimitRow = ({
             className={css.group}
           >
             {!isOnlySpendLimitBeneficiary && (
-              <FormControlLabel data-testid="standard-tx"
+              <FormControlLabel 
+                data-testid="standard-tx"
                 value={TokenTransferType.multiSig}
                 label={
                   <>
@@ -97,7 +98,8 @@ const SpendingLimitRow = ({
                 className={css.label}
               />
             )}
-            <FormControlLabel data-testid="spending-limit-tx"
+            <FormControlLabel 
+              data-testid="spending-limit-tx"
               value={TokenTransferType.spendingLimit}
               label={
                 <>

--- a/src/components/tx-flow/flows/TokenTransfer/SpendingLimitRow/index.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/SpendingLimitRow/index.tsx
@@ -55,7 +55,7 @@ const SpendingLimitRow = ({
             className={css.group}
           >
             {!isOnlySpendLimitBeneficiary && (
-              <FormControlLabel 
+              <FormControlLabel
                 data-testid="standard-tx"
                 value={TokenTransferType.multiSig}
                 label={
@@ -98,7 +98,7 @@ const SpendingLimitRow = ({
                 className={css.label}
               />
             )}
-            <FormControlLabel 
+            <FormControlLabel
               data-testid="spending-limit-tx"
               value={TokenTransferType.spendingLimit}
               label={


### PR DESCRIPTION
## What it solves

Resolves #3093 

## How this PR fixes it

As part of our continuous automation test coverage, we are adding Spending limits tests to our smoke and regression tests:

- Added data-testid for tests
- Added tests

**Tests added**

- Verify when spending limit is selected the nonce field is removed
- Verify spending limit option shows available amount
- Verify Spending limit option is available when selecting the corresponding token
- Verify values and trash icons are displayed in Beneficiary table
- Verify that the Review step shows beneficiary, amount allowed, reset time
- Verify A valid ENS name is resolved successfully
- Verify writing a valid address shows no errors
- Verify Fill by QR code with a valid address
- Verify Amount input cannot be 0
- Verify Amount input cannot be a negative number
- Verify Amount input cannot be characters
- Verify any positive number can be set in the amount input
- Verify the reset time is "One time" by default
- Validate Reset values present in dropdown: One time, 1 day, 1 week, 1 month

## How to test it

- Run E2E tests and observe outcome.
