### PR TITLE
fix: add basesep to testnets

### DIFF
--- a/src/components/common/NetworkSelector/index.tsx
+++ b/src/components/common/NetworkSelector/index.tsx
@@ -31,7 +31,7 @@ const MenuWithTooltip = forwardRef<HTMLUListElement>(function MenuWithTooltip(pr
   )
 })
 
-const testNets = ['gor', 'base-gor', 'sep']
+const testNets = ['gor', 'basegor', 'basesep', 'sep']
 const isTestnet = (shortName: string) => {
   return testNets.includes(shortName)
 }


### PR DESCRIPTION
## What it solves
Base Sepolia is not listed as Testnet.

## How this PR fixes it
Adds Base Sepolia to testnets.

## How to test it
- Check network selector

## Screenshots
![Screenshot 2024-02-08 at 14 26 28](https://github.com/safe-global/safe-wallet-web/assets/2670790/e697fad2-e2c3-4cc2-bc0d-e170acc54579)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
