### PR TITLE
fix: Don't show native transfer for unknown contract interactions

### DIFF
--- a/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
@@ -1,3 +1,4 @@
+import { isEmptyHexData } from '@/utils/hex'
 import { type InternalTransaction, Operation, type TransactionData } from '@safe-global/safe-gateway-typescript-sdk'
 import type { AccordionProps } from '@mui/material/Accordion/Accordion'
 import { useCurrentChain } from '@/hooks/useChains'
@@ -34,7 +35,7 @@ export const SingleTxDecoded = ({
   onChange,
 }: SingleTxDecodedProps) => {
   const chain = useCurrentChain()
-  const isNativeTransfer = tx.value !== '0'
+  const isNativeTransfer = tx.value !== '0' && tx.data && isEmptyHexData(tx.data)
   const method = tx.dataDecoded?.method || (isNativeTransfer ? 'native transfer' : 'Unknown contract interaction')
   const { decimals, symbol } = chain?.nativeCurrency || {}
   const amount = tx.value ? formatVisualAmount(tx.value, decimals) : 0

--- a/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
@@ -34,7 +34,8 @@ export const SingleTxDecoded = ({
   onChange,
 }: SingleTxDecodedProps) => {
   const chain = useCurrentChain()
-  const method = tx.dataDecoded?.method || ''
+  const isNativeTransfer = tx.value !== '0'
+  const method = tx.dataDecoded?.method || (isNativeTransfer ? 'native transfer' : 'Unknown contract interaction')
   const { decimals, symbol } = chain?.nativeCurrency || {}
   const amount = tx.value ? formatVisualAmount(tx.value, decimals) : 0
 
@@ -62,7 +63,7 @@ export const SingleTxDecoded = ({
           <Typography>{actionTitle}</Typography>
           <Typography ml="8px">
             {name ? name + ': ' : ''}
-            <b>{method || 'native transfer'}</b>
+            <b>{method}</b>
           </Typography>
         </div>
       </AccordionSummary>


### PR DESCRIPTION
## What it solves

Resolves #3301

## How this PR fixes it

Only sets `native transfer` as the method name if the transaction has a non-zero value.

## How to test it

1. Interact with an unknown contract e.g. via tx builder without an ABI
2. Add a native transfer in there as well
3. Observe the decoded view correctly shows native transfer for the second tx and "Unknown contract interaction" for the first

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
