### PR TITLE
Fix: Remove show more button from safe lists

### DIFF
--- a/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
+++ b/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
@@ -17,19 +17,18 @@ type PaginatedSafeListProps = {
 
 const DEFAULT_SHOWN = 5
 const MAX_DEFAULT_SHOWN = 7
-const PAGE_SIZE = 5
 
 const PaginatedSafeList = ({ safes, title, action, noSafesMessage, onLinkClick }: PaginatedSafeListProps) => {
-  const [maxShownSafes, setMaxShownSafes] = useState<number>(DEFAULT_SHOWN)
+  const [isListExpanded, setIsListExpanded] = useState<boolean>(false)
 
   const shownSafes = useMemo(() => {
     if (safes.length <= MAX_DEFAULT_SHOWN) {
       return safes
     }
-    return safes.slice(0, maxShownSafes)
-  }, [safes, maxShownSafes])
+    return isListExpanded ? safes : safes.slice(0, DEFAULT_SHOWN)
+  }, [safes, isListExpanded])
 
-  const onShowMoreSafes = () => setMaxShownSafes((prev) => prev + PAGE_SIZE)
+  const onShowMoreSafes = () => setIsListExpanded(true)
 
   return (
     <Paper className={css.safeList}>
@@ -52,7 +51,7 @@ const PaginatedSafeList = ({ safes, title, action, noSafesMessage, onLinkClick }
           {noSafesMessage}
         </Typography>
       )}
-      {safes.length > shownSafes.length && (
+      {!isListExpanded && (
         <Box display="flex" justifyContent="center">
           <Track {...OVERVIEW_EVENTS.SHOW_MORE_SAFES}>
             <Button data-testid="show-more-btn" onClick={onShowMoreSafes}>

--- a/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
+++ b/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
@@ -1,10 +1,7 @@
 import type { ReactElement, ReactNode } from 'react'
-import { useMemo, useState } from 'react'
-import { Button, Box, Paper, Typography } from '@mui/material'
+import { Paper, Typography } from '@mui/material'
 import AccountItem from './AccountItem'
 import { type SafeItems } from './useAllSafes'
-import Track from '@/components/common/Track'
-import { OVERVIEW_EVENTS } from '@/services/analytics'
 import css from './styles.module.css'
 
 type PaginatedSafeListProps = {
@@ -15,21 +12,7 @@ type PaginatedSafeListProps = {
   onLinkClick?: () => void
 }
 
-const DEFAULT_SHOWN = 5
-const MAX_DEFAULT_SHOWN = 7
-
 const PaginatedSafeList = ({ safes, title, action, noSafesMessage, onLinkClick }: PaginatedSafeListProps) => {
-  const [isListExpanded, setIsListExpanded] = useState<boolean>(false)
-
-  const shownSafes = useMemo(() => {
-    if (safes.length <= MAX_DEFAULT_SHOWN) {
-      return safes
-    }
-    return isListExpanded ? safes : safes.slice(0, DEFAULT_SHOWN)
-  }, [safes, isListExpanded])
-
-  const onShowMoreSafes = () => setIsListExpanded(true)
-
   return (
     <Paper className={css.safeList}>
       <div className={css.listHeader}>
@@ -44,21 +27,12 @@ const PaginatedSafeList = ({ safes, title, action, noSafesMessage, onLinkClick }
         </Typography>
         {action}
       </div>
-      {shownSafes.length ? (
-        shownSafes.map((item) => <AccountItem onLinkClick={onLinkClick} {...item} key={item.chainId + item.address} />)
+      {safes.length ? (
+        safes.map((item) => <AccountItem onLinkClick={onLinkClick} {...item} key={item.chainId + item.address} />)
       ) : (
         <Typography variant="body2" color="text.secondary" textAlign="center" py={3} mx="auto" width={250}>
           {noSafesMessage}
         </Typography>
-      )}
-      {!isListExpanded && (
-        <Box display="flex" justifyContent="center">
-          <Track {...OVERVIEW_EVENTS.SHOW_MORE_SAFES}>
-            <Button data-testid="show-more-btn" onClick={onShowMoreSafes}>
-              Show more
-            </Button>
-          </Track>
-        </Box>
       )}
     </Paper>
   )


### PR DESCRIPTION
## What it solves
Users have complained that it is difficult to find the safe they're looking for with the pagination on the safe lists.

## How this PR fixes it
Remove the show more button from the safes list. Show all safes in the list by default