### PR TITLE
fix: TxType overlap/overflow

### DIFF
--- a/src/components/batch/BatchSidebar/BatchTxItem.tsx
+++ b/src/components/batch/BatchSidebar/BatchTxItem.tsx
@@ -62,7 +62,7 @@ const BatchTxItem = ({
 
       <Accordion elevation={0} sx={{ flex: 1 }} onChange={handleExpand}>
         <AccordionSummary expandIcon={<ExpandMoreIcon />} disabled={dragging} className={css.accordion}>
-          <Box flex={1} display="flex" alignItems="center" gap={2} py={0.4}>
+          <Box flex={1} display="flex" alignItems="center" gap={2} py={0.4} width="100%">
             {draggable && (
               <SvgIcon
                 component={DragIcon}

--- a/src/components/batch/BatchSidebar/styles.module.css
+++ b/src/components/batch/BatchSidebar/styles.module.css
@@ -99,3 +99,10 @@
 .accordion {
   opacity: 1 !important;
 }
+
+.accordion :global .MuiAccordionSummary-content {
+  width: 100%;
+  overflow: hidden;
+  margin: 0;
+  padding: 12px 0px;
+}

--- a/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
+++ b/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
@@ -44,7 +44,18 @@ export const ExpandableTransactionItem = ({
         }
       }}
     >
-      <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ justifyContent: 'flex-start', overflowX: 'auto' }}>
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        sx={{
+          justifyContent: 'flex-start',
+          overflowX: 'auto',
+          ['.MuiAccordionSummary-content, .MuiAccordionSummary-content.Mui-expanded']: {
+            overflow: 'hidden',
+            margin: 0,
+            padding: '12px 0',
+          },
+        }}
+      >
         <TxSummary item={item} isGrouped={isGrouped} />
       </AccordionSummary>
 

--- a/src/components/transactions/TxSummary/styles.module.css
+++ b/src/components/transactions/TxSummary/styles.module.css
@@ -17,6 +17,10 @@
   grid-template-areas: 'nonce type info date confirmations status';
 }
 
+.gridContainer > * {
+  max-width: 100%;
+}
+
 .gridContainer.history {
   grid-template-columns: var(--grid-nonce) var(--grid-type) var(--grid-info) var(--grid-date) var(--grid-status);
   grid-template-areas: 'nonce type info date status';

--- a/src/components/transactions/TxType/index.tsx
+++ b/src/components/transactions/TxType/index.tsx
@@ -20,7 +20,7 @@ const TxType = ({ tx }: TxTypeProps) => {
         height={16}
         fallback="/images/transactions/custom.svg"
       />
-      {type.text}
+      <span className={css.txTypeText}>{type.text}</span>
     </Box>
   )
 }

--- a/src/components/transactions/TxType/styles.module.css
+++ b/src/components/transactions/TxType/styles.module.css
@@ -4,4 +4,11 @@
   flex-wrap: nowrap;
   gap: var(--space-1);
   color: var(--color-text-primary);
+  overflow: hidden;
+}
+
+.txTypeText {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-wrap: nowrap;
 }


### PR DESCRIPTION
## What it solves

Resolves #3136

## How this PR fixes it

Fixed overlap/overflow for TxType component (used in three different parent components):
- Tx history page
- Home pending txs module
- Batched transactions sidebar

I wasn't sure of the correct styling preference (inline, css module, etc), so I tried to follow the same convention in each component. If you prefer to make this fix another way, feel free to disregard this PR :)

Also, a lot of Cypress tests were failing for me, but they didn't seem to be related to my changes.

## Screenshots

| Before | After |
|--------|-------|
| ![Before Feature X](https://github.com/safe-global/safe-wallet-web/assets/12480362/b73d74bb-b245-46db-ab28-7ad5f20f3961) | ![After Feature X](https://github.com/safe-global/safe-wallet-web/assets/12480362/7b4ecda2-3d28-4953-ab38-af4764c51570) |
| ![Before Feature Y](https://github.com/safe-global/safe-wallet-web/assets/12480362/5ff04da1-acb3-45bd-9257-30accf6b74b8) | ![After Feature Y](https://github.com/safe-global/safe-wallet-web/assets/12480362/b3b2a78b-f5b0-4039-800b-1b3ef8e4ee3a) |
| ![Before Feature Z](https://github.com/safe-global/safe-wallet-web/assets/12480362/1a199319-963a-437a-a2ca-dc948b7a7b46) | ![After Feature Z](https://github.com/safe-global/safe-wallet-web/assets/12480362/269aa9c0-9cf5-479f-9e8b-02095558e9a7) |

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
