### PR TITLE
fix: Check all address books to find name for an address

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "safe-wallet-web",
   "homepage": "https://github.com/safe-global/safe-wallet-web",
   "license": "GPL-3.0",
-  "version": "1.29.1",
+  "version": "1.30.0",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "safe-wallet-web",
   "homepage": "https://github.com/safe-global/safe-wallet-web",
   "license": "GPL-3.0",
-  "version": "1.30.0",
+  "version": "1.29.1",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/src/components/common/AddressBookInput/index.test.tsx
+++ b/src/components/common/AddressBookInput/index.test.tsx
@@ -81,6 +81,7 @@ const setup = (
       addressBook: {
         [mockChain.chainId]: initialAddressBook,
       },
+      chains: { data: [mockChain], loading: false },
     },
   })
   const input = utils.getByLabelText('Recipient address', { exact: false })

--- a/src/components/common/EthHashInfo/index.test.tsx
+++ b/src/components/common/EthHashInfo/index.test.tsx
@@ -2,7 +2,7 @@ import { blo } from 'blo'
 import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 
 import { act, fireEvent, render, waitFor } from '@/tests/test-utils'
-import * as useAddressBook from '@/hooks/useAddressBook'
+import * as useAllAddressBooks from '@/hooks/useAllAddressBooks'
 import * as useChainId from '@/hooks/useChainId'
 import * as store from '@/store'
 import EthHashInfo from '.'
@@ -10,16 +10,19 @@ import EthHashInfo from '.'
 const originalClipboard = { ...global.navigator.clipboard }
 
 const MOCK_SAFE_ADDRESS = '0x0000000000000000000000000000000000005AFE'
+const MOCK_CHAIN_ID = '4'
 
-jest.mock('@/hooks/useAddressBook')
+jest.mock('@/hooks/useAllAddressBooks')
 jest.mock('@/hooks/useChainId')
 
 describe('EthHashInfo', () => {
   beforeEach(() => {
     jest.clearAllMocks()
 
-    jest.spyOn(useAddressBook, 'default').mockImplementation(() => ({
-      [MOCK_SAFE_ADDRESS]: 'Address book name',
+    jest.spyOn(useAllAddressBooks, 'default').mockImplementation(() => ({
+      [MOCK_CHAIN_ID]: {
+        [MOCK_SAFE_ADDRESS]: 'Address book name',
+      },
     }))
 
     //@ts-ignore

--- a/src/components/common/EthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/index.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement } from 'react'
-import useAddressBook from '@/hooks/useAddressBook'
+import useAllAddressBooks from '@/hooks/useAllAddressBooks'
 import useChainId from '@/hooks/useChainId'
 import { useAppSelector } from '@/store'
 import { selectSettings } from '@/store/settingsSlice'
@@ -15,9 +15,9 @@ const EthHashInfo = ({
   const settings = useAppSelector(selectSettings)
   const currentChainId = useChainId()
   const chain = useAppSelector((state) => selectChainById(state, props.chainId || currentChainId))
-  const addressBook = useAddressBook()
+  const addressBooks = useAllAddressBooks()
   const link = chain && props.hasExplorer ? getBlockExplorerLink(chain, props.address) : undefined
-  const name = showName ? addressBook[props.address] || props.name : undefined
+  const name = showName && chain ? addressBooks?.[chain.chainId]?.[props.address] || props.name : undefined
 
   return (
     <SrcEthHashInfo

--- a/src/components/settings/FallbackHandler/__tests__/index.test.tsx
+++ b/src/components/settings/FallbackHandler/__tests__/index.test.tsx
@@ -1,10 +1,14 @@
+import { chainBuilder } from '@/tests/builders/chains'
 import { render, waitFor } from '@/tests/test-utils'
 
 import * as useSafeInfoHook from '@/hooks/useSafeInfo'
+import * as useChainId from '@/hooks/useChainId'
 import * as useTxBuilderHook from '@/hooks/safe-apps/useTxBuilderApp'
 import { FallbackHandler } from '..'
 
 const GOERLI_FALLBACK_HANDLER = '0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4'
+
+const mockChain = chainBuilder().build()
 
 describe('FallbackHandler', () => {
   beforeEach(() => {
@@ -13,6 +17,8 @@ describe('FallbackHandler', () => {
     jest.spyOn(useTxBuilderHook, 'useTxBuilderApp').mockImplementation(() => ({
       link: { href: 'https://mock.link/tx-builder' },
     }))
+
+    jest.spyOn(useChainId, 'default').mockImplementation(() => mockChain.chainId)
   })
 
   it('should render the Fallback Handler when one is set', async () => {
@@ -30,7 +36,9 @@ describe('FallbackHandler', () => {
         } as unknown as ReturnType<typeof useSafeInfoHook.default>),
     )
 
-    const fbHandler = render(<FallbackHandler />)
+    const fbHandler = render(<FallbackHandler />, {
+      initialReduxState: { chains: { loading: false, data: [mockChain] } },
+    })
 
     await waitFor(() => {
       expect(
@@ -65,7 +73,9 @@ describe('FallbackHandler', () => {
         } as unknown as ReturnType<typeof useSafeInfoHook.default>),
     )
 
-    const fbHandler = render(<FallbackHandler />)
+    const fbHandler = render(<FallbackHandler />, {
+      initialReduxState: { chains: { loading: false, data: [mockChain] } },
+    })
 
     await waitFor(() => {
       expect(
@@ -96,7 +106,9 @@ describe('FallbackHandler', () => {
         } as unknown as ReturnType<typeof useSafeInfoHook.default>),
     )
 
-    const fbHandler = render(<FallbackHandler />)
+    const fbHandler = render(<FallbackHandler />, {
+      initialReduxState: { chains: { loading: false, data: [mockChain] } },
+    })
 
     await waitFor(() => {
       expect(fbHandler.getByText('CompatibilityFallbackHandler')).toBeDefined()

--- a/src/components/settings/PushNotifications/GlobalPushNotifications.tsx
+++ b/src/components/settings/PushNotifications/GlobalPushNotifications.tsx
@@ -470,6 +470,7 @@ export const GlobalPushNotifications = (): ReactElement | null => {
                               address={safeAddress || ''}
                               shortAddress={false}
                               showName={true}
+                              chainId={chainId}
                             />
                           </ListItemButton>
                         </ListItem>

--- a/src/hooks/useAllAddressBooks.ts
+++ b/src/hooks/useAllAddressBooks.ts
@@ -1,0 +1,8 @@
+import { useAppSelector } from '@/store'
+import { selectAllAddressBooks } from '@/store/addressBookSlice'
+
+const useAllAddressBooks = () => {
+  return useAppSelector(selectAllAddressBooks)
+}
+
+export default useAllAddressBooks

--- a/src/tests/builders/chains.ts
+++ b/src/tests/builders/chains.ts
@@ -27,8 +27,8 @@ const rpcUriBuilder = (): IBuilder<RpcUri> => {
 
 const blockExplorerUriTemplateBuilder = (): IBuilder<BlockExplorerUriTemplate> => {
   return Builder.new<BlockExplorerUriTemplate>().with({
-    address: faker.finance.ethereumAddress(),
-    txHash: faker.string.hexadecimal(),
+    address: faker.internet.url({ appendSlash: false }),
+    txHash: faker.internet.url({ appendSlash: false }),
     api: faker.internet.url({ appendSlash: false }),
   })
 }


### PR DESCRIPTION
## What it solves

Showing a name for an address via the `EthHashInfo` component uses the `useAddressBook` hook. This works well when on a specific safe view because there is a unique chain to check. However, on non-safe routes like the global notifications this doesn't work and can result in showing the wrong name for an address in case it has the same address on multiple chains.

## How this PR fixes it

- Adds a new hook `useAllAddressBooks`
- Uses that hook instead of `useAddressBook` to find a name in `EthHashInfo`

## How to test it

1. Create 2 safes with identical addresses on 2 different chains e.g. with counterfactual
2. Deploy both safes
3. Make sure both safe addresses are in the address book with different names
4. Go to the global notifications page
5. Observe both addresses show up with their correct name

## Screenshots
<img width="969" alt="Screenshot 2024-02-20 at 17 23 32" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/bd51876a-30f2-494c-87f8-598a3c1de1d5">



## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
