### PR TITLE
Fix: spending limit estimation in ethers v6

### DIFF
--- a/src/hooks/useSpendingLimitGas.ts
+++ b/src/hooks/useSpendingLimitGas.ts
@@ -1,5 +1,5 @@
 import useWallet from '@/hooks/wallets/useWallet'
-import { useWeb3 } from '@/hooks/wallets/web3'
+import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { getSpendingLimitContract } from '@/services/contracts/spendingLimitContracts'
 import useAsync from '@/hooks/useAsync'
 import { type SpendingLimitTxParams } from '@/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx'
@@ -7,17 +7,15 @@ import useChainId from '@/hooks/useChainId'
 
 const useSpendingLimitGas = (params: SpendingLimitTxParams) => {
   const chainId = useChainId()
-  const provider = useWeb3()
+  const provider = useWeb3ReadOnly()
   const wallet = useWallet()
 
   const [gasLimit, gasLimitError, gasLimitLoading] = useAsync<bigint | undefined>(async () => {
     if (!provider || !wallet) return
 
-    const signer = await provider.getSigner()
+    const contract = getSpendingLimitContract(chainId, provider)
 
-    const contract = getSpendingLimitContract(chainId, signer)
-
-    return contract.executeAllowanceTransfer.estimateGas(
+    const data = contract.interface.encodeFunctionData('executeAllowanceTransfer', [
       params.safeAddress,
       params.token,
       params.to,
@@ -26,7 +24,13 @@ const useSpendingLimitGas = (params: SpendingLimitTxParams) => {
       params.payment,
       params.delegate,
       params.signature,
-    )
+    ])
+
+    return provider.estimateGas({
+      to: await contract.getAddress(),
+      from: wallet.address,
+      data,
+    })
   }, [provider, wallet, chainId, params])
 
   return { gasLimit, gasLimitError, gasLimitLoading }

--- a/src/hooks/useSpendingLimitGas.ts
+++ b/src/hooks/useSpendingLimitGas.ts
@@ -1,5 +1,5 @@
 import useWallet from '@/hooks/wallets/useWallet'
-import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
+import { useWeb3 } from '@/hooks/wallets/web3'
 import { getSpendingLimitContract } from '@/services/contracts/spendingLimitContracts'
 import useAsync from '@/hooks/useAsync'
 import { type SpendingLimitTxParams } from '@/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx'
@@ -7,7 +7,7 @@ import useChainId from '@/hooks/useChainId'
 
 const useSpendingLimitGas = (params: SpendingLimitTxParams) => {
   const chainId = useChainId()
-  const provider = useWeb3ReadOnly()
+  const provider = useWeb3()
   const wallet = useWallet()
 
   const [gasLimit, gasLimitError, gasLimitLoading] = useAsync<bigint | undefined>(async () => {


### PR DESCRIPTION
## What it solves
https://www.notion.so/safe-global/b2bf1616be274eba8e02dedcfd272d1e?v=a922ede2ebd14ba3b629d2e36d43e3f6&p=4107e875bdc6454587fd61257e87fce1&pm=s

## How this PR fixes it
Does not use readOnly provider for gas estimation of spending limit tx.

## How to test it
- Setup a Spending limit and try to use it in a send funds tx

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
