### PR TITLE
Fix: don't display 0 nonce for grouped txs

### DIFF
--- a/src/components/transactions/TxSummary/index.tsx
+++ b/src/components/transactions/TxSummary/index.tsx
@@ -42,7 +42,7 @@ const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
       })}
       id={tx.id}
     >
-      {nonce && !isGrouped && (
+      {nonce != null && !isGrouped && (
         <Box gridArea="nonce" data-testid="nonce" className={css.nonce}>
           {nonce}
         </Box>

--- a/src/components/transactions/TxSummary/index.tsx
+++ b/src/components/transactions/TxSummary/index.tsx
@@ -42,7 +42,7 @@ const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
       })}
       id={tx.id}
     >
-      {nonce != null && !isGrouped && (
+      {nonce !== undefined && !isGrouped && (
         <Box gridArea="nonce" data-testid="nonce" className={css.nonce}>
           {nonce}
         </Box>


### PR DESCRIPTION
## What it solves

Resolves #3249

## How this PR fixes it

Nonce is a number, so 0 wasn't passing the check.

After the fix:
<img width="539" alt="Screenshot 2024-02-13 at 17 08 30" src="https://github.com/safe-global/safe-wallet-web/assets/381895/cb630efd-3a32-43f4-b2cc-57bc07382957">
