### PR TITLE
Fix: onboard initialization with ethers v6

### DIFF
--- a/src/services/onboard.ts
+++ b/src/services/onboard.ts
@@ -1,6 +1,5 @@
 import Onboard, { type OnboardAPI } from '@web3-onboard/core'
 import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
-import { toBeHex } from 'ethers'
 import { getAllWallets, getRecommendedInjectedWallets } from '@/hooks/wallets/wallets'
 import { getRpcServiceUrl } from '@/hooks/wallets/web3'
 import type { EnvState } from '@/store/settingsSlice'
@@ -17,7 +16,8 @@ export const createOnboard = (
   const wallets = getAllWallets(currentChain)
 
   const chains = chainConfigs.map((cfg) => ({
-    id: toBeHex(parseInt(cfg.chainId)),
+    // We cannot use ethers' toBeHex here as we do not want to pad it to an even number of characters.
+    id: `0x${parseInt(cfg.chainId).toString(16)}`,
     label: cfg.chainName,
     rpcUrl: rpcConfig?.[cfg.chainId] || getRpcServiceUrl(cfg.rpcUri),
     token: cfg.nativeCurrency.symbol,

--- a/src/services/onboard.ts
+++ b/src/services/onboard.ts
@@ -3,6 +3,7 @@ import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { getAllWallets, getRecommendedInjectedWallets } from '@/hooks/wallets/wallets'
 import { getRpcServiceUrl } from '@/hooks/wallets/web3'
 import type { EnvState } from '@/store/settingsSlice'
+import { numberToHex } from '@/utils/hex'
 
 let onboard: OnboardAPI | null = null
 
@@ -17,7 +18,7 @@ export const createOnboard = (
 
   const chains = chainConfigs.map((cfg) => ({
     // We cannot use ethers' toBeHex here as we do not want to pad it to an even number of characters.
-    id: `0x${parseInt(cfg.chainId).toString(16)}`,
+    id: numberToHex(parseInt(cfg.chainId)),
     label: cfg.chainName,
     rpcUrl: rpcConfig?.[cfg.chainId] || getRpcServiceUrl(cfg.rpcUri),
     token: cfg.nativeCurrency.symbol,


### PR DESCRIPTION
## What it solves
Switching to some chains threw an error that onboard does not know the chainId.

Resolves https://www.notion.so/safe-global/b2bf1616be274eba8e02dedcfd272d1e?v=a922ede2ebd14ba3b629d2e36d43e3f6&p=ac04ce127afd4987923caa3fb3b483bd&pm=s

## How this PR fixes it
When initializing onboard with all chainIds, we do not pad the chainId to bytes.

## How to test it
- Connect a wallet to Sepolia
- Open a Safe on görli
- Try to sign a tx where a chain switch is required first

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
