### PR TITLE
fix: show zero wallet balance

### DIFF
--- a/src/components/common/WalletBalance/index.test.tsx
+++ b/src/components/common/WalletBalance/index.test.tsx
@@ -1,8 +1,7 @@
-import { useCurrentChain } from '@/hooks/useChains'
 import { chainBuilder } from '@/tests/builders/chains'
 import { render } from '@/tests/test-utils'
 import { faker } from '@faker-js/faker'
-import { formatEther, parseEther } from 'ethers'
+import { parseEther } from 'ethers'
 import WalletBalance from '.'
 
 jest.mock('@/hooks/useChains', () => ({

--- a/src/components/common/WalletBalance/index.test.tsx
+++ b/src/components/common/WalletBalance/index.test.tsx
@@ -1,0 +1,42 @@
+import { useCurrentChain } from '@/hooks/useChains'
+import { chainBuilder } from '@/tests/builders/chains'
+import { render } from '@/tests/test-utils'
+import { faker } from '@faker-js/faker'
+import { formatEther, parseEther } from 'ethers'
+import WalletBalance from '.'
+
+jest.mock('@/hooks/useChains', () => ({
+  useCurrentChain: () =>
+    chainBuilder()
+      .with({
+        nativeCurrency: {
+          name: 'Ethereum',
+          symbol: 'ETH',
+          decimals: 18,
+          logoUri: faker.internet.url({ appendSlash: false }),
+        },
+      })
+      .build(),
+}))
+
+describe('WalletBalance', () => {
+  it('should render a skeleton if undefined', () => {
+    const result = render(<WalletBalance balance={undefined} />)
+    expect(result.queryByText('ETH')).toBeNull()
+  })
+
+  it('should render zero if zero balance', () => {
+    const result = render(<WalletBalance balance={0n} />)
+    expect(result.queryByText('0 ETH')).not.toBeNull()
+  })
+
+  it('should render formatted amount if non-zero balance', () => {
+    const result = render(<WalletBalance balance={parseEther('1')} />)
+    expect(result.queryByText('1 ETH')).not.toBeNull()
+  })
+
+  it('should render formatted decimals if non-zero balance', () => {
+    const result = render(<WalletBalance balance={parseEther('0.25')} />)
+    expect(result.queryByText('0.25 ETH')).not.toBeNull()
+  })
+})

--- a/src/components/common/WalletBalance/index.tsx
+++ b/src/components/common/WalletBalance/index.tsx
@@ -5,7 +5,7 @@ import { useCurrentChain } from '@/hooks/useChains'
 const WalletBalance = ({ balance }: { balance: string | bigint | undefined }) => {
   const currentChain = useCurrentChain()
 
-  if (!balance) {
+  if (balance === undefined) {
     return <Skeleton width={30} variant="text" sx={{ display: 'inline-block' }} />
   }
 


### PR DESCRIPTION
## What it solves

Resolves https://www.notion.so/safe-global/Wallet-balance-never-resolves-when-trying-to-submit-bulk-transactions-with-walletconnect-6110e4bcd28444b083315bd21a10100d?d=71a60b3cbfd64773ab148328894330cf

## How this PR fixes it
Checks that the balance is undefined instead of coalescing.

## How to test it
Connect a wallet with 0 balance and look at the wallet balance in the send transaction screen.

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
