### PR TITLE
fix: do not modify signatures for fully signed txs when estimating

### DIFF
--- a/src/hooks/__tests__/useGasLimit.test.ts
+++ b/src/hooks/__tests__/useGasLimit.test.ts
@@ -1,0 +1,115 @@
+import { mockWeb3Provider, renderHook, waitFor } from '@/tests/test-utils'
+import useGasLimit from '../useGasLimit'
+import * as safeCoreSDK from '../coreSDK/safeCoreSDK'
+import * as useWallet from '../wallets/useWallet'
+import * as useSafeInfo from '../useSafeInfo'
+import * as useIsSafeOwner from '../useIsSafeOwner'
+
+import { mockContractManager } from '@/tests/mocks/contractManager'
+import type Safe from '@safe-global/protocol-kit'
+import { faker } from '@faker-js/faker'
+import { connectedWalletBuilder } from '@/tests/builders/wallet'
+import { createMockSafeTransaction } from '@/tests/transactions'
+import { safeInfoBuilder } from '@/tests/builders/safe'
+import { type JsonRpcProvider, zeroPadValue } from 'ethers'
+import { Gnosis_safe__factory } from '@/types/contracts/factories/@safe-global/safe-deployments/dist/assets/v1.3.0'
+
+const contractManager = mockContractManager()
+
+const walletAddress = faker.finance.ethereumAddress()
+const prevSignerAddress = faker.finance.ethereumAddress()
+
+const safeInfo = safeInfoBuilder().with({ threshold: 1 }).build()
+let mockWeb3: JsonRpcProvider
+describe('useGasLimit', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+
+    jest.spyOn(safeCoreSDK, 'useSafeSDK').mockReturnValue({
+      getContractManager: () => contractManager,
+    } as unknown as Safe)
+
+    jest.spyOn(useWallet, 'default').mockReturnValue(connectedWalletBuilder().with({ address: walletAddress }).build())
+    jest.spyOn(useSafeInfo, 'default').mockReturnValue({
+      safe: { ...safeInfo, deployed: true },
+      safeAddress: safeInfo.address.value,
+      safeLoaded: true,
+      safeLoading: false,
+      safeError: undefined,
+    })
+    jest.spyOn(useIsSafeOwner, 'default').mockReturnValue(true)
+    mockWeb3 = mockWeb3Provider([])
+  })
+  it('should return undefined for undefined safeTx', () => {
+    const { result } = renderHook(() => useGasLimit())
+    expect(result.current).toEqual({ gasLimit: undefined, gasLimitLoading: false, gasLimitError: undefined })
+  })
+
+  it('should return undefined if no owner is connected', () => {
+    jest.spyOn(useWallet, 'default').mockReturnValue(
+      connectedWalletBuilder()
+        .with({
+          address: undefined,
+        })
+        .build(),
+    )
+
+    const safeTx = createMockSafeTransaction({
+      data: '0x00',
+      to: faker.finance.ethereumAddress(),
+    })
+
+    const { result } = renderHook(() => useGasLimit(safeTx))
+    expect(result.current).toEqual({ gasLimit: undefined, gasLimitLoading: false, gasLimitError: undefined })
+  })
+
+  it('should return estimated gas', async () => {
+    const safeTx = createMockSafeTransaction({
+      data: '0x00',
+      to: faker.finance.ethereumAddress(),
+    })
+
+    const { result } = renderHook(() => useGasLimit(safeTx))
+    await waitFor(async () => {
+      expect(result.current).toEqual({ gasLimit: 50_000n, gasLimitLoading: false, gasLimitError: undefined })
+    })
+  })
+
+  it('should not modify the signature if fully signed', async () => {
+    const safeTx = createMockSafeTransaction({
+      data: '0x00',
+      to: faker.finance.ethereumAddress(),
+    })
+
+    safeTx.addSignature({
+      signer: prevSignerAddress,
+      data: zeroPadValue('0x1234', 32),
+      isContractSignature: false,
+      dynamicPart: () => '',
+      staticPart: () => zeroPadValue('0x1234', 32),
+    })
+
+    const expectedCallData = Gnosis_safe__factory.createInterface().encodeFunctionData('execTransaction', [
+      safeTx.data.to,
+      safeTx.data.value,
+      safeTx.data.data,
+      safeTx.data.operation,
+      safeTx.data.safeTxGas,
+      safeTx.data.baseGas,
+      safeTx.data.gasPrice,
+      safeTx.data.gasToken,
+      safeTx.data.refundReceiver,
+      safeTx.encodedSignatures(),
+    ])
+
+    const { result } = renderHook(() => useGasLimit(safeTx))
+    await waitFor(async () => {
+      expect(result.current).toEqual({ gasLimit: 50_000n, gasLimitLoading: false, gasLimitError: undefined })
+    })
+    expect(mockWeb3.estimateGas).toHaveBeenCalledWith({
+      to: safeInfo.address.value,
+      from: walletAddress,
+      data: expectedCallData,
+    })
+  })
+})

--- a/src/hooks/useGasLimit.ts
+++ b/src/hooks/useGasLimit.ts
@@ -2,7 +2,6 @@ import { useEffect, useMemo } from 'react'
 import type Safe from '@safe-global/protocol-kit'
 import { encodeSignatures } from '@/services/tx/encodeSignatures'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
-import { OperationType } from '@safe-global/safe-core-sdk-types'
 import useAsync from '@/hooks/useAsync'
 import useChainId from '@/hooks/useChainId'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
@@ -66,11 +65,6 @@ const useGasLimit = (
     return getEncodedSafeTx(safeSDK, safeTx, isOwner ? walletAddress : undefined, safeTx.signatures.size < threshold)
   }, [safeSDK, safeTx, walletAddress, isOwner, threshold])
 
-  const operationType = useMemo<number>(
-    () => (safeTx?.data.operation == OperationType.DelegateCall ? 1 : 0),
-    [safeTx?.data.operation],
-  )
-
   const [gasLimit, gasLimitError, gasLimitLoading] = useAsync<bigint>(() => {
     if (!safeAddress || !walletAddress || !encodedSafeTx || !web3ReadOnly) return
 
@@ -79,7 +73,6 @@ const useGasLimit = (
         to: safeAddress,
         from: walletAddress,
         data: encodedSafeTx,
-        type: operationType,
       })
       .then((gasLimit) => {
         // Due to a bug in Nethermind estimation, we need to increment the gasLimit by 30%
@@ -91,7 +84,7 @@ const useGasLimit = (
 
         return gasLimit
       })
-  }, [currentChainId, safeAddress, hasSafeTxGas, walletAddress, encodedSafeTx, web3ReadOnly, operationType])
+  }, [currentChainId, safeAddress, hasSafeTxGas, walletAddress, encodedSafeTx, web3ReadOnly])
 
   useEffect(() => {
     if (gasLimitError) {

--- a/src/hooks/useIsValidExecution.ts
+++ b/src/hooks/useIsValidExecution.ts
@@ -61,6 +61,7 @@ const useIsValidExecution = (
   const { safe } = useSafeInfo()
   const readOnlyProvider = useWeb3ReadOnly()
   const isOwner = useIsSafeOwner()
+  const threshold = safe.threshold
 
   const [isValidExecution, executionValidationError, isValidExecutionLoading] = useAsync(async () => {
     if (!safeTx || !wallet || gasLimit === undefined || !readOnlyProvider) {
@@ -88,7 +89,7 @@ const useIsValidExecution = (
         safeTx.data.gasPrice,
         safeTx.data.gasToken,
         safeTx.data.refundReceiver,
-        encodeSignatures(safeTx, isOwner ? wallet.address : undefined),
+        encodeSignatures(safeTx, isOwner ? wallet.address : undefined, safeTx.signatures.size < threshold),
         { from: wallet.address, gasLimit: gasLimit.toString() },
       )
     } catch (_err) {

--- a/src/hooks/useIsValidExecution.ts
+++ b/src/hooks/useIsValidExecution.ts
@@ -102,7 +102,7 @@ const useIsValidExecution = (
 
       throw err
     }
-  }, [safeTx, wallet, gasLimit, safe, readOnlyProvider, isOwner])
+  }, [safeTx, wallet, gasLimit, safe, readOnlyProvider, isOwner, threshold])
 
   return { isValidExecution, executionValidationError, isValidExecutionLoading }
 }

--- a/src/services/tx/__tests__/encodeSignatures.test.ts
+++ b/src/services/tx/__tests__/encodeSignatures.test.ts
@@ -45,7 +45,7 @@ describe('encodeSignatures', () => {
 
     const owner = '0x123'
 
-    const encoded = encodeSignatures(safeTx, owner)
+    const encoded = encodeSignatures(safeTx, owner, false)
 
     expect(safeTx?.signatures.size).toBe(2)
     expect(encoded).toBe('0x123 = 0xEEE; 0x345 = 0xAAA')
@@ -64,7 +64,7 @@ describe('encodeSignatures', () => {
 
     const owner = '0x123'
 
-    const encoded = encodeSignatures(safeTx, owner)
+    const encoded = encodeSignatures(safeTx, owner, true)
 
     expect(safeTx?.signatures.size).toBe(1)
     expect(encoded).toBe(

--- a/src/services/tx/encodeSignatures.ts
+++ b/src/services/tx/encodeSignatures.ts
@@ -1,9 +1,13 @@
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { generatePreValidatedSignature } from '@safe-global/protocol-kit/dist/src/utils/signatures'
 
-export const encodeSignatures = (safeTx: SafeTransaction, from?: string): string => {
+export const encodeSignatures = (
+  safeTx: SafeTransaction,
+  from: string | undefined,
+  needsSignature: boolean,
+): string => {
   const owner = from?.toLowerCase()
-  const needsOwnerSig = owner && !safeTx.signatures.has(owner)
+  const needsOwnerSig = needsSignature && owner !== undefined && !safeTx.signatures.has(owner)
 
   // https://docs.gnosis.io/safe/docs/contracts_signatures/#pre-validated-signatures
   if (needsOwnerSig) {

--- a/src/tests/mocks/contractManager.ts
+++ b/src/tests/mocks/contractManager.ts
@@ -1,0 +1,57 @@
+import {
+  Gnosis_safe__factory,
+  Multi_send__factory,
+} from '@/types/contracts/factories/@safe-global/safe-deployments/dist/assets/v1.3.0'
+import { faker } from '@faker-js/faker'
+import type { ContractManager } from '@safe-global/protocol-kit'
+import { type SafeContract } from '@safe-global/safe-core-sdk-types'
+
+const safeContractInterface = Gnosis_safe__factory.createInterface()
+const multiSendInterface = Multi_send__factory.createInterface()
+
+const fakeDefaultOwner = faker.finance.ethereumAddress()
+const mockMultiSendCallOnlyAddress = faker.finance.ethereumAddress()
+const mockMultiSendAddress = faker.finance.ethereumAddress()
+
+export const mockContractManager = (owners: string[] = [fakeDefaultOwner], threshold: number = 1): ContractManager => {
+  const safeAddress = faker.finance.ethereumAddress()
+
+  return {
+    safeContract: {
+      encode: (methodName: string, params: any) => {
+        if (methodName === 'execTransaction') {
+          return safeContractInterface.encodeFunctionData(methodName, params)
+        }
+        throw new Error('Method not mocked yet')
+      },
+      getOwners: () => Promise.resolve(owners),
+      getThreshold: () => Promise.resolve(threshold),
+      getAddress: () => Promise.resolve(safeAddress),
+      getNonce: () => Promise.resolve(0),
+      getModules: () => Promise.resolve([]),
+      isOwner: (address: string) => Promise.resolve(owners.includes(address)),
+      isModuleEnabled: () => Promise.resolve(false),
+      getVersion: () => Promise.resolve('1.3.0'),
+    } as unknown as SafeContract,
+    contractNetworks: {},
+    isL1SafeSingleton: true,
+    multiSendCallOnlyContract: {
+      encode: (methodName: string, params: any) => {
+        if (methodName === 'multiSend') {
+          return multiSendInterface.encodeFunctionData(methodName, params)
+        }
+        throw new Error('Method not mocked yet')
+      },
+      getAddress: () => Promise.resolve(mockMultiSendCallOnlyAddress),
+    },
+    multiSendContract: {
+      encode: (methodName: string, params: any) => {
+        if (methodName === 'multiSend') {
+          return multiSendInterface.encodeFunctionData(methodName, params)
+        }
+        throw new Error('Method not mocked yet')
+      },
+      getAddress: () => Promise.resolve(mockMultiSendAddress),
+    },
+  } as unknown as ContractManager
+}

--- a/src/tests/transactions.ts
+++ b/src/tests/transactions.ts
@@ -1,9 +1,10 @@
 import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 import { solidityPacked, concat } from 'ethers'
-import { OperationType, type SafeSignature } from '@safe-global/safe-core-sdk-types'
+import { OperationType } from '@safe-global/safe-core-sdk-types'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 
 import { ERC20__factory, ERC721__factory, Multi_send__factory } from '@/types/contracts'
+import EthSafeTransaction from '@safe-global/protocol-kit/dist/src/utils/transactions/SafeTransaction'
 
 export const getMockErc20TransferCalldata = (to: string) => {
   const erc20Interface = ERC20__factory.createInterface()
@@ -74,28 +75,16 @@ export const createMockSafeTransaction = ({
   data: string
   operation?: OperationType
 }): SafeTransaction => {
-  const signatures = new Map<string, SafeSignature>([])
-
-  return {
-    data: {
-      to,
-      data,
-      baseGas: '0',
-      gasPrice: '0',
-      gasToken: ZERO_ADDRESS,
-      nonce: 1,
-      operation,
-      refundReceiver: ZERO_ADDRESS,
-      safeTxGas: '0',
-      value: '0x0',
-    },
-    signatures,
-    addSignature: (sig: SafeSignature) => {
-      signatures.set(sig.signer, sig)
-    },
-    encodedSignatures: () => {
-      return '0x'
-    },
-    getSignature: (signer: string) => signatures.get(signer),
-  }
+  return new EthSafeTransaction({
+    to,
+    data,
+    operation,
+    value: '0',
+    baseGas: '0',
+    gasPrice: '0',
+    gasToken: ZERO_ADDRESS,
+    nonce: 0,
+    refundReceiver: ZERO_ADDRESS,
+    safeTxGas: '0',
+  })
 }


### PR DESCRIPTION
## What it solves

Resolves #3332 

## How this PR fixes it
- Checks if a signature is needed before adding a pre-validated-sig.

## How to test it
- Open a 1/2 Safe where you control both owners
- Sign a transaction with the owner that has a higher address (higher hex number)
- Switch to the other owner with a lower address
- Try to execute the tx
- Observe that the gas estimation now matches

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
