### PR TITLE
fix: left sidebar ui

### DIFF
--- a/src/components/sidebar/Sidebar/styles.module.css
+++ b/src/components/sidebar/Sidebar/styles.module.css
@@ -9,7 +9,6 @@
 
 .container {
   width: 230px;
-  border-right: 1px solid var(--color-border-light);
 }
 
 .scroll {
@@ -69,6 +68,7 @@
 @media (max-width: 899.95px) {
   .container {
     padding-top: var(--header-height);
+    border-right: 1px solid var(--color-border-light);
   }
 
   .drawer {

--- a/src/components/sidebar/SidebarList/index.tsx
+++ b/src/components/sidebar/SidebarList/index.tsx
@@ -70,4 +70,4 @@ export const SidebarListItemText = ({
 )
 
 export const SidebarListItemCounter = ({ count }: { count?: string }): ReactElement | null =>
-  count ? <Badge color="secondary" variant="standard" badgeContent={count} sx={{ ml: 2 }} /> : null
+  count ? <Badge color="warning" variant="standard" badgeContent={count} sx={{ ml: 3 }} /> : null

--- a/src/components/sidebar/SidebarList/styles.module.css
+++ b/src/components/sidebar/SidebarList/styles.module.css
@@ -24,10 +24,6 @@
   background-color: var(--color-border-light);
 }
 
-[data-theme='dark'] .list :global .MuiBadge-standard {
-  background-color: var(--color-primary-main);
-}
-
 .list :global .MuiListItemButton-root:hover {
   border-radius: 6px;
   background-color: var(--color-background-light);


### PR DESCRIPTION
## What it solves

Resolves #3067

## How this PR fixes it

**Double border on desktop sidebar**
- Removed the border _only_ on desktop (mobile didn't have the double border issue).

**Transaction badge color**
- Used the _warning_ value for the badge color prop (I assume this is the color you're after, let me know if it needs changing!).

**Transaction badge spacing**
- Updated margin-left to 24px.

## How to test it

- Create some txs to render the pending txs badge.

## Screenshots

| Before | After |
| ------ | ----- |
| ![Before](https://github.com/safe-global/safe-wallet-web/assets/12480362/6388dd12-a874-49cb-bebb-f57de175ee04) | ![After](https://github.com/safe-global/safe-wallet-web/assets/12480362/e47d55b6-74e0-47ca-9683-912057de923f) |

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
