### PR TITLE
fix: message signing

### DIFF
--- a/src/services/safe-messages/__tests__/safeMsgSender.test.ts
+++ b/src/services/safe-messages/__tests__/safeMsgSender.test.ts
@@ -125,7 +125,7 @@ describe('safeMsgSender', () => {
           Test: [{ name: 'test', type: 'string' }],
         },
         domain: {
-          chainId: '0x1',
+          chainId: 1,
           name: 'TestDapp',
           verifyingContract: zeroPadValue('0x1234', 20),
         },

--- a/src/utils/web3.ts
+++ b/src/utils/web3.ts
@@ -12,5 +12,16 @@ export const hashTypedData = (typedData: EIP712TypedData): string => {
 
 export const normalizeTypedData = (typedData: EIP712TypedData): EIP712Normalized => {
   const { EIP712Domain: _, ...types } = typedData.types
-  return TypedDataEncoder.getPayload(typedData.domain as TypedDataDomain, types, typedData.message)
+  const payload = TypedDataEncoder.getPayload(typedData.domain as TypedDataDomain, types, typedData.message)
+
+  // ethers v6 converts the chainId to a hex value:
+  // https://github.com/ethers-io/ethers.js/blob/50b74b8806ef2064f2764b09f89c7ac75fda3a3c/src.ts/hash/typed-data.ts#L75
+  // Our SDK expects a number, that's why we convert it here
+  // If this gets fixed here: https://github.com/safe-global/safe-eth-py/issues/748
+  // we can remove this workaround
+  if (payload.domain.chainId) {
+    payload.domain.chainId = Number(BigInt(payload.domain.chainId))
+  }
+
+  return payload
 }


### PR DESCRIPTION
## What it solves
resolves: https://www.notion.so/safe-global/Can-not-sign-message-work-on-prod-70a71bf06be54c3fbf2a0e05cf19d657

Resolves #

## How this PR fixes it

ethers v6 converts the chainId to a hex value: https://github.com/ethers-io/ethers.js/blob/50b74b8806ef2064f2764b09f89c7ac75fda3a3c/src.ts/hash/typed-data.ts#L75
Our SDK expects a number, that's why we convert the hex value from ethers v6 to number.

## How to test it

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
