### PR TITLE
fix: ENS resolution

### DIFF
--- a/src/hooks/wallets/web3.ts
+++ b/src/hooks/wallets/web3.ts
@@ -1,6 +1,6 @@
 import { type ChainInfo, RPC_AUTHENTICATION, type RpcUri } from '@safe-global/safe-gateway-typescript-sdk'
 import { INFURA_TOKEN, SAFE_APPS_INFURA_TOKEN } from '@/config/constants'
-import { JsonRpcProvider, BrowserProvider, type Eip1193Provider, type Provider, Network } from 'ethers'
+import { JsonRpcProvider, BrowserProvider, type Eip1193Provider, type Provider } from 'ethers'
 import ExternalStore from '@/services/ExternalStore'
 import { EMPTY_DATA } from '@safe-global/protocol-kit/dist/src/utils/constants'
 
@@ -23,7 +23,7 @@ export const getRpcServiceUrl = (rpcUri: RpcUri): string => {
 export const createWeb3ReadOnly = (chain: ChainInfo, customRpc?: string): JsonRpcProvider | undefined => {
   const url = customRpc || getRpcServiceUrl(chain.rpcUri)
   if (!url) return
-  return new JsonRpcProvider(url, new Network(chain.chainName, chain.chainId), {
+  return new JsonRpcProvider(url, undefined, {
     staticNetwork: true,
   })
 }
@@ -35,7 +35,7 @@ export const createWeb3 = (walletProvider: Eip1193Provider): BrowserProvider => 
 export const createSafeAppsWeb3Provider = (chain: ChainInfo, customRpc?: string): JsonRpcProvider | undefined => {
   const url = customRpc || formatRpcServiceUrl(chain.rpcUri, SAFE_APPS_INFURA_TOKEN)
   if (!url) return
-  return new JsonRpcProvider(url, new Network(chain.chainName, chain.chainId), {
+  return new JsonRpcProvider(url, undefined, {
     staticNetwork: true,
   })
 }


### PR DESCRIPTION
## What it solves

The ENS resolution stopped working after #3208.

## How this PR fixes it

This PR partially reverts the changes and instantiates the `JsonRpcProvider` without a network object.

## How to test it

1. Open a safe on mainnet or sepolia
2. Create a new transaction
3. Type an ENS as the recipient
4. Observe the name resolves

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
