### PR TITLE
fix: Only show recovery expiry if its not null

### DIFF
--- a/src/features/recovery/components/RecoveryDetails/index.tsx
+++ b/src/features/recovery/components/RecoveryDetails/index.tsx
@@ -32,9 +32,8 @@ export function RecoveryDetails({ item }: { item: RecoveryQueueItem }): ReactEle
           <TxDataRow title="Transaction hash">{generateDataRowValue(transactionHash, 'hash', true)}</TxDataRow>
           <TxDataRow title="Created:">{dateString(Number(timestamp))}</TxDataRow>
           <TxDataRow title="Executable:">{dateString(Number(validFrom))}</TxDataRow>
-          <TxDataRow title="Expires:">{dateString(Number(expiresAt))}</TxDataRow>
 
-          {Number(expiresAt) && <TxDataRow title="Expires:">{dateString(Number(expiresAt))}</TxDataRow>}
+          {expiresAt ? <TxDataRow title="Expires:">{dateString(Number(expiresAt))}</TxDataRow> : null}
 
           <Link className={summaryCss.buttonExpand} onClick={toggleExpanded} component="button" variant="body1">
             Advanced details


### PR DESCRIPTION
## What it solves

Resolves https://www.notion.so/safe-global/Recovery-tx-1970-as-expires-date-for-never-expires-3e0fab8db7f94ef9bdfebcdcd9d11151

## How this PR fixes it

Checks if `expiresAt` exists before rendering it

## How to test it

1. Open a Safe with recovery where recovery attempts have no expiry
2. Propose a recovery
3. Go to the queue
4. Expand details
5. Observe expiry is not shown

## Screenshots

<img width="1264" alt="Screenshot 2024-01-30 at 14 37 52" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/cf447a0a-7023-4cc8-91c7-5e48a732f1a6">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
