### PR TITLE
fix: ignore trusted flags on networks without token list

### DIFF
--- a/src/components/transactions/TrustedToggle/TrustedToggleButton.tsx
+++ b/src/components/transactions/TrustedToggle/TrustedToggleButton.tsx
@@ -7,12 +7,18 @@ import Track from '@/components/common/Track'
 const _TrustedToggleButton = ({
   onlyTrusted,
   setOnlyTrusted,
+  hasDefaultTokenlist,
 }: {
   onlyTrusted: boolean
   setOnlyTrusted: (on: boolean) => void
-}): ReactElement => {
+  hasDefaultTokenlist: boolean
+}): ReactElement | null => {
   const onClick = () => {
     setOnlyTrusted(!onlyTrusted)
+  }
+
+  if (!hasDefaultTokenlist) {
+    return null
   }
 
   return (

--- a/src/components/transactions/TrustedToggle/index.tsx
+++ b/src/components/transactions/TrustedToggle/index.tsx
@@ -1,11 +1,17 @@
+import { useHasFeature } from '@/hooks/useChains'
 import { useAppDispatch, useAppSelector } from '@/store'
 import { selectSettings, setshowOnlyTrustedTransactions } from '@/store/settingsSlice'
+import { FEATURES } from '@/utils/chains'
 import madProps from '@/utils/mad-props'
 import _TrustedToggleButton from './TrustedToggleButton'
 
 const useOnlyTrusted = () => {
   const userSettings = useAppSelector(selectSettings)
   return userSettings.showOnlyTrustedTransactions || false
+}
+
+const useHasDefaultTokenList = () => {
+  return useHasFeature(FEATURES.DEFAULT_TOKENLIST)
 }
 
 const useSetOnlyTrusted = () => {
@@ -18,6 +24,7 @@ const useSetOnlyTrusted = () => {
 const TrustedToggle = madProps(_TrustedToggleButton, {
   onlyTrusted: useOnlyTrusted,
   setOnlyTrusted: useSetOnlyTrusted,
+  hasDefaultTokenlist: useHasDefaultTokenList,
 })
 
 export default TrustedToggle

--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -30,6 +30,8 @@ import Multisend from '@/components/transactions/TxDetails/TxData/DecodedData/Mu
 import useSafeInfo from '@/hooks/useSafeInfo'
 import useIsPending from '@/hooks/useIsPending'
 import { isTrustedTx } from '@/utils/transactions'
+import { useHasFeature } from '@/hooks/useChains'
+import { FEATURES } from '@/utils/chains'
 
 export const NOT_AVAILABLE = 'n/a'
 
@@ -40,6 +42,7 @@ type TxDetailsProps = {
 
 const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement => {
   const isPending = useIsPending(txSummary.id)
+  const hasDefaultTokenlist = useHasFeature(FEATURES.DEFAULT_TOKENLIST)
   const isQueue = isTxQueued(txSummary.txStatus)
   const awaitingExecution = isAwaitingExecution(txSummary.txStatus)
   const isUnsigned =
@@ -49,7 +52,8 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
     isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo) &&
     txDetails.detailedExecutionInfo.trusted === false
 
-  const isTrustedTransfer = isTrustedTx(txSummary)
+  // If we have no token list we always trust the transfer
+  const isTrustedTransfer = !hasDefaultTokenlist || isTrustedTx(txSummary)
 
   return (
     <>

--- a/src/components/transactions/TxSummary/index.tsx
+++ b/src/components/transactions/TxSummary/index.tsx
@@ -14,6 +14,8 @@ import QueueActions from './QueueActions'
 import useIsPending from '@/hooks/useIsPending'
 import TxStatusLabel from '../TxStatusLabel'
 import TxConfirmations from '../TxConfirmations'
+import { useHasFeature } from '@/hooks/useChains'
+import { FEATURES } from '@/utils/chains'
 
 type TxSummaryProps = {
   isGrouped?: boolean
@@ -21,10 +23,12 @@ type TxSummaryProps = {
 }
 
 const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
+  const hasDefaultTokenlist = useHasFeature(FEATURES.DEFAULT_TOKENLIST)
+
   const tx = item.transaction
   const isQueue = isTxQueued(tx.txStatus)
   const nonce = isMultisigExecutionInfo(tx.executionInfo) ? tx.executionInfo.nonce : undefined
-  const isTrusted = isTrustedTx(tx)
+  const isTrusted = !hasDefaultTokenlist || isTrustedTx(tx)
   const isPending = useIsPending(tx.id)
   const executionInfo = isMultisigExecutionInfo(tx.executionInfo) ? tx.executionInfo : undefined
 

--- a/src/hooks/loadables/useLoadTxHistory.ts
+++ b/src/hooks/loadables/useLoadTxHistory.ts
@@ -6,20 +6,23 @@ import useSafeInfo from '../useSafeInfo'
 import { getTxHistory } from '@/services/transactions'
 import { useAppSelector } from '@/store'
 import { selectSettings } from '@/store/settingsSlice'
+import { useHasFeature } from '../useChains'
+import { FEATURES } from '@/utils/chains'
 
 export const useLoadTxHistory = (): AsyncResult<TransactionListPage> => {
   const { safe, safeAddress, safeLoaded } = useSafeInfo()
   const { chainId, txHistoryTag } = safe
   const { showOnlyTrustedTransactions } = useAppSelector(selectSettings)
+  const hasDefaultTokenlist = useHasFeature(FEATURES.DEFAULT_TOKENLIST)
 
   // Re-fetch when chainId, address, showOnlyTrustedTransactions, or txHistoryTag changes
   const [data, error, loading] = useAsync<TransactionListPage>(
     () => {
       if (!safeLoaded) return
-      return getTxHistory(chainId, safeAddress, showOnlyTrustedTransactions)
+      return getTxHistory(chainId, safeAddress, hasDefaultTokenlist && showOnlyTrustedTransactions)
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [safeLoaded, chainId, safeAddress, showOnlyTrustedTransactions, txHistoryTag],
+    [safeLoaded, chainId, safeAddress, showOnlyTrustedTransactions, hasDefaultTokenlist, txHistoryTag],
     false,
   )
 

--- a/src/hooks/useTxHistory.ts
+++ b/src/hooks/useTxHistory.ts
@@ -7,6 +7,8 @@ import useSafeInfo from './useSafeInfo'
 import { fetchFilteredTxHistory, useTxFilter } from '@/utils/tx-history-filter'
 import { getTxHistory } from '@/services/transactions'
 import { selectSettings } from '@/store/settingsSlice'
+import { useHasFeature } from './useChains'
+import { FEATURES } from '@/utils/chains'
 
 const useTxHistory = (
   pageUrl?: string,
@@ -19,6 +21,7 @@ const useTxHistory = (
   const historyState = useAppSelector(selectTxHistory)
   const [filter] = useTxFilter()
   const { showOnlyTrustedTransactions } = useAppSelector(selectSettings)
+  const hasDefaultTokenlist = useHasFeature(FEATURES.DEFAULT_TOKENLIST)
 
   const {
     safe: { chainId },
@@ -32,9 +35,9 @@ const useTxHistory = (
 
       return filter
         ? fetchFilteredTxHistory(chainId, safeAddress, filter, pageUrl)
-        : getTxHistory(chainId, safeAddress, showOnlyTrustedTransactions, pageUrl)
+        : getTxHistory(chainId, safeAddress, hasDefaultTokenlist && showOnlyTrustedTransactions, pageUrl)
     },
-    [chainId, safeAddress, pageUrl, filter, showOnlyTrustedTransactions],
+    [chainId, safeAddress, pageUrl, filter, hasDefaultTokenlist, showOnlyTrustedTransactions],
     false,
   )
 


### PR DESCRIPTION
## What it solves

Resolves #3134 

## How this PR fixes it
- Does not filter out untrusted txs / mark untrusted txs on networks without token list.
- Hides the toggle for filtering untrusted txs if there is no token list

## How to test it
- Open a Safe with incoming ERC20 txs on e.g. Arbitrum.

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
