### PR TITLE
fix: [Spending Limit] wrong decoded data shown

### DIFF
--- a/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
+++ b/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useContext } from 'react'
+import { useEffect, useMemo, useContext } from 'react'
 import { useSelector } from 'react-redux'
 import { BigNumber } from 'ethers'
 import { Typography, Grid, Alert } from '@mui/material'
@@ -13,13 +13,11 @@ import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 import { createNewSpendingLimitTx } from '@/services/tx/tx-sender'
 import { selectSpendingLimits } from '@/store/spendingLimitsSlice'
 import { formatVisualAmount } from '@/utils/formatters'
-import type { SpendingLimitState } from '@/store/spendingLimitsSlice'
 import type { NewSpendingLimitFlowProps } from '.'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { SafeTxContext } from '../../SafeTxProvider'
 
 export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowProps }) => {
-  const [existingSpendingLimit, setExistingSpendingLimit] = useState<SpendingLimitState>()
   const spendingLimits = useSelector(selectSpendingLimits)
   const chainId = useChainId()
   const { balances } = useBalances()
@@ -27,12 +25,11 @@ export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowPr
   const token = balances.items.find((item) => item.tokenInfo.address === params.tokenAddress)
   const { decimals } = token?.tokenInfo || {}
 
-  useEffect(() => {
-    const existingSpendingLimit = spendingLimits.find(
+  const existingSpendingLimit = useMemo(() => {
+    return spendingLimits.find(
       (spendingLimit) =>
         spendingLimit.beneficiary === params.beneficiary && spendingLimit.token.address === params.tokenAddress,
     )
-    setExistingSpendingLimit(existingSpendingLimit)
   }, [spendingLimits, params])
 
   useEffect(() => {


### PR DESCRIPTION
## What it solves

Resolves #2397

## How this PR fixes it

`existingSpendingLimit` was set inside a `useEffect` which caused an additional call to `createNewSpendingLimitTx` with an undefined value for `existingSpendingLimit`. This results in a fallback and displays a wrong transaction to the user inside the decoded data field. Depending on which useEffect finishes first this wrong result can stay visible.

This PR moves `existingSpendingLimit` into a `useMemo` to prevent the additional call.

## How to test it

1. Go to Settings > Spending Limits
1. Create a new one-time spending limit
1. Execute a spending limit transaction with that
1. Go to Settings > Spending Limits
1. Reset the spending limit to another one-time spending limit
1. Observe the UI not showing a wrong transaction in the decoded tx view

## Screenshots
Before: This is the wrong transaction for resetting an already used spending limit
<img width="487" alt="Screenshot 2024-01-11 at 12 20 34" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/538a1ccf-69c5-404c-84bf-7e2fcc46f8e5">

After:
<img width="496" alt="Screenshot 2024-01-11 at 12 19 49" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/b07d0130-3a92-4e90-8571-572c8ffc9c9b">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
