### PR TITLE
Fix: don't load Spindl if no SDK key

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Here's the list of all the environment variables:
 | `NEXT_PUBLIC_FIREBASE_VAPID_KEY_STAGING`               | FCM vapid key on staging
 | `NEXT_PUBLIC_SOCIAL_WALLET_OPTIONS_PRODUCTION`         | Web3Auth and Google credentials (production)
 | `NEXT_PUBLIC_SOCIAL_WALLET_OPTIONS_STAGING`            | Web3Auth and Google credentials (staging)
+| `NEXT_PUBLIC_SPINDL_SDK_KEY`                           | [Spindl](http://spindl.xyz) SDK key
 
 If you don't provide some of the variables, the corresponding features will be disabled in the UI.
 

--- a/src/services/analytics/spindl.ts
+++ b/src/services/analytics/spindl.ts
@@ -2,9 +2,9 @@ import spindl from '@spindl-xyz/attribution-lite'
 import { IS_PRODUCTION } from '@/config/constants'
 
 export const spindlInit = () => {
-  if (!IS_PRODUCTION) return
-
   const SPINDL_SDK_KEY = process.env.NEXT_PUBLIC_SPINDL_SDK_KEY
+
+  if (!IS_PRODUCTION || !SPINDL_SDK_KEY) return
 
   spindl.configure({
     sdkKey: SPINDL_SDK_KEY || '',


### PR DESCRIPTION
## What it solves

Reported in #3153 – Spindl is loaded even if its env variable isn't set.

## How this PR fixes it
If the env var isn't provided, don't load Spindl.