### PR TITLE
[Release 1.28.0] Fix max amount button and timeout error

### DIFF
--- a/src/components/common/TokenAmountInput/index.tsx
+++ b/src/components/common/TokenAmountInput/index.tsx
@@ -67,11 +67,12 @@ const TokenAmountInput = ({
           variant="standard"
           InputProps={{
             disableUnderline: true,
-            endAdornment: maxAmount !== undefined && Number(maxAmount) && (
-              <Button data-testid="max-btn" className={css.max} onClick={onMaxAmountClick}>
-                Max
-              </Button>
-            ),
+            endAdornment:
+              maxAmount !== undefined && Number(maxAmount) ? (
+                <Button data-testid="max-btn" className={css.max} onClick={onMaxAmountClick}>
+                  Max
+                </Button>
+              ) : null,
           }}
           className={css.amount}
           required

--- a/src/components/common/TokenAmountInput/index.tsx
+++ b/src/components/common/TokenAmountInput/index.tsx
@@ -67,12 +67,11 @@ const TokenAmountInput = ({
           variant="standard"
           InputProps={{
             disableUnderline: true,
-            endAdornment:
-              maxAmount !== undefined && Number(maxAmount) ? (
-                <Button data-testid="max-btn" className={css.max} onClick={onMaxAmountClick}>
-                  Max
-                </Button>
-              ) : null,
+            endAdornment: maxAmount !== undefined && (
+              <Button data-testid="max-btn" className={css.max} onClick={onMaxAmountClick}>
+                Max
+              </Button>
+            ),
           }}
           className={css.amount}
           required

--- a/src/components/tx-flow/flows/SuccessScreen/StatusMessage.tsx
+++ b/src/components/tx-flow/flows/SuccessScreen/StatusMessage.tsx
@@ -1,4 +1,4 @@
-import { getTimeoutErrorMessage, isTimeoutError } from '@/utils/ethers-utils'
+import { isTimeoutError } from '@/utils/ethers-utils'
 import classNames from 'classnames'
 import { Box, Typography } from '@mui/material'
 import LoadingSpinner, { SpinnerStatus } from '@/components/new-safe/create/steps/StatusStep/LoadingSpinner'
@@ -21,7 +21,7 @@ const getStep = (status: PendingStatus, error?: Error) => {
     default:
       return {
         description: error ? 'Transaction failed' : 'Transaction was successful',
-        instruction: error ? (isTimeoutError(error) ? getTimeoutErrorMessage(error) : error.message) : '',
+        instruction: error ? (isTimeoutError(error) ? 'Transaction timed out' : error.message) : '',
       }
   }
 }

--- a/src/utils/ethers-utils.ts
+++ b/src/utils/ethers-utils.ts
@@ -26,11 +26,7 @@ type TimeoutError = Error & {
 }
 
 export const isTimeoutError = (value?: Error): value is TimeoutError => {
-  return !!value && 'timeout' in value && 'code' in value
-}
-
-export const getTimeoutErrorMessage = (error: TimeoutError) => {
-  return `Transaction timed out after ${Math.floor(error.timeout / 1000)} seconds`
+  return !!value && 'reason' in value && value.reason === 'timeout' && 'code' in value
 }
 
 export const splitSignature = (sigBytes: string): Signature => {


### PR DESCRIPTION
## What it solves

- Hides the MAX Button if the value is 0
- Shows a human-readable timeout error during tx execution

## How this PR fixes it

- `Number(0n)` resolves to 0 which gets rendered when trying to conditionally renders something with `&&`

## How to test it

1. Open a safe with no assets
2. Create a token transfer
3. Observe no MAX Button is visible
4. Create a transaction and execute with low gas
5. Wait until it times out
6. Observe a readable timeout error

## Screenshots
![Screenshot 2024-01-31 at 12 02 47](https://github.com/safe-global/safe-wallet-web/assets/5880855/c12f7f9b-a0fd-4118-94a8-3c5a92e86b75)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
