### PR TITLE
fix: [WalletConnect] scroll on smaller screens

### DIFF
--- a/src/components/common/Popup/index.tsx
+++ b/src/components/common/Popup/index.tsx
@@ -16,6 +16,7 @@ const Popup = ({ children, ...props }: PopoverProps): ReactElement => {
       sx={{
         '& > .MuiPaper-root': {
           top: 'var(--header-height) !important',
+          overflowY: 'auto',
         },
       }}
       {...props}


### PR DESCRIPTION
## What it solves

Resolves #3081

## How this PR fixes it

Adds `overflow-y: auto` property to the MUI `Popover` element

## How to test it

1. Try to connect to Snapshot.org on Sepolia with a smaller viewport height
2. The full WC screen is not visible
3. Try to scroll down should work

## Screenshots

<img width="562" alt="Screenshot 2024-01-10 at 16 50 04" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/697f4daa-1ceb-449e-95a3-162cfb7f9299">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
