### PR TITLE
Fix: a more accurate WC app detection

### DIFF
--- a/src/pages/apps/open.tsx
+++ b/src/pages/apps/open.tsx
@@ -18,9 +18,7 @@ import { getOrigin } from '@/components/safe-apps/utils'
 import { useHasFeature } from '@/hooks/useChains'
 import { FEATURES } from '@/utils/chains'
 import { openWalletConnect } from '@/features/walletconnect/components'
-
-// TODO: Remove this once we properly deprecate the WC app
-const WC_SAFE_APP = /wallet-connect/
+import { isWalletConnectSafeApp } from '@/utils/gateway'
 
 const SafeApps: NextPage = () => {
   const chainId = useChainId()
@@ -60,7 +58,7 @@ const SafeApps: NextPage = () => {
   // appUrl is required to be present
   if (!isSafeAppsEnabled || !appUrl || !router.isReady) return null
 
-  if (isWalletConnectEnabled && WC_SAFE_APP.test(appUrl)) {
+  if (isWalletConnectEnabled && isWalletConnectSafeApp(appUrl)) {
     openWalletConnect()
     goToList()
     return null

--- a/src/utils/gateway.ts
+++ b/src/utils/gateway.ts
@@ -28,6 +28,6 @@ export const getExplorerLink = (
 }
 
 export const isWalletConnectSafeApp = (url: string): boolean => {
-  const WALLET_CONNECT = /wallet-connect/
-  return WALLET_CONNECT.test(url)
+  const WC_APP_URL = 'https://apps-portal.safe.global/wallet-connect'
+  return url === WC_APP_URL
 }


### PR DESCRIPTION
## What it solves

Reported in #3153

The WalletConnect Safe app was detected by a URL substring which might give false positives for custom apps.

## How this PR fixes it
Makes it check the URL 1-to-1 with the WC Safe App's URL (it's the same on prod and staging unlike the app id).