### PR TITLE
fix: [Recovery] Stabilization

### DIFF
--- a/src/components/common/CooldownLink/index.tsx
+++ b/src/components/common/CooldownLink/index.tsx
@@ -40,7 +40,7 @@ const CooldownLink = ({
     <Link
       sx={{
         color: ({ palette }) => (isDisabled ? palette.text.disabled : undefined),
-        textDecorationColor: ({ palette }) => (isDisabled ? palette.text.disabled : undefined),
+        textDecoration: 'none',
         pointerEvents: isDisabled ? 'none' : undefined,
         verticalAlign: 'inherit',
       }}

--- a/src/features/recovery/components/RecoveryEmail/RegisterEmail.tsx
+++ b/src/features/recovery/components/RecoveryEmail/RegisterEmail.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+import ErrorMessage from '@/components/tx/ErrorMessage'
 import useRecoveryEmail from '@/features/recovery/components/RecoveryEmail/useRecoveryEmail'
 import { asError } from '@/services/exceptions/utils'
 import { isWalletRejection } from '@/utils/wallets'
@@ -21,6 +23,7 @@ const RegisterEmail = ({
   onRegister: (emailAddress: string) => void
   initialValue?: string
 }) => {
+  const [error, setError] = useState<string>()
   const { registerEmailAddress, editEmailAddress } = useRecoveryEmail()
 
   const { watch, register, formState } = useForm<{ emailAddress: string }>({
@@ -40,6 +43,8 @@ const RegisterEmail = ({
     } catch (e) {
       const error = asError(e)
       if (isWalletRejection(error)) return
+
+      setError('Failed to register email address. Please try again.')
     }
   }
 
@@ -63,10 +68,12 @@ const RegisterEmail = ({
             Cancel
           </Button>
           <Button variant="contained" size="small" onClick={handleContinue} disabled={isInvalidEmail}>
-            Continue
+            Verify
           </Button>
         </Stack>
       </Grid>
+
+      {error && <ErrorMessage>{error}</ErrorMessage>}
     </Grid>
   )
 }

--- a/src/features/recovery/components/RecoveryEmail/VerifyEmail.tsx
+++ b/src/features/recovery/components/RecoveryEmail/VerifyEmail.tsx
@@ -77,7 +77,7 @@ const VerifyEmail = ({ onCancel, onSuccess }: { onCancel: () => void; onSuccess:
           <Typography>
             Didn&apos;t get the code?{' '}
             <CooldownLink onClick={handleRetry} cooldown={60}>
-              Resend
+              Resend code
             </CooldownLink>
           </Typography>
 

--- a/src/features/recovery/components/RecoveryEmail/index.tsx
+++ b/src/features/recovery/components/RecoveryEmail/index.tsx
@@ -10,7 +10,6 @@ import EditIcon from '@/public/images/common/edit.svg'
 import { asError } from '@/services/exceptions/utils'
 import { useAppDispatch } from '@/store'
 import { showNotification } from '@/store/notificationsSlice'
-import { isWalletRejection } from '@/utils/wallets'
 import Stack from '@mui/material/Stack'
 import type { GetEmailResponse } from '@safe-global/safe-gateway-typescript-sdk/dist/types/emails'
 import { useState } from 'react'
@@ -33,7 +32,7 @@ const RecoveryEmail = () => {
       setEmail(response)
     } catch (e) {
       const error = asError(e)
-      if (isWalletRejection(error)) return
+      if (error.message !== 'Not Found') return
 
       setShowRegisterForm(true)
     }
@@ -127,7 +126,7 @@ const RecoveryEmail = () => {
           {!email.verified && <NotVerifiedMessage onVerify={toggleVerifyEmailDialog} />}
         </>
       ) : (
-        <CheckWallet>
+        <CheckWallet allowSpendingLimit>
           {(isOk) => (
             <Button
               onClick={signToViewEmail}

--- a/src/features/recovery/components/RecoveryEmail/index.tsx
+++ b/src/features/recovery/components/RecoveryEmail/index.tsx
@@ -45,6 +45,7 @@ const RecoveryEmail = () => {
 
   const onRegister = (emailAddress: string) => {
     setEmail({ email: emailAddress, verified: false })
+    setShowRegisterForm(false)
     setVerifyEmailOpen(true)
   }
 


### PR DESCRIPTION
## What it solves

- Rename "Resend" to "Resende code" and remove text underline
- Show an error in case registration fails
- Close the registration form if registration succeeds
- Enable the Sign to view button for spending limit users to get rid of the tooltip. This will be properly fixed in https://github.com/safe-global/safe-wallet-web/issues/3381

## Screenshots
<img width="455" alt="Screenshot 2024-02-29 at 12 42 21" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/6abba8dc-c31b-4a83-a466-90ab9d9cb993">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
