### PR TITLE
fix: [Counterfactual] Only show success screen once

### DIFF
--- a/src/components/dashboard/FirstSteps/index.tsx
+++ b/src/components/dashboard/FirstSteps/index.tsx
@@ -89,7 +89,7 @@ const AddFundsWidget = ({ completed }: { completed: boolean }) => {
             hideChainIndicator
           >
             <Box px={4} pb={5} pt={4}>
-              <Grid container spacing={2} alignItems="center" mb={4}>
+              <Grid container spacing={2} alignItems="center" justifyContent="center" mb={4}>
                 <Grid item>
                   <Box p={1} border={1} borderRadius="6px" borderColor="border.light" display="inline-flex">
                     <QRCode value={safeAddress} size={132} />
@@ -105,7 +105,7 @@ const AddFundsWidget = ({ completed }: { completed: boolean }) => {
                     <EthHashInfo
                       address={safeAddress}
                       showName={false}
-                      shortAddress={true}
+                      shortAddress={false}
                       showCopyButton
                       hasExplorer
                       avatarSize={24}

--- a/src/components/new-safe/create/steps/ReviewStep/styles.module.css
+++ b/src/components/new-safe/create/steps/ReviewStep/styles.module.css
@@ -17,7 +17,7 @@
 .networkFee {
   padding: var(--space-1);
   background-color: var(--color-secondary-background);
-  color: var(--color-static-main);
+  color: var(--color-text-primary);
   width: fit-content;
   border-radius: 6px;
 }

--- a/src/features/counterfactual/ActivateAccountFlow.tsx
+++ b/src/features/counterfactual/ActivateAccountFlow.tsx
@@ -83,10 +83,6 @@ const ActivateAccountFlow = () => {
   const { owners, threshold } = undeployedSafe.props.safeAccountConfig
   const { saltNonce, safeVersion } = undeployedSafe.props.safeDeploymentConfig || {}
 
-  const onSuccess = () => {
-    safeCreationDispatch(SafeCreationEvent.SUCCESS, { groupKey: CF_TX_GROUP_KEY, safeAddress })
-  }
-
   const onSubmit = (txHash?: string) => {
     trackEvent({ ...TX_EVENTS.CREATE, label: TX_TYPES.activate_without_tx })
     trackEvent({ ...TX_EVENTS.EXECUTE, label: TX_TYPES.activate_without_tx })
@@ -123,7 +119,6 @@ const ActivateAccountFlow = () => {
           },
           safeVersion,
         )
-        onSuccess()
       }
     } catch (_err) {
       const err = asError(_err)


### PR DESCRIPTION
## What it solves

Resolves #3156 

## How this PR fixes it

The `SUCCESS` event was emitted twice when deploying a safe. Once from the original promise coming from the protocol-kit and then also from the watcher that we start. I removed the `onSuccess` callback in the original promise since the watcher is always running.

This PR also fixes minor UI issues mentioned on the [QA Board](https://www.notion.so/safe-global/c56befc17429427fa47a67fbe5ebc4cb?v=c6cfec4c5b32445bab938f15a76d33e4)

## How to test it

1. Create a counterfactual safe
2. Go to dashboard and activate it now without an additional tx
3. Observe there is only one success screen at the end

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
