### PR TITLE
feat: [Recovery] Add register and verify email step in recovery flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@safe-global/safe-core-sdk-utils": "^1.7.4",
     "@safe-global/safe-deployments": "1.32.0",
     "@safe-global/safe-ethers-lib": "^1.9.4",
-    "@safe-global/safe-gateway-typescript-sdk": "3.17.0-alpha.1",
+    "@safe-global/safe-gateway-typescript-sdk": "3.18.0-alpha.0",
     "@safe-global/safe-modules-deployments": "^1.2.0",
     "@sentry/react": "^7.91.0",
     "@spindl-xyz/attribution-lite": "^1.4.0",

--- a/src/components/safe-apps/AppFrame/__tests__/AppFrame.test.tsx
+++ b/src/components/safe-apps/AppFrame/__tests__/AppFrame.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from '@/tests/test-utils'
 import AppFrame from '@/components/safe-apps/AppFrame'
+import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 import {
   ConflictType,
   DetailedExecutionInfoType,
@@ -55,6 +56,7 @@ describe('AppFrame', () => {
                     nonce: 3,
                     confirmationsRequired: 2,
                     confirmationsSubmitted: 1,
+                    proposer: { value: ZERO_ADDRESS },
                     missingSigners: [
                       {
                         value: '0xbc2BB26a6d821e69A38016f3858561a1D80d4182',

--- a/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowEmail.tsx
+++ b/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowEmail.tsx
@@ -53,10 +53,8 @@ const UpsertRecoveryFlowEmail = ({
       }
     } catch (e) {
       const error = asError(e)
-      if (isWalletRejection(error)) return
+      if (error.message !== 'Not Found') return
 
-      // If we didn't detect an email
-      // TODO: Move this into the try clause once the SDK is fixed for 204 responses
       registerEmail()
     }
   }

--- a/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowEmail.tsx
+++ b/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowEmail.tsx
@@ -44,13 +44,12 @@ const UpsertRecoveryFlowEmail = ({
         setValue('emailAddress', response.email)
         setValue('verified', response.verified)
       }
-
-      console.log(response)
     } catch (e) {
       const error = asError(e)
-      console.log(error)
       if (isWalletRejection(error)) return
 
+      // If we didn't detect an email
+      // TODO: Move this into the try clause once the SDK is fixed for 204 responses
       registerEmail()
     }
   }
@@ -119,7 +118,7 @@ const UpsertRecoveryFlowEmail = ({
 
             <Divider className={commonCss.nestedDivider} />
 
-            <CardActions sx={{ mt: '0 !important', flexDirection: 'row', justifyContent: 'flex-end' }}>
+            <CardActions sx={{ mt: '0 !important', flexDirection: 'row !important', justifyContent: 'flex-end' }}>
               {verified === undefined && (
                 <Button type="submit" disabled={false}>
                   Skip for now

--- a/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowEmail.tsx
+++ b/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowEmail.tsx
@@ -1,3 +1,4 @@
+import ErrorMessage from '@/components/tx/ErrorMessage'
 import { useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { Box, Button, CardActions, Divider, InputAdornment, TextField, Typography } from '@mui/material'
@@ -19,6 +20,7 @@ const UpsertRecoveryFlowEmail = ({
   params: UpsertRecoveryFlowProps
   onSubmit: (formData: UpsertRecoveryFlowProps) => void
 }) => {
+  const [error, setError] = useState<string>()
   const [verifyEmailOpen, setVerifyEmailOpen] = useState<boolean>(false)
   const { getSignerEmailAddress, registerEmailAddress } = useRecoveryEmail()
 
@@ -33,7 +35,12 @@ const UpsertRecoveryFlowEmail = ({
   const verified = watch('verified')
 
   const onFormSubmit = (data: { emailAddress: string }) => {
-    onSubmit({ ...params, ...data })
+    // In case the user skips but already typed in an email
+    if (verified === undefined) {
+      return onSubmit({ ...params })
+    }
+
+    return onSubmit({ ...params, ...data })
   }
 
   const signToViewEmail = async () => {
@@ -62,6 +69,8 @@ const UpsertRecoveryFlowEmail = ({
     } catch (e) {
       const error = asError(e)
       if (isWalletRejection(error)) return
+
+      setError('Failed to register email address. Please try again.')
     }
   }
 
@@ -115,6 +124,8 @@ const UpsertRecoveryFlowEmail = ({
             </Box>
 
             {verified === false && <NotVerifiedMessage onVerify={toggleVerifyEmailDialog} />}
+
+            {error && <ErrorMessage>{error}</ErrorMessage>}
 
             <Divider className={commonCss.nestedDivider} />
 

--- a/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowEmail.tsx
+++ b/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowEmail.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { Box, Button, CardActions, Divider, InputAdornment, TextField, Typography } from '@mui/material'
+import commonCss from '@/components/tx-flow/common/styles.module.css'
+import TxCard from '@/components/tx-flow/common/TxCard'
+import type { UpsertRecoveryFlowProps } from '@/components/tx-flow/flows/UpsertRecovery/index'
+import { EMAIL_REGEXP } from '@/features/recovery/components/RecoveryEmail/RegisterEmail'
+import useRecoveryEmail from '@/features/recovery/components/RecoveryEmail/useRecoveryEmail'
+import VerifyEmail, { NotVerifiedMessage } from '@/features/recovery/components/RecoveryEmail/VerifyEmail'
+import { asError } from '@/services/exceptions/utils'
+import { isWalletRejection } from '@/utils/wallets'
+import CheckFilledIcon from '@/public/images/common/check-filled.svg'
+import css from './styles.module.css'
+
+const UpsertRecoveryFlowEmail = ({
+  params,
+  onSubmit,
+}: {
+  params: UpsertRecoveryFlowProps
+  onSubmit: (formData: UpsertRecoveryFlowProps) => void
+}) => {
+  const [verifyEmailOpen, setVerifyEmailOpen] = useState<boolean>(false)
+  const { getSignerEmailAddress, registerEmailAddress } = useRecoveryEmail()
+
+  const formMethods = useForm<{ emailAddress: string; verified: boolean }>({
+    mode: 'onChange',
+    defaultValues: params,
+  })
+
+  const { watch, register, formState, handleSubmit, setValue } = formMethods
+
+  const emailAddress = watch('emailAddress')
+  const verified = watch('verified')
+
+  const onFormSubmit = (data: { emailAddress: string }) => {
+    onSubmit({ ...params, ...data })
+  }
+
+  const signToViewEmail = async () => {
+    try {
+      const response = await getSignerEmailAddress()
+
+      if (response) {
+        setValue('emailAddress', response.email)
+        setValue('verified', response.verified)
+      }
+
+      console.log(response)
+    } catch (e) {
+      const error = asError(e)
+      console.log(error)
+      if (isWalletRejection(error)) return
+
+      registerEmail()
+    }
+  }
+
+  const registerEmail = async () => {
+    try {
+      await registerEmailAddress(emailAddress)
+      setValue('verified', false)
+      toggleVerifyEmailDialog()
+    } catch (e) {
+      const error = asError(e)
+      if (isWalletRejection(error)) return
+    }
+  }
+
+  const toggleVerifyEmailDialog = () => {
+    setVerifyEmailOpen((prev) => !prev)
+  }
+
+  const onVerifySuccess = () => {
+    toggleVerifyEmailDialog()
+    setValue('verified', true)
+  }
+
+  const isInvalidEmail = !formState.isValid && formState.isDirty
+
+  const continueButtonText = verified === false ? 'Verify' : verified === true ? 'Continue' : 'Sign & Verify'
+  const continueButtonAction =
+    verified === false ? toggleVerifyEmailDialog : verified === true ? handleSubmit(onFormSubmit) : signToViewEmail
+
+  return (
+    <>
+      <FormProvider {...formMethods}>
+        <form onSubmit={handleSubmit(onFormSubmit)} className={commonCss.form}>
+          <TxCard>
+            <Typography>
+              We will contact you via your notification email address about any initiated recovery attempts and their
+              status. You can always change it later.
+            </Typography>
+
+            <Box width={{ xs: 1, md: '60%' }}>
+              <TextField
+                {...register('emailAddress', { pattern: EMAIL_REGEXP })}
+                error={isInvalidEmail}
+                variant="outlined"
+                label="Enter email address"
+                helperText={
+                  isInvalidEmail ? 'Enter a valid email address' : 'We will send a verification code to this email'
+                }
+                InputProps={{
+                  endAdornment:
+                    verified === true ? (
+                      <InputAdornment position="end">
+                        <Box className={css.checkIcon}>
+                          <CheckFilledIcon />
+                        </Box>
+                      </InputAdornment>
+                    ) : null,
+                }}
+                fullWidth
+                sx={{ my: 1 }}
+              />
+            </Box>
+
+            {verified === false && <NotVerifiedMessage onVerify={toggleVerifyEmailDialog} />}
+
+            <Divider className={commonCss.nestedDivider} />
+
+            <CardActions sx={{ mt: '0 !important', flexDirection: 'row', justifyContent: 'flex-end' }}>
+              {verified === undefined && (
+                <Button type="submit" disabled={false}>
+                  Skip for now
+                </Button>
+              )}
+              <Button variant="contained" onClick={continueButtonAction} disabled={isInvalidEmail || !emailAddress}>
+                {continueButtonText}
+              </Button>
+            </CardActions>
+          </TxCard>
+        </form>
+      </FormProvider>
+
+      {verifyEmailOpen && <VerifyEmail onCancel={toggleVerifyEmailDialog} onSuccess={onVerifySuccess} />}
+    </>
+  )
+}
+
+export default UpsertRecoveryFlowEmail

--- a/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowReview.tsx
+++ b/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowReview.tsx
@@ -1,6 +1,6 @@
 import { SvgIcon, Tooltip, Typography } from '@mui/material'
 import { getSafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
-import { useContext, useEffect } from 'react'
+import { useContext, useEffect, useRef } from 'react'
 import type { ReactElement } from 'react'
 
 import EthHashInfo from '@/components/common/EthHashInfo'
@@ -37,13 +37,22 @@ const getAddressType = async (address: string, chainId: string) => {
   return AddressType.Other
 }
 
-const onSubmit = async (isEdit: boolean, params: UpsertRecoveryFlowProps, chainId: string) => {
+const onSubmit = async (
+  isEdit: boolean,
+  params: UpsertRecoveryFlowProps,
+  chainId: string,
+  predictedModuleAddress?: string,
+) => {
   const addressType = await getAddressType(params.recoverer, chainId)
   const creationEvent = isEdit ? RECOVERY_EVENTS.SUBMIT_RECOVERY_EDIT : RECOVERY_EVENTS.SUBMIT_RECOVERY_CREATE
   const settings = `delay_${params.delay},expiry_${params.expiry},type_${addressType}`
 
   trackEvent({ ...creationEvent })
   trackEvent({ ...RECOVERY_EVENTS.RECOVERY_SETTINGS, label: settings })
+
+  if (predictedModuleAddress) {
+    // TODO: Register the module address for alerts
+  }
 }
 
 export function UpsertRecoveryFlowReview({
@@ -53,6 +62,7 @@ export function UpsertRecoveryFlowReview({
   params: UpsertRecoveryFlowProps
   moduleAddress?: string
 }): ReactElement {
+  const predictedModuleAddress = useRef<string>()
   const web3ReadOnly = useWeb3ReadOnly()
   const { safe, safeAddress } = useSafeInfo()
   const { setSafeTx, safeTxError, setSafeTxError } = useContext(SafeTxContext)
@@ -75,7 +85,11 @@ export function UpsertRecoveryFlowReview({
       safeAddress,
       moduleAddress,
     })
-      .then((transactions) => {
+      .then(({ transactions, expectedModuleAddress }) => {
+        if (expectedModuleAddress) {
+          predictedModuleAddress.current = expectedModuleAddress
+        }
+
         return transactions.length > 1 ? createMultiSendCallOnlyTx(transactions) : createTx(transactions[0])
       })
       .then(setSafeTx)
@@ -91,7 +105,7 @@ export function UpsertRecoveryFlowReview({
   const isEdit = !!moduleAddress
 
   return (
-    <SignOrExecuteForm onSubmit={() => onSubmit(isEdit, params, safe.chainId)}>
+    <SignOrExecuteForm onSubmit={() => onSubmit(isEdit, params, safe.chainId, predictedModuleAddress.current)}>
       <Typography>
         This transaction will {moduleAddress ? 'update' : 'enable'} the Account recovery feature once executed.
       </Typography>

--- a/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowReview.tsx
+++ b/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowReview.tsx
@@ -61,6 +61,7 @@ export function UpsertRecoveryFlowReview({
   const recoverer = params[UpsertRecoveryFlowFields.recoverer]
   const delay = periods.delay.find(({ value }) => value === params[UpsertRecoveryFlowFields.delay])!.label
   const expiry = periods.expiration.find(({ value }) => value === params[UpsertRecoveryFlowFields.expiry])!.label
+  const emailAddress = params[UpsertRecoveryFlowFields.emailAddress]
 
   useEffect(() => {
     if (!web3ReadOnly) {
@@ -142,6 +143,8 @@ export function UpsertRecoveryFlowReview({
           {expiry}
         </TxDataRow>
       )}
+
+      {emailAddress !== '' && <TxDataRow title="Notification email">{emailAddress}</TxDataRow>}
     </SignOrExecuteForm>
   )
 }

--- a/src/components/tx-flow/flows/UpsertRecovery/index.tsx
+++ b/src/components/tx-flow/flows/UpsertRecovery/index.tsx
@@ -1,8 +1,10 @@
+import UpsertRecoveryFlowEmail from '@/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowEmail'
 import { SETUP_RECOVERY_CATEGORY } from '@/services/analytics/events/recovery'
 import type { ReactElement } from 'react'
 
 import TxLayout from '@/components/tx-flow/common/TxLayout'
 import RecoveryPlus from '@/public/images/common/recovery-plus.svg'
+import MailOutlineRoundedIcon from '@mui/icons-material/MailOutlineRounded'
 import useTxStepper from '../../useTxStepper'
 import { UpsertRecoveryFlowReview as UpsertRecoveryFlowReview } from './UpsertRecoveryFlowReview'
 import { UpsertRecoveryFlowSettings as UpsertRecoveryFlowSettings } from './UpsertRecoveryFlowSettings'
@@ -10,18 +12,18 @@ import { UpsertRecoveryFlowIntro as UpsertRecoveryFlowIntro } from './UpsertReco
 import { DAY_IN_SECONDS } from './useRecoveryPeriods'
 import type { RecoveryState } from '@/features/recovery/services/recovery-state'
 
-const Subtitles = ['How does recovery work?', 'Set up recovery settings', 'Set up account recovery']
-
 export enum UpsertRecoveryFlowFields {
   recoverer = 'recoverer',
   delay = 'delay',
   expiry = 'expiry',
+  emailAddress = 'emailAddress',
 }
 
 export type UpsertRecoveryFlowProps = {
   [UpsertRecoveryFlowFields.recoverer]: string
   [UpsertRecoveryFlowFields.delay]: string
   [UpsertRecoveryFlowFields.expiry]: string
+  [UpsertRecoveryFlowFields.emailAddress]?: string
 }
 
 function UpsertRecoveryFlow({ delayModifier }: { delayModifier?: RecoveryState[number] }): ReactElement {
@@ -42,12 +44,23 @@ function UpsertRecoveryFlow({ delayModifier }: { delayModifier?: RecoveryState[n
       delayModifier={delayModifier}
       onSubmit={(formData) => nextStep({ ...data, ...formData })}
     />,
+    !delayModifier ? (
+      <UpsertRecoveryFlowEmail params={data} onSubmit={(formData) => nextStep({ ...data, ...formData })} />
+    ) : null,
     <UpsertRecoveryFlowReview key={2} params={data} moduleAddress={delayModifier?.address} />,
   ]
 
-  const isIntro = step === 0
+  const Subtitles = [
+    'How does recovery work?',
+    'Set up recovery settings',
+    !delayModifier ? 'Enable email notifications' : null,
+    'Set up account recovery',
+  ]
 
-  const icon = isIntro ? undefined : RecoveryPlus
+  const isIntro = step === 0
+  const isEmailStep = step === 2 && !delayModifier
+
+  const icon = isIntro ? undefined : isEmailStep ? MailOutlineRoundedIcon : RecoveryPlus
 
   return (
     <TxLayout

--- a/src/components/tx-flow/flows/UpsertRecovery/styles.module.css
+++ b/src/components/tx-flow/flows/UpsertRecovery/styles.module.css
@@ -52,3 +52,8 @@
   width: 65px;
   height: 15px;
 }
+
+.checkIcon {
+  color: var(--color-success-main);
+  display: inline-flex;
+}

--- a/src/features/recovery/components/RecoveryEmail/RegisterEmail.tsx
+++ b/src/features/recovery/components/RecoveryEmail/RegisterEmail.tsx
@@ -9,7 +9,7 @@ import { useForm } from 'react-hook-form'
  * This is the same pattern we use on the CGW
  * https://github.com/safe-global/safe-client-gateway/blob/main/src/domain/account/entities/account.entity.ts#L24
  */
-const EMAIL_REGEXP =
+export const EMAIL_REGEXP =
   /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
 
 const RegisterEmail = ({

--- a/src/features/recovery/components/RecoveryEmail/RegisterEmail.tsx
+++ b/src/features/recovery/components/RecoveryEmail/RegisterEmail.tsx
@@ -44,7 +44,7 @@ const RegisterEmail = ({
       const error = asError(e)
       if (isWalletRejection(error)) return
 
-      setError('Failed to register email address. Please try again.')
+      setError(`Failed to ${initialValue ? 'edit' : 'register'} email address. Please try again.`)
     }
   }
 

--- a/src/features/recovery/components/RecoveryEmail/VerifyEmail.tsx
+++ b/src/features/recovery/components/RecoveryEmail/VerifyEmail.tsx
@@ -46,7 +46,7 @@ const VerifyEmail = ({ onCancel, onSuccess }: { onCancel: () => void; onSuccess:
   const handleVerify = async () => {
     try {
       setError(undefined)
-      const result = await verifyEmailAddress(verificationCode)
+      await verifyEmailAddress(verificationCode)
     } catch (e) {
       const error = asError(e)
 

--- a/src/features/recovery/components/RecoveryEmail/VerifyEmail.tsx
+++ b/src/features/recovery/components/RecoveryEmail/VerifyEmail.tsx
@@ -1,4 +1,3 @@
-import { asError } from '@/services/exceptions/utils'
 import { useAppDispatch } from '@/store'
 import { showNotification } from '@/store/notificationsSlice'
 import { useState } from 'react'
@@ -23,23 +22,18 @@ export const NotVerifiedMessage = ({ onVerify }: { onVerify: () => void }) => {
   )
 }
 
-export const isNoContentResponse = (error: string) => {
-  return error === 'Invalid response content: No Content'
-}
-
 const VerifyEmail = ({ onCancel, onSuccess }: { onCancel: () => void; onSuccess: () => void }) => {
   const [error, setError] = useState<string>()
   const [verificationCode, setVerificationCode] = useState<string>('')
-  const { verifyEmailAddress, resendVerification } = useRecoveryEmail()
+  const { verifyEmailAddress, resendVerification, registerRecovery } = useRecoveryEmail()
   const dispatch = useAppDispatch()
 
   const handleRetry = async () => {
     try {
-      await resendVerification()
       setError(undefined)
+      await resendVerification()
     } catch (e) {
-      console.log(e)
-      // TODO: logError
+      setError('Error requesting verification code. Please try again.')
     }
   }
 
@@ -47,21 +41,18 @@ const VerifyEmail = ({ onCancel, onSuccess }: { onCancel: () => void; onSuccess:
     try {
       setError(undefined)
       await verifyEmailAddress(verificationCode)
+
+      dispatch(
+        showNotification({
+          variant: 'success',
+          groupKey: 'verify-email-complete',
+          message: 'Your email address is verified',
+        }),
+      )
+
+      onSuccess()
+      await registerRecovery()
     } catch (e) {
-      const error = asError(e)
-
-      // TODO: Handle empty body responses in the SDK or CGW
-      if (isNoContentResponse(error.message)) {
-        dispatch(
-          showNotification({
-            variant: 'success',
-            groupKey: 'verify-email-complete',
-            message: 'Your email address is verified',
-          }),
-        )
-        onSuccess()
-      }
-
       setError('Wrong verification code. Try again.')
     }
   }

--- a/src/features/recovery/components/RecoveryEmail/index.tsx
+++ b/src/features/recovery/components/RecoveryEmail/index.tsx
@@ -1,10 +1,7 @@
 import CheckWallet from '@/components/common/CheckWallet'
 import RegisterEmail from '@/features/recovery/components/RecoveryEmail/RegisterEmail'
 import useRecoveryEmail from '@/features/recovery/components/RecoveryEmail/useRecoveryEmail'
-import VerifyEmail, {
-  isNoContentResponse,
-  NotVerifiedMessage,
-} from '@/features/recovery/components/RecoveryEmail/VerifyEmail'
+import VerifyEmail, { NotVerifiedMessage } from '@/features/recovery/components/RecoveryEmail/VerifyEmail'
 import DeleteIcon from '@/public/images/common/delete.svg'
 import EditIcon from '@/public/images/common/edit.svg'
 import { asError } from '@/services/exceptions/utils'
@@ -67,20 +64,17 @@ const RecoveryEmail = () => {
   const onDelete = async () => {
     try {
       await deleteEmailAddress()
+      setEmail(undefined)
+
+      dispatch(
+        showNotification({
+          variant: 'success',
+          groupKey: 'delete-email-complete',
+          message: 'Your email was deleted',
+        }),
+      )
     } catch (e) {
-      const error = asError(e)
-
-      if (isNoContentResponse(error.message)) {
-        setEmail(undefined)
-
-        dispatch(
-          showNotification({
-            variant: 'success',
-            groupKey: 'delete-email-complete',
-            message: 'Your email was deleted',
-          }),
-        )
-      }
+      console.log(e)
     }
   }
 

--- a/src/features/recovery/components/RecoveryEmail/useRecoveryEmail.ts
+++ b/src/features/recovery/components/RecoveryEmail/useRecoveryEmail.ts
@@ -1,8 +1,10 @@
+import useRecovery from '@/features/recovery/hooks/useRecovery'
 import {
   changeEmail,
   deleteRegisteredEmail,
   getRegisteredEmail,
   registerEmail,
+  registerRecoveryModule,
   resendEmailVerificationCode,
   verifyEmail,
 } from '@safe-global/safe-gateway-typescript-sdk'
@@ -13,6 +15,7 @@ import { getAssertedChainSigner } from '@/services/tx/tx-sender/sdk'
 const useRecoveryEmail = () => {
   const onboard = useOnboard()
   const { safe, safeAddress } = useSafeInfo()
+  const [recovery] = useRecovery()
 
   const registerEmailAddress = async (emailAddress: string) => {
     if (!onboard) return
@@ -100,6 +103,12 @@ const useRecoveryEmail = () => {
     )
   }
 
+  const registerRecovery = () => {
+    if (!recovery || recovery.length === 0) return
+
+    return registerRecoveryModule(safe.chainId, safeAddress, { moduleAddress: recovery[0].address })
+  }
+
   return {
     getSignerEmailAddress,
     registerEmailAddress,
@@ -107,6 +116,7 @@ const useRecoveryEmail = () => {
     deleteEmailAddress,
     editEmailAddress,
     resendVerification,
+    registerRecovery,
   }
 }
 

--- a/src/features/recovery/services/setup.ts
+++ b/src/features/recovery/services/setup.ts
@@ -176,20 +176,18 @@ export async function getRecoveryUpsertTransactions({
   provider: JsonRpcProvider
   chainId: string
   safeAddress: string
-}): Promise<{ transactions: Array<MetaTransactionData>; expectedModuleAddress?: string }> {
+}): Promise<Array<MetaTransactionData>> {
   if (moduleAddress) {
-    const transactions = await _getEditRecoveryTransactions({
+    return _getEditRecoveryTransactions({
       moduleAddress,
       newDelay: delay,
       newExpiry: expiry,
       newRecoverers: [recoverer],
       provider,
     })
-
-    return { transactions }
   }
 
-  const { transactions, expectedModuleAddress } = await _getRecoverySetupTransactions({
+  const { transactions } = await _getRecoverySetupTransactions({
     delay,
     expiry,
     recoverers: [recoverer],
@@ -198,5 +196,5 @@ export async function getRecoveryUpsertTransactions({
     provider,
   })
 
-  return { transactions, expectedModuleAddress }
+  return transactions
 }

--- a/src/features/recovery/services/setup.ts
+++ b/src/features/recovery/services/setup.ts
@@ -176,18 +176,20 @@ export async function getRecoveryUpsertTransactions({
   provider: JsonRpcProvider
   chainId: string
   safeAddress: string
-}): Promise<Array<MetaTransactionData>> {
+}): Promise<{ transactions: Array<MetaTransactionData>; expectedModuleAddress?: string }> {
   if (moduleAddress) {
-    return _getEditRecoveryTransactions({
+    const transactions = await _getEditRecoveryTransactions({
       moduleAddress,
       newDelay: delay,
       newExpiry: expiry,
       newRecoverers: [recoverer],
       provider,
     })
+
+    return { transactions }
   }
 
-  const { transactions } = await _getRecoverySetupTransactions({
+  const { transactions, expectedModuleAddress } = await _getRecoverySetupTransactions({
     delay,
     expiry,
     recoverers: [recoverer],
@@ -196,5 +198,5 @@ export async function getRecoveryUpsertTransactions({
     provider,
   })
 
-  return transactions
+  return { transactions, expectedModuleAddress }
 }

--- a/src/tests/mocks/transactions.ts
+++ b/src/tests/mocks/transactions.ts
@@ -1,3 +1,4 @@
+import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 import {
   type AddressEx,
   ConflictType,
@@ -43,6 +44,7 @@ export const defaultTx: TransactionSummary = {
     nonce: 1,
     confirmationsRequired: 2,
     confirmationsSubmitted: 2,
+    proposer: { value: ZERO_ADDRESS },
   },
 }
 

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -62,6 +62,7 @@ export const makeTxFromDetails = (txDetails: TransactionDetails): Transaction =>
       confirmationsRequired: detailedExecutionInfo.confirmationsRequired,
       confirmationsSubmitted: detailedExecutionInfo.confirmations?.length ?? 0,
       missingSigners: getMissingSigners(detailedExecutionInfo),
+      proposer: detailedExecutionInfo.signers[0],
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4032,10 +4032,10 @@
     "@safe-global/safe-core-sdk-utils" "^1.7.4"
     ethers "5.7.2"
 
-"@safe-global/safe-gateway-typescript-sdk@3.17.0-alpha.1":
-  version "3.17.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.17.0-alpha.1.tgz#5d224a9fc06cc90568dbaa2ee55c31d2d18db67e"
-  integrity sha512-viDOXzMAjiNGxQCauSQea26wj3lcIrfk4xa/FmqshGwzzCMvn+tjHSzzuK0UV4Br7ApUFrpki4Dnx8Tnzv+vcg==
+"@safe-global/safe-gateway-typescript-sdk@3.18.0-alpha.0":
+  version "3.18.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.18.0-alpha.0.tgz#88cdd16f868d1a6e7d6c705395f28d5954a05b9d"
+  integrity sha512-gOdTX7EtAG+x9u83XTo6E2kqZx42Tunisehb34OS9IX4iN/hpd18SDFzfiKjdw6JaydFXnQqOj/iCSSsPG9etw==
 
 "@safe-global/safe-gateway-typescript-sdk@^3.5.3":
   version "3.12.0"


### PR DESCRIPTION
## What it solves

Resolves #3148 

## How this PR fixes it

- Adds a new component `UpsertRecoveryFlowEmail` as an optional step during recovery setup

## How to test it

## Screenshots
<img width="706" alt="Screenshot 2024-02-28 at 18 27 18" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/71c13131-2c3f-4c72-9341-ea2aa3592d8f">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
