### PR TITLE
Tests: add more tests for spending limits

### DIFF
--- a/cypress/e2e/pages/spending_limits.pages.js
+++ b/cypress/e2e/pages/spending_limits.pages.js
@@ -21,8 +21,15 @@ const spentAmountInfo = '[data-testid="spent-amount"]'
 const spendingLimitTxOption = '[data-testid="spending-limit-tx"]'
 const standartTxOption = '[data-testid="standard-tx"]'
 const tokenBalance = '[data-testid="token-balance"]'
+const tokenItem = '[data-testid="token-item"]'
 const maxBtn = '[data-testid="max-btn"]'
 const nonceFld = '[data-testid="nonce-fld"]'
+const splimitBeneficiaryIcon = '[data-testid="beneficiary-icon"]'
+const splimitAssetIcon = '[data-testid="asset-icon"]'
+const splimitTimeIcon = '[data-testid="time-icon"]'
+const oldTokenAmount = '[data-testid="old-token-amount"]'
+const oldResetTime = '[data-testid="old-reset-time"]'
+const slimitReplacementWarning = '[data-testid="limit-replacement-warning"]'
 
 export const timePeriodOptions = {
   oneTime: 'One time',
@@ -38,6 +45,35 @@ const newTransactionStr = 'New transaction'
 const confirmTxStr = 'Confirm transaction'
 const invalidNumberErrorStr = 'The value must be greater than 0'
 const invalidCharErrorStr = 'The value must be a number'
+
+export function verifyOldValuesAreDisplayed() {
+  main.verifyElementsIsVisible([oldTokenAmount, oldResetTime, slimitReplacementWarning])
+}
+export function verifySpendingLimitBtnIsDisabled() {
+  cy.get(newSpendingLimitBtn).should('be.disabled')
+}
+
+export function verifySpendingLimitsIcons() {
+  main.verifyElementsIsVisible([splimitBeneficiaryIcon, splimitAssetIcon, splimitTimeIcon])
+}
+
+export function selectToken(token) {
+  cy.get(tokenBalance).click()
+  cy.get(tokenItem).contains(token).click()
+  main.verifyValuesExist(tokenBalance, [token])
+}
+
+export function checkMaxValue() {
+  const maxValue = []
+
+  main.extractDigitsToArray(tokenBalance, maxValue)
+  cy.get(tokenAmountFld)
+    .find('input')
+    .invoke('val')
+    .then((value) => {
+      expect(maxValue).to.contain(value)
+    })
+}
 
 export function verifyNonceState(state) {
   if (state === constants.elementExistanceStates.exist) {
@@ -81,8 +117,13 @@ export function clickOnNextBtn() {
   cy.get(nextBtn).click()
   cy.get(modalTitle).should('have.text', confirmTxStr)
 }
+
 export function clickOnTimePeriodDropdown() {
   cy.get(timePeriodSection).click()
+}
+
+export function selectTimePeriod(period) {
+  cy.get(timePeriodItem).contains(period).click()
 }
 
 export function checkTimeDropdownOptions() {

--- a/cypress/e2e/regression/spending_limits.cy.js
+++ b/cypress/e2e/regression/spending_limits.cy.js
@@ -61,7 +61,7 @@ describe('Spending limits tests', () => {
     spendinglimit.checkMaxValue()
   })
 
-  it('In new tx, verify selecting a native token from the dropdown', () => {
+  it('Verify selecting a native token from the dropdown in new tx', () => {
     navigation.clickOnNewTxBtn()
     tx.clickOnSendTokensBtn()
     spendinglimit.selectToken(constants.tokenNames.sepoliaEther)

--- a/cypress/e2e/regression/spending_limits.cy.js
+++ b/cypress/e2e/regression/spending_limits.cy.js
@@ -6,6 +6,7 @@ import * as navigation from '../pages/navigation.page'
 import * as tx from '../pages/create_tx.pages'
 
 const tokenAmount = 0.1
+const newTokenAmount = 0.001
 const spendingLimitBalance = '(0.17 ETH)'
 
 describe('Spending limits tests', () => {
@@ -51,5 +52,28 @@ describe('Spending limits tests', () => {
     tx.clickOnSendTokensBtn()
     spendinglimit.selectSpendingLimitOption()
     spendinglimit.verifyNonceState(constants.elementExistanceStates.not_exist)
+  })
+
+  it('Verify "Max" button value set to be no more than the allowed amount', () => {
+    navigation.clickOnNewTxBtn()
+    tx.clickOnSendTokensBtn()
+    spendinglimit.clickOnMaxBtn()
+    spendinglimit.checkMaxValue()
+  })
+
+  it('In new tx, verify selecting a native token from the dropdown', () => {
+    navigation.clickOnNewTxBtn()
+    tx.clickOnSendTokensBtn()
+    spendinglimit.selectToken(constants.tokenNames.sepoliaEther)
+  })
+
+  it('Verify that when replacing spending limit for the same owner, previous values are displayed in red', () => {
+    spendinglimit.clickOnNewSpendingLimitBtn()
+    spendinglimit.enterBeneficiaryAddress(constants.DEFAULT_OWNER_ADDRESS)
+    spendinglimit.enterSpendingLimitAmount(newTokenAmount)
+    spendinglimit.clickOnTimePeriodDropdown()
+    spendinglimit.selectTimePeriod(spendinglimit.timePeriodOptions.fiveMin)
+    tx.clickOnNextBtn()
+    spendinglimit.verifyOldValuesAreDisplayed()
   })
 })

--- a/cypress/e2e/regression/spending_limits_nonowner.cy.js
+++ b/cypress/e2e/regression/spending_limits_nonowner.cy.js
@@ -1,0 +1,26 @@
+import * as constants from '../../support/constants.js'
+import * as main from '../pages/main.page.js'
+import * as spendinglimit from '../pages/spending_limits.pages.js'
+import * as owner from '../pages/owners.pages.js'
+
+describe('Spending limits non-owner tests', () => {
+  beforeEach(() => {
+    cy.visit(constants.securityUrl + constants.SEPOLIA_TEST_SAFE_2)
+    cy.clearLocalStorage()
+    main.acceptCookies()
+    owner.waitForConnectionStatus()
+    cy.get(spendinglimit.spendingLimitsSection).should('be.visible')
+  })
+
+  it('Verify that where there are no spending limits setup, information images are displayed', () => {
+    spendinglimit.verifySpendingLimitsIcons
+  })
+
+  it('Verify that where there are no spending limits setup, information images are displayed', () => {
+    spendinglimit.verifySpendingLimitsIcons
+  })
+
+  it('Verify "New spending limit" button only available for owners', () => {
+    spendinglimit.verifySpendingLimitBtnIsDisabled()
+  })
+})

--- a/cypress/e2e/regression/spending_limits_nonowner.cy.js
+++ b/cypress/e2e/regression/spending_limits_nonowner.cy.js
@@ -16,10 +16,6 @@ describe('Spending limits non-owner tests', () => {
     spendinglimit.verifySpendingLimitsIcons
   })
 
-  it('Verify that where there are no spending limits setup, information images are displayed', () => {
-    spendinglimit.verifySpendingLimitsIcons
-  })
-
   it('Verify "New spending limit" button only available for owners', () => {
     spendinglimit.verifySpendingLimitBtnIsDisabled()
   })

--- a/cypress/support/constants.js
+++ b/cypress/support/constants.js
@@ -5,6 +5,7 @@ export const GOERLI_TEST_SAFE = 'gor:0x97d314157727D517A706B5D08507A1f9B44AaaE9'
 // SEPOLIA_TEST_SAFE_1 should always have no transactions, tokens and NFTs
 export const SEPOLIA_TEST_SAFE_1 = 'sep:0xBb26E3717172d5000F87DeFd391994f789D80aEB'
 // SEPOLIA_TEST_SAFE_2 Has no transactions, 1 owner, using for verificatons only
+// Also used for non-owner verifications in spending limits
 export const SEPOLIA_TEST_SAFE_2 = 'sep:0x33C4AA5729D91FfB3B87AEf8a324bb6304Fb905c'
 export const SEPOLIA_TEST_SAFE_3 = 'sep:0x6E834E9D04ad6b26e1525dE1a37BFd9b215f40B7'
 export const SEPOLIA_TEST_SAFE_4 = 'sep:0x03042B890b99552b60A073F808100517fb148F60'

--- a/src/components/common/TokenAmountInput/index.tsx
+++ b/src/components/common/TokenAmountInput/index.tsx
@@ -101,7 +101,7 @@ const TokenAmountInput = ({
           required
         >
           {balances.map((item) => (
-            <MenuItem key={item.tokenInfo.address} value={item.tokenInfo.address}>
+            <MenuItem data-testid="token-item" key={item.tokenInfo.address} value={item.tokenInfo.address}>
               <AutocompleteItem {...item} />
             </MenuItem>
           ))}

--- a/src/components/settings/SpendingLimits/NoSpendingLimits.tsx
+++ b/src/components/settings/SpendingLimits/NoSpendingLimits.tsx
@@ -8,7 +8,7 @@ export const NoSpendingLimits = () => {
   return (
     <Grid mt={2} container direction="row" justifyContent="space-between" spacing={2}>
       <Grid item sm={2}>
-        <BeneficiaryIcon />
+        <BeneficiaryIcon data-testid="beneficiary-icon" />
       </Grid>
       <Grid item sm={10}>
         <Typography>
@@ -21,7 +21,7 @@ export const NoSpendingLimits = () => {
       </Grid>
 
       <Grid item sm={2}>
-        <AssetAmountIcon />
+        <AssetAmountIcon data-testid="asset-icon" />
       </Grid>
       <Grid item sm={10}>
         <Typography>
@@ -31,7 +31,7 @@ export const NoSpendingLimits = () => {
       </Grid>
 
       <Grid item sm={2}>
-        <TimeIcon />
+        <TimeIcon data-testid="time-icon" />
       </Grid>
       <Grid item sm={10}>
         <Typography>

--- a/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
+++ b/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
@@ -69,7 +69,12 @@ export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowPr
         <SendAmountBlock amount={params.amount} tokenInfo={token.tokenInfo} title="Amount">
           {existingAmount && existingAmount !== params.amount && (
             <>
-              <Typography color="error" sx={{ textDecoration: 'line-through' }} component="span">
+              <Typography
+                data-testid="old-token-amount"
+                color="error"
+                sx={{ textDecoration: 'line-through' }}
+                component="span"
+              >
                 {existingAmount}
               </Typography>
               {'→'}
@@ -111,6 +116,7 @@ export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowPr
                     {existingSpendingLimit.resetTimeMin !== params.resetTime && (
                       <>
                         <Typography
+                          data-testid="old-reset-time"
                           color="error"
                           sx={{ textDecoration: 'line-through' }}
                           display="inline"
@@ -140,7 +146,9 @@ export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowPr
       </Grid>
       {existingSpendingLimit && (
         <Alert severity="warning" sx={{ border: 'unset' }}>
-          <Typography fontWeight={700}>You are about to replace an existing spending limit</Typography>
+          <Typography data-testid="limit-replacement-warning" fontWeight={700}>
+            You are about to replace an existing spending limit
+          </Typography>
         </Alert>
       )}
     </SignOrExecuteForm>


### PR DESCRIPTION
## What it solves

Resolves #3093 

## How this PR fixes it
As part of our continuous automation test coverage, we are adding more Spending limits tests to:

**Added data-testids**

**Tests added:**

- Verify "Max" button value set to be no more than the allowed amount
- Verify selecting a native token from the dropdown in new tx
- Verify that when replacing spending limit for the same owner, previous values are displayed in red
- Verify that where there are no spending limits setup, information images are displayed
- Verify "New spending limit" button only available for owners

## How to test it

- Run Cypress tests and observe outcome.
