### PR TITLE
feat: [Recovery] Add register email form

### DIFF
--- a/src/features/recovery/components/RecoveryEmail/RegisterEmail.tsx
+++ b/src/features/recovery/components/RecoveryEmail/RegisterEmail.tsx
@@ -1,0 +1,80 @@
+import useSafeInfo from '@/hooks/useSafeInfo'
+import useOnboard from '@/hooks/wallets/useOnboard'
+import { asError } from '@/services/exceptions/utils'
+import { getAssertedChainSigner } from '@/services/tx/tx-sender/sdk'
+import { isWalletRejection } from '@/utils/wallets'
+import { Button, Grid, TextField } from '@mui/material'
+import Stack from '@mui/material/Stack'
+import { registerEmail } from '@safe-global/safe-gateway-typescript-sdk'
+import { useForm } from 'react-hook-form'
+
+const RegisterEmail = ({
+  onCancel,
+  onRegister,
+}: {
+  onCancel: () => void
+  onRegister: (emailAddress: string) => void
+}) => {
+  const onboard = useOnboard()
+  const { safe, safeAddress } = useSafeInfo()
+
+  const { watch, register } = useForm<{ emailAddress: string }>({
+    mode: 'onChange',
+  })
+
+  const emailAddress = watch('emailAddress')
+
+  const handleContinue = async () => {
+    if (!onboard) return
+
+    try {
+      const signer = await getAssertedChainSigner(onboard, safe.chainId)
+      const timestamp = Date.now().toString()
+      const messageToSign = `email-register-${safe.chainId}-${safeAddress}-${emailAddress}-${signer.address}-${timestamp}`
+      const signedMessage = await signer.signMessage(messageToSign)
+
+      await registerEmail(
+        safe.chainId,
+        safeAddress,
+        {
+          emailAddress,
+          signer: signer.address,
+        },
+        {
+          'Safe-Wallet-Signature': signedMessage,
+          'Safe-Wallet-Signature-Timestamp': timestamp,
+        },
+      )
+
+      onRegister(emailAddress)
+      // TODO: Open the verification dialog
+    } catch (e) {
+      const error = asError(e)
+      if (isWalletRejection(error)) return
+    }
+  }
+  return (
+    <Grid container gap={2} my={2}>
+      <Grid item xs>
+        <TextField
+          {...register('emailAddress')}
+          variant="outlined"
+          label="Enter email address"
+          helperText="We will send a verification code to this email"
+        />
+      </Grid>
+      <Grid item xs={12}>
+        <Stack direction="row" spacing={1}>
+          <Button variant="outlined" size="small" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button variant="contained" size="small" onClick={handleContinue} disabled={!emailAddress}>
+            Continue
+          </Button>
+        </Stack>
+      </Grid>
+    </Grid>
+  )
+}
+
+export default RegisterEmail

--- a/src/features/recovery/components/RecoveryEmail/RegisterEmail.tsx
+++ b/src/features/recovery/components/RecoveryEmail/RegisterEmail.tsx
@@ -8,6 +8,13 @@ import Stack from '@mui/material/Stack'
 import { registerEmail } from '@safe-global/safe-gateway-typescript-sdk'
 import { useForm } from 'react-hook-form'
 
+/**
+ * This is the same pattern we use on the CGW
+ * https://github.com/safe-global/safe-client-gateway/blob/main/src/domain/account/entities/account.entity.ts#L24
+ */
+const EMAIL_REGEXP =
+  /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+
 const RegisterEmail = ({
   onCancel,
   onRegister,
@@ -18,7 +25,7 @@ const RegisterEmail = ({
   const onboard = useOnboard()
   const { safe, safeAddress } = useSafeInfo()
 
-  const { watch, register } = useForm<{ emailAddress: string }>({
+  const { watch, register, formState } = useForm<{ emailAddress: string }>({
     mode: 'onChange',
   })
 
@@ -53,14 +60,19 @@ const RegisterEmail = ({
       if (isWalletRejection(error)) return
     }
   }
+
+  const isInvalidEmail = !formState.isValid && formState.isDirty
+
   return (
     <Grid container gap={2} my={2}>
-      <Grid item xs>
+      <Grid item xs md={6}>
         <TextField
-          {...register('emailAddress')}
+          {...register('emailAddress', { required: true, pattern: EMAIL_REGEXP })}
+          error={isInvalidEmail}
           variant="outlined"
           label="Enter email address"
-          helperText="We will send a verification code to this email"
+          helperText={isInvalidEmail ? 'Enter a valid email address' : 'We will send a verification code to this email'}
+          fullWidth
         />
       </Grid>
       <Grid item xs={12}>
@@ -68,7 +80,7 @@ const RegisterEmail = ({
           <Button variant="outlined" size="small" onClick={onCancel}>
             Cancel
           </Button>
-          <Button variant="contained" size="small" onClick={handleContinue} disabled={!emailAddress}>
+          <Button variant="contained" size="small" onClick={handleContinue} disabled={isInvalidEmail}>
             Continue
           </Button>
         </Stack>


### PR DESCRIPTION
## What it solves

Resolves #3320

## How this PR fixes it

- Adds a form to enter an email address and Cancel and Continue buttons
- On Continue, registers the email
- On Cancel, hides the form and displays the "Sign to view" button again

## How to test it

1. Open a safe with recovery enabled
2. Go to the settings page
3. Observe the "Sign to view" button is disabled if no wallet is connected or wallet is not an owner
4. Press "Sign to view" and sign the message
5. An email form should be visible
6. Press cancel
7. The "Sign to view" button should be visible again
8. Do Step 4 again
9. Enter a valid email and submit
10. The email address should be visible

Note: With the addition of #3321, Step 9 will open a new dialog to verify the email.

## Screenshots
<img width="793" alt="Screenshot 2024-02-23 at 16 37 55" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/63d8f690-bb88-45d1-acd4-375153548380">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
