### PR TITLE
Fix: rm old domain link

### DIFF
--- a/src/components/settings/DataManagement/index.tsx
+++ b/src/components/settings/DataManagement/index.tsx
@@ -8,8 +8,6 @@ import { addressBookSlice, selectAllAddressBooks } from '@/store/addressBookSlic
 import { addedSafesSlice, selectAllAddedSafes } from '@/store/addedSafesSlice'
 import { safeAppsSlice, selectSafeApps } from '@/store/safeAppsSlice'
 import { selectSettings, settingsSlice } from '@/store/settingsSlice'
-import InfoIcon from '@/public/images/notifications/info.svg'
-import ExternalLink from '@/components/common/ExternalLink'
 import { ImportFileUpload } from '@/components/settings/DataManagement/ImportFileUpload'
 import { ImportDialog } from '@/components/settings/DataManagement/ImportDialog'
 import { SAFE_EXPORT_VERSION } from '@/components/settings/DataManagement/useGlobalImportFileParser'
@@ -98,20 +96,6 @@ const DataManagement = () => {
               settings={settings}
               safeApps={safeApps}
             />
-            <Typography>
-              <SvgIcon
-                component={InfoIcon}
-                inheritViewBox
-                fontSize="small"
-                color="border"
-                sx={{
-                  verticalAlign: 'middle',
-                  mr: 0.5,
-                }}
-              />
-              You can also export your data from the{' '}
-              <ExternalLink href="https://gnosis-safe.io/app/export">old app</ExternalLink>
-            </Typography>
           </Grid>
         </Grid>
       </Paper>


### PR DESCRIPTION
The old export link doesn't work anymore as the domain was taken down.

![image](https://github.com/safe-global/safe-wallet-web/assets/381895/572bdffc-d5c5-44c8-9169-4b45eb188078)
![image (1)](https://github.com/safe-global/safe-wallet-web/assets/381895/482f331b-b542-4dc2-9ba5-e8b0d07e8cb7)
