### PR TITLE
fix: Add hide address overflow on transaction history

### DIFF
--- a/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
@@ -62,7 +62,7 @@ const SrcEthHashInfo = ({
   )
 
   return (
-    <div className={css.container} style={{ width: '100%' }}>
+    <div className={css.container}>
       {showAvatar && (
         <div
           className={css.avatarContainer}

--- a/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
@@ -62,7 +62,7 @@ const SrcEthHashInfo = ({
   )
 
   return (
-    <div className={css.container}>
+    <div className={css.container} style={{ width: '100%' }}>
       {showAvatar && (
         <div
           className={css.avatarContainer}
@@ -84,7 +84,7 @@ const SrcEthHashInfo = ({
         )}
 
         <div className={css.addressContainer}>
-          <Box fontWeight="inherit" fontSize="inherit">
+          <Box fontWeight="inherit" fontSize="inherit" overflow="hidden" textOverflow="ellipsis">
             {copyAddress ? (
               <CopyAddressButton prefix={prefix} address={address} copyPrefix={shouldCopyPrefix} trusted={trusted}>
                 {addressElement}

--- a/src/components/common/EthHashInfo/SrcEthHashInfo/styles.module.css
+++ b/src/components/common/EthHashInfo/SrcEthHashInfo/styles.module.css
@@ -3,6 +3,7 @@
   align-items: center;
   gap: 0.5em;
   line-height: 1.4;
+  width: 100%;
 }
 
 .avatarContainer {
@@ -10,7 +11,7 @@
   position: relative;
 }
 
-.avatarContainer > * {
+.avatarContainer>* {
   width: 100% !important;
   height: 100% !important;
 }

--- a/src/components/transactions/TxDetails/TxData/Transfer/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/Transfer/index.tsx
@@ -38,7 +38,7 @@ const TransferTxInfo = ({ txInfo, txStatus, trusted }: TransferTxInfoProps & { t
     <Box display="flex" flexDirection="column" gap={1}>
       <TransferTxInfoSummary txInfo={txInfo} txStatus={txStatus} trusted={trusted} />
 
-      <Box display="flex" alignItems="center">
+      <Box display="flex" alignItems="center" width="100%">
         <EthHashInfo
           address={address.value}
           name={address.name}

--- a/src/components/welcome/MyAccounts/styles.module.css
+++ b/src/components/welcome/MyAccounts/styles.module.css
@@ -43,8 +43,9 @@
   background-color: var(--color-secondary-background) !important;
 }
 
-.listItem > :first-child {
+.listItem> :first-child {
   flex: 1;
+  width: 90%;
 }
 
 .safeLink {
@@ -54,9 +55,11 @@
 }
 
 .safeAddress {
-  flex: 1;
   white-space: nowrap;
   padding-left: var(--space-2);
+  overflow: hidden;
+  margin-right: 10px;
+  text-overflow: ellipsis;
 }
 
 .listHeader {


### PR DESCRIPTION
## What it solves

Resolves #3197

## How this PR fixes it
It truncates text with ellipsis on shrink, adding width 100% to TransferTxInfo container (Box) and hiding overflow on SrcEthHashInfo component (text Box itself).

## How to test it
Open http://localhost:3000/transactions/history?safe=oeth:0x773D7c58941295aF412092efF5Aa3d188525e81a , open accordion of any transaction and check if address shortens with "..." at the end on smaller viewports.

## Screenshots
![image](https://github.com/safe-global/safe-wallet-web/assets/34529009/d6e4b6a2-8da5-42c4-b5bd-3b77a2cbcd81)
![image](https://github.com/safe-global/safe-wallet-web/assets/34529009/81dbc6d9-ab08-4a07-bf2c-c83893952f48)
