### PR TITLE
Show remove from watchlist option when viewing a watchlist safe

### DIFF
--- a/src/components/sidebar/WatchlistAddButton/index.tsx
+++ b/src/components/sidebar/WatchlistAddButton/index.tsx
@@ -1,14 +1,24 @@
-import Button from '@mui/material/Button'
 import { OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
 import { useRouter } from 'next/router'
 import { AppRoutes } from '@/config/routes'
 import { useCurrentChain } from '@/hooks/useChains'
 import useSafeAddress from '@/hooks/useSafeAddress'
+import { Button, SvgIcon } from '@mui/material'
+import SafeListRemoveDialog from '../SafeListRemoveDialog'
+import { useAppSelector } from '@/store'
+import { selectAddedSafes } from '@/store/addedSafesSlice'
+import { useState } from 'react'
+import { VisibilityOutlined } from '@mui/icons-material'
+import DeleteIcon from '@/public/images/common/delete.svg'
 
 const WatchlistAddButton = () => {
+  const [open, setOpen] = useState(false)
   const router = useRouter()
   const chain = useCurrentChain()
   const address = useSafeAddress()
+  const chainId = chain?.chainId || ''
+  const addedSafes = useAppSelector((state) => selectAddedSafes(state, chainId))
+  const isInWatchlist = !!addedSafes?.[address]
 
   const onClick = () => {
     trackEvent({ ...OVERVIEW_EVENTS.ADD_SAFE })
@@ -23,17 +33,39 @@ const WatchlistAddButton = () => {
   }
 
   return (
-    <Button
-      data-testid="add-watchlist-btn"
-      onClick={onClick}
-      variant="contained"
-      size="small"
-      fullWidth
-      disableElevation
-      sx={{ py: 1.3 }}
-    >
-      Add to watchlist
-    </Button>
+    <>
+      {!isInWatchlist ? (
+        <Button
+          data-testid="add-watchlist-btn"
+          onClick={onClick}
+          variant="outlined"
+          size="small"
+          fullWidth
+          disableElevation
+          sx={{ py: 1.3 }}
+          startIcon={<VisibilityOutlined sx={{ verticalAlign: 'middle', marginRight: 1 }} />}
+        >
+          Add to watchlist
+        </Button>
+      ) : (
+        <Button
+          data-testid="add-watchlist-btn"
+          onClick={() => setOpen(true)}
+          variant="outlined"
+          size="small"
+          fullWidth
+          disableElevation
+          sx={{ py: 1.3, px: 1 }}
+          startIcon={<SvgIcon component={DeleteIcon} inheritViewBox fontSize="small" />}
+        >
+          Remove from watchlist
+        </Button>
+      )}
+
+      {open && chainId && (
+        <SafeListRemoveDialog handleClose={() => setOpen(false)} address={address} chainId={chainId} />
+      )}
+    </>
   )
 }
 


### PR DESCRIPTION
## What it solves

Resolves https://www.notion.so/safe-global/570f3459753047f49022d5b63ee1e57e?v=ed82ae2a7e28401086a736f6af1c31ae&p=0fcb3a7e98424536ad271f4512112594&pm=s

## How this PR fixes it
When viewing a safe that is in the watchlist, show an option to remove it, in place of the add to watchlist button

Also changes the appearance of the add to watchlist button in the sidebar

## Screenshots
<img width="1052" alt="image" src="https://github.com/safe-global/safe-wallet-web/assets/17801424/65130a55-eea8-46f5-8c20-1575ac503fbc">

<img width="1039" alt="image" src="https://github.com/safe-global/safe-wallet-web/assets/17801424/7d31ef1d-5460-416f-8ded-c92a8ae67b32">

