### PR TITLE
fix: [RC] Add pay later hint to safe creation step

### DIFF
--- a/cypress/e2e/pages/owners.pages.js
+++ b/cypress/e2e/pages/owners.pages.js
@@ -90,8 +90,7 @@ export function getThresholdOptions() {
 export function verifyThresholdLimit(startValue, endValue) {
   cy.get('p').contains(`out of ${endValue} owner(s)`)
   clickOnThresholdDropdown()
-  getThresholdOptions().eq(0).should('have.text', startValue)
-  cy.get('body').click()
+  getThresholdOptions().eq(0).should('have.text', startValue).click()
 }
 
 export function verifyRemoveBtnIsEnabled() {

--- a/src/components/dashboard/FirstSteps/index.tsx
+++ b/src/components/dashboard/FirstSteps/index.tsx
@@ -8,12 +8,13 @@ import useBalances from '@/hooks/useBalances'
 import { useCurrentChain } from '@/hooks/useChains'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { OVERVIEW_EVENTS } from '@/services/analytics'
-import { useAppSelector } from '@/store'
+import { useAppDispatch, useAppSelector } from '@/store'
+import { selectSettings, setQrShortName } from '@/store/settingsSlice'
 import { selectOutgoingTransactions } from '@/store/txHistorySlice'
 import classnames from 'classnames'
 import { type ReactNode, useState } from 'react'
 import { Card, WidgetBody, WidgetContainer } from '@/components/dashboard/styled'
-import { Box, Button, CircularProgress, Divider, Grid, Typography } from '@mui/material'
+import { Box, Button, CircularProgress, Divider, FormControlLabel, Grid, Switch, Typography } from '@mui/material'
 import CircleOutlinedIcon from '@mui/icons-material/CircleOutlined'
 import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded'
 import CheckCircleOutlineRoundedIcon from '@mui/icons-material/CheckCircleOutlineRounded'
@@ -60,10 +61,14 @@ const StatusCard = ({
 }
 
 const AddFundsWidget = ({ completed }: { completed: boolean }) => {
-  const { safeAddress } = useSafeInfo()
   const [open, setOpen] = useState<boolean>(false)
-
+  const { safeAddress } = useSafeInfo()
   const chain = useCurrentChain()
+  const dispatch = useAppDispatch()
+  const settings = useAppSelector(selectSettings)
+  const qrPrefix = settings.shortName.qr ? `${chain?.shortName}:` : ''
+  const qrCode = `${qrPrefix}${safeAddress}`
+
   const title = 'Add native assets'
   const content = `Receive ${chain?.nativeCurrency.name} to start interacting with your account.`
 
@@ -90,9 +95,24 @@ const AddFundsWidget = ({ completed }: { completed: boolean }) => {
           >
             <Box px={4} pb={5} pt={4}>
               <Grid container spacing={2} alignItems="center" justifyContent="center" mb={4}>
-                <Grid item>
+                <Grid item textAlign="center">
                   <Box p={1} border={1} borderRadius="6px" borderColor="border.light" display="inline-flex">
-                    <QRCode value={safeAddress} size={132} />
+                    <QRCode value={qrCode} size={132} />
+                  </Box>
+                  <Box>
+                    <FormControlLabel
+                      control={
+                        <Switch
+                          checked={settings.shortName.qr}
+                          onChange={(e) => dispatch(setQrShortName(e.target.checked))}
+                        />
+                      }
+                      label={
+                        <>
+                          QR code with chain prefix (<b>{chain?.shortName}:</b>)
+                        </>
+                      }
+                    />
                   </Box>
                 </Grid>
                 <Grid item xs>

--- a/src/components/new-safe/create/steps/OwnerPolicyStep/index.tsx
+++ b/src/components/new-safe/create/steps/OwnerPolicyStep/index.tsx
@@ -1,3 +1,4 @@
+import CounterfactualHint from '@/features/counterfactual/CounterfactualHint'
 import { Button, SvgIcon, MenuItem, Tooltip, Typography, Divider, Box, Grid, TextField } from '@mui/material'
 import { Controller, FormProvider, useFieldArray, useForm } from 'react-hook-form'
 import type { ReactElement } from 'react'
@@ -12,8 +13,6 @@ import { useSafeSetupHints } from '@/components/new-safe/create/steps/OwnerPolic
 import useSyncSafeCreationStep from '@/components/new-safe/create/useSyncSafeCreationStep'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import layoutCss from '@/components/new-safe/create/styles.module.css'
-import NetworkWarning from '@/components/new-safe/create/NetworkWarning'
-import useIsWrongChain from '@/hooks/useIsWrongChain'
 import { CREATE_SAFE_EVENTS, trackEvent } from '@/services/analytics'
 import OwnerRow from '@/components/new-safe/OwnerRow'
 
@@ -38,7 +37,6 @@ const OwnerPolicyStep = ({
 }: StepRenderProps<NewSafeFormData> & {
   setDynamicHint: (hints: CreateSafeInfoItem | undefined) => void
 }): ReactElement => {
-  const isWrongChain = useIsWrongChain()
   useSyncSafeCreationStep(setStep)
 
   const formMethods = useForm<OwnerPolicyStepForm>({
@@ -66,7 +64,7 @@ const OwnerPolicyStep = ({
     trigger(OwnerPolicyStepFields.owners)
   }
 
-  const isDisabled = isWrongChain || !formState.isValid
+  const isDisabled = !formState.isValid
 
   useSafeSetupHints(threshold, ownerFields.length, setDynamicHint)
 
@@ -165,7 +163,7 @@ const OwnerPolicyStep = ({
             </Grid>
           </Grid>
 
-          {isWrongChain && <NetworkWarning />}
+          {ownerFields.length > 1 && <CounterfactualHint />}
         </Box>
         <Divider />
         <Box className={layoutCss.row}>

--- a/src/components/new-safe/create/steps/OwnerPolicyStep/useSafeSetupHints.ts
+++ b/src/components/new-safe/create/steps/OwnerPolicyStep/useSafeSetupHints.ts
@@ -13,7 +13,7 @@ export const useSafeSetupHints = (
     if (threshold === 1) {
       safeSetupWarningSteps.push({
         title: `1/${noOwners} policy`,
-        text: 'We recommend using a threshold higher than one to prevent losing access to your Safe Account in case an owner key is lost or compromised.',
+        text: 'Use a threshold higher than one to prevent losing access to your Safe Account in case an owner key is lost or compromised.',
       })
     }
 
@@ -21,7 +21,7 @@ export const useSafeSetupHints = (
     if (threshold === noOwners && noOwners > 1) {
       safeSetupWarningSteps.push({
         title: `${noOwners}/${noOwners} policy`,
-        text: 'We recommend using a threshold which is lower than the total number of owners of your Safe Account in case an owner loses access to their account and needs to be replaced.',
+        text: 'Use a threshold which is lower than the total number of owners of your Safe Account in case an owner loses access to their account and needs to be replaced.',
       })
     }
 

--- a/src/components/new-safe/create/steps/OwnerPolicyStep/useSafeSetupHints.ts
+++ b/src/components/new-safe/create/steps/OwnerPolicyStep/useSafeSetupHints.ts
@@ -25,7 +25,7 @@ export const useSafeSetupHints = (
       })
     }
 
-    setHint({ title: 'Safe Account setup', variant: 'warning', steps: safeSetupWarningSteps })
+    setHint({ title: 'Safe Account setup', variant: 'info', steps: safeSetupWarningSteps })
 
     // Clear dynamic hints when the step / hook unmounts
     return () => {

--- a/src/features/counterfactual/CounterfactualHint.tsx
+++ b/src/features/counterfactual/CounterfactualHint.tsx
@@ -1,0 +1,12 @@
+import { Alert } from '@mui/material'
+
+const CounterfactualHint = () => {
+  return (
+    <Alert severity="info" sx={{ mt: 2 }}>
+      Please note that Safe Accounts with more than one owner will have to be activated with a network fee right away.
+      You can add more owners after Safe creation.
+    </Alert>
+  )
+}
+
+export default CounterfactualHint

--- a/src/features/counterfactual/CounterfactualHint.tsx
+++ b/src/features/counterfactual/CounterfactualHint.tsx
@@ -1,10 +1,13 @@
-import { Alert } from '@mui/material'
+import { Alert, Typography } from '@mui/material'
 
 const CounterfactualHint = () => {
   return (
     <Alert severity="info" sx={{ mt: 2 }}>
-      Please note that Safe Accounts with more than one owner will have to be activated with a network fee right away.
-      You can add more owners after Safe creation.
+      <Typography fontWeight="bold" mb={1}>
+        Create now, pay later! Only for 1/1 Accounts
+      </Typography>
+      Explore Safe{'{Wallet}'} without additional hassle. Pay the gas fees later at any time, and don&apos;t forget to
+      add extra owners for better security.
     </Alert>
   )
 }

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -55,7 +55,7 @@ export const initialState: SettingsState = {
   showOnlyTrustedTransactions: false,
 
   shortName: {
-    copy: false,
+    copy: true,
     qr: true,
   },
   theme: {},

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -55,7 +55,7 @@ export const initialState: SettingsState = {
   showOnlyTrustedTransactions: false,
 
   shortName: {
-    copy: true,
+    copy: false,
     qr: true,
   },
   theme: {},


### PR DESCRIPTION
## What it solves

- Adds a hint to the owner step during safe creation informing the user that pay later is only supported for single owner setups
- Changes the 1/1 warning to an info box to make it less scary
- Adds a toggle option to the QR code in the first steps widget
- Removes the wrong chain warning on the owner step because the user is redirected away if their wallet has a different network so they will never see that warning

## How to test it

1. Go through the safe creation flow
2. Observe in the owner step that the 1/1 warning is now blue
3. Observe there is no pay later hint
4. Add another owner
5. Observe there is a pay later hint
6. Create the safe counterfactually
7. Press Add funds on the dashboard
8. Observe a toggle option under the QR code

## Screenshots
<img width="650" alt="Screenshot 2024-02-21 at 15 15 02" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/4dec1755-253c-48ef-9d25-e776483d32a2">
<img width="1212" alt="Screenshot 2024-02-21 at 15 17 18" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/1aedcfb2-082e-4892-a9de-d82a79b21c8b">



## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
