### PR TITLE
fix: Show more accurate total fee during safe creation

### DIFF
--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -6,7 +6,7 @@ import lightPalette from '@/components/theme/lightPalette'
 import ChainIndicator from '@/components/common/ChainIndicator'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { useCurrentChain } from '@/hooks/useChains'
-import useGasPrice from '@/hooks/useGasPrice'
+import useGasPrice, { getTotalFee } from '@/hooks/useGasPrice'
 import { useEstimateSafeCreationGas } from '@/components/new-safe/create/useEstimateSafeCreationGas'
 import { formatVisualAmount } from '@/utils/formatters'
 import type { StepRenderProps } from '@/components/new-safe/CardStepper/useCardStepper'
@@ -130,11 +130,7 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
 
   const totalFee =
     gasLimit && maxFeePerGas
-      ? formatVisualAmount(
-          // maxPriorityFeePerGas is undefined if EIP-1559 disabled
-          (maxFeePerGas + (maxPriorityFeePerGas || 0n)) * gasLimit,
-          chain?.nativeCurrency.decimals,
-        )
+      ? formatVisualAmount(getTotalFee(maxFeePerGas, maxPriorityFeePerGas, gasLimit), chain?.nativeCurrency.decimals)
       : '> 0.001'
 
   const handleBack = () => {

--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -131,9 +131,8 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
   const totalFee =
     gasLimit && maxFeePerGas
       ? formatVisualAmount(
-          maxFeePerGas +
-            // maxPriorityFeePerGas is undefined if EIP-1559 disabled
-            (maxPriorityFeePerGas || 0n) * gasLimit,
+          // maxPriorityFeePerGas is undefined if EIP-1559 disabled
+          (maxFeePerGas + (maxPriorityFeePerGas || 0n)) * gasLimit,
           chain?.nativeCurrency.decimals,
         )
       : '> 0.001'

--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -51,6 +51,7 @@ export const _GasParams = ({
   const isError = gasLimitError && !gasLimit
 
   // Total gas cost
+  // TODO: Check how to use getTotalFee here
   const totalFee = !isLoading ? formatVisualAmount(maxFeePerGas * gasLimit, chain?.nativeCurrency.decimals) : '> 0.001'
 
   // Individual gas params

--- a/src/hooks/__tests__/useGasPrice.test.ts
+++ b/src/hooks/__tests__/useGasPrice.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@/tests/test-utils'
-import useGasPrice from '@/hooks/useGasPrice'
+import useGasPrice, { getTotalFee } from '@/hooks/useGasPrice'
 import { useCurrentChain } from '../useChains'
 
 // mock useWeb3Readonly
@@ -284,5 +284,31 @@ describe('useGasPrice', () => {
     expect(result.current[2]).toBe(false)
 
     expect(result2.current[0]?.maxFeePerGas?.toString()).toBe('22000000000')
+  })
+})
+
+describe('getTotalFee', () => {
+  it('returns the totalFee', () => {
+    const result = getTotalFee(1n, 1n, 100n)
+
+    expect(result).toEqual(200n)
+  })
+
+  it('ignores maxPriorityFeePerGas if its undefined', () => {
+    const result = getTotalFee(1n, undefined, 100n)
+
+    expect(result).toEqual(100n)
+  })
+
+  it('ignores maxPriorityFeePerGas if its null', () => {
+    const result = getTotalFee(1n, null, 100n)
+
+    expect(result).toEqual(100n)
+  })
+
+  it('handles large numbers', () => {
+    const result = getTotalFee(11230000000000123n, 2000000000000n, 123123123n)
+
+    expect(result).toEqual(1382918917536015144144129n)
   })
 })

--- a/src/hooks/useGasPrice.ts
+++ b/src/hooks/useGasPrice.ts
@@ -123,6 +123,16 @@ const getGasParameters = (
     maxPriorityFeePerGas: undefined,
   }
 }
+
+export const getTotalFee = (
+  maxFeePerGas: bigint,
+  maxPriorityFeePerGas: bigint | null | undefined,
+  gasLimit: bigint,
+) => {
+  // maxPriorityFeePerGas is undefined if EIP-1559 disabled
+  return (maxFeePerGas + (maxPriorityFeePerGas || 0n)) * gasLimit
+}
+
 const useGasPrice = (): AsyncResult<GasFeeParams> => {
   const chain = useCurrentChain()
   const gasPriceConfigs = chain?.gasPrice


### PR DESCRIPTION
## What it solves

The correct formula is `(baseFee + maxPrioFee) * gasLimit` but with the switch to BigInt we did `baseFee + (maxPrioFee * gasLimit)` instead which resulted in the total fee being too low

## How this PR fixes it

## How to test it

1. Create a safe on sepolia
2. Observe the total fee not showing something like < 0,000001 ETH

## Screenshots
<img width="776" alt="Screenshot 2024-01-18 at 16 20 23" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/e3632f17-be47-4fa6-acc2-efc218fff553">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
