### PR TITLE
Fix: remove recommended injected wallet in web3-onboard

### DIFF
--- a/src/hooks/wallets/__tests__/useOnboard.test.ts
+++ b/src/hooks/wallets/__tests__/useOnboard.test.ts
@@ -6,7 +6,6 @@ import { getConnectedWallet, switchWallet } from '../useOnboard'
 // mock wallets
 jest.mock('@/hooks/wallets/wallets', () => ({
   getDefaultWallets: jest.fn(() => []),
-  getRecommendedInjectedWallets: jest.fn(() => []),
 }))
 
 describe('useOnboard', () => {

--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -105,12 +105,6 @@ const trackWalletType = (wallet: ConnectedWallet) => {
     .catch(() => null)
 }
 
-// Detect mobile devices
-const isMobile = () => /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
-
-// Detect injected wallet
-const hasInjectedWallet = () => typeof window !== 'undefined' && !!window?.ethereum
-
 let isConnecting = false
 
 // Wrapper that tracks/sets the last used wallet
@@ -123,13 +117,6 @@ export const connectWallet = async (
   }
 
   isConnecting = true
-
-  // On mobile, automatically choose WalletConnect if there is no injected wallet
-  if (!options && isMobile() && !hasInjectedWallet()) {
-    options = {
-      autoSelect: WALLETCONNECT,
-    }
-  }
 
   let wallets: WalletState[] | undefined
 

--- a/src/hooks/wallets/wallets.ts
+++ b/src/hooks/wallets/wallets.ts
@@ -1,9 +1,9 @@
 import { CYPRESS_MNEMONIC, TREZOR_APP_URL, TREZOR_EMAIL, WC_PROJECT_ID } from '@/config/constants'
-import type { RecommendedInjectedWallets, WalletInit } from '@web3-onboard/common/dist/types.d'
+import type { WalletInit } from '@web3-onboard/common/dist/types.d'
 import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 
 import coinbaseModule from '@web3-onboard/coinbase'
-import injectedWalletModule, { ProviderLabel } from '@web3-onboard/injected-wallets'
+import injectedWalletModule from '@web3-onboard/injected-wallets'
 import keystoneModule from '@web3-onboard/keystone/dist/index'
 import ledgerModule from '@web3-onboard/ledger/dist/index'
 import trezorModule from '@web3-onboard/trezor'
@@ -49,10 +49,6 @@ const WALLET_MODULES: { [key in WALLET_KEYS]: (chain: ChainInfo) => WalletInit }
 
 export const getAllWallets = (chain: ChainInfo): WalletInit[] => {
   return Object.values(WALLET_MODULES).map((module) => module(chain))
-}
-
-export const getRecommendedInjectedWallets = (): RecommendedInjectedWallets[] => {
-  return [{ name: ProviderLabel.MetaMask, url: 'https://metamask.io' }]
 }
 
 export const isWalletSupported = (disabledWallets: string[], walletLabel: string): boolean => {

--- a/src/services/onboard.ts
+++ b/src/services/onboard.ts
@@ -1,7 +1,7 @@
 import Onboard, { type OnboardAPI } from '@web3-onboard/core'
 import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { hexValue } from '@ethersproject/bytes'
-import { getAllWallets, getRecommendedInjectedWallets } from '@/hooks/wallets/wallets'
+import { getAllWallets } from '@/hooks/wallets/wallets'
 import { getRpcServiceUrl } from '@/hooks/wallets/web3'
 import type { EnvState } from '@/store/settingsSlice'
 
@@ -44,7 +44,6 @@ export const createOnboard = (
       name: 'Safe{Wallet}',
       icon: location.origin + '/images/logo-round.svg',
       description: 'Safe{Wallet} – smart contract wallet for Ethereum (ex-Gnosis Safe multisig)',
-      recommendedInjectedWallets: getRecommendedInjectedWallets(),
     },
 
     connect: {


### PR DESCRIPTION
## What it solves

Resolves #3116

## How this PR fixes it

Removes the `recommendedInjectedWallets` option in the onboard config. Not sure why it was there in the first place. It seems to work the same sans the annoying warning.

The docs say:

>  if your app only supports injected wallets and when no injected wallets detected, recommend the user to install some

This is clearly not our case.

## Mobile wallets

I've also removed auto-connection ot WalletConnect on mobile because it was briefly flashing the same warning.