### PR TITLE
Fix: move Linea bridge to warned bridges

### DIFF
--- a/src/features/walletconnect/constants.ts
+++ b/src/features/walletconnect/constants.ts
@@ -51,7 +51,6 @@ export const BlockedBridges = [
   // Unsupported chain bridges
   'bridge.zora.energy',
   'bridge.mantle.xyz',
-  'bridge.linea.build',
   'bridge.metis.io',
   'scroll.io',
   'pacific-bridge.manta.network',
@@ -70,6 +69,7 @@ export const WarnedBridges = [
   'app.allbridge.io',
   'bridge.arbitrum.io',
   'bridge.base.org',
+  'bridge.linea.build',
   'core.allbridge.io',
   'bungee.exchange',
   'www.carrier.so',


### PR DESCRIPTION
## What it solves

Resolves #3078

## How this PR fixes it

I've moved the Linea bridge from the red unsupported bridges to the yellow warned bridges list.