### PR TITLE
Feat: remember last connected wallet address

### DIFF
--- a/src/components/welcome/MyAccounts/useAllSafes.ts
+++ b/src/components/welcome/MyAccounts/useAllSafes.ts
@@ -9,6 +9,7 @@ import useChainId from '@/hooks/useChainId'
 import useWallet from '@/hooks/wallets/useWallet'
 import { selectUndeployedSafes } from '@/store/slices'
 import { sameAddress } from '@/utils/addresses'
+import useLastWallet from '@/hooks/wallets/useLastWallet'
 
 export type SafeItems = Array<{
   chainId: string
@@ -37,7 +38,7 @@ export const useHasSafes = () => {
 }
 
 const useAllSafes = (): SafeItems => {
-  const { address: walletAddress = '' } = useWallet() || {}
+  const walletAddress = useLastWallet() || ''
   const [allOwned = {}] = useAllOwnedSafes(walletAddress)
   const allAdded = useAddedSafes()
   const { configs } = useChains()

--- a/src/hooks/wallets/useLastWallet.ts
+++ b/src/hooks/wallets/useLastWallet.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+import { getLastWalletAddress } from './useOnboard'
+import useWallet from './useWallet'
+
+const useLastWallet = (): string | null => {
+  const [lastWallet, setLastWallet] = useState<string | null>(null)
+  const wallet = useWallet()
+
+  useEffect(() => {
+    if (wallet) {
+      setLastWallet(wallet.address)
+    } else {
+      setLastWallet(getLastWalletAddress())
+    }
+  }, [wallet])
+
+  return lastWallet
+}
+
+export default useLastWallet

--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -150,10 +150,15 @@ export const switchWallet = async (onboard: OnboardAPI) => {
   }
 }
 
-const lastWalletStorage = localItem<string>('lastWallet')
+const lastWalletTypeStorage = localItem<string>('lastWallet')
+const lastWalletAddressStorage = localItem<string>('lastWalletAddress')
+
+export const getLastWalletAddress = () => {
+  return lastWalletAddressStorage.get()
+}
 
 const connectLastWallet = async (onboard: OnboardAPI) => {
-  const lastWalletLabel = lastWalletStorage.get()
+  const lastWalletLabel = lastWalletTypeStorage.get()
   if (lastWalletLabel) {
     const isUnlocked = await isWalletUnlocked(lastWalletLabel)
 
@@ -163,10 +168,6 @@ const connectLastWallet = async (onboard: OnboardAPI) => {
       })
     }
   }
-}
-
-const saveLastWallet = (walletLabel: string) => {
-  lastWalletStorage.set(walletLabel)
 }
 
 // Disable/enable wallets according to chain
@@ -213,14 +214,16 @@ export const useInitOnboard = () => {
     const walletSubscription = onboard.state.select('wallets').subscribe((wallets) => {
       const newWallet = getConnectedWallet(wallets)
       if (newWallet) {
+        lastWalletAddressStorage.set(newWallet.address)
+
         if (newWallet.label !== lastConnectedWallet) {
           lastConnectedWallet = newWallet.label
-          saveLastWallet(lastConnectedWallet)
+          lastWalletTypeStorage.set(lastConnectedWallet)
           trackWalletType(newWallet)
         }
       } else if (lastConnectedWallet) {
         lastConnectedWallet = ''
-        saveLastWallet(lastConnectedWallet)
+        lastWalletTypeStorage.set(lastConnectedWallet)
       }
     })
 


### PR DESCRIPTION
## What it solves

Save the last connected wallet address into the localStorage so that the owned Safe list is displayed even if you disconnect your wallet.

This emulates the old "Added Safes" behavior that is now reimagined as a Watchlist feature.

## Screenshots

<img width="1448" alt="Screenshot 2024-02-27 at 17 13 07" src="https://github.com/safe-global/safe-wallet-web/assets/381895/06cf9e5a-52f0-41dc-9106-385011ee1fae">
