### PR TITLE
fix: only rehydrate if social login is enabled

### DIFF
--- a/src/hooks/wallets/mpc/useRehydrateSocialWallet.ts
+++ b/src/hooks/wallets/mpc/useRehydrateSocialWallet.ts
@@ -65,7 +65,6 @@ const useRehydrateSocialWallet = () => {
     }
     const isOnboardModuleEnabled = isSocialWalletEnabled(chain)
     if (isSocialLoginEnabled && isOnboardModuleEnabled) {
-      console.log('REHYDRATIN')
       void rehydrate()
     }
   }, [chain, onboard, updateAddressBook, isSocialLoginEnabled])

--- a/src/hooks/wallets/mpc/useRehydrateSocialWallet.ts
+++ b/src/hooks/wallets/mpc/useRehydrateSocialWallet.ts
@@ -1,6 +1,6 @@
 import useAddressBook from '@/hooks/useAddressBook'
 import useChainId from '@/hooks/useChainId'
-import { useCurrentChain } from '@/hooks/useChains'
+import { useCurrentChain, useHasFeature } from '@/hooks/useChains'
 import useOnboard, { connectWallet } from '@/hooks/wallets/useOnboard'
 import { ONBOARD_MPC_MODULE_LABEL } from '@/services/mpc/SocialLoginModule'
 import { useAppDispatch } from '@/store'
@@ -9,6 +9,7 @@ import { type WalletState } from '@web3-onboard/core'
 import { type UserInfo } from '@web3auth/mpc-core-kit'
 import { useCallback, useEffect } from 'react'
 import { checksumAddress } from '@/utils/addresses'
+import { FEATURES } from '@/utils/chains'
 
 const useRehydrateSocialWallet = () => {
   const chain = useCurrentChain()
@@ -16,6 +17,7 @@ const useRehydrateSocialWallet = () => {
   const currentChainId = useChainId()
   const addressBook = useAddressBook()
   const dispatch = useAppDispatch()
+  const isSocialLoginEnabled = useHasFeature(FEATURES.SOCIAL_LOGIN)
 
   const updateAddressBook = useCallback(
     (userInfo: UserInfo | undefined, wallets: WalletState[] | undefined | void) => {
@@ -60,9 +62,10 @@ const useRehydrateSocialWallet = () => {
 
       socialWalletService.setOnConnect(onConnect)
     }
-
-    void rehydrate()
-  }, [chain, onboard, updateAddressBook])
+    if (isSocialLoginEnabled) {
+      void rehydrate()
+    }
+  }, [chain, onboard, updateAddressBook, isSocialLoginEnabled])
 }
 
 export default useRehydrateSocialWallet

--- a/src/hooks/wallets/mpc/useRehydrateSocialWallet.ts
+++ b/src/hooks/wallets/mpc/useRehydrateSocialWallet.ts
@@ -10,6 +10,7 @@ import { type UserInfo } from '@web3auth/mpc-core-kit'
 import { useCallback, useEffect } from 'react'
 import { checksumAddress } from '@/utils/addresses'
 import { FEATURES } from '@/utils/chains'
+import { isSocialWalletEnabled } from '../wallets'
 
 const useRehydrateSocialWallet = () => {
   const chain = useCurrentChain()
@@ -62,7 +63,9 @@ const useRehydrateSocialWallet = () => {
 
       socialWalletService.setOnConnect(onConnect)
     }
-    if (isSocialLoginEnabled) {
+    const isOnboardModuleEnabled = isSocialWalletEnabled(chain)
+    if (isSocialLoginEnabled && isOnboardModuleEnabled) {
+      console.log('REHYDRATIN')
       void rehydrate()
     }
   }, [chain, onboard, updateAddressBook, isSocialLoginEnabled])


### PR DESCRIPTION
## What it solves

Resolves #3109 

## How this PR fixes it

## How to test it
- Open a unsupported Social login chain and observe that it does not try to rehydrate the connection

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
