### PR TITLE
feat: [Recovery] Delete registered email

### DIFF
--- a/src/features/recovery/components/RecoveryEmail/VerifyEmail.tsx
+++ b/src/features/recovery/components/RecoveryEmail/VerifyEmail.tsx
@@ -23,7 +23,7 @@ export const NotVerifiedMessage = ({ onVerify }: { onVerify: () => void }) => {
   )
 }
 
-const isNoContentResponse = (error: unknown): error is boolean => {
+export const isNoContentResponse = (error: string) => {
   return error === 'Invalid response content: No Content'
 }
 

--- a/src/features/recovery/components/RecoveryEmail/useRecoveryEmail.ts
+++ b/src/features/recovery/components/RecoveryEmail/useRecoveryEmail.ts
@@ -1,4 +1,5 @@
 import {
+  deleteRegisteredEmail,
   getRegisteredEmail,
   registerEmail,
   resendEmailVerificationCode,
@@ -64,10 +65,25 @@ const useRecoveryEmail = () => {
     return resendEmailVerificationCode(safe.chainId, safeAddress, signer.address)
   }
 
+  const deleteEmailAddress = async () => {
+    if (!onboard) return
+
+    const signer = await getAssertedChainSigner(onboard, safe.chainId)
+    const timestamp = Date.now().toString()
+    const messageToSign = `email-delete-${safe.chainId}-${safeAddress}-${signer.address}-${timestamp}`
+    const signedMessage = await signer.signMessage(messageToSign)
+
+    return deleteRegisteredEmail(safe.chainId, safeAddress, signer.address, {
+      'Safe-Wallet-Signature': signedMessage,
+      'Safe-Wallet-Signature-Timestamp': timestamp,
+    })
+  }
+
   return {
     getSignerEmailAddress,
     registerEmailAddress,
     verifyEmailAddress,
+    deleteEmailAddress,
     resendVerification,
   }
 }


### PR DESCRIPTION
## What it solves

Resolves #3149

## How this PR fixes it

- Adds a new function `deleteEmailAddress`
- Shows a delete button with the email
- Shows a notification on successful deletion

## How to test it

1. Register an email address
2. Press "Sign to view"
3. Observe a delete button next to the email
4. Press the button and sign
5. Observe a success message
6. Observe that the form is visible again

## Screenshots

<img width="691" alt="Screenshot 2024-02-27 at 17 46 01" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/5ba05a75-b66b-4204-9562-e08b7cda72e6">
<img width="907" alt="Screenshot 2024-02-27 at 17 55 02" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/a76d762d-30f3-475f-9e3f-f79c1409dd5f">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
