### PR TITLE
fix: [Counterfactual] try signing methods when signing

### DIFF
--- a/src/features/counterfactual/utils.ts
+++ b/src/features/counterfactual/utils.ts
@@ -7,7 +7,7 @@ import { getWeb3ReadOnly } from '@/hooks/wallets/web3'
 import ExternalStore from '@/services/ExternalStore'
 import { type ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import { asError } from '@/services/exceptions/utils'
-import { assertWalletChain, getUncheckedSafeSDK } from '@/services/tx/tx-sender/sdk'
+import { assertWalletChain, getUncheckedSafeSDK, tryOffChainTxSigning } from '@/services/tx/tx-sender/sdk'
 import { txDispatch, TxEvent } from '@/services/tx/txEvents'
 import type { AppDispatch } from '@/store'
 import { addOrUpdateSafe } from '@/store/addedSafesSlice'
@@ -63,7 +63,7 @@ export const dispatchTxExecutionAndDeploySafe = async (
 
   let result: ContractTransactionResponse | undefined
   try {
-    const signedTx = await sdkUnchecked.signTransaction(safeTx)
+    const signedTx = await tryOffChainTxSigning(safeTx, await sdkUnchecked.getContractVersion(), sdkUnchecked)
 
     const wallet = await assertWalletChain(onboard, chainId)
     const provider = createWeb3(wallet.provider)


### PR DESCRIPTION
## What it solves

Part of #3156

## How this PR fixes it

- Uses the existing `tryOffChainSigning` method when signing the bundled transaction

## How to test it

1. Create a counterfactual safe with a hardware wallet
2. Deploy the safe with the first transaction
3. Observe no error when signing

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
