### PR TITLE
fix: Deploy Safes with version 1.4.1 by default

### DIFF
--- a/src/components/new-safe/create/logic/index.ts
+++ b/src/components/new-safe/create/logic/index.ts
@@ -87,8 +87,9 @@ export const createNewSafe = async (
 export const computeNewSafeAddress = async (
   ethersProvider: BrowserProvider,
   props: DeploySafeProps,
+  safeVersion?: SafeVersion,
 ): Promise<string> => {
-  const safeFactory = await getSafeFactory(ethersProvider)
+  const safeFactory = await getSafeFactory(ethersProvider, safeVersion)
   return safeFactory.predictSafeAddress(props.safeAccountConfig, props.saltNonce)
 }
 

--- a/src/components/new-safe/create/logic/utils.ts
+++ b/src/components/new-safe/create/logic/utils.ts
@@ -1,15 +1,24 @@
 import { computeNewSafeAddress } from '@/components/new-safe/create/logic/index'
 import { isSmartContract } from '@/hooks/wallets/web3'
 import type { DeploySafeProps } from '@safe-global/protocol-kit'
+import type { SafeVersion } from '@safe-global/safe-core-sdk-types'
 import type { BrowserProvider } from 'ethers'
 
-export const getAvailableSaltNonce = async (provider: BrowserProvider, props: DeploySafeProps): Promise<string> => {
-  const safeAddress = await computeNewSafeAddress(provider, props)
+export const getAvailableSaltNonce = async (
+  provider: BrowserProvider,
+  props: DeploySafeProps,
+  safeVersion?: SafeVersion,
+): Promise<string> => {
+  const safeAddress = await computeNewSafeAddress(provider, props, safeVersion)
   const isContractDeployed = await isSmartContract(provider, safeAddress)
 
   // Safe is already deployed so we try the next saltNonce
   if (isContractDeployed) {
-    return getAvailableSaltNonce(provider, { ...props, saltNonce: (Number(props.saltNonce) + 1).toString() })
+    return getAvailableSaltNonce(
+      provider,
+      { ...props, saltNonce: (Number(props.saltNonce) + 1).toString() },
+      safeVersion,
+    )
   }
 
   // We know that there will be a saltNonce but the type has it as optional

--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -34,6 +34,7 @@ import { hasRemainingRelays } from '@/utils/relaying'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import { Alert, Box, Button, CircularProgress, Divider, Grid, Typography } from '@mui/material'
 import { type DeploySafeProps } from '@safe-global/protocol-kit'
+import type { SafeVersion } from '@safe-global/safe-core-sdk-types'
 import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import classnames from 'classnames'
 import Image from 'next/image'
@@ -195,10 +196,9 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
     setIsCreating(true)
 
     try {
-      const readOnlyFallbackHandlerContract = await getReadOnlyFallbackHandlerContract(
-        chain.chainId,
-        LATEST_SAFE_VERSION,
-      )
+      const safeVersion = LATEST_SAFE_VERSION as SafeVersion
+
+      const readOnlyFallbackHandlerContract = await getReadOnlyFallbackHandlerContract(chain.chainId, safeVersion)
 
       const props: DeploySafeProps = {
         safeAccountConfig: {
@@ -208,8 +208,8 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
         },
       }
 
-      const saltNonce = await getAvailableSaltNonce(provider, { ...props, saltNonce: '0' })
-      const safeAddress = await computeNewSafeAddress(provider, { ...props, saltNonce })
+      const saltNonce = await getAvailableSaltNonce(provider, { ...props, saltNonce: '0' }, safeVersion)
+      const safeAddress = await computeNewSafeAddress(provider, { ...props, saltNonce }, safeVersion)
 
       if (isCounterfactual && payMethod === PayMethod.PayLater) {
         trackEvent({ ...OVERVIEW_EVENTS.PROCEED_WITH_TX, label: 'counterfactual', category: CREATE_SAFE_CATEGORY })

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -11,7 +11,7 @@ export const GATEWAY_URL_STAGING = process.env.NEXT_PUBLIC_GATEWAY_URL_STAGING |
 export const POLLING_INTERVAL = 15_000
 export const BASE_TX_GAS = 21_000
 export const LS_NAMESPACE = 'SAFE_v2__'
-export const LATEST_SAFE_VERSION = process.env.NEXT_PUBLIC_SAFE_VERSION || '1.3.0'
+export const LATEST_SAFE_VERSION = process.env.NEXT_PUBLIC_SAFE_VERSION || '1.4.1'
 
 // Access keys
 export const INFURA_TOKEN = process.env.NEXT_PUBLIC_INFURA_TOKEN || ''


### PR DESCRIPTION
## What it solves

Newly created safes are deployed with version 1.4.1 of the safe contracts.

Contracts: https://github.com/safe-global/safe-smart-account/releases/tag/v1.4.1

## How to test it

1. Open the app and create a safe on any network
2. Observe it being a 1.4.1 safe
3. Observe no outdated version warning for 1.3.0 safes

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
