### PR TITLE
[Counterfactual] Add first steps widget

### DIFF
--- a/src/components/dashboard/FirstSteps/index.tsx
+++ b/src/components/dashboard/FirstSteps/index.tsx
@@ -26,7 +26,7 @@ type StatusProgressItems = Array<{
 const StatusProgress = ({ items }: { items: StatusProgressItems }) => {
   const totalNumberOfItems = items.length
   const completedItems = items.filter((item) => item.completed)
-  const progress = Math.ceil(completedItems.length / totalNumberOfItems) * 100
+  const progress = Math.round((completedItems.length / totalNumberOfItems) * 100)
 
   return (
     <>

--- a/src/components/dashboard/FirstSteps/index.tsx
+++ b/src/components/dashboard/FirstSteps/index.tsx
@@ -19,13 +19,11 @@ const calculateProgress = (items: StatusProgressItems) => {
 
 const StatusCard = ({
   badge,
-  step,
   title,
   content,
   completed,
 }: {
   badge: string
-  step: number
   title: string
   content: string
   completed: boolean
@@ -43,7 +41,6 @@ const StatusCard = ({
         )}
       </div>
       <Typography variant="h4" fontWeight="bold" mb={2}>
-        <span className={css.circleBadge}>{step}</span>
         {title}
       </Typography>
       <Typography>{content}</Typography>
@@ -129,16 +126,10 @@ const FirstSteps = () => {
           </Grid>
         </Grid>
         <Grid container spacing={3}>
-          {items.map((item, index) => {
+          {items.map((item) => {
             return (
               <Grid item xs={12} md={4} key={item.title}>
-                <StatusCard
-                  badge="First steps"
-                  step={index + 1}
-                  title={item.title}
-                  content={item.content}
-                  completed={item.completed}
-                />
+                <StatusCard badge="First steps" title={item.title} content={item.content} completed={item.completed} />
               </Grid>
             )
           })}

--- a/src/components/dashboard/FirstSteps/index.tsx
+++ b/src/components/dashboard/FirstSteps/index.tsx
@@ -1,7 +1,10 @@
+import { TxModalContext } from '@/components/tx-flow'
+import { ActivateAccountFlow } from '@/features/counterfactual/ActivateAccount'
 import useBalances from '@/hooks/useBalances'
+import useSafeInfo from '@/hooks/useSafeInfo'
 import { useAppSelector } from '@/store'
 import { selectOutgoingTransactions } from '@/store/txHistorySlice'
-import { useMemo } from 'react'
+import React, { useContext, useMemo } from 'react'
 import { Card, WidgetBody, WidgetContainer } from '@/components/dashboard/styled'
 import { Button, CircularProgress, Grid, Link, Typography } from '@mui/material'
 import CircleOutlinedIcon from '@mui/icons-material/CircleOutlined'
@@ -69,7 +72,9 @@ const FirstStepsContent: StatusProgressItems = [
 
 const FirstSteps = () => {
   const { balances } = useBalances()
+  const { safe } = useSafeInfo()
   const outgoingTransactions = useAppSelector(selectOutgoingTransactions)
+  const { setTxFlow } = useContext(TxModalContext)
 
   const hasNonZeroBalance = balances && (balances.items.length > 1 || BigInt(balances.items[0]?.balance || 0) > 0)
   const hasOutgoingTransactions = !!outgoingTransactions && outgoingTransactions.length > 0
@@ -83,14 +88,13 @@ const FirstSteps = () => {
   )
 
   const activateAccount = () => {
-    // TODO: Open safe deployment flow
+    setTxFlow(<ActivateAccountFlow />)
   }
 
   const progress = calculateProgress(items)
   const stepsCompleted = items.filter((item) => item.completed).length
-  const isCounterfactual = false // TODO: Add real check here
 
-  if (!isCounterfactual) return null
+  if (safe.deployed) return null
 
   return (
     <WidgetContainer>

--- a/src/components/dashboard/FirstSteps/index.tsx
+++ b/src/components/dashboard/FirstSteps/index.tsx
@@ -1,27 +1,12 @@
 import useBalances from '@/hooks/useBalances'
 import { useAppSelector } from '@/store'
 import { selectOutgoingTransactions } from '@/store/txHistorySlice'
-import { type ReactNode, useMemo } from 'react'
+import { useMemo } from 'react'
 import { Card, WidgetBody, WidgetContainer } from '@/components/dashboard/styled'
-import { LinearProgress, List, ListItem, ListItemIcon, Typography } from '@mui/material'
+import { Button, CircularProgress, Grid, Link, Typography } from '@mui/material'
 import CircleOutlinedIcon from '@mui/icons-material/CircleOutlined'
 import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded'
-
-const StatusItem = ({ children, completed = false }: { children: ReactNode; completed?: boolean }) => {
-  return (
-    <ListItem disableGutters>
-      <ListItemIcon sx={{ minWidth: 24, mr: 1, color: (theme) => theme.palette.primary.main }}>
-        {completed ? <CheckCircleRoundedIcon /> : <CircleOutlinedIcon />}
-      </ListItemIcon>
-      {children}
-    </ListItem>
-  )
-}
-
-type StatusProgressItems = Array<{
-  name: string
-  completed: boolean
-}>
+import css from './styles.module.css'
 
 const calculateProgress = (items: StatusProgressItems) => {
   const totalNumberOfItems = items.length
@@ -29,33 +14,58 @@ const calculateProgress = (items: StatusProgressItems) => {
   return Math.round((completedItems.length / totalNumberOfItems) * 100)
 }
 
-const StatusProgress = ({ items }: { items: StatusProgressItems }) => {
-  const progress = calculateProgress(items)
-
+const StatusCard = ({
+  badge,
+  step,
+  title,
+  content,
+  completed,
+}: {
+  badge: string
+  step: number
+  title: string
+  content: string
+  completed: boolean
+}) => {
   return (
-    <>
-      <List disablePadding sx={{ py: 3 }}>
-        {items.map(({ name, completed }) => {
-          return (
-            <StatusItem key={name} completed={completed}>
-              {name}
-            </StatusItem>
-          )
-        })}
-      </List>
-      <LinearProgress color="secondary" variant="determinate" value={progress} sx={{ borderRadius: 1 }} />
-      <Typography variant="body2" mt={0.5}>
-        {progress}% completed
+    <Card className={css.card}>
+      <div className={css.topBadge}>
+        <Typography variant="body2">{badge}</Typography>
+      </div>
+      <div className={css.status}>
+        {completed ? (
+          <CheckCircleRoundedIcon color="primary" fontSize="medium" />
+        ) : (
+          <CircleOutlinedIcon color="inherit" fontSize="medium" />
+        )}
+      </div>
+      <Typography variant="h4" fontWeight="bold" mb={2}>
+        <span className={css.circleBadge}>{step}</span>
+        {title}
       </Typography>
-    </>
+      <Typography>{content}</Typography>
+    </Card>
   )
 }
 
-enum FirstStepNames {
-  AddFunds = 'Add funds',
-  CreateFirstTx = 'Create your first transaction',
-  SafeReady = 'Safe is ready',
+type StatusProgressItem = {
+  title: string
+  content: string
+  completed?: boolean
 }
+
+type StatusProgressItems = Array<StatusProgressItem>
+
+const FirstStepsContent: StatusProgressItems = [
+  {
+    title: 'Add funds',
+    content: 'Receive assets to start interacting with your account.',
+  },
+  {
+    title: 'Create your first transaction',
+    content: 'Do a simple transfer or use a safe app to create your first transaction.',
+  },
+]
 
 const FirstSteps = () => {
   const { balances } = useBalances()
@@ -66,22 +76,81 @@ const FirstSteps = () => {
 
   const items = useMemo(
     () => [
-      { name: FirstStepNames.AddFunds, completed: hasNonZeroBalance },
-      { name: FirstStepNames.CreateFirstTx, completed: hasOutgoingTransactions },
-      { name: FirstStepNames.SafeReady, completed: hasNonZeroBalance && hasOutgoingTransactions },
+      { ...FirstStepsContent[0], completed: hasNonZeroBalance },
+      { ...FirstStepsContent[1], completed: hasOutgoingTransactions },
     ],
     [hasNonZeroBalance, hasOutgoingTransactions],
   )
 
+  const activateAccount = () => {
+    // TODO: Open safe deployment flow
+  }
+
+  const progress = calculateProgress(items)
+  const stepsCompleted = items.filter((item) => item.completed).length
+  const isCounterfactual = false // TODO: Add real check here
+
+  if (!isCounterfactual) return null
+
   return (
     <WidgetContainer>
       <WidgetBody>
-        <Card>
-          <Typography variant="h4" fontWeight="bold">
-            First steps
-          </Typography>
-          <StatusProgress items={items} />
-        </Card>
+        <Grid container gap={3} mb={2} flexWrap="nowrap">
+          <Grid item position="relative">
+            <CircularProgress variant="determinate" value={100} className={css.circleBg} size={60} thickness={5} />
+            <CircularProgress
+              variant="determinate"
+              value={progress}
+              className={css.circleProgress}
+              size={60}
+              thickness={5}
+            />
+          </Grid>
+          <Grid item>
+            <Typography component="div" variant="h2" fontWeight={700} mb={1}>
+              Activate your Safe Account
+            </Typography>
+            <Typography variant="body2">
+              <strong>
+                {stepsCompleted} of {items.length} steps completed.
+              </strong>{' '}
+              {progress === 100 ? (
+                <>
+                  Congratulations! You finished the first steps. <Link>Hide this section</Link>
+                </>
+              ) : (
+                'Finish the next steps to start using all Safe Account features:'
+              )}
+            </Typography>
+          </Grid>
+        </Grid>
+        <Grid container spacing={3}>
+          {items.map((item, index) => {
+            return (
+              <Grid item xs={12} md={4} key={item.title}>
+                <StatusCard
+                  badge="First steps"
+                  step={index + 1}
+                  title={item.title}
+                  content={item.content}
+                  completed={item.completed}
+                />
+              </Grid>
+            )
+          })}
+
+          <Grid item xs={12} md={4}>
+            <Card className={css.card}>
+              <Typography variant="h4" fontWeight="bold" mb={2}>
+                Skip first steps
+              </Typography>
+              <Typography mb={2}>Pay a network fee to immediately access all Safe Account features.</Typography>
+              <Button variant="contained" onClick={activateAccount}>
+                Activate Safe Account
+              </Button>
+            </Card>
+          </Grid>
+        </Grid>
       </WidgetBody>
     </WidgetContainer>
   )

--- a/src/components/dashboard/FirstSteps/index.tsx
+++ b/src/components/dashboard/FirstSteps/index.tsx
@@ -29,7 +29,7 @@ const calculateProgress = (items: StatusProgressItems) => {
   return Math.round((completedItems.length / totalNumberOfItems) * 100)
 }
 
-const StatusProgress = ({ items, completedName }: { items: StatusProgressItems; completedName?: string }) => {
+const StatusProgress = ({ items }: { items: StatusProgressItems }) => {
   const progress = calculateProgress(items)
 
   return (
@@ -42,7 +42,6 @@ const StatusProgress = ({ items, completedName }: { items: StatusProgressItems; 
             </StatusItem>
           )
         })}
-        {completedName && <StatusItem completed={progress === 100}>{completedName}</StatusItem>}
       </List>
       <LinearProgress color="secondary" variant="determinate" value={progress} sx={{ borderRadius: 1 }} />
       <Typography variant="body2" mt={0.5}>
@@ -69,6 +68,7 @@ const FirstSteps = () => {
     () => [
       { name: FirstStepNames.AddFunds, completed: hasNonZeroBalance },
       { name: FirstStepNames.CreateFirstTx, completed: hasOutgoingTransactions },
+      { name: FirstStepNames.SafeReady, completed: hasNonZeroBalance && hasOutgoingTransactions },
     ],
     [hasNonZeroBalance, hasOutgoingTransactions],
   )
@@ -80,7 +80,7 @@ const FirstSteps = () => {
           <Typography variant="h4" fontWeight="bold">
             First steps
           </Typography>
-          <StatusProgress items={items} completedName={FirstStepNames.SafeReady} />
+          <StatusProgress items={items} />
         </Card>
       </WidgetBody>
     </WidgetContainer>

--- a/src/components/dashboard/FirstSteps/index.tsx
+++ b/src/components/dashboard/FirstSteps/index.tsx
@@ -1,0 +1,77 @@
+import useBalances from '@/hooks/useBalances'
+import { useAppSelector } from '@/store'
+import { selectOutgoingTransactions } from '@/store/txHistorySlice'
+import { type ReactNode } from 'react'
+import { Card, WidgetBody, WidgetContainer } from '@/components/dashboard/styled'
+import { LinearProgress, List, ListItem, ListItemIcon, Typography } from '@mui/material'
+import CircleOutlinedIcon from '@mui/icons-material/CircleOutlined'
+import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded'
+
+const StatusItem = ({ children, completed = false }: { children: ReactNode; completed?: boolean }) => {
+  return (
+    <ListItem disableGutters>
+      <ListItemIcon sx={{ minWidth: 24, mr: 1, color: (theme) => theme.palette.primary.main }}>
+        {completed ? <CheckCircleRoundedIcon /> : <CircleOutlinedIcon />}
+      </ListItemIcon>
+      {children}
+    </ListItem>
+  )
+}
+
+type StatusProgressItems = Array<{
+  name: string
+  completed: boolean
+}>
+
+const StatusProgress = ({ items }: { items: StatusProgressItems }) => {
+  const totalNumberOfItems = items.length
+  const completedItems = items.filter((item) => item.completed)
+  const progress = Math.ceil(completedItems.length / totalNumberOfItems) * 100
+
+  return (
+    <>
+      <List disablePadding sx={{ py: 3 }}>
+        {items.map(({ name, completed }) => {
+          return (
+            <StatusItem key={name} completed={completed}>
+              {name}
+            </StatusItem>
+          )
+        })}
+      </List>
+      <LinearProgress color="secondary" variant="determinate" value={progress} sx={{ borderRadius: 1 }} />
+      <Typography variant="body2" mt={0.5}>
+        {progress}% completed
+      </Typography>
+    </>
+  )
+}
+
+const FirstSteps = () => {
+  const { balances } = useBalances()
+  const outgoingTransactions = useAppSelector(selectOutgoingTransactions)
+
+  const hasNonZeroBalance = balances && (balances.items.length > 1 || BigInt(balances.items[0]?.balance || 0) > 0)
+  const hasOutgoingTransactions = !!outgoingTransactions && outgoingTransactions.length > 0
+
+  const items = [
+    { name: 'Add funds', completed: hasNonZeroBalance },
+    { name: 'Create your first transaction', completed: hasOutgoingTransactions },
+    { name: 'Safe is ready', completed: hasNonZeroBalance && hasOutgoingTransactions },
+  ]
+
+  return (
+    <WidgetContainer>
+      <WidgetBody>
+        <Card>
+          <Typography variant="h4" fontWeight="bold">
+            First steps
+          </Typography>
+          <StatusProgress items={items} />
+        </Card>
+      </WidgetBody>
+    </WidgetContainer>
+  )
+}
+
+export default FirstSteps

--- a/src/components/dashboard/FirstSteps/styles.module.css
+++ b/src/components/dashboard/FirstSteps/styles.module.css
@@ -1,0 +1,43 @@
+.circleProgress {
+  color: var(--color-secondary-main);
+}
+
+.circleBg {
+  color: var(--color-border-light);
+  position: absolute;
+}
+
+.circleBadge {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background-color: var(--color-secondary-light);
+  text-align: center;
+  font-weight: normal;
+  font-size: 16px;
+  display: inline-block;
+  margin-right: var(--space-1);
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: flex-start;
+  min-height: 240px;
+}
+
+.topBadge {
+  position: absolute;
+  top: 0;
+  right: 24px;
+  background-color: var(--color-secondary-light);
+  border-radius: 0 0 4px 4px;
+  padding: 4px var(--space-1);
+}
+
+.status {
+  align-self: flex-start;
+  margin-bottom: auto;
+  color: var(--color-border-light);
+}

--- a/src/components/dashboard/FirstSteps/styles.module.css
+++ b/src/components/dashboard/FirstSteps/styles.module.css
@@ -7,18 +7,6 @@
   position: absolute;
 }
 
-.circleBadge {
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  background-color: var(--color-secondary-light);
-  text-align: center;
-  font-weight: normal;
-  font-size: 16px;
-  display: inline-block;
-  margin-right: var(--space-1);
-}
-
 .card {
   display: flex;
   flex-direction: column;

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -34,11 +34,7 @@ const Dashboard = (): ReactElement => {
         </Grid>
 
         <Grid item xs={12}>
-          <Grid container>
-            <Grid item xs={12} lg={4}>
-              <FirstSteps />
-            </Grid>
-          </Grid>
+          <FirstSteps />
         </Grid>
 
         <Grid item xs={12} lg={6}>

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -1,3 +1,4 @@
+import FirstSteps from '@/components/dashboard/FirstSteps'
 import type { ReactElement } from 'react'
 import dynamic from 'next/dynamic'
 import { Grid } from '@mui/material'
@@ -30,6 +31,14 @@ const Dashboard = (): ReactElement => {
 
         <Grid item xs={12} lg={6}>
           <Overview />
+        </Grid>
+
+        <Grid item xs={12}>
+          <Grid container>
+            <Grid item xs={12} lg={4}>
+              <FirstSteps />
+            </Grid>
+          </Grid>
         </Grid>
 
         <Grid item xs={12} lg={6}>

--- a/src/features/counterfactual/ActivateAccount.tsx
+++ b/src/features/counterfactual/ActivateAccount.tsx
@@ -54,7 +54,7 @@ const useActivateAccount = () => {
   return { options, totalFee, walletCanPay }
 }
 
-const ActivateAccountFlow = () => {
+export const ActivateAccountFlow = () => {
   const [isSubmittable, setIsSubmittable] = useState<boolean>(true)
   const [submitError, setSubmitError] = useState<Error | undefined>()
   const [executionMethod, setExecutionMethod] = useState(ExecutionMethod.RELAY)

--- a/src/store/txHistorySlice.ts
+++ b/src/store/txHistorySlice.ts
@@ -1,6 +1,7 @@
 import type { listenerMiddlewareInstance } from '@/store'
+import { createSelector } from '@reduxjs/toolkit'
 import type { TransactionListPage } from '@safe-global/safe-gateway-typescript-sdk'
-import { isTransactionListItem } from '@/utils/transaction-guards'
+import { isCreationTxInfo, isIncomingTransfer, isTransactionListItem } from '@/utils/transaction-guards'
 import { txDispatch, TxEvent } from '@/services/tx/txEvents'
 import { selectPendingTxs } from './pendingTxsSlice'
 import { makeLoadableSlice } from './common'
@@ -9,6 +10,12 @@ const { slice, selector } = makeLoadableSlice('txHistory', undefined as Transact
 
 export const txHistorySlice = slice
 export const selectTxHistory = selector
+
+export const selectOutgoingTransactions = createSelector(selectTxHistory, (txHistory) => {
+  return txHistory.data?.results.filter(isTransactionListItem).filter((tx) => {
+    return !isIncomingTransfer(tx.transaction.txInfo) && !isCreationTxInfo(tx.transaction.txInfo)
+  })
+})
 
 export const txHistoryListener = (listenerMiddleware: typeof listenerMiddlewareInstance) => {
   listenerMiddleware.startListening({

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -100,6 +100,10 @@ export const isOutgoingTransfer = (txInfo: TransactionInfo): boolean => {
   return isTransferTxInfo(txInfo) && txInfo.direction.toUpperCase() === TransferDirection.OUTGOING
 }
 
+export const isIncomingTransfer = (txInfo: TransactionInfo): boolean => {
+  return isTransferTxInfo(txInfo) && txInfo.direction.toUpperCase() === TransferDirection.INCOMING
+}
+
 // TransactionListItem type guards
 export const isLabelListItem = (value: TransactionListItem): value is Label => {
   return value.type === TransactionListItemType.LABEL


### PR DESCRIPTION
## What it solves

Part of #3207 

## How this PR fixes it

- Creates a new widget for the dashboard to show first steps
- Creates `StatusProgress` component that can be reused for other widgets

## How to test it

1. Create a new counterfactual safe
2. Observe first steps card visible on the dashboard
3. Complete first steps or deploy safe immediately
4. Observe cards are not visible anymore

## Screenshots
<img width="1269" alt="Screenshot 2024-02-07 at 16 55 48" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/18d25dab-a05e-4609-8e8f-5fe80973b221">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
