### PR TITLE
Tests: add more tests for address book

### DIFF
--- a/cypress/e2e/pages/address_book.page.js
+++ b/cypress/e2e/pages/address_book.page.js
@@ -1,3 +1,4 @@
+import * as constants from '../../support/constants'
 import * as main from '../pages/main.page'
 
 export const addressBookRecipient = '[data-testid="address-book-recipient"]'
@@ -15,16 +16,27 @@ const importBtn = '[data-testid="import-btn"]'
 const cancelImportBtn = '[data-testid="cancel-btn"]'
 const uploadErrorMsg = '[data-testid="error-message"]'
 const modalSummaryMessage = '[data-testid="summary-message"]'
+const saveBtn = '[data-testid="save-btn"]'
+const divInput = '[data-testid="name-input"]'
+const exportSummary = '[data-testid="export-summary"]'
+const sendBtn = '[data-testid="send-btn"]'
+
+//TODO Move to specific component
+const moreActionIcon = '[data-testid="MoreHorizIcon"]'
 
 export const acceptSelection = 'Save settings'
 export const addressBook = 'Address book'
 const createEntryBtn = 'Create entry'
 export const delteEntryModaldeleteBtn = 'Delete'
 const exportBtn = 'Export'
-const saveBtn = 'Save'
+// const saveBtn = 'Save'
 const whatsNewBtnStr = "What's new"
 const beamrCookiesStr = 'accept the "Beamer" cookies'
 const headerImportBtnStr = 'Import'
+const mandatoryNameStr = 'Name *'
+const nameSortBtn = 'Name'
+const addressortBtn = 'Address'
+const addToAddressBookStr = 'Add to address book'
 
 export const emptyCSVFile = '../fixtures/address_book_empty_test.csv'
 export const nonCSVFile = '../fixtures/balances.json'
@@ -32,6 +44,9 @@ export const duplicatedCSVFile = 'address_book_duplicated.csv'
 export const validCSVFile = '../fixtures/address_book_test.csv'
 export const networksCSVFile = '../fixtures/address_book_networks.csv'
 export const addedSafesCSVFile = '../fixtures/address_book_addedsafes.csv'
+
+const sortSafe1 = 'AA Safe'
+const sortSafe2 = 'BB Safe'
 
 export const entries = [
   '0x6E834E9D04ad6b26e1525dE1a37BFd9b215f40B7',
@@ -43,6 +58,56 @@ export const entries = [
   '0xBd69b0a9DC90eB6F9bAc3E4a5875f437348b6415',
   'assets-test-sepolia',
 ]
+
+export function verifyRecipientData(data) {
+  main.verifyValuesExist(addressBookRecipient, data)
+}
+
+export function clickOnSendBtn() {
+  cy.get(sendBtn).click()
+}
+
+export function clickOnMoreActionsBtn() {
+  cy.get(moreActionIcon).click()
+}
+
+export function clickOnAddToAddressBookBtn() {
+  cy.get('li span').contains(addToAddressBookStr).click()
+}
+
+export function verifyExportMessage(count) {
+  let msg = `${count} address book`
+  cy.get(exportSummary).should('contain', msg)
+}
+
+export function clickOnNameSortBtn() {
+  cy.get(tableContainer).contains(nameSortBtn).click()
+  cy.wait(500)
+}
+
+export function clickOnAddrressSortBtn() {
+  cy.get(tableContainer).contains(addressortBtn).click()
+  cy.wait(500)
+}
+
+export function verifyEntriesOrder(option = 'ascending') {
+  let address = constants.DEFAULT_OWNER_ADDRESS
+  let name = sortSafe1
+  if (option == 'descending') {
+    address = constants.RECIPIENT_ADDRESS
+    name = sortSafe2
+  }
+
+  cy.get(tableRow).eq(0).contains(address)
+  cy.get(tableRow).eq(0).contains(name)
+}
+
+export function addEntryByENS(name, ens) {
+  typeInName(name)
+  typeInAddress(ens)
+  clickOnSaveEntryBtn()
+  verifyNewEntryAdded(name, constants.SEPOLIA_TEST_SAFE_7)
+}
 
 export function verifyModalSummaryMessage(entryCount, chainCount) {
   cy.get(modalSummaryMessage).should(
@@ -104,7 +169,7 @@ export function typeInAddress(address) {
 }
 
 export function clickOnSaveEntryBtn() {
-  cy.contains('button', saveBtn).click()
+  cy.get(saveBtn).click()
 }
 
 export function verifyNewEntryAdded(name, address) {
@@ -125,10 +190,6 @@ export function clickOnEditEntryBtn() {
 
 export function typeInNameInput(name) {
   cy.get(nameInput).clear().type(name).should('have.value', name)
-}
-
-export function clickOnSaveButton() {
-  cy.contains('button', saveBtn).click()
 }
 
 export function verifyNameWasChanged(name, editedName) {
@@ -163,4 +224,10 @@ export function verifyBeamerIsChecked() {
 export function verifyBeameriFrameExists() {
   cy.wait(1000)
   cy.get(beameriFrameContainer).should('exist')
+}
+
+export function verifyEmptyOwnerNameNotAllowed() {
+  cy.get(nameInput).clear()
+  main.verifyElementsStatus([saveBtn], constants.enabledStates.disabled)
+  cy.get(divInput).contains(mandatoryNameStr)
 }

--- a/cypress/e2e/regression/address_book.cy.js
+++ b/cypress/e2e/regression/address_book.cy.js
@@ -13,12 +13,12 @@ const importedSafe = 'imported-safe'
 
 describe('Address book tests', () => {
   beforeEach(() => {
-    cy.clearLocalStorage()
     cy.visit(constants.addressBookUrl + constants.SEPOLIA_TEST_SAFE_1)
+    cy.clearLocalStorage()
     main.acceptCookies()
   })
 
-  it('Verify entered entry in Name input can be saved', () => {
+  it('Verify owners name can be edited', () => {
     main
       .addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sepoliaAddress1)
       .then(() => {
@@ -28,7 +28,7 @@ describe('Address book tests', () => {
             cy.reload()
             addressBook.clickOnEditEntryBtn()
             addressBook.typeInNameInput(EDITED_NAME)
-            addressBook.clickOnSaveButton()
+            addressBook.clickOnSaveEntryBtn()
             addressBook.verifyNameWasChanged(NAME, EDITED_NAME)
           })
       })
@@ -65,6 +65,7 @@ describe('Address book tests', () => {
           const fileName = `safe-address-book-${date}.csv`
 
           addressBook.clickOnExportFileBtn()
+          addressBook.verifyExportMessage(12)
           addressBook.confirmExport()
 
           const downloadsFolder = Cypress.config('downloadsFolder')

--- a/cypress/e2e/regression/address_book_2.cy.js
+++ b/cypress/e2e/regression/address_book_2.cy.js
@@ -1,0 +1,69 @@
+import * as constants from '../../support/constants.js'
+import * as addressBook from '../pages/address_book.page.js'
+import * as main from '../pages/main.page.js'
+import * as ls from '../../support/localstorage_data.js'
+import * as createtx from '../../e2e/pages/create_tx.pages'
+import * as data from '../../fixtures/txhistory_data_data.json'
+
+const typeReceive = data.type.receive
+
+const owner1 = 'Automation owner'
+const onwer2 = 'Changed Automation owner'
+const onwer3 = 'New Automation owner'
+
+describe('Address book tests - 2', () => {
+  beforeEach(() => {
+    cy.visit(constants.addressBookUrl + constants.SEPOLIA_TEST_SAFE_1)
+    cy.clearLocalStorage()
+    cy.wait(1000)
+    main.acceptCookies()
+  })
+
+  it('Verify Name and Address columns sorting works', () => {
+    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sortingData)
+    cy.reload()
+    addressBook.clickOnNameSortBtn()
+    addressBook.verifyEntriesOrder()
+    addressBook.clickOnNameSortBtn()
+    addressBook.verifyEntriesOrder('descending')
+
+    // Clicking twice is required to trigger actual click after swtiching from Name
+    addressBook.clickOnAddrressSortBtn()
+    addressBook.clickOnAddrressSortBtn()
+    addressBook.verifyEntriesOrder()
+    addressBook.clickOnAddrressSortBtn()
+    addressBook.verifyEntriesOrder('descending')
+  })
+
+  it('Verify that edit owners name changes the name in the settings', () => {
+    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sepoliaAddress2)
+    cy.reload()
+    addressBook.clickOnEditEntryBtn()
+    addressBook.typeInNameInput(onwer2)
+    addressBook.clickOnSaveEntryBtn()
+    addressBook.verifyNameWasChanged(owner1, onwer2)
+    cy.visit(constants.setupUrl + constants.SEPOLIA_TEST_SAFE_1)
+    addressBook.verifyNameWasChanged(owner1, onwer2)
+  })
+
+  it('Verify that editing an entry from the transaction details updates the name in address book', () => {
+    cy.visit(constants.transactionsHistoryUrl + constants.SEPOLIA_TEST_SAFE_8)
+    main.waitForHistoryCallToComplete()
+    createtx.clickOnTransactionItemByName(typeReceive.summaryTitle, typeReceive.summaryTxInfo)
+    addressBook.clickOnMoreActionsBtn()
+    addressBook.clickOnAddToAddressBookBtn()
+    addressBook.typeInNameInput(onwer3)
+    addressBook.clickOnSaveEntryBtn()
+    addressBook.verifyNameWasChanged(owner1, onwer3)
+    cy.visit(constants.addressBookUrl + constants.SEPOLIA_TEST_SAFE_8)
+    addressBook.verifyNameWasChanged(owner1, onwer3)
+  })
+
+  it('Verify copy to clipboard/Etherscan work as expected', () => {
+    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sepoliaAddress1)
+    cy.wait(1000)
+    cy.reload()
+    createtx.verifyCopyIconWorks(0, constants.RECIPIENT_ADDRESS)
+    createtx.verifyNumberOfExternalLinks(1)
+  })
+})

--- a/cypress/e2e/safe-apps/tx-builder.spec.cy.js
+++ b/cypress/e2e/safe-apps/tx-builder.spec.cy.js
@@ -200,6 +200,7 @@ describe('Transaction Builder tests', { defaultCommandTimeout: 20000 }, () => {
   it('Verify a batch cannot be created without asset amount', () => {
     cy.enter(iframeSelector).then((getBody) => {
       getBody().findByLabelText(safeapps.enterAddressStr).type(constants.SEPOLIA_TEST_SAFE_10)
+      getBody().findByText(safeapps.keepProxiABIStr).click()
       getBody().findByText(safeapps.addTransactionStr).click()
       getBody().findAllByText(safeapps.requiredStr).should('have.css', 'color', 'rgb(244, 67, 54)')
     })
@@ -269,6 +270,7 @@ describe('Transaction Builder tests', { defaultCommandTimeout: 20000 }, () => {
   it('Verify a valid batch as successful can be simulated', () => {
     cy.enter(iframeSelector).then((getBody) => {
       getBody().findByLabelText(safeapps.enterAddressStr).type(constants.SEPOLIA_TEST_SAFE_10)
+      getBody().findByText(safeapps.keepProxiABIStr).click()
       getBody().findByLabelText(safeapps.tokenAmount).type('0')
       getBody().findByText(safeapps.addTransactionStr).click()
       getBody().findByText(safeapps.createBatchStr).click()
@@ -281,6 +283,7 @@ describe('Transaction Builder tests', { defaultCommandTimeout: 20000 }, () => {
   it('Verify an invalid batch as failed can be simulated', () => {
     cy.enter(iframeSelector).then((getBody) => {
       getBody().findByLabelText(safeapps.enterAddressStr).type(constants.SEPOLIA_TEST_SAFE_10)
+      getBody().findByText(safeapps.keepProxiABIStr).click()
       getBody().findByLabelText(safeapps.tokenAmount).type('100')
       getBody().findByText(safeapps.addTransactionStr).click()
       getBody().findByText(safeapps.createBatchStr).click()

--- a/cypress/e2e/smoke/address_book.cy.js
+++ b/cypress/e2e/smoke/address_book.cy.js
@@ -5,13 +5,17 @@ import * as main from '../../e2e/pages/main.page'
 import * as ls from '../../support/localstorage_data.js'
 
 const NAME = 'Owner1'
+const NAME_2 = 'Owner2'
 const EDITED_NAME = 'Edited Owner1'
 const duplicateEntry = 'test-sepolia-90'
+const owner1 = 'Automation owner'
+
+const recipientData = [owner1, constants.DEFAULT_OWNER_ADDRESS]
 
 describe('[SMOKE] Address book tests', () => {
   beforeEach(() => {
-    cy.clearLocalStorage()
     cy.visit(constants.addressBookUrl + constants.SEPOLIA_TEST_SAFE_1)
+    cy.clearLocalStorage()
     main.waitForHistoryCallToComplete()
     main.acceptCookies()
   })
@@ -73,5 +77,26 @@ describe('[SMOKE] Address book tests', () => {
     addressBook.importCSVFile(addressBook.networksCSVFile)
     addressBook.verifyImportBtnStatus(constants.enabledStates.enabled)
     addressBook.verifyModalSummaryMessage(4, 3)
+  })
+
+  it('[SMOKE] Verify an entry can be added by ENS name', () => {
+    addressBook.clickOnCreateEntryBtn()
+    addressBook.addEntryByENS(NAME_2, constants.ENS_TEST_SEPOLIA)
+  })
+
+  it('[SMOKE] Verify empty name is not allowed when editing', () => {
+    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sepoliaAddress1)
+    cy.wait(1000)
+    cy.reload()
+    addressBook.clickOnEditEntryBtn()
+    addressBook.verifyEmptyOwnerNameNotAllowed()
+  })
+
+  it('[SMOKE] Verify clicking on Send button autofills the recipient filed with correct value', () => {
+    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sepoliaAddress2)
+    cy.wait(1000)
+    cy.reload()
+    addressBook.clickOnSendBtn()
+    addressBook.verifyRecipientData(recipientData)
   })
 })

--- a/cypress/support/localstorage_data.js
+++ b/cypress/support/localstorage_data.js
@@ -326,6 +326,13 @@ export const addressBookData = {
       '0x9E6DAfe829431e1892EcF8461FDAd02665170c31': 'Added non-owner',
     },
   },
+  sortingData: {
+    11155111: {
+      '0xC16Db0251654C0a72E91B190d81eAD367d2C6fED': 'AA Safe',
+      '0x6a5602335a878ADDCa4BF63a050E34946B56B5bC': 'BB Safe',
+    },
+  },
+  cookies: { necessary: true, updates: true, analytics: true },
 }
 
 export const safeSettings = {

--- a/src/components/address-book/AddressBookTable/index.tsx
+++ b/src/components/address-book/AddressBookTable/index.tsx
@@ -120,6 +120,7 @@ function AddressBookTable({ chain, setTxFlow }: AddressBookTableProps) {
               {(isOk) => (
                 <Track {...ADDRESS_BOOK_EVENTS.SEND}>
                   <Button
+                    data-testid="send-btn"
                     variant="contained"
                     color="primary"
                     size="small"

--- a/src/components/address-book/ExportDialog/index.tsx
+++ b/src/components/address-book/ExportDialog/index.tsx
@@ -63,7 +63,7 @@ function ExportDialog({
   return (
     <ModalDialog open onClose={handleClose} dialogTitle="Export address book" hideChainIndicator>
       <DialogContent sx={{ p: '24px !important' }}>
-        <Typography>
+        <Typography data-testid="export-summary">
           You&apos;re about to export a CSV file with{' '}
           <b>
             {length} address book {length === 1 ? 'entry' : 'entries'}
@@ -84,7 +84,7 @@ function ExportDialog({
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
         <CSVDownloader filename={filename} bom config={{ delimiter: ',' }} data={csvData} style={{ order: 2 }}>
-          <Button variant="contained" disableElevation onClick={onSubmit}>
+          <Button data-testid="export-modal-btn" variant="contained" disableElevation onClick={onSubmit}>
             Export
           </Button>
         </CSVDownloader>


### PR DESCRIPTION
## What it solves

Resolves #3229 

## How this PR fixes it

- Added tests to cover remaining tests in Address Book
- 
Tests added:

- Verify an entry can be added by ENS name
- Verify empty name is not allowed when editing
- Verify clicking on Send button autofills the recipient filed with correct value
- Verify Name and Address columns sorting works
- Verify that edit owners name changes the name in the settings
- Verify that editing an entry from the transaction details updates the name in address book
- Verify copy to clipboard/Etherscan work as expected

## How to test it

- Run Cypress tests and observe outcome

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
