### PR TITLE
Add connect button to owned safe list when no wallet is connected

### DIFF
--- a/src/components/common/ConnectWallet/ConnectWalletButton.tsx
+++ b/src/components/common/ConnectWallet/ConnectWalletButton.tsx
@@ -1,7 +1,15 @@
 import { Button } from '@mui/material'
 import useConnectWallet from '@/components/common/ConnectWallet/useConnectWallet'
 
-const ConnectWalletButton = ({ onConnect }: { onConnect?: () => void }): React.ReactElement => {
+const ConnectWalletButton = ({
+  onConnect,
+  contained = true,
+  text,
+}: {
+  onConnect?: () => void
+  contained?: boolean
+  text?: string
+}): React.ReactElement => {
   const connectWallet = useConnectWallet()
 
   const handleConnect = () => {
@@ -12,13 +20,13 @@ const ConnectWalletButton = ({ onConnect }: { onConnect?: () => void }): React.R
   return (
     <Button
       onClick={handleConnect}
-      variant="contained"
+      variant={contained ? 'contained' : 'text'}
       size="small"
       disableElevation
       fullWidth
       sx={{ fontSize: ['12px', '13px'] }}
     >
-      Connect
+      {text || 'Connect'}
     </Button>
   )
 }

--- a/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
+++ b/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
@@ -7,11 +7,11 @@ import Track from '@/components/common/Track'
 import { OVERVIEW_EVENTS } from '@/services/analytics'
 import css from './styles.module.css'
 import useWallet from '@/hooks/wallets/useWallet'
-import useConnectWallet from '@/components/common/ConnectWallet/useConnectWallet'
 
 type PaginatedSafeListProps = {
   safes: SafeItems
   title: ReactNode
+  noSafesMessage?: ReactNode
   action?: ReactElement
   onLinkClick?: () => void
 }
@@ -20,10 +20,9 @@ const DEFAULT_SHOWN = 5
 const MAX_DEFAULT_SHOWN = 7
 const PAGE_SIZE = 5
 
-const PaginatedSafeList = ({ safes, title, action, onLinkClick }: PaginatedSafeListProps) => {
+const PaginatedSafeList = ({ safes, title, action, noSafesMessage, onLinkClick }: PaginatedSafeListProps) => {
   const [maxShownSafes, setMaxShownSafes] = useState<number>(DEFAULT_SHOWN)
   const wallet = useWallet()
-  const handleConnect = useConnectWallet()
 
   const shownSafes = useMemo(() => {
     if (safes.length <= MAX_DEFAULT_SHOWN) {
@@ -50,16 +49,9 @@ const PaginatedSafeList = ({ safes, title, action, onLinkClick }: PaginatedSafeL
       </div>
       {shownSafes.length ? (
         shownSafes.map((item) => <AccountItem onLinkClick={onLinkClick} {...item} key={item.chainId + item.address} />)
-      ) : !wallet ? (
-        <Typography variant="body2" color="text.secondary" textAlign="center" my={3} mx="auto" width={250}>
-          Connect a wallet to view your Safe Accounts or to create a new one
-          <Button onClick={handleConnect} disableElevation size="small" sx={{ mt: 2 }}>
-            Connect a wallet
-          </Button>
-        </Typography>
       ) : (
-        <Typography variant="body2" color="text.secondary" textAlign="center" my={3}>
-          You don&apos;t have any Safe Accounts yet
+        <Typography variant="body2" color="text.secondary" textAlign="center" my={3} mx="auto" width={250}>
+          {noSafesMessage}
         </Typography>
       )}
       {safes.length > shownSafes.length && (

--- a/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
+++ b/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
@@ -6,6 +6,8 @@ import { type SafeItems } from './useAllSafes'
 import Track from '@/components/common/Track'
 import { OVERVIEW_EVENTS } from '@/services/analytics'
 import css from './styles.module.css'
+import useWallet from '@/hooks/wallets/useWallet'
+import useConnectWallet from '@/components/common/ConnectWallet/useConnectWallet'
 
 type PaginatedSafeListProps = {
   safes: SafeItems
@@ -20,6 +22,8 @@ const PAGE_SIZE = 5
 
 const PaginatedSafeList = ({ safes, title, action, onLinkClick }: PaginatedSafeListProps) => {
   const [maxShownSafes, setMaxShownSafes] = useState<number>(DEFAULT_SHOWN)
+  const wallet = useWallet()
+  const handleConnect = useConnectWallet()
 
   const shownSafes = useMemo(() => {
     if (safes.length <= MAX_DEFAULT_SHOWN) {
@@ -46,8 +50,15 @@ const PaginatedSafeList = ({ safes, title, action, onLinkClick }: PaginatedSafeL
       </div>
       {shownSafes.length ? (
         shownSafes.map((item) => <AccountItem onLinkClick={onLinkClick} {...item} key={item.chainId + item.address} />)
+      ) : !wallet ? (
+        <Typography variant="body2" color="text.secondary" textAlign="center" my={3} mx="auto" width={250}>
+          Connect a wallet to view your Safe Accounts or to create a new one
+          <Button onClick={handleConnect} disableElevation size="small" sx={{ marginTop: 2 }}>
+            Connect a wallet
+          </Button>
+        </Typography>
       ) : (
-        <Typography variant="body2" color="primary.light" textAlign="center" my={3}>
+        <Typography variant="body2" color="text.secondary" textAlign="center" my={3} mx="auto" width={250}>
           You don&apos;t have any Safe Accounts yet
         </Typography>
       )}

--- a/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
+++ b/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
@@ -58,7 +58,7 @@ const PaginatedSafeList = ({ safes, title, action, onLinkClick }: PaginatedSafeL
           </Button>
         </Typography>
       ) : (
-        <Typography variant="body2" color="text.secondary" textAlign="center" my={3} mx="auto" width={250}>
+        <Typography variant="body2" color="text.secondary" textAlign="center" my={3}>
           You don&apos;t have any Safe Accounts yet
         </Typography>
       )}

--- a/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
+++ b/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
@@ -53,7 +53,7 @@ const PaginatedSafeList = ({ safes, title, action, onLinkClick }: PaginatedSafeL
       ) : !wallet ? (
         <Typography variant="body2" color="text.secondary" textAlign="center" my={3} mx="auto" width={250}>
           Connect a wallet to view your Safe Accounts or to create a new one
-          <Button onClick={handleConnect} disableElevation size="small" sx={{ marginTop: 2 }}>
+          <Button onClick={handleConnect} disableElevation size="small" sx={{ mt: 2 }}>
             Connect a wallet
           </Button>
         </Typography>

--- a/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
+++ b/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
@@ -6,7 +6,6 @@ import { type SafeItems } from './useAllSafes'
 import Track from '@/components/common/Track'
 import { OVERVIEW_EVENTS } from '@/services/analytics'
 import css from './styles.module.css'
-import useWallet from '@/hooks/wallets/useWallet'
 
 type PaginatedSafeListProps = {
   safes: SafeItems
@@ -22,7 +21,6 @@ const PAGE_SIZE = 5
 
 const PaginatedSafeList = ({ safes, title, action, noSafesMessage, onLinkClick }: PaginatedSafeListProps) => {
   const [maxShownSafes, setMaxShownSafes] = useState<number>(DEFAULT_SHOWN)
-  const wallet = useWallet()
 
   const shownSafes = useMemo(() => {
     if (safes.length <= MAX_DEFAULT_SHOWN) {

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -11,6 +11,7 @@ import PaginatedSafeList from './PaginatedSafeList'
 import { VisibilityOutlined } from '@mui/icons-material'
 import AddIcon from '@/public/images/common/add.svg'
 import { AppRoutes } from '@/config/routes'
+import useConnectWallet from '@/components/common/ConnectWallet/useConnectWallet'
 
 type AccountsListProps = {
   safes: SafeItems
@@ -19,6 +20,7 @@ type AccountsListProps = {
 const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
   const ownedSafes = useMemo(() => safes.filter(({ isWatchlist }) => !isWatchlist), [safes])
   const watchlistSafes = useMemo(() => safes.filter(({ isWatchlist }) => isWatchlist), [safes])
+  const handleConnect = useConnectWallet()
 
   return (
     <Box className={css.container}>
@@ -30,7 +32,19 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
           <CreateButton />
         </Box>
 
-        <PaginatedSafeList title="My accounts" safes={ownedSafes} onLinkClick={onLinkClick} />
+        <PaginatedSafeList
+          title="My accounts"
+          safes={ownedSafes}
+          onLinkClick={onLinkClick}
+          noSafesMessage={
+            <>
+              Connect a wallet to view your Safe Accounts or to create a new one
+              <Button onClick={handleConnect} disableElevation size="small" sx={{ mt: 2 }}>
+                Connect a wallet
+              </Button>
+            </>
+          }
+        />
 
         <PaginatedSafeList
           title={
@@ -54,6 +68,7 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
               </Link>
             </Track>
           }
+          noSafesMessage="You don't have any Safe Accounts yet"
           onLinkClick={onLinkClick}
         />
 

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -11,7 +11,7 @@ import PaginatedSafeList from './PaginatedSafeList'
 import { VisibilityOutlined } from '@mui/icons-material'
 import AddIcon from '@/public/images/common/add.svg'
 import { AppRoutes } from '@/config/routes'
-import useConnectWallet from '@/components/common/ConnectWallet/useConnectWallet'
+import ConnectWalletButton from '@/components/common/ConnectWallet/ConnectWalletButton'
 
 type AccountsListProps = {
   safes: SafeItems
@@ -20,7 +20,6 @@ type AccountsListProps = {
 const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
   const ownedSafes = useMemo(() => safes.filter(({ isWatchlist }) => !isWatchlist), [safes])
   const watchlistSafes = useMemo(() => safes.filter(({ isWatchlist }) => isWatchlist), [safes])
-  const handleConnect = useConnectWallet()
 
   return (
     <Box className={css.container}>
@@ -38,10 +37,8 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
           onLinkClick={onLinkClick}
           noSafesMessage={
             <>
-              Connect a wallet to view your Safe Accounts or to create a new one
-              <Button onClick={handleConnect} disableElevation size="small" sx={{ mt: 2 }}>
-                Connect a wallet
-              </Button>
+              <Box mb={2}>Connect a wallet to view your Safe Accounts or to create a new one</Box>
+              <ConnectWalletButton text="Connect a wallet" contained={false} />
             </>
           }
         />

--- a/src/components/welcome/MyAccounts/styles.module.css
+++ b/src/components/welcome/MyAccounts/styles.module.css
@@ -107,15 +107,18 @@
 
   .header {
     padding: var(--space-3);
+    border-bottom: 1px solid var(--color-border-light);
   }
 
   .safeList {
-    border-top: 1px solid var(--color-border-light);
-    border-bottom: 1px solid var(--color-border-light);
     border-radius: 0;
   }
 
   .title {
     font-size: 20px;
+  }
+
+  .card {
+    border-top: 1px solid var(--color-border-light);
   }
 }


### PR DESCRIPTION
## What it solves

https://www.notion.so/My-accounts-Empty-state-b92fff61cd454471bb9af8cc18c589bd?pvs=4

## How this PR fixes it
Adds a state to the owned safes list for when a wallet is not connected. Includes a button for connecting a wallet
