### PR TITLE
Chore: update @web3-onboard/walletconnect

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@web3-onboard/keystone": "^2.3.7",
     "@web3-onboard/ledger": "2.3.2",
     "@web3-onboard/trezor": "^2.4.2",
-    "@web3-onboard/walletconnect": "^2.5.3-alpha.1",
+    "@web3-onboard/walletconnect": "^2.5.3",
     "@web3auth/mpc-core-kit": "^1.1.3",
     "blo": "^1.1.1",
     "bn.js": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@web3-onboard/keystone": "^2.3.7",
     "@web3-onboard/ledger": "2.3.2",
     "@web3-onboard/trezor": "^2.4.2",
-    "@web3-onboard/walletconnect": "^2.5.2",
+    "@web3-onboard/walletconnect": "^2.5.3-alpha.1",
     "@web3auth/mpc-core-kit": "^1.1.3",
     "blo": "^1.1.1",
     "bn.js": "^5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5725,7 +5725,7 @@
   dependencies:
     tslib "1.14.1"
 
-"@walletconnect/ethereum-provider@^2.10.6":
+"@walletconnect/ethereum-provider@^2.10.6", "@walletconnect/ethereum-provider@^2.11.0":
   version "2.10.6"
   resolved "https://registry.yarnpkg.com/@walletconnect/ethereum-provider/-/ethereum-provider-2.10.6.tgz#53720771cc2d6accd452916a853ac927f26acbaa"
   integrity sha512-bBQ+yUfxLv8VxNttgNKY7nED35gSVayO/BnLHbNKvyV1gpvSCla5mWB9MsXuQs70MK0g+/qtgRVSrOtdSubaNQ==
@@ -6094,12 +6094,12 @@
     ethereumjs-util "^7.1.3"
     hdkey "^2.0.1"
 
-"@web3-onboard/walletconnect@^2.5.2":
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/@web3-onboard/walletconnect/-/walletconnect-2.5.2.tgz#799eb4bcbe9ec0abcb088392a02c32eeb1117a7e"
-  integrity sha512-BoRAaMzkgUzSRRH0YSeCJHdUybNsKydKCocgt/6PY8NZVvJBV3CDasYgVIeIwj+bYB6pWm9IIyFE6VN5/Gzxtg==
+"@web3-onboard/walletconnect@^2.5.3-alpha.1":
+  version "2.5.3-alpha.1"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/walletconnect/-/walletconnect-2.5.3-alpha.1.tgz#0bae0b5ff0991e13ffd16b39c87266c98dc8d3aa"
+  integrity sha512-PgK8lyzEZzLqKnh6sp4iFaWdbM0zeI9aGGqOhv9+UmRctsUBg2PIzAzcEqGd9moNxWIzP33slsOmRJKKYyaoEA==
   dependencies:
-    "@walletconnect/ethereum-provider" "^2.10.6"
+    "@walletconnect/ethereum-provider" "^2.11.0"
     "@web3-onboard/common" "^2.3.3"
     joi "17.9.1"
     rxjs "^7.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6094,10 +6094,10 @@
     ethereumjs-util "^7.1.3"
     hdkey "^2.0.1"
 
-"@web3-onboard/walletconnect@^2.5.3-alpha.1":
-  version "2.5.3-alpha.1"
-  resolved "https://registry.yarnpkg.com/@web3-onboard/walletconnect/-/walletconnect-2.5.3-alpha.1.tgz#0bae0b5ff0991e13ffd16b39c87266c98dc8d3aa"
-  integrity sha512-PgK8lyzEZzLqKnh6sp4iFaWdbM0zeI9aGGqOhv9+UmRctsUBg2PIzAzcEqGd9moNxWIzP33slsOmRJKKYyaoEA==
+"@web3-onboard/walletconnect@^2.5.3":
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/walletconnect/-/walletconnect-2.5.3.tgz#b8f71ee93de8cf151dd31732715bff250fcda293"
+  integrity sha512-ENrUwXBbja6gXWfF4G2pxhwOodT9MAMPum0E1KPyphzcs+QxjrC+aaXnYUpLLhZsjlAcIWcGrgpmtLP2NDhRXg==
   dependencies:
     "@walletconnect/ethereum-provider" "^2.11.0"
     "@web3-onboard/common" "^2.3.3"


### PR DESCRIPTION
The latest update if @web3-onboard/walletconnect fixes the dynamic import of the walletconnect package which decreases the main bundle size significantly.