### PR TITLE
fix: do not copy address on wallet button

### DIFF
--- a/src/components/welcome/WelcomeLogin/WalletLogin.tsx
+++ b/src/components/welcome/WelcomeLogin/WalletLogin.tsx
@@ -30,7 +30,13 @@ const WalletLogin = ({ onLogin }: { onLogin: () => void }) => {
                   Continue with {wallet.label}
                 </Typography>
                 {wallet.address && (
-                  <EthHashInfo address={wallet.address} shortAddress avatarSize={16} showName={false} />
+                  <EthHashInfo
+                    address={wallet.address}
+                    shortAddress
+                    avatarSize={16}
+                    showName={false}
+                    copyAddress={false}
+                  />
                 )}
               </Box>
               {wallet.icon && (


### PR DESCRIPTION
## What it solves
Copy address on WalletLogin button.
![Screenshot 2024-01-10 at 18 00 16](https://github.com/safe-global/safe-wallet-web/assets/2670790/438dcd53-a463-480e-8e61-f75b2626abfb)

## How this PR fixes it
sets `copyAddress` to false.

## How to test it
Hover over the address on the button and observe that it does not copy anymore.

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
