### PR TITLE
fix: useWalletCanPay with 0 balance

### DIFF
--- a/src/hooks/__tests__/useWalletCanPay.test.ts
+++ b/src/hooks/__tests__/useWalletCanPay.test.ts
@@ -27,6 +27,14 @@ describe('useWalletCanPay', () => {
     expect(result.current).toEqual(true)
   })
 
+  it('should return false if wallet balance is zero', () => {
+    jest.spyOn(walletBalance, 'default').mockReturnValue([BigInt(0), undefined, false])
+
+    const { result } = renderHook(() => useWalletCanPay({ gasLimit: BigInt(21000), maxFeePerGas: BigInt(1) }))
+
+    expect(result.current).toEqual(false)
+  })
+
   it('should return false if wallet balance is smaller than gas costs', () => {
     jest.spyOn(walletBalance, 'default').mockReturnValue([BigInt(20999), undefined, false])
 

--- a/src/hooks/useWalletCanPay.ts
+++ b/src/hooks/useWalletCanPay.ts
@@ -13,7 +13,7 @@ const useWalletCanPay = ({
 
   // Take an optimistic approach and assume the wallet can pay
   // if gasLimit, maxFeePerGas or their walletBalance are missing
-  if (!gasLimit || !maxFeePerGas || !walletBalance) return true
+  if (!gasLimit || !maxFeePerGas || walletBalance === undefined) return true
 
   const totalFee = (maxFeePerGas + BigInt(maxPriorityFeePerGas || 0)) * gasLimit
 


### PR DESCRIPTION
## What it solves

Resolves https://www.notion.so/safe-global/Wallet-balance-never-resolves-when-trying-to-submit-bulk-transactions-with-walletconnect-6110e4bcd28444b083315bd21a10100d?d=71a60b3cbfd64773ab148328894330cf

## How this PR fixes it
Checks that the wallet balance is undefined.

## How to test it
Connect a wallet with 0 balance and try to execute a tx.
The "not enough funds" warning should appear.
## Screenshots

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
