### PR TITLE
fix: show empty balance change response correctly

### DIFF
--- a/src/components/tx/security/redefine/RedefineBalanceChange.tsx
+++ b/src/components/tx/security/redefine/RedefineBalanceChange.tsx
@@ -102,7 +102,7 @@ const BalanceChange = ({
 
 const BalanceChanges = () => {
   const { balanceChange, isLoading } = useContext(TxSecurityContext)
-  const totalBalanceChanges = balanceChange ? balanceChange.in.length + balanceChange.out.length : undefined
+  const totalBalanceChanges = balanceChange ? balanceChange.in.length + balanceChange.out.length : 0
 
   if (isLoading && !balanceChange) {
     return (
@@ -120,7 +120,7 @@ const BalanceChanges = () => {
     )
   }
 
-  if (totalBalanceChanges && totalBalanceChanges === 0) {
+  if (totalBalanceChanges === 0) {
     return (
       <Typography variant="body2" color="text.secondary" justifySelf="flex-end">
         No balance change detected


### PR DESCRIPTION
## What it solves

Resolves #3120 

## How this PR fixes it

## How to test it
- Add a new owner to a Safe
- Observe that it shows the empty balance change correctly.

## Screenshots
![Screenshot 2024-01-18 at 11 30 35](https://github.com/safe-global/safe-wallet-web/assets/2670790/33324b80-3ed4-47c9-bc21-529acb69007f)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
