### PR TITLE
docs: improve the “preparing a release” steps

### DIFF
--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -20,10 +20,12 @@ We prepare at least one release every sprint. Sprints are two weeks long.
 * Bump the version in the `package.json`
 * Create a PR with the list of changes
 
-💡 To generate a quick changelog:
-```
-git log origin/main..origin/dev --pretty=format:'* %s'
-```
+  >    💡 To generate a quick changelog:
+  > ```bash
+  > git log origin/main..origin/dev --pretty=format:'* %s'
+  > ```
+* Add the PR to the Project `Web Squad` and set the status to `Ready for QA`
+
 
 ### QA
 * The QA team do regression testing on this branch
@@ -47,7 +49,7 @@ git pull origin release/3.15.0
 git push
 ```
 
-A deploy workflow will kick in and do the following things:
+A deployment workflow will kick in and do the following things:
 
 * Deploy the code to staging
 * Create a new git tag from the version in package.json


### PR DESCRIPTION
## What it solves

When preparing the last release I was not sure how to notify QA about it. And I obviously did it wrong.

Resolves #


## How this PR fixes it
Ads the necessary info to the docs about the current process

## How to test it

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
