### PR TITLE
[Analytics] origin as label for safe app txs

### DIFF
--- a/src/services/analytics/__tests__/tx-tracking.test.ts
+++ b/src/services/analytics/__tests__/tx-tracking.test.ts
@@ -161,7 +161,7 @@ describe('getTransactionTrackingType', () => {
       },
     } as unknown)
 
-    expect(txType).toEqual(TX_TYPES.safeapps)
+    expect(txType).toEqual('https://gnosis-safe.io/app')
   })
 
   it('should return batch for multisend transactions', async () => {

--- a/src/services/analytics/events/transactions.ts
+++ b/src/services/analytics/events/transactions.ts
@@ -19,7 +19,6 @@ export enum TX_TYPES {
   batch = 'batch',
   rejection = 'rejection',
   typed_message = 'typed_message',
-  safeapps = 'safeapps',
   walletconnect = 'walletconnect',
   custom = 'custom',
 }

--- a/src/services/analytics/tx-tracking.ts
+++ b/src/services/analytics/tx-tracking.ts
@@ -56,7 +56,7 @@ export const getTransactionTrackingType = async (chainId: string, txId: string):
     }
 
     if (details.safeAppInfo) {
-      return isWalletConnectSafeApp(details.safeAppInfo.url) ? TX_TYPES.walletconnect : TX_TYPES.safeapps
+      return isWalletConnectSafeApp(details.safeAppInfo.url) ? TX_TYPES.walletconnect : details.safeAppInfo.url
     }
 
     if (isMultiSendTxInfo(txInfo)) {


### PR DESCRIPTION
## What it solves

Safe Apps tx events will now have the Safe App URL as their label.

## How to test it

1. Make a transaction via any Safe App
2. See in the console that the GTM events tx_created, tx_confirmed and tx_executed have the Safe App's URL as the `eventLabel` property.
