### PR TITLE
feat: One-click add safes to watchlist

### DIFF
--- a/src/components/new-safe/load/logic/index.ts
+++ b/src/components/new-safe/load/logic/index.ts
@@ -1,0 +1,43 @@
+import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import type { AppDispatch } from '@/store'
+import { addOrUpdateSafe } from '@/store/addedSafesSlice'
+import { upsertAddressBookEntry } from '@/store/addressBookSlice'
+import { defaultSafeInfo } from '@/store/safeInfoSlice'
+
+export const addSafeToWatchlist = (dispatch: AppDispatch, safe: SafeInfo, safeName: string) => {
+  // Add safe to watchlist
+  dispatch(
+    addOrUpdateSafe({
+      safe: {
+        ...defaultSafeInfo,
+        address: { value: safe.address.value },
+        threshold: safe.threshold,
+        owners: safe.owners.map((owner) => ({
+          value: owner.value,
+          name: owner.name,
+        })),
+        chainId: safe.chainId,
+      },
+    }),
+  )
+
+  // Add safe to address book
+  dispatch(
+    upsertAddressBookEntry({
+      chainId: safe.chainId,
+      address: safe.address.value,
+      name: safeName,
+    }),
+  )
+
+  // Add all owners of the safe to address book
+  for (const { value } of safe.owners) {
+    dispatch(
+      upsertAddressBookEntry({
+        chainId: safe.chainId,
+        address: value,
+        name: `${safeName} owner`,
+      }),
+    )
+  }
+}

--- a/src/components/sidebar/SafeListRemoveDialog/index.tsx
+++ b/src/components/sidebar/SafeListRemoveDialog/index.tsx
@@ -1,3 +1,4 @@
+import { removeAddressBookEntry } from '@/store/addressBookSlice'
 import DialogContent from '@mui/material/DialogContent'
 import DialogActions from '@mui/material/DialogActions'
 import Typography from '@mui/material/Typography'
@@ -25,6 +26,7 @@ const SafeListRemoveDialog = ({
 
   const handleConfirm = () => {
     dispatch(removeSafe({ chainId, address }))
+    dispatch(removeAddressBookEntry({ chainId, address }))
     handleClose()
   }
 

--- a/src/components/sidebar/WatchlistAddButton/index.tsx
+++ b/src/components/sidebar/WatchlistAddButton/index.tsx
@@ -1,34 +1,25 @@
+import { addSafeToWatchlist } from '@/components/new-safe/load/logic'
+import { useMnemonicSafeName } from '@/hooks/useMnemonicName'
+import useSafeInfo from '@/hooks/useSafeInfo'
 import { OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
-import { useRouter } from 'next/router'
-import { AppRoutes } from '@/config/routes'
-import { useCurrentChain } from '@/hooks/useChains'
-import useSafeAddress from '@/hooks/useSafeAddress'
 import { Button } from '@mui/material'
 import SafeListRemoveDialog from '../SafeListRemoveDialog'
-import { useAppSelector } from '@/store'
+import { useAppDispatch, useAppSelector } from '@/store'
 import { selectAddedSafes } from '@/store/addedSafesSlice'
 import { useState } from 'react'
 import { VisibilityOutlined } from '@mui/icons-material'
 
 const WatchlistAddButton = () => {
   const [open, setOpen] = useState(false)
-  const router = useRouter()
-  const chain = useCurrentChain()
-  const address = useSafeAddress()
-  const chainId = chain?.chainId || ''
-  const addedSafes = useAppSelector((state) => selectAddedSafes(state, chainId))
-  const isInWatchlist = !!addedSafes?.[address]
+  const { safe } = useSafeInfo()
+  const dispatch = useAppDispatch()
+  const safeName = useMnemonicSafeName()
+  const addedSafes = useAppSelector((state) => selectAddedSafes(state, safe.chainId))
+  const isInWatchlist = !!addedSafes?.[safe.address.value]
 
   const onClick = () => {
     trackEvent({ ...OVERVIEW_EVENTS.ADD_SAFE })
-
-    router.push({
-      pathname: AppRoutes.newSafe.load,
-      query: {
-        chain: chain?.shortName,
-        address: address,
-      },
-    })
+    addSafeToWatchlist(dispatch, safe, safeName)
   }
 
   return (
@@ -60,8 +51,8 @@ const WatchlistAddButton = () => {
         </Button>
       )}
 
-      {open && chainId && (
-        <SafeListRemoveDialog handleClose={() => setOpen(false)} address={address} chainId={chainId} />
+      {open && safe.chainId && (
+        <SafeListRemoveDialog handleClose={() => setOpen(false)} address={safe.address.value} chainId={safe.chainId} />
       )}
     </>
   )


### PR DESCRIPTION
## What it solves

Resolves #3304 

## How this PR fixes it

- Adds a new function `addSafeToWatchlist` that requires a `SafeInfo` object

## How to test it

1. Open any safe with a disconnected wallet
2. Click on the "Add to watchlist" button in the sidebar
3. Observe not leaving the page
4. Observe the safe is part of the watchlist and has a mnemonic name assigned
5. Remove the safe from watchlist
6. Observe the safe is removed from watchlist and from the address book

## Screenshots

https://github.com/safe-global/safe-wallet-web/assets/5880855/171596ca-fb1c-4679-bec2-e8a8d4c56605


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
