### PR TITLE
add View Watchlist button to welcome page when there are safes to show

### DIFF
--- a/src/components/welcome/WelcomeLogin/index.tsx
+++ b/src/components/welcome/WelcomeLogin/index.tsx
@@ -73,16 +73,28 @@ const WelcomeLogin = () => {
           </>
         )}
 
-        <Divider sx={{ mt: 2, mb: 2, width: '100%' }}>
-          <Typography color="text.secondary" fontWeight={700} variant="overline">
-            or
-          </Typography>
-        </Divider>
-        <Link href={AppRoutes.newSafe.load}>
-          <Button disableElevation size="small">
-            Watch any account
-          </Button>
-        </Link>
+        {!wallet && (
+          <>
+            <Divider sx={{ mt: 2, mb: 2, width: '100%' }}>
+              <Typography color="text.secondary" fontWeight={700} variant="overline">
+                or
+              </Typography>
+            </Divider>
+            {hasSafes ? (
+              <Link href={AppRoutes.welcome.accounts}>
+                <Button disableElevation size="small">
+                  View my Watchlist
+                </Button>
+              </Link>
+            ) : (
+              <Link href={AppRoutes.newSafe.load}>
+                <Button disableElevation size="small">
+                  Watch any account
+                </Button>
+              </Link>
+            )}
+          </>
+        )}
       </Box>
     </Paper>
   )


### PR DESCRIPTION
## What it solves
When a disconnected user has watchlist safes stored locally lands on the welcome page, add the option to view the watchlist safes.
- add a button on the welcome page to redirect to the accounts page to view the watchlist safes.
- when there are already local safes, show a button to add a watchlist safe, as before.

## Screenshots
<img width="1016" alt="image" src="https://github.com/safe-global/safe-wallet-web/assets/17801424/21199253-8509-483f-a999-a4760c07cd71">

