### PR TITLE
Add tracking events for adding and selecting safes

### DIFF
--- a/src/components/welcome/MyAccounts/AccountItem.tsx
+++ b/src/components/welcome/MyAccounts/AccountItem.tsx
@@ -3,7 +3,7 @@ import { ListItemButton, Box, Typography } from '@mui/material'
 import Link from 'next/link'
 import SafeIcon from '@/components/common/SafeIcon'
 import Track from '@/components/common/Track'
-import { OPEN_SAFE_LABELS, OVERVIEW_EVENTS } from '@/services/analytics'
+import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
 import { AppRoutes } from '@/config/routes'
 import { useAppSelector } from '@/store'
 import { selectChainById } from '@/store/chainsSlice'
@@ -16,6 +16,7 @@ import useSafeAddress from '@/hooks/useSafeAddress'
 import useChainId from '@/hooks/useChainId'
 import { sameAddress } from '@/utils/addresses'
 import classnames from 'classnames'
+import { useRouter } from 'next/router'
 
 type AccountItemProps = {
   chainId: string
@@ -34,7 +35,10 @@ const AccountItem = ({ onLinkClick, chainId, address, ...rest }: AccountItemProp
   const chain = useAppSelector((state) => selectChainById(state, chainId))
   const safeAddress = useSafeAddress()
   const currChainId = useChainId()
+  const router = useRouter()
   const isCurrentSafe = chainId === currChainId && sameAddress(safeAddress, address)
+  const trackingLabel =
+    router.pathname === AppRoutes.welcome.accounts ? OVERVIEW_LABELS.login_page : OVERVIEW_LABELS.sidebar
 
   const href = useMemo(() => {
     return chain ? getSafeHref(chain.shortName, address) : ''
@@ -48,7 +52,7 @@ const AccountItem = ({ onLinkClick, chainId, address, ...rest }: AccountItemProp
       selected={isCurrentSafe}
       className={classnames(css.listItem, { [css.currentListItem]: isCurrentSafe })}
     >
-      <Track {...OVERVIEW_EVENTS.OPEN_SAFE} label={OPEN_SAFE_LABELS.login_page}>
+      <Track {...OVERVIEW_EVENTS.OPEN_SAFE} label={trackingLabel}>
         <Link onClick={onLinkClick} href={href} className={css.safeLink}>
           <SafeIcon address={address} {...rest} />
 

--- a/src/components/welcome/MyAccounts/CreateButton.tsx
+++ b/src/components/welcome/MyAccounts/CreateButton.tsx
@@ -1,28 +1,34 @@
 import { Button } from '@mui/material'
 import Link from 'next/link'
 import { AppRoutes } from '@/config/routes'
-import { OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
+import { useRouter } from 'next/router'
+import { OVERVIEW_EVENTS, OVERVIEW_LABELS, trackEvent } from '@/services/analytics'
 
 const buttonSx = { width: ['100%', 'auto'] }
 
-const onClick = () => {
-  trackEvent(OVERVIEW_EVENTS.CREATE_NEW_SAFE)
-}
+const CreateButton = () => {
+  const router = useRouter()
+  const trackingLabel =
+    router.pathname === AppRoutes.welcome.accounts ? OVERVIEW_LABELS.login_page : OVERVIEW_LABELS.sidebar
 
-const CreateButton = () => (
-  <Link href={AppRoutes.newSafe.create} passHref legacyBehavior>
-    <Button
-      data-testid="create-safe-btn"
-      disableElevation
-      size="small"
-      variant="contained"
-      sx={buttonSx}
-      component="a"
-      onClick={onClick}
-    >
-      Create account
-    </Button>
-  </Link>
-)
+  const onClick = () => {
+    trackEvent({ ...OVERVIEW_EVENTS.CREATE_NEW_SAFE, label: trackingLabel })
+  }
+  return (
+    <Link href={AppRoutes.newSafe.create} passHref legacyBehavior>
+      <Button
+        data-testid="create-safe-btn"
+        disableElevation
+        size="small"
+        variant="contained"
+        sx={buttonSx}
+        component="a"
+        onClick={onClick}
+      >
+        Create account
+      </Button>
+    </Link>
+  )
+}
 
 export default CreateButton

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -4,7 +4,7 @@ import madProps from '@/utils/mad-props'
 import CreateButton from './CreateButton'
 import useAllSafes, { type SafeItems } from './useAllSafes'
 import Track from '@/components/common/Track'
-import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
+import { OVERVIEW_EVENTS } from '@/services/analytics'
 import { DataWidget } from '@/components/welcome/MyAccounts/DataWidget'
 import css from './styles.module.css'
 import PaginatedSafeList from './PaginatedSafeList'
@@ -13,7 +13,6 @@ import AddIcon from '@/public/images/common/add.svg'
 import { AppRoutes } from '@/config/routes'
 import ConnectWalletButton from '@/components/common/ConnectWallet/ConnectWalletButton'
 import useWallet from '@/hooks/wallets/useWallet'
-import router from 'next/router'
 
 const NO_SAFES_MESSAGE = "You don't have any Safe Accounts yet"
 
@@ -25,8 +24,6 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
   const ownedSafes = useMemo(() => safes.filter(({ isWatchlist }) => !isWatchlist), [safes])
   const watchlistSafes = useMemo(() => safes.filter(({ isWatchlist }) => isWatchlist), [safes])
   const wallet = useWallet()
-  const trackingLabel =
-    router.pathname === AppRoutes.welcome.accounts ? OVERVIEW_LABELS.login_page : OVERVIEW_LABELS.sidebar
 
   return (
     <Box data-testid="sidebar-safe-container" className={css.container}>
@@ -35,9 +32,7 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
           <Typography variant="h1" fontWeight={700} className={css.title}>
             Safe accounts
           </Typography>
-          <Track {...OVERVIEW_EVENTS.CREATE_NEW_SAFE} label={trackingLabel}>
-            <CreateButton />
-          </Track>
+          <CreateButton />
         </Box>
 
         <PaginatedSafeList

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -4,7 +4,7 @@ import madProps from '@/utils/mad-props'
 import CreateButton from './CreateButton'
 import useAllSafes, { type SafeItems } from './useAllSafes'
 import Track from '@/components/common/Track'
-import { OVERVIEW_EVENTS } from '@/services/analytics'
+import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
 import { DataWidget } from '@/components/welcome/MyAccounts/DataWidget'
 import css from './styles.module.css'
 import PaginatedSafeList from './PaginatedSafeList'
@@ -13,6 +13,7 @@ import AddIcon from '@/public/images/common/add.svg'
 import { AppRoutes } from '@/config/routes'
 import ConnectWalletButton from '@/components/common/ConnectWallet/ConnectWalletButton'
 import useWallet from '@/hooks/wallets/useWallet'
+import router from 'next/router'
 
 const NO_SAFES_MESSAGE = "You don't have any Safe Accounts yet"
 
@@ -24,6 +25,8 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
   const ownedSafes = useMemo(() => safes.filter(({ isWatchlist }) => !isWatchlist), [safes])
   const watchlistSafes = useMemo(() => safes.filter(({ isWatchlist }) => isWatchlist), [safes])
   const wallet = useWallet()
+  const trackingLabel =
+    router.pathname === AppRoutes.welcome.accounts ? OVERVIEW_LABELS.login_page : OVERVIEW_LABELS.sidebar
 
   return (
     <Box data-testid="sidebar-safe-container" className={css.container}>
@@ -32,7 +35,9 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
           <Typography variant="h1" fontWeight={700} className={css.title}>
             Safe accounts
           </Typography>
-          <CreateButton />
+          <Track {...OVERVIEW_EVENTS.CREATE_NEW_SAFE} label={trackingLabel}>
+            <CreateButton />
+          </Track>
         </Box>
 
         <PaginatedSafeList

--- a/src/services/analytics/events/overview.ts
+++ b/src/services/analytics/events/overview.ts
@@ -143,3 +143,8 @@ export enum OPEN_SAFE_LABELS {
   after_add = 'after_add',
   login_page = 'login_page',
 }
+
+export enum OVERVIEW_LABELS {
+  sidebar = 'sidebar',
+  login_page = 'login_page',
+}


### PR DESCRIPTION
Add tracking events for:
- `Open Safe`
  - labels: login_page | sidebar
- `Create new Safe`
  - labels: login_page | sidebar

## How to test it
-  choose a safe from the safe list in both the login page and the sidebar.
-  click the button to create a new safe, both from the login page and the sidebar
-  Check that the events are fired in the console with the appropriate labels
