### PR TITLE
feat: allow adding safes from the welcome page

### DIFF
--- a/src/components/welcome/WelcomeLogin/index.tsx
+++ b/src/components/welcome/WelcomeLogin/index.tsx
@@ -1,7 +1,7 @@
 import { AppRoutes } from '@/config/routes'
 import { useHasFeature } from '@/hooks/useChains'
 import { FEATURES } from '@/utils/chains'
-import { Paper, SvgIcon, Typography, Divider, Box, Skeleton } from '@mui/material'
+import { Paper, SvgIcon, Typography, Divider, Box, Skeleton, Button, Link } from '@mui/material'
 import SafeLogo from '@/public/images/logo-text.svg'
 import dynamic from 'next/dynamic'
 import css from './styles.module.css'
@@ -62,6 +62,17 @@ const WelcomeLogin = () => {
             <SocialSigner />
           </>
         )}
+
+        <Divider sx={{ mt: 2, mb: 2, width: '100%' }}>
+          <Typography color="text.secondary" fontWeight={700} variant="overline">
+            or
+          </Typography>
+        </Divider>
+        <Link href={AppRoutes.newSafe.load}>
+          <Button disableElevation size="small">
+            Watch any account
+          </Button>
+        </Link>
       </Box>
     </Paper>
   )


### PR DESCRIPTION
## What it solves

Resolves #3357 

## How this PR fixes it
Add a button to the welcome page for adding watchlist safes even when there is no wallet connected.

## How to test it
- make sure no wallet is connected
- go to `/welcome`
- see that the button is present and leads to adding a new account to the watchlist.

## Screenshots

<img width="1300" alt="image" src="https://github.com/safe-global/safe-wallet-web/assets/17801424/c61344e6-22f5-4f00-b1c6-cf63a0c14879">


With social login:
<img width="1300" alt="image" src="https://github.com/safe-global/safe-wallet-web/assets/17801424/9371e4de-ba9c-4c73-bc88-2749fa604fb5">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
