### PR TITLE
feat: better number input

### DIFF
--- a/cypress/e2e/pages/create_tx.pages.js
+++ b/cypress/e2e/pages/create_tx.pages.js
@@ -250,19 +250,9 @@ export function verifyWrongChecksum(wronglyChecksummedAddress) {
   cy.contains(constants.addressBookErrrMsg.invalidChecksum).should('be.visible')
 }
 
-export function verifyAmountNegativeNumber() {
-  setSendValue(-1)
-  cy.contains(constants.amountErrorMsg.negativeValue).should('be.visible')
-}
-
 export function verifyAmountLargerThanCurrentBalance() {
   setSendValue(9999)
   cy.contains(constants.amountErrorMsg.largerThanCurrentBalance).should('be.visible')
-}
-
-export function verifyAmountMustBeNumber() {
-  setSendValue('abc')
-  cy.contains(constants.amountErrorMsg.randomString).should('be.visible')
 }
 
 export function verifyTooltipMessage(message) {

--- a/cypress/e2e/pages/spending_limits.pages.js
+++ b/cypress/e2e/pages/spending_limits.pages.js
@@ -191,3 +191,7 @@ export function verifyNumberErrorValidation() {
 export function verifyCharErrorValidation() {
   cy.get(tokenAmountSection).find('label').should('contain', invalidCharErrorStr)
 }
+
+export function verifyNumberAmountEntered(amount) {
+  cy.get(tokenAmountFld).find('input').should('have.value', amount)
+}

--- a/cypress/e2e/smoke/create_tx.cy.js
+++ b/cypress/e2e/smoke/create_tx.cy.js
@@ -33,9 +33,7 @@ describe('[SMOKE] Create transactions tests', () => {
 
   it('[SMOKE] Verify error message for invalid amount input', () => {
     createtx.clickOnTokenselectorAndSelectSepoliaEth()
-    createtx.verifyAmountNegativeNumber()
     createtx.verifyAmountLargerThanCurrentBalance()
-    createtx.verifyAmountMustBeNumber()
   })
 
   it('[SMOKE] Verify MaxAmount button', () => {
@@ -44,14 +42,10 @@ describe('[SMOKE] Create transactions tests', () => {
   })
 
   it('[SMOKE] Verify nonce tooltip warning messages', () => {
-    createtx.changeNonce(-1)
-    createtx.verifyTooltipMessage(constants.nonceTooltipMsg.lowerThanCurrent + currentNonce.toString())
     createtx.changeNonce(currentNonce + 50)
     createtx.verifyTooltipMessage(constants.nonceTooltipMsg.higherThanRecommended)
     createtx.changeNonce(currentNonce + 150)
     createtx.verifyTooltipMessage(constants.nonceTooltipMsg.muchHigherThanRecommended)
-    createtx.changeNonce('abc')
-    createtx.verifyTooltipMessage(constants.nonceTooltipMsg.mustBeNumber)
   })
 
   it('[SMOKE] Verify advance parameters gas limit input', () => {

--- a/cypress/e2e/smoke/spending_limits.cy.js
+++ b/cypress/e2e/smoke/spending_limits.cy.js
@@ -36,12 +36,12 @@ describe('[SMOKE] Spending limits tests', () => {
 
   it('Verify Amount input cannot be a negative number', () => {
     spendinglimit.enterSpendingLimitAmount('-1')
-    spendinglimit.verifyNumberErrorValidation()
+    spendinglimit.verifyNumberAmountEntered('1')
   })
 
   it('Verify Amount input cannot be characters', () => {
     spendinglimit.enterSpendingLimitAmount('abc')
-    spendinglimit.verifyCharErrorValidation()
+    spendinglimit.verifyNumberAmountEntered('')
   })
 
   it('Verify any positive number can be set in the amount input', () => {

--- a/src/components/common/NumberField/index.test.ts
+++ b/src/components/common/NumberField/index.test.ts
@@ -10,4 +10,28 @@ describe('NumberField', () => {
     expect(_formatNumber('000123')).toBe('123')
     expect(_formatNumber('0000.001')).toBe('0.001')
   })
+
+  it('should replace , with .', () => {
+    expect(_formatNumber('123,456')).toBe('123.456')
+    expect(_formatNumber('00,3')).toBe('0.3')
+    expect(_formatNumber('123,456.789')).toBe('123.456789')
+  })
+
+  it('should remove the leading .', () => {
+    expect(_formatNumber('.123')).toBe('0.123')
+    expect(_formatNumber('.123456')).toBe('0.123456')
+    expect(_formatNumber(',123')).toBe('0.123')
+  })
+
+  it('should not be possible to enter multiple . or ,', () => {
+    expect(_formatNumber('123.456.789')).toBe('123.456789')
+    expect(_formatNumber('123.456...789')).toBe('123.456789')
+    expect(_formatNumber('123,456,789')).toBe('123.456789')
+    expect(_formatNumber('123,456,,,,789')).toBe('123.456789')
+  })
+  it('should not be possible to enter characters', () => {
+    expect(_formatNumber('abc')).toBe('')
+    expect(_formatNumber('abc123')).toBe('123')
+    expect(_formatNumber('123abc')).toBe('123')
+  })
 })

--- a/src/components/common/NumberField/index.tsx
+++ b/src/components/common/NumberField/index.tsx
@@ -10,11 +10,19 @@ export const _formatNumber = (value: string) => {
     return value
   }
 
-  // Remove leading zeros from the string
-  value = value.replace(/^0+/, '')
+  // Replace commas with dots (used as decimal separator)
+  value = value.replace(/,/g, '.')
 
-  if (value === '') {
-    return '0'
+  let index = 0
+  // replace all dots except the first one
+  value = value.replace(/\./g, (item) => (!index++ ? item : ''))
+
+  // Remove all characters except numbers and dots
+  value = value.replace(/[^0-9.]/g, '')
+
+  if (value.length > 1) {
+    // Remove leading zeros from the string
+    value = value.replace(/^0+/, '')
   }
 
   // If the string starts with a decimal point, add a leading zero


### PR DESCRIPTION
We were not automatically replacing comma (,) with a dot (.) when entering numbers in the send tokens interface and this was driving me nuts as I always had to remove the comma and make sure to enter a dot. 

## What it solves

This improves the number input. On German keyboard instead of a dot on the numpad one has a comma (,). With this change a comma will be automatically replaced with a dot.

Resolves #

## How this PR fixes it

## How to test it
Try to enter a number with comma. You can start with a comma `,` and you should get `0.` instead.

Commas anywhere in the number will be automatically replaced with dots.

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
