### PR TITLE
feat: [Recovery] Add unsubscribe page

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@safe-global/safe-core-sdk-utils": "^1.7.4",
     "@safe-global/safe-deployments": "1.32.0",
     "@safe-global/safe-ethers-lib": "^1.9.4",
-    "@safe-global/safe-gateway-typescript-sdk": "3.17.0-alpha.1",
+    "@safe-global/safe-gateway-typescript-sdk": "3.18.0-alpha.2",
     "@safe-global/safe-modules-deployments": "^1.2.0",
     "@sentry/react": "^7.91.0",
     "@spindl-xyz/attribution-lite": "^1.4.0",

--- a/src/components/common/PageLayout/index.tsx
+++ b/src/components/common/PageLayout/index.tsx
@@ -1,3 +1,4 @@
+import { useIsHeaderRoute } from '@/hooks/useIsHeaderRoute'
 import { useContext, useEffect, useState, type ReactElement } from 'react'
 import classnames from 'classnames'
 
@@ -12,6 +13,7 @@ import BatchSidebar from '@/components/batch/BatchSidebar'
 
 const PageLayout = ({ pathname, children }: { pathname: string; children: ReactElement }): ReactElement => {
   const [isSidebarRoute, isAnimated] = useIsSidebarRoute(pathname)
+  const isHeaderRoute = useIsHeaderRoute(pathname)
   const [isSidebarOpen, setSidebarOpen] = useState<boolean>(true)
   const [isBatchOpen, setBatchOpen] = useState<boolean>(false)
   const { setFullWidth } = useContext(TxModalContext)
@@ -22,9 +24,11 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
 
   return (
     <>
-      <header className={css.header}>
-        <Header onMenuToggle={isSidebarRoute ? setSidebarOpen : undefined} onBatchToggle={setBatchOpen} />
-      </header>
+      {isHeaderRoute && (
+        <header className={css.header}>
+          <Header onMenuToggle={isSidebarRoute ? setSidebarOpen : undefined} onBatchToggle={setBatchOpen} />
+        </header>
+      )}
 
       {isSidebarRoute && <SideDrawer isOpen={isSidebarOpen} onToggle={setSidebarOpen} />}
 

--- a/src/components/tx/ErrorMessage/index.tsx
+++ b/src/components/tx/ErrorMessage/index.tsx
@@ -11,11 +11,13 @@ const ErrorMessage = ({
   error,
   className,
   level = 'error',
+  noMargin = false,
 }: {
   children: ReactNode
   error?: Error & { reason?: string }
   className?: string
   level?: 'error' | 'warning' | 'info' | 'border'
+  noMargin?: boolean
 }): ReactElement => {
   const [showDetails, setShowDetails] = useState<boolean>(false)
 
@@ -25,7 +27,10 @@ const ErrorMessage = ({
   }
 
   return (
-    <div data-testid="error-message" className={classNames(css.container, css[level], className, 'errorMessage')}>
+    <div
+      data-testid="error-message"
+      className={classNames(css.container, css[level], className, 'errorMessage', { [css.noMargin]: noMargin })}
+    >
       <div className={css.message}>
         <SvgIcon
           component={level === 'info' || level === 'border' ? InfoIcon : WarningIcon}

--- a/src/components/tx/ErrorMessage/styles.module.css
+++ b/src/components/tx/ErrorMessage/styles.module.css
@@ -4,6 +4,10 @@
   border-radius: 4px;
 }
 
+.container.noMargin {
+  margin: 0;
+}
+
 .container.error {
   background-color: var(--color-error-background);
   color: var(--color-error-dark);

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -1,6 +1,7 @@
 export const AppRoutes = {
   '404': '/404',
   wc: '/wc',
+  unsubscribe: '/unsubscribe',
   terms: '/terms',
   privacy: '/privacy',
   licenses: '/licenses',

--- a/src/features/recovery/components/RecoveryEmail/UnsubscribeEmail.tsx
+++ b/src/features/recovery/components/RecoveryEmail/UnsubscribeEmail.tsx
@@ -1,0 +1,44 @@
+import { Box, Button, Card, Typography } from '@mui/material'
+import SafeLogo from '@/public/images/logo-text.svg'
+import Stack from '@mui/material/Stack'
+import { useSearchParams } from 'next/navigation'
+
+const UnsubscribeEmail = () => {
+  const query = useSearchParams()
+  const token = query.get('token')
+  const category = query.get('category')
+
+  const handleUnsubscribe = () => {
+    if (!token || !category) return // Better display an error
+
+    // TODO: Implement once the SDK is ready
+  }
+
+  const handleCancel = () => {
+    // TODO: Show a specific message
+  }
+
+  return (
+    <Box maxWidth={600} mx="auto">
+      <SafeLogo />
+      <Card sx={{ p: 4, mt: 3 }}>
+        <Stack gap={3}>
+          <Typography variant="h1" fontWeight="bold">
+            Confirm unsubscription from recovery updates
+          </Typography>
+          <Typography>
+            Are you sure you would like to unsubscribe from the mailing list for the account recovery? Unsubscribing
+            will mean that you won&apos;t receive any more emails for recovery attempts.
+          </Typography>
+          <Stack direction="row" gap={2} flexWrap="wrap">
+            <Button variant="contained">Yes, unsubscribe</Button>
+            <Button variant="outlined">Keep me subscribed</Button>
+          </Stack>
+        </Stack>
+      </Card>
+      <Typography mt={3}>© 2024 Core Contributors GmbH</Typography>
+    </Box>
+  )
+}
+
+export default UnsubscribeEmail

--- a/src/features/recovery/components/RecoveryEmail/UnsubscribeEmail.tsx
+++ b/src/features/recovery/components/RecoveryEmail/UnsubscribeEmail.tsx
@@ -1,39 +1,51 @@
+import ErrorMessage from '@/components/tx/ErrorMessage'
+import { useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+import useRecoveryEmail from '@/features/recovery/components/RecoveryEmail/useRecoveryEmail'
 import { Box, Button, Card, Typography } from '@mui/material'
 import SafeLogo from '@/public/images/logo-text.svg'
 import Stack from '@mui/material/Stack'
-import { useSearchParams } from 'next/navigation'
 
 const UnsubscribeEmail = () => {
+  const [success, setSuccess] = useState<boolean>(false)
+  const [error, setError] = useState<string>()
   const query = useSearchParams()
   const token = query.get('token')
   const category = query.get('category')
+  const { unsubscribeFromSingleCategory } = useRecoveryEmail()
 
-  const handleUnsubscribe = () => {
-    if (!token || !category) return // Better display an error
+  const handleUnsubscribe = async () => {
+    if (!token || !category) return
 
-    // TODO: Implement once the SDK is ready
-  }
-
-  const handleCancel = () => {
-    // TODO: Show a specific message
+    try {
+      await unsubscribeFromSingleCategory(token, category)
+      setSuccess(true)
+    } catch (e) {
+      setError('Error unsubscribing from email notifications. Please try again.')
+    }
   }
 
   return (
     <Box maxWidth={600} mx="auto">
       <SafeLogo />
       <Card sx={{ p: 4, mt: 3 }}>
-        <Stack gap={3}>
+        <Stack gap={3} alignItems="flex-start">
           <Typography variant="h1" fontWeight="bold">
-            Confirm unsubscription from recovery updates
+            Unsubscribe from recovery updates
           </Typography>
           <Typography>
-            Are you sure you would like to unsubscribe from the mailing list for the account recovery? Unsubscribing
-            will mean that you won&apos;t receive any more emails for recovery attempts.
+            {success
+              ? 'You have successfully unsubscribed!'
+              : 'Are you sure you want to unsubscribe from receiving email notifications for recovery proposals?'}
           </Typography>
-          <Stack direction="row" gap={2} flexWrap="wrap">
-            <Button variant="contained">Yes, unsubscribe</Button>
-            <Button variant="outlined">Keep me subscribed</Button>
-          </Stack>
+
+          {!success && (
+            <Button variant="contained" onClick={handleUnsubscribe}>
+              Yes, unsubscribe
+            </Button>
+          )}
+
+          {error && <ErrorMessage noMargin>{error}</ErrorMessage>}
         </Stack>
       </Card>
       <Typography mt={3}>© 2024 Core Contributors GmbH</Typography>

--- a/src/features/recovery/components/RecoveryEmail/useRecoveryEmail.ts
+++ b/src/features/recovery/components/RecoveryEmail/useRecoveryEmail.ts
@@ -4,6 +4,7 @@ import {
   getRegisteredEmail,
   registerEmail,
   resendEmailVerificationCode,
+  unsubscribeSingle,
   verifyEmail,
 } from '@safe-global/safe-gateway-typescript-sdk'
 import useSafeInfo from '@/hooks/useSafeInfo'
@@ -100,6 +101,10 @@ const useRecoveryEmail = () => {
     )
   }
 
+  const unsubscribeFromSingleCategory = (token: string, category: string) => {
+    return unsubscribeSingle({ token, category })
+  }
+
   return {
     getSignerEmailAddress,
     registerEmailAddress,
@@ -107,6 +112,7 @@ const useRecoveryEmail = () => {
     deleteEmailAddress,
     editEmailAddress,
     resendVerification,
+    unsubscribeFromSingleCategory,
   }
 }
 

--- a/src/hooks/useIsHeaderRoute.ts
+++ b/src/hooks/useIsHeaderRoute.ts
@@ -1,0 +1,15 @@
+import { AppRoutes } from '@/config/routes'
+import { usePathname } from 'next/navigation'
+
+const NO_HEADER_ROUTES = [AppRoutes.unsubscribe]
+
+/**
+ * Returns a boolean tuple indicating if the current route should display the header
+ * @param pathname Optional server-side pathname to check against
+ * @returns A boolean indicating if the sidebar should be displayed
+ */
+export function useIsHeaderRoute(pathname?: string): boolean {
+  const clientPathname = usePathname()
+  const route = pathname || clientPathname
+  return !NO_HEADER_ROUTES.includes(route)
+}

--- a/src/hooks/useIsSidebarRoute.ts
+++ b/src/hooks/useIsSidebarRoute.ts
@@ -15,6 +15,7 @@ const NO_SIDEBAR_ROUTES = [
   AppRoutes.cookie,
   AppRoutes.terms,
   AppRoutes.licenses,
+  AppRoutes.unsubscribe,
 ]
 
 const TOGGLE_SIDEBAR_ROUTES = [AppRoutes.apps.open]

--- a/src/pages/unsubscribe.tsx
+++ b/src/pages/unsubscribe.tsx
@@ -1,0 +1,19 @@
+import UnsubscribeEmail from '@/features/recovery/components/RecoveryEmail/UnsubscribeEmail'
+import type { NextPage } from 'next'
+import Head from 'next/head'
+
+const Unsubscribe: NextPage = () => {
+  return (
+    <>
+      <Head>
+        <title>{'Safe{Wallet} – Unsubscribe from Emails'}</title>
+      </Head>
+
+      <main>
+        <UnsubscribeEmail />
+      </main>
+    </>
+  )
+}
+
+export default Unsubscribe

--- a/yarn.lock
+++ b/yarn.lock
@@ -4032,10 +4032,10 @@
     "@safe-global/safe-core-sdk-utils" "^1.7.4"
     ethers "5.7.2"
 
-"@safe-global/safe-gateway-typescript-sdk@3.17.0-alpha.1":
-  version "3.17.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.17.0-alpha.1.tgz#5d224a9fc06cc90568dbaa2ee55c31d2d18db67e"
-  integrity sha512-viDOXzMAjiNGxQCauSQea26wj3lcIrfk4xa/FmqshGwzzCMvn+tjHSzzuK0UV4Br7ApUFrpki4Dnx8Tnzv+vcg==
+"@safe-global/safe-gateway-typescript-sdk@3.18.0-alpha.2":
+  version "3.18.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.18.0-alpha.2.tgz#5f0a9936c7512033d26b2f33745479c5648d2c25"
+  integrity sha512-Xr+K5XpCmN8qvdRrSfy6rCXcTOT4oAR93ypvwxieVtCDRo5Dr4R8HT/cKxlEM4y8K/c20k59igZ6S/IyeCYdOg==
 
 "@safe-global/safe-gateway-typescript-sdk@^3.5.3":
   version "3.12.0"


### PR DESCRIPTION
## What it solves

Resolves #3387 

## How this PR fixes it

Adds a new page `/unsubscribe`

## How to test it

Note: The unsubscribe link from received emails doesn't work yet so we need to request the uuid and manually test this.

1. Open the `/unsubscribe` page
2. Observe the design

## Screenshots

<img width="703" alt="Screenshot 2024-03-05 at 17 00 56" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/65ecbab0-bcd2-4680-a5a7-75e2da2d43f2">
<img width="697" alt="Screenshot 2024-03-05 at 16 58 13" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/039c0315-c5a7-4ee4-9fcd-214acbda187b">

https://github.com/safe-global/safe-wallet-web/assets/5880855/be9683b7-bed7-4a75-be67-a120841e570a

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
