### PR TITLE
fix: not possible to click on a safe in listItem

### DIFF
--- a/src/components/welcome/MyAccounts/styles.module.css
+++ b/src/components/welcome/MyAccounts/styles.module.css
@@ -32,12 +32,12 @@
   border: 1px solid var(--color-border-light);
   border-radius: var(--space-1);
   margin-bottom: 12px;
-  padding-top: var(--space-2);
-  padding-bottom: var(--space-2);
+  padding-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
 }
 
 .currentListItem {
-  padding-left: var(--space-2);
   border: 1px solid var(--color-secondary-light);
   border-left-width: 6px;
   background-color: var(--color-secondary-background) !important;
@@ -51,7 +51,7 @@
 .safeLink {
   display: flex;
   align-items: center;
-  padding-right: var(--space-1);
+  padding: var(--space-2) var(--space-1) var(--space-2) var(--space-2);
 }
 
 .safeAddress {


### PR DESCRIPTION
Since the .listItem had a padding, the <a> tag inside of it was only clickable if you manage to hit it directly. But ListItem actually looks like a clickable button, so you won’t expect that you have to be clicking directly in the center.

## What it solves
Since a picture is worth 1000 words, a gif is worth ????

![2024-03-01 10 08 20](https://github.com/safe-global/safe-wallet-web/assets/693770/dce41023-348f-46bb-8010-8861018ef5c0)


Resolves #

## How this PR fixes it

## How to test it

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
