### PR TITLE
chore: exclude generated & test folders from coverage

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -20,6 +20,7 @@ const customJestConfig = {
   globals: {
     fetch: global.fetch,
   },
+  coveragePathIgnorePatterns: ['/node_modules/', '/src/tests/', '/src/types/contracts/'],
 }
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async


### PR DESCRIPTION
## What it solves
Improves our coverage accuracy by excluding some irrelevant folders.

## How this PR fixes it
- Excludes generated typechain files
- Excludes our test-utils and mocks

## How to test it
Run `yarn test --coverage`
Observe that there are no more generated files and testutils

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
