### PR TITLE
Fixed the Spacing issue between image and NFT

### DIFF
--- a/src/components/nfts/NftGrid/index.tsx
+++ b/src/components/nfts/NftGrid/index.tsx
@@ -205,7 +205,7 @@ const NftGrid = ({
                     <Box display="flex" alignItems="center" gap={2}>
                       {item.imageUri ? activeNftIcon : inactiveNftIcon}
 
-                      <div>
+                      <div style={{ marginLeft: '20px' }}>
                         <Typography>{item.tokenName || item.tokenSymbol}</Typography>
 
                         <Typography fontSize="small" color="text.secondary" component="div">


### PR DESCRIPTION
## What it solves
(UI)NFT image and info are too close on the New Transaction page

## How this PR fixes it
Added margin-left property to the parent container to provide spacing between the image and data

## How to test it
Just a UI change, you can run the code on your device and test

## Checklist
* [x] I've documented how it affects the analytics (if at all) 📊
