### PR TITLE
Point to development

### DIFF
--- a/src/components/swap/CowWidget.tsx
+++ b/src/components/swap/CowWidget.tsx
@@ -46,7 +46,8 @@ export const CowWidget = () => {
         TradeType.LIMIT,
         TradeType.ADVANCED,
       ],
-      theme: { // light/dark or provide your own color palette
+      env: 'dev',
+      theme: {
         baseTheme: 'dark',
         primary: '#12ff80',
         background: '#1c1c1c',
@@ -56,7 +57,6 @@ export const CowWidget = () => {
       interfaceFeeBips: '50', // 0.5% - COMING SOON! Fill the form above if you are interested
     })
   }, [walletProvider])
-
 
   if (!params.provider) {
     return null


### PR DESCRIPTION
## What it solves
The current version of CoW Swap in prod doesn't work with the PoC in #feat-cow-swap branch. 

This PR changes the environment to `dev` which means, the iframe use https://dev.swap.cow.fi/ instead of https://swap.cow.fi

We just applied a fix in DEV to disable bundling of transactions if CoW Swap doesn't manage to get an instance of the SWAP, this will solve the issue.

We should bring back bundling of transactions, so this will be a temporal fix. 