### PR TITLE
[Counterfactual] Enable addOwner and swapOwner flow for counterfactual safes

### DIFF
--- a/src/components/tx-flow/flows/AddOwner/ReviewOwner.tsx
+++ b/src/components/tx-flow/flows/AddOwner/ReviewOwner.tsx
@@ -1,3 +1,4 @@
+import { useCurrentChain } from '@/hooks/useChains'
 import { useContext, useEffect } from 'react'
 import { Typography, Divider, Box, SvgIcon, Paper } from '@mui/material'
 
@@ -20,21 +21,24 @@ export const ReviewOwner = ({ params }: { params: AddOwnerFlowProps | ReplaceOwn
   const { setSafeTx, setSafeTxError } = useContext(SafeTxContext)
   const { safe } = useSafeInfo()
   const { chainId } = safe
+  const chain = useCurrentChain()
   const { newOwner, removedOwner, threshold } = params
 
   useEffect(() => {
+    if (!chain) return
+
     const promise = removedOwner
-      ? createSwapOwnerTx({
+      ? createSwapOwnerTx(chain, safe.deployed, {
           newOwnerAddress: newOwner.address,
           oldOwnerAddress: removedOwner.address,
         })
-      : createAddOwnerTx({
+      : createAddOwnerTx(chain, safe.deployed, {
           ownerAddress: newOwner.address,
           threshold,
         })
 
     promise.then(setSafeTx).catch(setSafeTxError)
-  }, [removedOwner, newOwner, threshold, setSafeTx, setSafeTxError])
+  }, [removedOwner, newOwner, threshold, setSafeTx, setSafeTxError, chain, safe.deployed])
 
   const addAddressBookEntryAndSubmit = () => {
     if (typeof newOwner.name !== 'undefined') {

--- a/src/features/counterfactual/hooks/useDeployGasLimit.ts
+++ b/src/features/counterfactual/hooks/useDeployGasLimit.ts
@@ -1,9 +1,25 @@
+import { id } from 'ethers'
 import useAsync from '@/hooks/useAsync'
 import useChainId from '@/hooks/useChainId'
 import useOnboard from '@/hooks/wallets/useOnboard'
 import { getSafeSDKWithSigner } from '@/services/tx/tx-sender/sdk'
 import { estimateSafeDeploymentGas, estimateSafeTxGas, estimateTxBaseGas } from '@safe-global/protocol-kit'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
+
+const ADD_OWNER_WITH_THRESHOLD_SIG_HASH = id('addOwnerWithThreshold(address,uint256)').slice(0, 10)
+const SWAP_OWNER_SIG_HASH = id('swapOwner(address,address,address)').slice(0, 10)
+
+/**
+ * The estimation from the protocol-kit is too low for swapOwner and addOwnerWithThreshold,
+ * so we add a fixed amount
+ * @param safeTx
+ */
+const getExtraGasForSafety = (safeTx?: SafeTransaction): bigint => {
+  return safeTx?.data.data.startsWith(ADD_OWNER_WITH_THRESHOLD_SIG_HASH) ||
+    safeTx?.data.data.startsWith(SWAP_OWNER_SIG_HASH)
+    ? 25000n
+    : 0n
+}
 
 const useDeployGasLimit = (safeTx?: SafeTransaction) => {
   const onboard = useOnboard()
@@ -14,13 +30,15 @@ const useDeployGasLimit = (safeTx?: SafeTransaction) => {
 
     const sdk = await getSafeSDKWithSigner(onboard, chainId)
 
+    const extraGasForSafety = getExtraGasForSafety(safeTx)
+
     const [gas, safeTxGas, safeDeploymentGas] = await Promise.all([
       safeTx ? estimateTxBaseGas(sdk, safeTx) : '0',
       safeTx ? estimateSafeTxGas(sdk, safeTx) : '0',
       estimateSafeDeploymentGas(sdk),
     ])
 
-    return BigInt(gas) + BigInt(safeTxGas) + BigInt(safeDeploymentGas)
+    return BigInt(gas) + BigInt(safeTxGas) + BigInt(safeDeploymentGas) + extraGasForSafety
   }, [onboard, chainId, safeTx])
 
   return { gasLimit, gasLimitError, gasLimitLoading }


### PR DESCRIPTION
## What it solves

Resolves #3191

## How this PR fixes it

- Implements `addOwner` and `swapOwner` functions for undeployed safes

## How to test it

1. Create a counterfactual 1/1 safe
2. Navigate to the settings page
3. Add or swap an owner
4. Observe that there are no errors in the transaction flow
5. Observe that the transaction executes, deploys the safe and adds/swaps the owner

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
