### PR TITLE
fix: show newly depoyed safes under owned safes

### DIFF
--- a/src/components/welcome/MyAccounts/useAllSafes.ts
+++ b/src/components/welcome/MyAccounts/useAllSafes.ts
@@ -36,8 +36,8 @@ export const useHasSafes = () => {
 }
 
 const useAllSafes = (): SafeItems => {
-  const { address = '' } = useWallet() || {}
-  const [allOwned = {}] = useAllOwnedSafes(address)
+  const { address: walletAddress = '' } = useWallet() || {}
+  const [allOwned = {}] = useAllOwnedSafes(walletAddress)
   const allAdded = useAddedSafes()
   const { configs } = useChains()
   const currentChainId = useChainId()
@@ -54,8 +54,10 @@ const useAllSafes = (): SafeItems => {
       const uniqueAddresses = uniq(addedOnChain.concat(ownedOnChain)).filter(Boolean)
 
       return uniqueAddresses.map((address) => {
+        const owners = allAdded?.[chainId]?.[address]?.owners
+        const isOwner = owners?.map((address) => address.value).includes(walletAddress)
         const isUndeployed = undeployedOnChain.includes(address)
-        const isOwned = (ownedOnChain || []).includes(address)
+        const isOwned = (ownedOnChain || []).includes(address) || isOwner
         return {
           address,
           chainId,
@@ -65,7 +67,7 @@ const useAllSafes = (): SafeItems => {
         }
       })
     })
-  }, [configs, allAdded, allOwned, currentChainId, undeployedSafes])
+  }, [currentChainId, allAdded, allOwned, configs, undeployedSafes, walletAddress])
 }
 
 export default useAllSafes

--- a/src/components/welcome/MyAccounts/useAllSafes.ts
+++ b/src/components/welcome/MyAccounts/useAllSafes.ts
@@ -55,7 +55,7 @@ const useAllSafes = (): SafeItems => {
 
       return uniqueAddresses.map((address) => {
         const owners = allAdded?.[chainId]?.[address]?.owners
-        const isOwner = owners?.map((address) => address.value).includes(walletAddress)
+        const isOwner = owners?.some(({ value }) => sameAddress(walletAddress))
         const isUndeployed = undeployedOnChain.includes(address)
         const isOwned = (ownedOnChain || []).includes(address) || isOwner
         return {

--- a/src/components/welcome/MyAccounts/useAllSafes.ts
+++ b/src/components/welcome/MyAccounts/useAllSafes.ts
@@ -8,6 +8,7 @@ import useChains from '@/hooks/useChains'
 import useChainId from '@/hooks/useChainId'
 import useWallet from '@/hooks/wallets/useWallet'
 import { selectUndeployedSafes } from '@/store/slices'
+import { sameAddress } from '@/utils/addresses'
 
 export type SafeItems = Array<{
   chainId: string
@@ -55,7 +56,7 @@ const useAllSafes = (): SafeItems => {
 
       return uniqueAddresses.map((address) => {
         const owners = allAdded?.[chainId]?.[address]?.owners
-        const isOwner = owners?.some(({ value }) => sameAddress(walletAddress))
+        const isOwner = owners?.some(({ value }) => sameAddress(walletAddress, value))
         const isUndeployed = undeployedOnChain.includes(address)
         const isOwned = (ownedOnChain || []).includes(address) || isOwner
         return {


### PR DESCRIPTION
## What it solves

Resolves https://www.notion.so/safe-global/570f3459753047f49022d5b63ee1e57e?v=ed82ae2a7e28401086a736f6af1c31ae&p=bc70bcc7233d488e84e2d4dd96c9bcf9&pm=s

## How this PR fixes it
Newly created safes take around 5 minutes to show up in responses from the CGW. As a workaround, display newly created safes in the owned safes list by referencing the owners array in localstorage.
