### PR TITLE
fix: [Analytics] Set safe address during safe creation

### DIFF
--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -26,6 +26,7 @@ import useWalletCanPay from '@/hooks/useWalletCanPay'
 import useWallet from '@/hooks/wallets/useWallet'
 import { useWeb3 } from '@/hooks/wallets/web3'
 import { CREATE_SAFE_CATEGORY, CREATE_SAFE_EVENTS, OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
+import { gtmSetSafeAddress } from '@/services/analytics/gtm'
 import { getReadOnlyFallbackHandlerContract } from '@/services/contracts/safeContracts'
 import { isSocialLoginWallet } from '@/services/mpc/SocialLoginModule'
 import { useAppDispatch } from '@/store'
@@ -212,6 +213,8 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
       const safeAddress = await computeNewSafeAddress(provider, { ...props, saltNonce })
 
       if (isCounterfactual && payMethod === PayMethod.PayLater) {
+        gtmSetSafeAddress(safeAddress)
+
         trackEvent({ ...OVERVIEW_EVENTS.PROCEED_WITH_TX, label: 'counterfactual', category: CREATE_SAFE_CATEGORY })
         await createCounterfactualSafe(chain, safeAddress, saltNonce, data, dispatch, props, router)
         trackEvent({ ...CREATE_SAFE_EVENTS.CREATED_SAFE, label: 'counterfactual' })


### PR DESCRIPTION
## What it solves

Part of #3270

## How this PR fixes it

In some cases it can happen that `gtmSetSafeAddress` is called too late after safe creation so that certain key events like `safe_created` do not contain the `safeAddress`. To solve this we additionally call `gtmSetSafeAddress` when the counterfactual safe creation is submitted.

## How to test it

1. Create a counterfactual safe
2. Observe in the console that all events after pressing Create contain the safe address

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
