### PR TITLE
fix: [RC] issues

### DIFF
--- a/src/components/common/BuyCryptoButton/index.tsx
+++ b/src/components/common/BuyCryptoButton/index.tsx
@@ -80,6 +80,7 @@ const _BuyCryptoButton = ({ href, pagePath }: { href?: LinkProps['href']; pagePa
             sx={buttonStyles}
             startIcon={<AddIcon />}
             className={css.buyCryptoButton}
+            fullWidth
           >
             Buy crypto
           </Button>

--- a/src/components/dashboard/Overview/Overview.tsx
+++ b/src/components/dashboard/Overview/Overview.tsx
@@ -80,7 +80,7 @@ const Overview = (): ReactElement => {
 
               {safe.deployed && (
                 <Grid item>
-                  <Grid container spacing={1} flexWrap="wrap">
+                  <Grid container spacing={1}>
                     <Grid item xs={12} sm="auto">
                       <BuyCryptoButton />
                     </Grid>

--- a/src/components/dashboard/Overview/Overview.tsx
+++ b/src/components/dashboard/Overview/Overview.tsx
@@ -79,33 +79,39 @@ const Overview = (): ReactElement => {
               </Grid>
 
               {safe.deployed && (
-                <Grid item>
-                  <Grid container spacing={1}>
-                    <Grid item xs={12} sm="auto">
-                      <BuyCryptoButton />
-                    </Grid>
+                <Grid
+                  item
+                  container
+                  spacing={1}
+                  xs={12}
+                  sm
+                  justifyContent="flex-end"
+                  flexWrap={{ xs: 'wrap', sm: 'nowrap' }}
+                >
+                  <Grid item xs={12} sm="auto">
+                    <BuyCryptoButton />
+                  </Grid>
 
-                    <Grid item xs={6} sm="auto">
-                      <Button
-                        onClick={handleOnSend}
-                        size="small"
-                        variant="outlined"
-                        color="primary"
-                        startIcon={<ArrowIconNW />}
-                        fullWidth
-                      >
-                        Send
-                      </Button>
-                    </Grid>
-                    <Grid item xs={6} sm="auto">
-                      <Track {...OVERVIEW_EVENTS.SHOW_QR} label="dashboard">
-                        <QrCodeButton>
-                          <Button size="small" variant="outlined" color="primary" startIcon={<ArrowIconSE />} fullWidth>
-                            Receive
-                          </Button>
-                        </QrCodeButton>
-                      </Track>
-                    </Grid>
+                  <Grid item xs={6} sm="auto">
+                    <Button
+                      onClick={handleOnSend}
+                      size="small"
+                      variant="outlined"
+                      color="primary"
+                      startIcon={<ArrowIconNW />}
+                      fullWidth
+                    >
+                      Send
+                    </Button>
+                  </Grid>
+                  <Grid item xs={6} sm="auto">
+                    <Track {...OVERVIEW_EVENTS.SHOW_QR} label="dashboard">
+                      <QrCodeButton>
+                        <Button size="small" variant="outlined" color="primary" startIcon={<ArrowIconSE />} fullWidth>
+                          Receive
+                        </Button>
+                      </QrCodeButton>
+                    </Track>
                   </Grid>
                 </Grid>
               )}

--- a/src/features/counterfactual/FirstTxFlow.tsx
+++ b/src/features/counterfactual/FirstTxFlow.tsx
@@ -1,4 +1,6 @@
 import { AppRoutes } from '@/config/routes'
+import { useIsRecoverySupported } from '@/features/recovery/hooks/useIsRecoverySupported'
+import useRecovery from '@/features/recovery/hooks/useRecovery'
 import dynamic from 'next/dynamic'
 import { OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
 import { useRouter } from 'next/router'
@@ -52,6 +54,8 @@ const FirstTxFlow = ({ open, onClose }: { open: boolean; onClose: () => void }) 
   const txBuilder = useTxBuilderApp()
   const router = useRouter()
   const { setTxFlow } = useContext(TxModalContext)
+  const supportsRecovery = useIsRecoverySupported()
+  const [recovery] = useRecovery()
 
   const handleClick = (onClick: () => void) => {
     onClose()
@@ -90,6 +94,8 @@ const FirstTxFlow = ({ open, onClose }: { open: boolean; onClose: () => void }) 
     router.push(txBuilder.link)
   }
 
+  const showRecoveryOption = supportsRecovery && !recovery
+
   return (
     <ModalDialog open={open} dialogTitle="Create new transaction" hideChainIndicator onClose={onClose}>
       <Grid container justifyContent="center" flexDirection="column" p={3} spacing={2}>
@@ -111,14 +117,16 @@ const FirstTxFlow = ({ open, onClose }: { open: boolean; onClose: () => void }) 
           />
         </Grid>
 
-        <Grid item>
-          <TxButton
-            title="Set up recovery"
-            description="Ensure you never lose access to your funds"
-            icon={RecoveryPlus}
-            onClick={() => handleClick(onRecovery)}
-          />
-        </Grid>
+        {showRecoveryOption && (
+          <Grid item>
+            <TxButton
+              title="Set up recovery"
+              description="Ensure you never lose access to your funds"
+              icon={RecoveryPlus}
+              onClick={() => handleClick(onRecovery)}
+            />
+          </Grid>
+        )}
 
         <Grid item>
           <TxButton

--- a/src/features/counterfactual/hooks/usePendingSafeStatuses.ts
+++ b/src/features/counterfactual/hooks/usePendingSafeStatuses.ts
@@ -86,7 +86,8 @@ const usePendingSafeStatus = (): void => {
 
     const checkDeploymentStatus = async () => {
       // In case the safe info hasn't been updated yet when switching safes
-      if ((await provider.getNetwork()).chainId !== BigInt(safe.chainId)) return
+      const { chainId } = await provider.getNetwork()
+      if (chainId !== BigInt(safe.chainId)) return
 
       const isContractDeployed = await isSmartContract(provider, safeAddress)
 

--- a/src/features/counterfactual/hooks/usePendingSafeStatuses.ts
+++ b/src/features/counterfactual/hooks/usePendingSafeStatuses.ts
@@ -85,6 +85,9 @@ const usePendingSafeStatus = (): void => {
     if (!provider || !safeAddress) return
 
     const checkDeploymentStatus = async () => {
+      // In case the safe info hasn't been updated yet when switching safes
+      if ((await provider.getNetwork()).chainId !== BigInt(safe.chainId)) return
+
       const isContractDeployed = await isSmartContract(provider, safeAddress)
 
       if (isContractDeployed) {

--- a/src/features/counterfactual/store/undeployedSafesSlice.ts
+++ b/src/features/counterfactual/store/undeployedSafesSlice.ts
@@ -54,7 +54,7 @@ export const undeployedSafesSlice = createSlice({
     ) => {
       const { chainId, address, status } = action.payload
 
-      if (!state[chainId][address]) return state
+      if (!state[chainId]?.[address]) return state
 
       state[chainId][address] = {
         props: state[chainId][address].props,

--- a/src/hooks/coreSDK/__tests__/safeCoreSDK.test.ts
+++ b/src/hooks/coreSDK/__tests__/safeCoreSDK.test.ts
@@ -255,5 +255,24 @@ describe('safeCoreSDK', () => {
         expect(sdk).toBeUndefined()
       })
     })
+
+    it('should return undefined if provider does not match safe', async () => {
+      const chainId = '1'
+      const safeChainId = '100'
+      const version = '1.3.0'
+
+      const mockProvider = getMockProvider(chainId, version)
+
+      const sdk = await initSafeSDK({
+        provider: mockProvider,
+        chainId: safeChainId,
+        address: toBeHex('0x1', 20),
+        version: null,
+        implementation: '0xinvalid',
+        implementationVersionState: ImplementationVersionState.UNKNOWN,
+      })
+
+      expect(sdk).toBeUndefined()
+    })
   })
 })

--- a/src/hooks/coreSDK/safeCoreSDK.ts
+++ b/src/hooks/coreSDK/safeCoreSDK.ts
@@ -68,6 +68,9 @@ export const initSafeSDK = async ({
   implementation,
   undeployedSafe,
 }: SafeCoreSDKProps): Promise<Safe | undefined> => {
+  const providerNetwork = (await provider.getNetwork()).chainId
+  if (providerNetwork !== BigInt(chainId)) return
+
   const safeVersion = version ?? (await Gnosis_safe__factory.connect(address, provider).VERSION())
   let isL1SafeSingleton = chainId === chains.eth
 


### PR DESCRIPTION
## What it solves

When switching from an undeployed safe we run a `useEffect` to check `checkDeploymentStatus` which contains the updated `provider` but can still contain the previous safeInfo. In that case it can happen that the undeployed state is wrongfully removed.

## How this PR fixes it

Make sure that the `provider` and the `safeInfo` have the same chainId before checking if a contract is deployed on the safeAddress

## How to test it

1. Create a counterfactual safe with address X on network A
2. Deploy that safe
3. Create a counterfactual safe on network B and make sure that the safe ends up with the same address X
4. Switch back to network A
5. Switch back to the network B
6. Observe the counterfactual safe on network B is still accessible

---

1. Create a counterfactual safe on Celo
2. Press on "Create transaction" on the dashboard
3. Observe no "Set up recovery" option
4. Create a counterfactual safe on Mainnet
5. Observe there is a "Set up recovery" option

---

1. Open any safe that is already deployed in Firefox
2. Observe the overview buttons on the dashboard are aligned in a row

## Screenshots
<img width="644" alt="Screenshot 2024-02-20 at 16 08 44" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/31cb33af-acba-4b7a-843f-ea3770def594">
<img width="1270" alt="Screenshot 2024-02-20 at 16 14 41" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/e9498d61-77d2-46de-a045-d6cb513efd06">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
