### PR TITLE
feat: show approval editor for permit2 messages

### DIFF
--- a/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
+++ b/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
@@ -44,6 +44,9 @@ import { SafeTxContext } from '../../SafeTxProvider'
 import RiskConfirmationError from '@/components/tx/SignOrExecuteForm/RiskConfirmationError'
 import { Redefine } from '@/components/tx/security/redefine'
 import { TxSecurityContext } from '@/components/tx/security/shared/TxSecurityContext'
+import { isEIP712TypedData } from '@/utils/safe-messages'
+import ApprovalEditor from '@/components/tx/ApprovalEditor'
+import { ErrorBoundary } from '@sentry/react'
 
 const createSkeletonMessage = (confirmationsRequired: number): SafeMessage => {
   return {
@@ -233,7 +236,13 @@ const SignMessage = ({ message, safeAppId, requestId }: ProposeProps | ConfirmPr
         <CardContent>
           <DialogHeader threshold={safe.threshold} />
 
-          <Typography fontWeight={700} mb={1}>
+          {isEIP712TypedData(decodedMessage) && (
+            <ErrorBoundary fallback={<div>Error parsing data</div>}>
+              <ApprovalEditor safeMessage={decodedMessage} />
+            </ErrorBoundary>
+          )}
+
+          <Typography fontWeight={700} mt={2} mb={1}>
             Message: <CopyButton text={decodedMessageAsString} />
           </Typography>
           <DecodedMsg message={decodedMessage} isInModal />

--- a/src/components/tx-flow/flows/SignMessageOnChain/ReviewSignMessageOnChain.tsx
+++ b/src/components/tx-flow/flows/SignMessageOnChain/ReviewSignMessageOnChain.tsx
@@ -25,6 +25,8 @@ import { type SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { asError } from '@/services/exceptions/utils'
 import { isEIP712TypedData } from '@/utils/safe-messages'
+import ApprovalEditor from '@/components/tx/ApprovalEditor'
+import { ErrorBoundary } from '@sentry/react'
 
 export type SignMessageOnChainProps = {
   app?: SafeAppData
@@ -113,6 +115,12 @@ const ReviewSignMessageOnChain = ({ message, method, requestId }: SignMessageOnC
       <InfoDetails title="Interact with SignMessageLib">
         <EthHashInfo address={signMessageAddress} shortAddress={false} showCopyButton hasExplorer />
       </InfoDetails>
+
+      {isEIP712TypedData(decodedMessage) && (
+        <ErrorBoundary fallback={<div>Error parsing data</div>}>
+          <ApprovalEditor safeMessage={decodedMessage} />
+        </ErrorBoundary>
+      )}
 
       {safeTx && (
         <Box pb={1}>

--- a/src/components/tx/ApprovalEditor/ApprovalItem.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalItem.tsx
@@ -7,6 +7,7 @@ import type { Approval } from '@/services/security/modules/ApprovalModule'
 const approvalMethodDescription: Record<Approval['method'], string> = {
   approve: 'Set allowance to',
   increaseAllowance: 'Increase allowance by',
+  Permit2: 'Give permission to spend',
 }
 
 const ApprovalItem = ({

--- a/src/components/tx/ApprovalEditor/hooks/useApprovalInfos.test.ts
+++ b/src/components/tx/ApprovalEditor/hooks/useApprovalInfos.test.ts
@@ -6,9 +6,11 @@ import { createMockSafeTransaction } from '@/tests/transactions'
 import { OperationType } from '@safe-global/safe-core-sdk-types'
 import { ERC20__factory } from '@/types/contracts'
 import * as balances from '@/hooks/useBalances'
-import { TokenType } from '@safe-global/safe-gateway-typescript-sdk'
+import { type EIP712TypedData, TokenType } from '@safe-global/safe-gateway-typescript-sdk'
 import { BigNumber } from '@ethersproject/bignumber'
 import * as getTokenInfo from '@/utils/tokens'
+import { faker } from '@faker-js/faker'
+import { PSEUDO_APPROVAL_VALUES } from '../utils/approvals'
 
 const ERC20_INTERFACE = ERC20__factory.createInterface()
 
@@ -22,7 +24,7 @@ describe('useApprovalInfos', () => {
   })
 
   it('returns an empty array if no Safe Transaction exists', async () => {
-    const { result } = renderHook(() => useApprovalInfos(undefined))
+    const { result } = renderHook(() => useApprovalInfos({}))
 
     expect(result.current).toStrictEqual([[], undefined, true])
 
@@ -38,7 +40,7 @@ describe('useApprovalInfos', () => {
       operation: OperationType.DelegateCall,
     })
 
-    const { result } = renderHook(() => useApprovalInfos(mockSafeTx))
+    const { result } = renderHook(() => useApprovalInfos({ safeTransaction: mockSafeTx }))
 
     await waitFor(() => {
       expect(result.current).toStrictEqual([[], undefined, false])
@@ -54,7 +56,7 @@ describe('useApprovalInfos', () => {
       operation: OperationType.Call,
     })
 
-    const { result } = renderHook(() => useApprovalInfos(mockSafeTx))
+    const { result } = renderHook(() => useApprovalInfos({ safeTransaction: mockSafeTx }))
 
     const mockApproval: ApprovalInfo = {
       amount: BigNumber.from('123'),
@@ -79,7 +81,7 @@ describe('useApprovalInfos', () => {
       operation: OperationType.Call,
     })
 
-    const { result } = renderHook(() => useApprovalInfos(mockSafeTx))
+    const { result } = renderHook(() => useApprovalInfos({ safeTransaction: mockSafeTx }))
 
     const mockApproval: ApprovalInfo = {
       amount: BigNumber.from('123'),
@@ -92,6 +94,219 @@ describe('useApprovalInfos', () => {
 
     await waitFor(() => {
       expect(result.current).toEqual([[mockApproval], undefined, false])
+    })
+  })
+
+  it('returns an ApprovalInfo for Permit2 PermitSingle message', async () => {
+    const spenderAddress = faker.finance.ethereumAddress()
+    const mockMessage: EIP712TypedData = {
+      types: {
+        EIP712Domain: [
+          {
+            name: 'name',
+            type: 'string',
+          },
+          {
+            name: 'chainId',
+            type: 'uint256',
+          },
+          {
+            name: 'verifyingContract',
+            type: 'address',
+          },
+        ],
+        PermitSingle: [
+          {
+            name: 'details',
+            type: 'PermitDetails',
+          },
+          {
+            name: 'spender',
+            type: 'address',
+          },
+          {
+            name: 'sigDeadline',
+            type: 'uint256',
+          },
+        ],
+        PermitDetails: [
+          {
+            name: 'token',
+            type: 'address',
+          },
+          {
+            name: 'amount',
+            type: 'uint160',
+          },
+          {
+            name: 'expiration',
+            type: 'uint48',
+          },
+          {
+            name: 'nonce',
+            type: 'uint48',
+          },
+        ],
+      },
+      domain: {
+        name: 'Permit2',
+        chainId: 137,
+        verifyingContract: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
+      },
+      message: {
+        spender: spenderAddress,
+        sigDeadline: {
+          type: 'BigNumber',
+          hex: '0xffffffffffff',
+        },
+        details: {
+          token: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+          amount: {
+            type: 'BigNumber',
+            hex: '0xffffffffffffffffffffffffffffffffffffffff',
+          },
+          expiration: {
+            type: 'BigNumber',
+            hex: '0xffffffffffff',
+          },
+          nonce: 0,
+        },
+      },
+    }
+
+    const { result } = renderHook(() => useApprovalInfos({ safeMessage: mockMessage }))
+
+    const mockApproval: ApprovalInfo = {
+      amount: getTokenInfo.UNLIMITED_PERMIT2_AMOUNT.toBigInt(),
+      amountFormatted: PSEUDO_APPROVAL_VALUES.UNLIMITED,
+      spender: spenderAddress,
+      tokenAddress: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174'.toLowerCase(),
+      tokenInfo: undefined,
+      method: 'Permit2',
+    }
+
+    await waitFor(() => {
+      expect(result.current).toEqual([[mockApproval], undefined, false])
+    })
+  })
+
+  it('returns multiple ApprovalInfos for Permit2 PermitBatch message', async () => {
+    const spenderAddress = faker.finance.ethereumAddress()
+    const token1 = faker.finance.ethereumAddress()
+    const token2 = faker.finance.ethereumAddress()
+
+    const mockMessage: EIP712TypedData = {
+      types: {
+        EIP712Domain: [
+          {
+            name: 'name',
+            type: 'string',
+          },
+          {
+            name: 'chainId',
+            type: 'uint256',
+          },
+          {
+            name: 'verifyingContract',
+            type: 'address',
+          },
+        ],
+        PermitBatch: [
+          {
+            name: 'details',
+            type: 'PermitDetails[]',
+          },
+          {
+            name: 'spender',
+            type: 'address',
+          },
+          {
+            name: 'sigDeadline',
+            type: 'uint256',
+          },
+        ],
+        PermitDetails: [
+          {
+            name: 'token',
+            type: 'address',
+          },
+          {
+            name: 'amount',
+            type: 'uint160',
+          },
+          {
+            name: 'expiration',
+            type: 'uint48',
+          },
+          {
+            name: 'nonce',
+            type: 'uint48',
+          },
+        ],
+      },
+      domain: {
+        name: 'Permit2',
+        chainId: 137,
+        verifyingContract: '0x000000000022D473030F116dDEE9F6B43aC78BA3',
+      },
+      message: {
+        spender: spenderAddress,
+        sigDeadline: {
+          type: 'BigNumber',
+          hex: '0xffffffffffff',
+        },
+        details: [
+          {
+            token: token1,
+            amount: {
+              type: 'BigNumber',
+              hex: '0xffffffffffffffffffffffffffffffffffffffff',
+            },
+            expiration: {
+              type: 'BigNumber',
+              hex: '0xffffffffffff',
+            },
+            nonce: 0,
+          },
+          {
+            token: token2,
+            amount: {
+              type: 'BigNumber',
+              hex: '0xffffffffffffffffffffffffffffffffffffffff',
+            },
+            expiration: {
+              type: 'BigNumber',
+              hex: '0xffffffffffff',
+            },
+            nonce: 0,
+          },
+        ],
+      },
+    }
+
+    const { result } = renderHook(() => useApprovalInfos({ safeMessage: mockMessage }))
+
+    const expectedApprovals: ApprovalInfo[] = [
+      {
+        amount: getTokenInfo.UNLIMITED_PERMIT2_AMOUNT.toBigInt(),
+        amountFormatted: PSEUDO_APPROVAL_VALUES.UNLIMITED,
+        spender: spenderAddress,
+        tokenAddress: token1.toLowerCase(),
+        tokenInfo: undefined,
+        method: 'Permit2',
+      },
+      {
+        amount: getTokenInfo.UNLIMITED_PERMIT2_AMOUNT.toBigInt(),
+        amountFormatted: PSEUDO_APPROVAL_VALUES.UNLIMITED,
+        spender: spenderAddress,
+        tokenAddress: token2.toLowerCase(),
+        tokenInfo: undefined,
+        method: 'Permit2',
+      },
+    ]
+
+    await waitFor(() => {
+      expect(result.current).toEqual([expectedApprovals, undefined, false])
     })
   })
 
@@ -121,7 +336,7 @@ describe('useApprovalInfos', () => {
       operation: OperationType.DelegateCall,
     })
 
-    const { result } = renderHook(() => useApprovalInfos(mockSafeTx))
+    const { result } = renderHook(() => useApprovalInfos({ safeTransaction: mockSafeTx }))
 
     const mockApproval: ApprovalInfo = {
       amount: BigNumber.from('123'),
@@ -155,7 +370,7 @@ describe('useApprovalInfos', () => {
       operation: OperationType.DelegateCall,
     })
 
-    const { result } = renderHook(() => useApprovalInfos(mockSafeTx))
+    const { result } = renderHook(() => useApprovalInfos({ safeTransaction: mockSafeTx }))
 
     const mockApproval: ApprovalInfo = {
       amount: BigNumber.from('123'),

--- a/src/components/tx/ApprovalEditor/hooks/useApprovalInfos.test.ts
+++ b/src/components/tx/ApprovalEditor/hooks/useApprovalInfos.test.ts
@@ -177,7 +177,7 @@ describe('useApprovalInfos', () => {
     const { result } = renderHook(() => useApprovalInfos({ safeMessage: mockMessage }))
 
     const mockApproval: ApprovalInfo = {
-      amount: getTokenInfo.UNLIMITED_PERMIT2_AMOUNT.toBigInt(),
+      amount: BigNumber.from(getTokenInfo.UNLIMITED_PERMIT2_AMOUNT),
       amountFormatted: PSEUDO_APPROVAL_VALUES.UNLIMITED,
       spender: spenderAddress,
       tokenAddress: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174'.toLowerCase(),
@@ -288,7 +288,7 @@ describe('useApprovalInfos', () => {
 
     const expectedApprovals: ApprovalInfo[] = [
       {
-        amount: getTokenInfo.UNLIMITED_PERMIT2_AMOUNT.toBigInt(),
+        amount: BigNumber.from(getTokenInfo.UNLIMITED_PERMIT2_AMOUNT),
         amountFormatted: PSEUDO_APPROVAL_VALUES.UNLIMITED,
         spender: spenderAddress,
         tokenAddress: token1.toLowerCase(),
@@ -296,7 +296,7 @@ describe('useApprovalInfos', () => {
         method: 'Permit2',
       },
       {
-        amount: getTokenInfo.UNLIMITED_PERMIT2_AMOUNT.toBigInt(),
+        amount: BigNumber.from(getTokenInfo.UNLIMITED_PERMIT2_AMOUNT),
         amountFormatted: PSEUDO_APPROVAL_VALUES.UNLIMITED,
         spender: spenderAddress,
         tokenAddress: token2.toLowerCase(),

--- a/src/components/tx/ApprovalEditor/hooks/useApprovalInfos.ts
+++ b/src/components/tx/ApprovalEditor/hooks/useApprovalInfos.ts
@@ -27,9 +27,12 @@ export const useApprovalInfos = (payload: {
   const { safeTransaction, safeMessage } = payload
   const { balances } = useBalances()
   const approvals = useMemo(() => {
-    if (!safeTransaction && !safeMessage) return
-
-    return ApprovalModuleInstance.scanTransaction({ safeTransaction, safeMessage })
+    if (safeTransaction) {
+      return ApprovalModuleInstance.scanTransaction({ safeTransaction })
+    }
+    if (safeMessage) {
+      return ApprovalModuleInstance.scanMessage({ safeMessage })
+    }
   }, [safeMessage, safeTransaction])
 
   const hasApprovalSignatures = !!approvals && !!approvals.payload && approvals.payload.length > 0

--- a/src/components/tx/ApprovalEditor/hooks/useApprovalInfos.ts
+++ b/src/components/tx/ApprovalEditor/hooks/useApprovalInfos.ts
@@ -1,12 +1,13 @@
 import useAsync from '@/hooks/useAsync'
 import useBalances from '@/hooks/useBalances'
 import { type Approval, ApprovalModule } from '@/services/security/modules/ApprovalModule'
-import { getERC20TokenInfoOnChain, UNLIMITED_APPROVAL_AMOUNT } from '@/utils/tokens'
+import { getERC20TokenInfoOnChain, UNLIMITED_APPROVAL_AMOUNT, UNLIMITED_PERMIT2_AMOUNT } from '@/utils/tokens'
 import { type SafeTransaction } from '@safe-global/safe-core-sdk-types'
-import { type TokenInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { ethers } from 'ethers'
 import { PSEUDO_APPROVAL_VALUES } from '../utils/approvals'
 import { useMemo } from 'react'
+import { type EIP712TypedData, type TokenInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { sameAddress } from '@/utils/addresses'
 
 export type ApprovalInfo = {
   tokenInfo: (Omit<TokenInfo, 'logoUri' | 'name'> & { logoUri?: string }) | undefined
@@ -19,15 +20,17 @@ export type ApprovalInfo = {
 
 const ApprovalModuleInstance = new ApprovalModule()
 
-export const useApprovalInfos = (
-  safeTransaction: SafeTransaction | undefined,
-): [ApprovalInfo[] | undefined, Error | undefined, boolean] => {
+export const useApprovalInfos = (payload: {
+  safeTransaction?: SafeTransaction
+  safeMessage?: EIP712TypedData
+}): [ApprovalInfo[] | undefined, Error | undefined, boolean] => {
+  const { safeTransaction, safeMessage } = payload
   const { balances } = useBalances()
   const approvals = useMemo(() => {
-    if (!safeTransaction) return
+    if (!safeTransaction && !safeMessage) return
 
-    return ApprovalModuleInstance.scanTransaction({ safeTransaction })
-  }, [safeTransaction])
+    return ApprovalModuleInstance.scanTransaction({ safeTransaction, safeMessage })
+  }, [safeMessage, safeTransaction])
 
   const hasApprovalSignatures = !!approvals && !!approvals.payload && approvals.payload.length > 0
 
@@ -37,17 +40,18 @@ export const useApprovalInfos = (
 
       return Promise.all(
         approvals.payload.map(async (approval) => {
-          let tokenInfo: Omit<TokenInfo, 'name' | 'logoUri'> | undefined = balances.items.find(
-            (item) => item.tokenInfo.address === approval.tokenAddress,
+          let tokenInfo: Omit<TokenInfo, 'name' | 'logoUri'> | undefined = balances.items.find((item) =>
+            sameAddress(item.tokenInfo.address, approval.tokenAddress),
           )?.tokenInfo
 
           if (!tokenInfo) {
             tokenInfo = await getERC20TokenInfoOnChain(approval.tokenAddress)
           }
 
-          const amountFormatted = UNLIMITED_APPROVAL_AMOUNT.eq(approval.amount)
-            ? PSEUDO_APPROVAL_VALUES.UNLIMITED
-            : ethers.utils.formatUnits(approval.amount, tokenInfo?.decimals)
+          const amountFormatted =
+            UNLIMITED_APPROVAL_AMOUNT.eq(approval.amount) || UNLIMITED_PERMIT2_AMOUNT.eq(approval.amount)
+              ? PSEUDO_APPROVAL_VALUES.UNLIMITED
+              : ethers.utils.formatUnits(approval.amount, tokenInfo?.decimals)
 
           return { ...approval, tokenInfo: tokenInfo, amountFormatted }
         }),

--- a/src/services/security/modules/ApprovalModule/index.ts
+++ b/src/services/security/modules/ApprovalModule/index.ts
@@ -7,6 +7,7 @@ import { decodeMultiSendTxs } from '@/utils/transactions'
 import { normalizeTypedData } from '@/utils/web3'
 import { type SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { type EIP712TypedData } from '@safe-global/safe-gateway-typescript-sdk'
+import { BigNumber } from 'ethers'
 import { id } from 'ethers/lib/utils'
 import { type SecurityResponse, type SecurityModule, SecuritySeverity } from '../types'
 
@@ -62,7 +63,7 @@ export class ApprovalModule implements SecurityModule<ApprovalModuleRequest, App
 
   private static getPermitDetails(details: PermitDetails): Pick<Approval, 'amount' | 'tokenAddress'> {
     return {
-      amount: BigInt(details.amount),
+      amount: BigNumber.from(details.amount),
       tokenAddress: details.token,
     }
   }

--- a/src/services/security/modules/ApprovalModule/index.ts
+++ b/src/services/security/modules/ApprovalModule/index.ts
@@ -60,7 +60,7 @@ export class ApprovalModule implements SecurityModule<ApprovalModuleRequest, App
     return []
   }
 
-  private static scanPermitDetails(details: PermitDetails): Pick<Approval, 'amount' | 'tokenAddress'> {
+  private static getPermitDetails(details: PermitDetails): Pick<Approval, 'amount' | 'tokenAddress'> {
     return {
       amount: BigInt(details.amount),
       tokenAddress: details.token,
@@ -75,7 +75,7 @@ export class ApprovalModule implements SecurityModule<ApprovalModuleRequest, App
       if (normalizedMessage.types['PermitSingle'] !== undefined) {
         const spender = normalizedMessage.message['spender'] as string
         const details = normalizedMessage.message['details'] as PermitDetails
-        const permitInfo = ApprovalModule.scanPermitDetails(details)
+        const permitInfo = ApprovalModule.getPermitDetails(details)
 
         approvalInfos.push({
           ...permitInfo,
@@ -86,7 +86,7 @@ export class ApprovalModule implements SecurityModule<ApprovalModuleRequest, App
         const spender = normalizedMessage.message['spender'] as string
         const details = normalizedMessage.message['details'] as PermitDetails[]
         details.forEach((details) => {
-          const permitInfo = ApprovalModule.scanPermitDetails(details)
+          const permitInfo = ApprovalModule.getPermitDetails(details)
 
           approvalInfos.push({
             ...permitInfo,

--- a/src/services/security/modules/ApprovalModule/index.ts
+++ b/src/services/security/modules/ApprovalModule/index.ts
@@ -24,7 +24,7 @@ export type Approval = {
   spender: any
   amount: any
   tokenAddress: string
-  method: 'approve' | 'increaseAllowance' | 'Permit2' | 'Permit'
+  method: 'approve' | 'increaseAllowance' | 'Permit2'
 }
 
 type PermitDetails = { token: string; amount: string }

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -4,6 +4,7 @@ import { type TokenInfo, TokenType } from '@safe-global/safe-gateway-typescript-
 import { BigNumber } from 'ethers'
 
 export const UNLIMITED_APPROVAL_AMOUNT = BigNumber.from(2).pow(256).sub(1)
+export const UNLIMITED_PERMIT2_AMOUNT = BigNumber.from(2).pow(160).sub(1)
 
 /**
  * Fetches ERC20 token symbol and decimals from on-chain.


### PR DESCRIPTION
## What it solves
Permit2 signature are not highlighted in our UI.

## How this PR fixes it
Shows the readonly approval editor for `PermitSingle` and `PermitBatch` Permit2 messages in SignOnchain and Offchain modals

## How to test it
- Request a signature for a PermitSingle or PermitBatch message (I extended the [example drainer app](https://github.com/5afe/eip-1271-dapp/tree/drain-wallet-example-dapp))
- Observe the new Approval Editor

## Screenshots
![Screenshot 2024-01-12 at 16 48 10](https://github.com/safe-global/safe-wallet-web/assets/2670790/fc18563b-97d1-4f9d-a0da-bf1200012a00)

![Screenshot 2024-01-12 at 18 03 37](https://github.com/safe-global/safe-wallet-web/assets/2670790/369db206-f495-4f1b-a17a-10a4e55184c8)


## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
