### PR TITLE
Fix: zksync nested safe gas estimation

### DIFF
--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -162,7 +162,9 @@ export const ExecuteForm = ({
             Cannot execute a transaction from the Safe Account itself, please connect a different account.
           </ErrorMessage>
         ) : !walletCanPay && !willRelay ? (
-          <ErrorMessage>Your connected wallet doesn&apos;t have enough funds to execute this transaction.</ErrorMessage>
+          <ErrorMessage level={'info'}>
+            Your connected wallet doesn&apos;t have enough funds to execute this transaction.
+          </ErrorMessage>
         ) : (
           (executionValidationError || gasLimitError) && (
             <ErrorMessage error={executionValidationError || gasLimitError}>

--- a/src/hooks/useGasLimit.ts
+++ b/src/hooks/useGasLimit.ts
@@ -77,6 +77,10 @@ const getGasLimitForZkSync = async (
   safeSDK: Safe,
   safeTx: SafeTransaction,
 ) => {
+  // use a random EOA address as the from address
+  // https://github.com/zkSync-Community-Hub/zksync-developers/discussions/144
+  const fakeEOAFromAddress = '0x330d9F4906EDA1f73f668660d1946bea71f48827'
+  const zkSyncBaseFeeMultiplier = 20n
   const customContracts = safeSDK.getContractManager().contractNetworks?.[safe.chainId]
   const safeVersion = await safeSDK.getContractVersion()
   const ethAdapter = safeSDK.getEthAdapter()
@@ -107,15 +111,13 @@ const getGasLimitForZkSync = async (
 
   const gas = await web3.estimateGas({
     to: safe.address.value,
-    // use a random EOA address as the from address
-    // https://github.com/zkSync-Community-Hub/zksync-developers/discussions/144
-    from: '0x330d9F4906EDA1f73f668660d1946bea71f48827',
+    from: fakeEOAFromAddress,
     value: '0',
     data: safeFunctionToEstimate,
   })
 
   // The estimateTxBaseGas function seems to estimate too low for zkSync
-  const baseGas = BigInt(await estimateTxBaseGas(safeSDK, safeTx)) * 20n
+  const baseGas = BigInt(await estimateTxBaseGas(safeSDK, safeTx)) * zkSyncBaseFeeMultiplier
 
   return BigInt(gas) + baseGas
 }


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/safe-wallet-web/issues/3141

## How this PR fixes it
Instead of using the safe wallet as "from" for the gas estimation, we use a random EOA address. 
Also, I don't think that we should show an error for when we determine that the connected walelt might not have enough funds. I changed it to info, maybe warning would be even more appropriate, opinions? 

## How to test it
You need a nested safe setup: parent/child. The parent should be owner of the child. Create a tx in the child (e.g. add owner etc) and try to sign in the parent safe. Without this fix the process will fail with an estimation error. With the fix, the transaction should go through. 

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
