### PR TITLE
fix: Adjust dashboard widget positions

### DIFF
--- a/src/components/dashboard/FeaturedApps/FeaturedApps.tsx
+++ b/src/components/dashboard/FeaturedApps/FeaturedApps.tsx
@@ -52,14 +52,9 @@ export const FeaturedApps = ({ stackedLayout }: { stackedLayout: boolean }): Rea
           Connect &amp; transact
         </Typography>
         <WidgetBody>
-          <Grid
-            container
-            flexDirection={{ xs: 'column', sm: 'row', lg: stackedLayout ? 'column' : undefined }}
-            gap={3}
-            height={1}
-          >
+          <Grid container spacing={3} height={1}>
             {featuredApps?.map((app) => (
-              <Grid item xs md key={app.id}>
+              <Grid item xs={12} md={6} key={app.id}>
                 <NextLink
                   passHref
                   href={{ pathname: AppRoutes.apps.open, query: { ...router.query, appUrl: app.url } }}

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -11,7 +11,6 @@ import GovernanceSection from '@/components/dashboard/GovernanceSection/Governan
 import CreationDialog from '@/components/dashboard/CreationDialog'
 import { useRouter } from 'next/router'
 import { CREATION_MODAL_QUERY_PARM } from '../new-safe/create/logic'
-import css from './styles.module.css'
 import useRecovery from '@/features/recovery/hooks/useRecovery'
 import { useIsRecoverySupported } from '@/features/recovery/hooks/useIsRecoverySupported'
 const RecoveryHeader = dynamic(() => import('@/features/recovery/components/RecoveryHeader'))
@@ -28,7 +27,7 @@ const Dashboard = (): ReactElement => {
 
   return (
     <>
-      <Grid container spacing={3} className={css.container}>
+      <Grid container spacing={3}>
         {supportsRecovery && <RecoveryHeader />}
 
         <Grid item xs={12}>
@@ -45,15 +44,15 @@ const Dashboard = (): ReactElement => {
               <PendingTxsList />
             </Grid>
 
-            <Grid item xs={12} lg={showRecoveryWidget ? 6 : undefined}>
-              <FeaturedApps stackedLayout={!!showRecoveryWidget} />
-            </Grid>
-
             {showRecoveryWidget ? (
               <Grid item xs={12} lg={6}>
                 <RecoveryWidget />
               </Grid>
             ) : null}
+
+            <Grid item xs={12}>
+              <FeaturedApps stackedLayout={!!showRecoveryWidget} />
+            </Grid>
 
             <Grid item xs={12}>
               <GovernanceSection />

--- a/src/components/dashboard/styles.module.css
+++ b/src/components/dashboard/styles.module.css
@@ -1,3 +1,0 @@
-.container > div:empty {
-  display: none;
-}

--- a/src/features/recovery/components/RecoveryWidget/index.tsx
+++ b/src/features/recovery/components/RecoveryWidget/index.tsx
@@ -33,7 +33,7 @@ function RecoveryWidget(): ReactElement {
                 <Chip label="New" />
               </Box>
 
-              <Typography mt={1} mb={3}>
+              <Typography mt={1}>
                 Ensure you never lose access to your funds by choosing a recovery option to recover your Safe Account.
               </Typography>
 

--- a/src/features/recovery/components/RecoveryWidget/styles.module.css
+++ b/src/features/recovery/components/RecoveryWidget/styles.module.css
@@ -4,7 +4,7 @@
 }
 
 .card {
-  padding: var(--space-4);
+  padding: var(--space-3) var(--space-4);
   height: inherit;
 }
 


### PR DESCRIPTION
## What it solves

Updating the overview widget layout as part of #3207 caused an empty widget slot that was closed from the top and bottom so it looks out of balance.

## How this PR fixes it

- Move the recovery widget to the top and spread the walletconnect and tx builder over the whole width

## How to test it

1. Open dashboard
2. See gap at the top

## Screenshots

<img width="1270" alt="Screenshot 2024-02-20 at 10 20 40" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/84678cdf-7f3f-452c-a99b-3eb4e83de900">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
