### PR TITLE
fix: [Counterfactual] Deploy safe with specific version

### DIFF
--- a/src/components/new-safe/create/logic/index.ts
+++ b/src/components/new-safe/create/logic/index.ts
@@ -1,3 +1,4 @@
+import type { SafeVersion } from '@safe-global/safe-core-sdk-types'
 import { type BrowserProvider, type Provider } from 'ethers'
 
 import { getSafeInfo, type SafeInfo, type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
@@ -59,10 +60,14 @@ export const getSafeDeployProps = async (
 /**
  * Create a Safe creation transaction via Core SDK and submits it to the wallet
  */
-export const createNewSafe = async (ethersProvider: BrowserProvider, props: DeploySafeProps): Promise<Safe> => {
+export const createNewSafe = async (
+  ethersProvider: BrowserProvider,
+  props: DeploySafeProps,
+  safeVersion?: SafeVersion,
+): Promise<Safe> => {
   const ethAdapter = await createEthersAdapter(ethersProvider)
 
-  const safeFactory = await SafeFactory.create({ ethAdapter })
+  const safeFactory = await SafeFactory.create({ ethAdapter, safeVersion })
   return safeFactory.deploySafe(props)
 }
 
@@ -280,10 +285,22 @@ export const getRedirect = (
   return redirectUrl + `${appendChar}safe=${address}`
 }
 
-export const relaySafeCreation = async (chain: ChainInfo, owners: string[], threshold: number, saltNonce: number) => {
-  const readOnlyProxyFactoryContract = await getReadOnlyProxyFactoryContract(chain.chainId, LATEST_SAFE_VERSION)
+export const relaySafeCreation = async (
+  chain: ChainInfo,
+  owners: string[],
+  threshold: number,
+  saltNonce: number,
+  safeVersion?: SafeVersion,
+) => {
+  const readOnlyProxyFactoryContract = await getReadOnlyProxyFactoryContract(
+    chain.chainId,
+    safeVersion ?? LATEST_SAFE_VERSION,
+  )
   const proxyFactoryAddress = await readOnlyProxyFactoryContract.getAddress()
-  const readOnlyFallbackHandlerContract = await getReadOnlyFallbackHandlerContract(chain.chainId, LATEST_SAFE_VERSION)
+  const readOnlyFallbackHandlerContract = await getReadOnlyFallbackHandlerContract(
+    chain.chainId,
+    safeVersion ?? LATEST_SAFE_VERSION,
+  )
   const fallbackHandlerAddress = await readOnlyFallbackHandlerContract.getAddress()
   const readOnlySafeContract = await getReadOnlyGnosisSafeContract(chain)
   const safeContractAddress = await readOnlySafeContract.getAddress()

--- a/src/features/counterfactual/ActivateAccount.tsx
+++ b/src/features/counterfactual/ActivateAccount.tsx
@@ -96,6 +96,7 @@ const ActivateAccountFlow = () => {
           undeployedSafe.safeAccountConfig.owners,
           undeployedSafe.safeAccountConfig.threshold,
           Number(undeployedSafe.safeDeploymentConfig?.saltNonce!),
+          undeployedSafe.safeDeploymentConfig?.safeVersion,
         )
 
         waitForCreateSafeTx(taskId, (status) => {
@@ -104,11 +105,15 @@ const ActivateAccountFlow = () => {
           }
         })
       } else {
-        await createNewSafe(provider, {
-          safeAccountConfig: undeployedSafe.safeAccountConfig,
-          saltNonce: undeployedSafe.safeDeploymentConfig?.saltNonce,
-          options,
-        })
+        await createNewSafe(
+          provider,
+          {
+            safeAccountConfig: undeployedSafe.safeAccountConfig,
+            saltNonce: undeployedSafe.safeDeploymentConfig?.saltNonce,
+            options,
+          },
+          undeployedSafe.safeDeploymentConfig?.safeVersion,
+        )
         onSuccess()
       }
     } catch (_err) {


### PR DESCRIPTION
## What it solves

Part of #3156 

## How this PR fixes it

- Adds a new optional parameter `safeVersion` to `createNewSafe` and `relaySafeCreation`
- Passes the `safeVersion` to those functions for undeployed safes

## How to test it

1. Create a new counterfactual safe
2. Deploy the safe either via first transaction or separate deployment
3. Observe the safe address is deployed
4. Create a safe normally
5. Observe the predicted safe address is the one that is also deployed

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
