### PR TITLE
fix: [Seedless] Hide tooltip when connected with social signer

### DIFF
--- a/src/components/common/NetworkSelector/index.tsx
+++ b/src/components/common/NetworkSelector/index.tsx
@@ -4,30 +4,20 @@ import { useTheme } from '@mui/material/styles'
 import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import Link from 'next/link'
 import type { SelectChangeEvent } from '@mui/material'
-import { ListSubheader, MenuItem, Select, Skeleton, Tooltip } from '@mui/material'
+import { ListSubheader, MenuItem, Select, Skeleton } from '@mui/material'
 import partition from 'lodash/partition'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import useChains from '@/hooks/useChains'
 import { useRouter } from 'next/router'
 import css from './styles.module.css'
 import { useChainId } from '@/hooks/useChainId'
-import { type ReactElement, forwardRef, useMemo } from 'react'
+import { type ReactElement, useMemo } from 'react'
 import { useCallback } from 'react'
 import { AppRoutes } from '@/config/routes'
 import { trackEvent, OVERVIEW_EVENTS } from '@/services/analytics'
 import useWallet from '@/hooks/wallets/useWallet'
 import { isSocialWalletEnabled } from '@/hooks/wallets/wallets'
 import { isSocialLoginWallet } from '@/services/mpc/SocialLoginModule'
-
-const MenuWithTooltip = forwardRef<HTMLUListElement>(function MenuWithTooltip(props: any, ref) {
-  return (
-    <Tooltip title="More network support coming soon" arrow placement="left">
-      <ul ref={ref} {...props}>
-        {props.children}
-      </ul>
-    </Tooltip>
-  )
-})
 
 const NetworkSelector = (props: { onChainSelect?: () => void }): ReactElement => {
   const wallet = useWallet()
@@ -104,7 +94,6 @@ const NetworkSelector = (props: { onChainSelect?: () => void }): ReactElement =>
       IconComponent={ExpandMoreIcon}
       MenuProps={{
         transitionDuration: 0,
-        MenuListProps: { component: isSocialLogin ? MenuWithTooltip : undefined },
         sx: {
           '& .MuiPaper-root': {
             overflow: 'auto',

--- a/src/components/common/SocialSigner/__tests__/SocialSignerLogin.test.tsx
+++ b/src/components/common/SocialSigner/__tests__/SocialSignerLogin.test.tsx
@@ -29,13 +29,7 @@ describe('SocialSignerLogin', () => {
 
     const result = render(
       <TxModalProvider>
-        <SocialSigner
-          socialWalletService={mockSocialWalletService}
-          wallet={mockWallet}
-          supportedChains={['Goerli']}
-          isMPCLoginEnabled={true}
-          onLogin={mockOnLogin}
-        />
+        <SocialSigner socialWalletService={mockSocialWalletService} wallet={mockWallet} onLogin={mockOnLogin} />
         <PasswordRecoveryModal />
       </TxModalProvider>,
     )
@@ -58,13 +52,7 @@ describe('SocialSignerLogin', () => {
 
     const result = render(
       <TxModalProvider>
-        <SocialSigner
-          socialWalletService={mockSocialWalletService}
-          wallet={null}
-          supportedChains={['Goerli']}
-          isMPCLoginEnabled={true}
-          onLogin={mockOnLogin}
-        />
+        <SocialSigner socialWalletService={mockSocialWalletService} wallet={null} onLogin={mockOnLogin} />
         <PasswordRecoveryModal />
       </TxModalProvider>,
     )
@@ -81,13 +69,7 @@ describe('SocialSignerLogin', () => {
 
     const result = render(
       <TxModalProvider>
-        <SocialSigner
-          socialWalletService={mockSocialWalletService}
-          wallet={mockWallet}
-          supportedChains={['Goerli']}
-          isMPCLoginEnabled={true}
-          onLogin={mockOnLogin}
-        />
+        <SocialSigner socialWalletService={mockSocialWalletService} wallet={mockWallet} onLogin={mockOnLogin} />
         <PasswordRecoveryModal />
       </TxModalProvider>,
     )
@@ -100,20 +82,6 @@ describe('SocialSignerLogin', () => {
     expect(mockOnLogin).toHaveBeenCalled()
   })
 
-  it('should disable the Google Login button with a message when not on gnosis chain', async () => {
-    const result = render(
-      <SocialSigner
-        socialWalletService={mockSocialWalletService}
-        wallet={mockWallet}
-        supportedChains={['Goerli']}
-        isMPCLoginEnabled={false}
-      />,
-    )
-
-    expect(result.getByText('Currently only supported on Goerli')).toBeInTheDocument()
-    expect(await result.findByRole('button')).toBeDisabled()
-  })
-
   it('should display Password Recovery form and display a Continue as button when login succeeds', async () => {
     const mockOnLogin = jest.fn()
     mockSocialWalletService.loginAndCreate = jest.fn(() => Promise.resolve(COREKIT_STATUS.REQUIRED_SHARE))
@@ -122,13 +90,7 @@ describe('SocialSignerLogin', () => {
 
     const result = render(
       <TxModalProvider>
-        <SocialSigner
-          socialWalletService={mockSocialWalletService}
-          wallet={mockWallet}
-          supportedChains={['Goerli']}
-          isMPCLoginEnabled={true}
-          onLogin={mockOnLogin}
-        />
+        <SocialSigner socialWalletService={mockSocialWalletService} wallet={mockWallet} onLogin={mockOnLogin} />
         <PasswordRecoveryModal />
       </TxModalProvider>,
     )
@@ -166,13 +128,7 @@ describe('SocialSignerLogin', () => {
 
     result.rerender(
       <TxModalProvider>
-        <SocialSigner
-          socialWalletService={mockSocialWalletService}
-          wallet={mockWallet}
-          supportedChains={['Goerli']}
-          isMPCLoginEnabled={true}
-          onLogin={mockOnLogin}
-        />
+        <SocialSigner socialWalletService={mockSocialWalletService} wallet={mockWallet} onLogin={mockOnLogin} />
         <PasswordRecoveryModal />
       </TxModalProvider>,
     )

--- a/src/components/common/SocialSigner/index.tsx
+++ b/src/components/common/SocialSigner/index.tsx
@@ -1,18 +1,15 @@
 import useSocialWallet from '@/hooks/wallets/mpc/useSocialWallet'
 import { type ISocialWalletService } from '@/services/mpc/interfaces'
-import { Box, Button, LinearProgress, SvgIcon, Tooltip, Typography } from '@mui/material'
+import { Box, Button, LinearProgress, SvgIcon, Typography } from '@mui/material'
 import { COREKIT_STATUS } from '@web3auth/mpc-core-kit'
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import GoogleLogo from '@/public/images/welcome/logo-google.svg'
-import InfoIcon from '@/public/images/notifications/info.svg'
 
 import css from './styles.module.css'
 import useWallet from '@/hooks/wallets/useWallet'
 import Track from '@/components/common/Track'
 import { CREATE_SAFE_EVENTS } from '@/services/analytics'
 import { MPC_WALLET_EVENTS } from '@/services/analytics/events/mpcWallet'
-import useChains, { useCurrentChain } from '@/hooks/useChains'
-import { isSocialWalletEnabled } from '@/hooks/wallets/wallets'
 import { isSocialLoginWallet } from '@/services/mpc/SocialLoginModule'
 import { CGW_NAMES } from '@/hooks/wallets/consts'
 import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
@@ -26,41 +23,19 @@ export const _getSupportedChains = (chains: ChainInfo[]) => {
     .filter((chain) => CGW_NAMES.SOCIAL_LOGIN && !chain.disabledWallets.includes(CGW_NAMES.SOCIAL_LOGIN))
     .map((chainConfig) => chainConfig.chainName)
 }
-const useGetSupportedChains = () => {
-  const chains = useChains()
-
-  return useMemo(() => {
-    return _getSupportedChains(chains.configs)
-  }, [chains.configs])
-}
-
-const useIsSocialWalletEnabled = () => {
-  const currentChain = useCurrentChain()
-
-  return isSocialWalletEnabled(currentChain)
-}
 
 type SocialSignerLoginProps = {
   socialWalletService: ISocialWalletService | undefined
   wallet: ReturnType<typeof useWallet>
-  supportedChains: ReturnType<typeof useGetSupportedChains>
-  isMPCLoginEnabled: ReturnType<typeof useIsSocialWalletEnabled>
   onLogin?: () => void
   onRequirePassword?: () => void
 }
 
-export const SocialSigner = ({
-  socialWalletService,
-  wallet,
-  supportedChains,
-  isMPCLoginEnabled,
-  onLogin,
-  onRequirePassword,
-}: SocialSignerLoginProps) => {
+export const SocialSigner = ({ socialWalletService, wallet, onLogin, onRequirePassword }: SocialSignerLoginProps) => {
   const [loginPending, setLoginPending] = useState<boolean>(false)
   const [loginError, setLoginError] = useState<string | undefined>(undefined)
   const userInfo = socialWalletService?.getUserInfo()
-  const isDisabled = loginPending || !isMPCLoginEnabled
+  const isDisabled = loginPending
 
   const isWelcomePage = !!onLogin
 
@@ -156,26 +131,6 @@ export const SocialSigner = ({
         )}
         {loginError && <ErrorMessage className={css.loginError}>{loginError}</ErrorMessage>}
       </Box>
-
-      {!isMPCLoginEnabled && (
-        <Typography variant="body2" color="text.secondary" display="flex" gap={1}>
-          <Tooltip title="More network support coming soon." arrow placement="top">
-            <span>
-              <SvgIcon
-                component={InfoIcon}
-                inheritViewBox
-                color="border"
-                fontSize="small"
-                sx={{
-                  verticalAlign: 'middle',
-                  ml: 0.5,
-                }}
-              />
-            </span>
-          </Tooltip>
-          <span>Currently only supported on {supportedChains.join(supportedChains.length === 2 ? ' and ' : ', ')}</span>
-        </Typography>
-      )}
     </>
   )
 }
@@ -183,6 +138,4 @@ export const SocialSigner = ({
 export default madProps(SocialSigner, {
   socialWalletService: useSocialWallet,
   wallet: useWallet,
-  supportedChains: useGetSupportedChains,
-  isMPCLoginEnabled: useIsSocialWalletEnabled,
 })


### PR DESCRIPTION
## What it solves

Resolves #3266

## How this PR fixes it

- Hides the `More network support coming soon` toolip

## How to test it

1. Connect with social signer on Gnosis chain
2. Open the Network selector
3. Observe other network items are still disabled
4. Observe there is no tooltip

## Screenshots
<img width="418" alt="Screenshot 2024-02-29 at 10 26 05" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/8c5ecbb4-e89f-43ba-8550-6e885d27f6e4">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
