### PR TITLE
Redirect form /welcome page when wallet is connected

### DIFF
--- a/cypress/e2e/regression/create_safe_simple.cy.js
+++ b/cypress/e2e/regression/create_safe_simple.cy.js
@@ -13,7 +13,6 @@ describe('Safe creation tests', () => {
   it('Verify Next button is disabled until switching to network is done', () => {
     owner.waitForConnectionStatus()
     createwallet.selectNetwork(constants.networks.ethereum)
-    createwallet.clickOnContinueWithWalletBtn()
     createwallet.clickOnCreateNewSafeBtn()
     createwallet.checkNetworkChangeWarningMsg()
     createwallet.verifyNextBtnIsDisabled()
@@ -24,7 +23,6 @@ describe('Safe creation tests', () => {
   // TODO: Check unit tests
   it('Verify error message is displayed if wallet name input exceeds 50 characters', () => {
     owner.waitForConnectionStatus()
-    createwallet.clickOnContinueWithWalletBtn()
     createwallet.clickOnCreateNewSafeBtn()
     createwallet.typeWalletName(main.generateRandomString(51))
     owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.exceedChars)
@@ -35,7 +33,6 @@ describe('Safe creation tests', () => {
   // TODO: Check unit tests
   it('Verify there is no error message is displayed if wallet name input contains less than 50 characters', () => {
     owner.waitForConnectionStatus()
-    createwallet.clickOnContinueWithWalletBtn()
     createwallet.clickOnCreateNewSafeBtn()
     createwallet.typeWalletName(main.generateRandomString(50))
     owner.verifyValidWalletName(constants.addressBookErrrMsg.exceedChars)
@@ -43,7 +40,6 @@ describe('Safe creation tests', () => {
 
   it('Verify current connected account is shown as default owner', () => {
     owner.waitForConnectionStatus()
-    createwallet.clickOnContinueWithWalletBtn()
     createwallet.clickOnCreateNewSafeBtn()
     createwallet.clickOnNextBtn()
     owner.verifyExistingOwnerAddress(0, constants.DEFAULT_OWNER_ADDRESS)
@@ -52,7 +48,6 @@ describe('Safe creation tests', () => {
   // TODO: Check unit tests
   it('Verify error message is displayed if owner name input exceeds 50 characters', () => {
     owner.waitForConnectionStatus()
-    createwallet.clickOnContinueWithWalletBtn()
     createwallet.clickOnCreateNewSafeBtn()
     owner.typeExistingOwnerName(main.generateRandomString(51))
     owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.exceedChars)
@@ -61,7 +56,6 @@ describe('Safe creation tests', () => {
   // TODO: Check unit tests
   it('Verify there is no error message is displayed if owner name input contains less than 50 characters', () => {
     owner.waitForConnectionStatus()
-    createwallet.clickOnContinueWithWalletBtn()
     createwallet.clickOnCreateNewSafeBtn()
     owner.typeExistingOwnerName(main.generateRandomString(50))
     owner.verifyValidWalletName(constants.addressBookErrrMsg.exceedChars)
@@ -70,7 +64,6 @@ describe('Safe creation tests', () => {
   it('Verify data persistence', () => {
     const ownerName = 'David'
     owner.waitForConnectionStatus()
-    createwallet.clickOnContinueWithWalletBtn()
     createwallet.clickOnCreateNewSafeBtn()
     createwallet.clickOnNextBtn()
     createwallet.clickOnAddNewOwnerBtn()
@@ -103,7 +96,6 @@ describe('Safe creation tests', () => {
 
   it('Verify tip is displayed on right side for threshold 1/1', () => {
     owner.waitForConnectionStatus()
-    createwallet.clickOnContinueWithWalletBtn()
     createwallet.clickOnCreateNewSafeBtn()
     createwallet.clickOnNextBtn()
     createwallet.verifyPolicy1_1()
@@ -112,7 +104,6 @@ describe('Safe creation tests', () => {
   // TODO: Check unit tests
   it('Verify address input validation rules', () => {
     owner.waitForConnectionStatus()
-    createwallet.clickOnContinueWithWalletBtn()
     createwallet.clickOnCreateNewSafeBtn()
     createwallet.clickOnNextBtn()
     createwallet.clickOnAddNewOwnerBtn()

--- a/cypress/e2e/smoke/create_safe_simple.cy.js
+++ b/cypress/e2e/smoke/create_safe_simple.cy.js
@@ -10,7 +10,6 @@ describe('[SMOKE] Safe creation tests', () => {
     main.acceptCookies()
   })
   it('[SMOKE] Verify a Wallet can be connected', () => {
-    createwallet.clickOnContinueWithWalletBtn()
     createwallet.clickOnCreateNewSafeBtn()
     owner.clickOnWalletExpandMoreIcon()
     owner.clickOnDisconnectBtn()
@@ -20,14 +19,12 @@ describe('[SMOKE] Safe creation tests', () => {
 
   it('[SMOKE] Verify that a new Wallet has default name related to the selected network', () => {
     owner.waitForConnectionStatus()
-    createwallet.clickOnContinueWithWalletBtn()
     createwallet.clickOnCreateNewSafeBtn()
     createwallet.verifyDefaultWalletName(createwallet.defaltSepoliaPlaceholder)
   })
 
   it('[SMOKE] Verify Add and Remove Owner Row works as expected', () => {
     owner.waitForConnectionStatus()
-    createwallet.clickOnContinueWithWalletBtn()
     createwallet.clickOnCreateNewSafeBtn()
     createwallet.clickOnNextBtn()
     createwallet.clickOnAddNewOwnerBtn()
@@ -42,7 +39,6 @@ describe('[SMOKE] Safe creation tests', () => {
 
   it('[SMOKE] Verify Threshold Setup', () => {
     owner.waitForConnectionStatus()
-    createwallet.clickOnContinueWithWalletBtn()
     createwallet.clickOnCreateNewSafeBtn()
     createwallet.clickOnNextBtn()
     createwallet.clickOnAddNewOwnerBtn()

--- a/src/components/common/ConnectWallet/ConnectWalletButton.tsx
+++ b/src/components/common/ConnectWallet/ConnectWalletButton.tsx
@@ -4,10 +4,12 @@ import useConnectWallet from '@/components/common/ConnectWallet/useConnectWallet
 const ConnectWalletButton = ({
   onConnect,
   contained = true,
+  small = false,
   text,
 }: {
   onConnect?: () => void
   contained?: boolean
+  small?: boolean
   text?: string
 }): React.ReactElement => {
   const connectWallet = useConnectWallet()
@@ -21,10 +23,10 @@ const ConnectWalletButton = ({
     <Button
       onClick={handleConnect}
       variant={contained ? 'contained' : 'text'}
-      size="small"
+      size={small ? 'small' : 'medium'}
       disableElevation
       fullWidth
-      sx={{ fontSize: ['12px', '13px'] }}
+      sx={{ fontSize: small ? ['12px', '13px'] : '' }}
     >
       {text || 'Connect'}
     </Button>

--- a/src/components/common/ConnectWallet/ConnectionCenter.tsx
+++ b/src/components/common/ConnectWallet/ConnectionCenter.tsx
@@ -30,7 +30,7 @@ export const ConnectionCenter = ({ isSocialLoginEnabled }: { isSocialLoginEnable
   if (!isSocialLoginEnabled) {
     return (
       <Box className={css.buttonContainer}>
-        <ConnectWalletButton />
+        <ConnectWalletButton small={true} />
       </Box>
     )
   }

--- a/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
+++ b/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
@@ -48,7 +48,7 @@ const PaginatedSafeList = ({ safes, title, action, noSafesMessage, onLinkClick }
       {shownSafes.length ? (
         shownSafes.map((item) => <AccountItem onLinkClick={onLinkClick} {...item} key={item.chainId + item.address} />)
       ) : (
-        <Typography variant="body2" color="text.secondary" textAlign="center" my={3} mx="auto" width={250}>
+        <Typography variant="body2" color="text.secondary" textAlign="center" py={3} mx="auto" width={250}>
           {noSafesMessage}
         </Typography>
       )}

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -12,6 +12,9 @@ import { VisibilityOutlined } from '@mui/icons-material'
 import AddIcon from '@/public/images/common/add.svg'
 import { AppRoutes } from '@/config/routes'
 import ConnectWalletButton from '@/components/common/ConnectWallet/ConnectWalletButton'
+import useWallet from '@/hooks/wallets/useWallet'
+
+const NO_SAFES_MESSAGE = "You don't have any Safe Accounts yet"
 
 type AccountsListProps = {
   safes: SafeItems
@@ -20,6 +23,7 @@ type AccountsListProps = {
 const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
   const ownedSafes = useMemo(() => safes.filter(({ isWatchlist }) => !isWatchlist), [safes])
   const watchlistSafes = useMemo(() => safes.filter(({ isWatchlist }) => isWatchlist), [safes])
+  const wallet = useWallet()
 
   return (
     <Box className={css.container}>
@@ -36,10 +40,14 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
           safes={ownedSafes}
           onLinkClick={onLinkClick}
           noSafesMessage={
-            <>
-              <Box mb={2}>Connect a wallet to view your Safe Accounts or to create a new one</Box>
-              <ConnectWalletButton text="Connect a wallet" contained={false} />
-            </>
+            wallet ? (
+              NO_SAFES_MESSAGE
+            ) : (
+              <>
+                <Box mb={2}>Connect a wallet to view your Safe Accounts or to create a new one</Box>
+                <ConnectWalletButton text="Connect a wallet" contained={false} />
+              </>
+            )
           }
         />
 
@@ -65,7 +73,7 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
               </Link>
             </Track>
           }
-          noSafesMessage="You don't have any Safe Accounts yet"
+          noSafesMessage={NO_SAFES_MESSAGE}
           onLinkClick={onLinkClick}
         />
 

--- a/src/components/welcome/MyAccounts/styles.module.css
+++ b/src/components/welcome/MyAccounts/styles.module.css
@@ -20,10 +20,6 @@
   margin-bottom: 0;
 }
 
-.safeList :last-child {
-  margin-bottom: 0;
-}
-
 .header {
   display: flex;
   flex-wrap: wrap;

--- a/src/components/welcome/MyAccounts/useAllSafes.ts
+++ b/src/components/welcome/MyAccounts/useAllSafes.ts
@@ -25,9 +25,14 @@ const useAddedSafes = () => {
 export const useHasSafes = () => {
   const { address = '' } = useWallet() || {}
   const allAdded = useAddedSafes()
-  const hasAdded = isEmpty(allAdded)
+  const hasAdded = !isEmpty(allAdded)
   const [allOwned] = useAllOwnedSafes(!hasAdded ? address : '') // pass an empty string to not fetch owned safes
-  return hasAdded || !isEmpty(allOwned)
+
+  if (hasAdded) return { isLoaded: true, hasSafes: hasAdded }
+  if (!allOwned) return { isLoaded: false }
+
+  const hasOwned = !isEmpty(Object.values(allOwned).flat())
+  return { isLoaded: true, hasSafes: hasOwned }
 }
 
 const useAllSafes = (): SafeItems => {

--- a/src/components/welcome/WelcomeLogin/index.tsx
+++ b/src/components/welcome/WelcomeLogin/index.tsx
@@ -6,11 +6,12 @@ import SafeLogo from '@/public/images/logo-text.svg'
 import dynamic from 'next/dynamic'
 import css from './styles.module.css'
 import { useRouter } from 'next/router'
-import WalletLogin from './WalletLogin'
 import { CREATE_SAFE_EVENTS } from '@/services/analytics/events/createLoadSafe'
 import { trackEvent } from '@/services/analytics'
 import useWallet from '@/hooks/wallets/useWallet'
 import { useHasSafes } from '../MyAccounts/useAllSafes'
+import { useEffect } from 'react'
+import ConnectWalletButton from '@/components/common/ConnectWallet/ConnectWalletButton'
 
 const SocialSigner = dynamic(() => import('@/components/common/SocialSigner'), {
   loading: () => <Skeleton variant="rounded" height={42} width="100%" />,
@@ -20,16 +21,18 @@ const WelcomeLogin = () => {
   const router = useRouter()
   const wallet = useWallet()
   const isSocialLoginEnabled = useHasFeature(FEATURES.SOCIAL_LOGIN)
-  const hasSafes = useHasSafes()
+  const { isLoaded, hasSafes } = useHasSafes()
 
-  const continueToCreation = () => {
-    if (hasSafes) {
-      router.push({ pathname: AppRoutes.welcome.accounts, query: router.query })
-    } else {
-      trackEvent(CREATE_SAFE_EVENTS.OPEN_SAFE_CREATION)
-      router.push({ pathname: AppRoutes.newSafe.create, query: router.query })
+  useEffect(() => {
+    if (wallet && isLoaded) {
+      if (hasSafes) {
+        router.push({ pathname: AppRoutes.welcome.accounts, query: router.query })
+      } else {
+        trackEvent(CREATE_SAFE_EVENTS.OPEN_SAFE_CREATION)
+        router.push({ pathname: AppRoutes.newSafe.create, query: router.query })
+      }
     }
-  }
+  }, [hasSafes, isLoaded, router, wallet])
 
   return (
     <Paper className={css.loginCard} data-testid="welcome-login">
@@ -46,7 +49,7 @@ const WelcomeLogin = () => {
             : 'Connect your wallet to create a new Safe Account or open an existing one'}
         </Typography>
 
-        <WalletLogin onLogin={continueToCreation} />
+        <ConnectWalletButton text="Connect wallet" />
 
         {isSocialLoginEnabled && (
           <>
@@ -56,7 +59,7 @@ const WelcomeLogin = () => {
               </Typography>
             </Divider>
 
-            <SocialSigner onLogin={continueToCreation} />
+            <SocialSigner />
           </>
         )}
       </Box>


### PR DESCRIPTION
Redirect from the welcome page depending on wether the user has any safes:
- If the user has either owned or added safes, redirect to the accounts page `/welcome/accounts`
- If the user has no safes to show, redirect them to create a new safe page `/new-safe/create`

## How to test it
On the `/welcome` page:
- Connect an account with owned safes, but with no added safes in the browser (private window)
  - should redirect to `/welcome/accounts`
- Connect an account with no owned safes (fresh MM account), but with added safes in the browser
  - should redirect to `/welcome/accounts`
- Connect an account with no owned safes, and no added safes
  - should redirect to `/new-safe/create`