### PR TITLE
fix: UI not updating if signing from walletconnect

### DIFF
--- a/src/services/tx/tx-sender/__tests__/ts-sender.test.ts
+++ b/src/services/tx/tx-sender/__tests__/ts-sender.test.ts
@@ -34,7 +34,7 @@ import type { EIP1193Provider, OnboardAPI, WalletState, AppState } from '@web3-o
 import { toBeHex } from 'ethers'
 import { generatePreValidatedSignature } from '@safe-global/protocol-kit/dist/src/utils/signatures'
 import { createMockSafeTransaction } from '@/tests/transactions'
-import type { JsonRpcSigner } from 'ethers/lib.commonjs/providers/provider-jsonrpc'
+import type { JsonRpcSigner } from 'ethers'
 
 // Mock getTransactionDetails
 jest.mock('@safe-global/safe-gateway-typescript-sdk', () => ({
@@ -136,11 +136,14 @@ describe('txSender', () => {
   beforeAll(() => {
     const mockBrowserProvider = new BrowserProvider(jest.fn() as unknown as EIP1193Provider)
 
-    jest
-      .spyOn(mockBrowserProvider, 'getSigner')
-      .mockImplementation(
-        async (address?: string | number | undefined) => Promise.resolve(jest.fn()) as unknown as JsonRpcSigner,
-      )
+    jest.spyOn(mockBrowserProvider, 'getSigner').mockImplementation(
+      async (address?: string | number | undefined) =>
+        Promise.resolve({
+          getAddress: jest.fn(() => Promise.resolve('0x0000000000000000000000000000000000000123')),
+          provider: mockProvider,
+        }) as unknown as JsonRpcSigner,
+    )
+
     jest.spyOn(web3, 'createWeb3').mockImplementation(() => mockBrowserProvider)
 
     setSafeSDK(mockSafeSDK)

--- a/src/services/tx/tx-sender/sdk.ts
+++ b/src/services/tx/tx-sender/sdk.ts
@@ -1,7 +1,8 @@
 import { getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 import type Safe from '@safe-global/protocol-kit'
 import { EthersAdapter } from '@safe-global/protocol-kit'
-import { ethers, JsonRpcProvider, Signer, JsonRpcSigner, TransactionRequest, TransactionResponse } from 'ethers'
+import type { JsonRpcSigner } from 'ethers'
+import { ethers } from 'ethers'
 import { isWalletRejection, isHardwareWallet } from '@/utils/wallets'
 import { OperationType, type SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
@@ -13,7 +14,6 @@ import { connectWallet, getConnectedWallet } from '@/hooks/wallets/useOnboard'
 import { type OnboardAPI } from '@web3-onboard/core'
 import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import { asError } from '@/services/exceptions/utils'
-import { Deferrable } from '@ethersproject/properties'
 import { UncheckedJsonRpcSigner } from '@/utils/providers/UncheckedJsonRpcSigner'
 
 export const getAndValidateSafeSDK = (): Safe => {

--- a/src/services/tx/tx-sender/sdk.ts
+++ b/src/services/tx/tx-sender/sdk.ts
@@ -1,7 +1,7 @@
 import { getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 import type Safe from '@safe-global/protocol-kit'
 import { EthersAdapter } from '@safe-global/protocol-kit'
-import { ethers } from 'ethers'
+import { ethers, JsonRpcProvider, Signer, JsonRpcSigner, TransactionRequest, TransactionResponse } from 'ethers'
 import { isWalletRejection, isHardwareWallet } from '@/utils/wallets'
 import { OperationType, type SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
@@ -12,8 +12,9 @@ import { toQuantity } from 'ethers'
 import { connectWallet, getConnectedWallet } from '@/hooks/wallets/useOnboard'
 import { type OnboardAPI } from '@web3-onboard/core'
 import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
-import type { JsonRpcSigner } from 'ethers'
 import { asError } from '@/services/exceptions/utils'
+import { Deferrable } from '@ethersproject/properties'
+import { UncheckedJsonRpcSigner } from '@/utils/providers/UncheckedJsonRpcSigner'
 
 export const getAndValidateSafeSDK = (): Safe => {
   const safeSDK = getSafeSDK()
@@ -98,16 +99,13 @@ export const getAssertedChainSigner = async (
  * dealing with smart-contract wallet owners
  */
 export const getUncheckedSafeSDK = async (onboard: OnboardAPI, chainId: SafeInfo['chainId']): Promise<Safe> => {
-  // console.log('getUncheckedSafeSDK', onboard, chainId)
   const signer = await getAssertedChainSigner(onboard, chainId)
+  const uncheckedJsonRpcSigner = new UncheckedJsonRpcSigner(signer.provider, await signer.getAddress())
   const sdk = getAndValidateSafeSDK()
 
   const ethAdapter = new EthersAdapter({
     ethers,
-    // TODO: in etherhs v6 this method is no longer existing
-    // we should find out if this is still necessary
-    // signerOrProvider: signer.getUncheckedSigner(),
-    signerOrProvider: signer,
+    signerOrProvider: uncheckedJsonRpcSigner,
   })
 
   return sdk.connect({ ethAdapter })

--- a/src/utils/providers/UncheckedJsonRpcSigner.ts
+++ b/src/utils/providers/UncheckedJsonRpcSigner.ts
@@ -1,4 +1,4 @@
-import { JsonRpcSigner, TransactionRequest, TransactionResponse } from 'ethers'
+import { JsonRpcSigner, type TransactionRequest, type TransactionResponse } from 'ethers'
 
 /**
  * This class is basically a copy of the UncheckedJonRpcSigner from ethers.js v 5.7:
@@ -16,7 +16,7 @@ import { JsonRpcSigner, TransactionRequest, TransactionResponse } from 'ethers'
 export class UncheckedJsonRpcSigner extends JsonRpcSigner {
   async sendTransaction(transaction: TransactionRequest): Promise<TransactionResponse> {
     return this.sendUncheckedTransaction(transaction).then((hash) => {
-      return <TransactionResponse><unknown>{
+      return <TransactionResponse>(<unknown>{
         hash: hash,
         nonce: null,
         gasLimit: null,
@@ -29,7 +29,7 @@ export class UncheckedJsonRpcSigner extends JsonRpcSigner {
         wait: (confirmations?: number) => {
           return this.provider.waitForTransaction(hash, confirmations)
         },
-      };
-    });
+      })
+    })
   }
 }

--- a/src/utils/providers/UncheckedJsonRpcSigner.ts
+++ b/src/utils/providers/UncheckedJsonRpcSigner.ts
@@ -1,0 +1,35 @@
+import { JsonRpcSigner, TransactionRequest, TransactionResponse } from 'ethers'
+
+/**
+ * This class is basically a copy of the UncheckedJonRpcSigner from ethers.js v 5.7:
+ * https://github.com/ethers-io/ethers.js/blob/v5.7/packages/providers/src.ts/json-rpc-provider.ts#L370
+ *
+ * Why do we need this?
+ * If you have 2 Wallets - a Parent wallet and a Child Wallet. The parent is the owner of the child.
+ * You connect the child to the Parent through Walletconnect and then use the parent to sign and execute tx.
+ *
+ * In such case if you use the normal JsonRpcSigner from ethers.js to sign a transaction off-chain the UI will be
+ * stuck, because the signer will wait for the transaction receipt to come back from the RPC Server (which won't happen
+ * because we are just signing and not executing the tx on chain). In such cases however we need to return immediately
+ * with a hash. If we don't the UI in the child is stuck. Waiting for the promise to resolve.
+ */
+export class UncheckedJsonRpcSigner extends JsonRpcSigner {
+  async sendTransaction(transaction: TransactionRequest): Promise<TransactionResponse> {
+    return this.sendUncheckedTransaction(transaction).then((hash) => {
+      return <TransactionResponse><unknown>{
+        hash: hash,
+        nonce: null,
+        gasLimit: null,
+        gasPrice: null,
+        data: null,
+        value: null,
+        chainId: null,
+        confirmations: 0,
+        from: null,
+        wait: (confirmations?: number) => {
+          return this.provider.waitForTransaction(hash, confirmations)
+        },
+      };
+    });
+  }
+}


### PR DESCRIPTION
If another safe is owner of a safe and we use walletconnect to sign transaction the UI was not updating. It turns out we need to port the  UncheckedJsonRpcSigner from ethers v5.

The UncheckedJsonRpcSigner fakes a transaction receipt without actually having one, and this is needed for transactions that don’t actually end on-chain.

## What it solves
Signing with a safe should close the transaction popup in the child's safe.

Resolves #

## How this PR fixes it
Test cases:
1. Create a transaction in C and sign in P
2. Create a transaction in C and immediately execute in P

In both cases the UI flows close and the transaction in C only appears in the queue after the transaction in P has been executed. 

3. Create and immediately execute transaction in C and sign in P
4. Create and immediately execute transaction in C and immediately execute in P

In case 4 there will be a timeout error if P takes longer than a minute to execute which results in the processing transaction of C being deleted from the queue. It later appears in the history once the transaction in P has executed.

## How to test it

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
