### PR TITLE
fix: [Recovery] Register recovery module for alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@safe-global/safe-core-sdk-utils": "^1.7.4",
     "@safe-global/safe-deployments": "1.32.0",
     "@safe-global/safe-ethers-lib": "^1.9.4",
-    "@safe-global/safe-gateway-typescript-sdk": "3.17.0-alpha.1",
+    "@safe-global/safe-gateway-typescript-sdk": "3.18.0-alpha.0",
     "@safe-global/safe-modules-deployments": "^1.2.0",
     "@sentry/react": "^7.91.0",
     "@spindl-xyz/attribution-lite": "^1.4.0",

--- a/src/components/safe-apps/AppFrame/__tests__/AppFrame.test.tsx
+++ b/src/components/safe-apps/AppFrame/__tests__/AppFrame.test.tsx
@@ -60,6 +60,7 @@ describe('AppFrame', () => {
                         value: '0xbc2BB26a6d821e69A38016f3858561a1D80d4182',
                       },
                     ],
+                    proposer: null,
                   },
                 },
                 conflictType: ConflictType.NONE,

--- a/src/features/recovery/components/RecoveryEmail/RegisterEmail.tsx
+++ b/src/features/recovery/components/RecoveryEmail/RegisterEmail.tsx
@@ -44,7 +44,7 @@ const RegisterEmail = ({
       const error = asError(e)
       if (isWalletRejection(error)) return
 
-      setError('Failed to register email address. Please try again.')
+      setError(`Failed to ${initialValue ? 'edit' : 'register'} email address. Please try again.`)
     }
   }
 

--- a/src/features/recovery/components/RecoveryEmail/index.tsx
+++ b/src/features/recovery/components/RecoveryEmail/index.tsx
@@ -1,10 +1,7 @@
 import CheckWallet from '@/components/common/CheckWallet'
 import RegisterEmail from '@/features/recovery/components/RecoveryEmail/RegisterEmail'
 import useRecoveryEmail from '@/features/recovery/components/RecoveryEmail/useRecoveryEmail'
-import VerifyEmail, {
-  isNoContentResponse,
-  NotVerifiedMessage,
-} from '@/features/recovery/components/RecoveryEmail/VerifyEmail'
+import VerifyEmail, { NotVerifiedMessage } from '@/features/recovery/components/RecoveryEmail/VerifyEmail'
 import DeleteIcon from '@/public/images/common/delete.svg'
 import EditIcon from '@/public/images/common/edit.svg'
 import { asError } from '@/services/exceptions/utils'
@@ -67,20 +64,17 @@ const RecoveryEmail = () => {
   const onDelete = async () => {
     try {
       await deleteEmailAddress()
+      setEmail(undefined)
+
+      dispatch(
+        showNotification({
+          variant: 'success',
+          groupKey: 'delete-email-complete',
+          message: 'Your email was deleted',
+        }),
+      )
     } catch (e) {
-      const error = asError(e)
-
-      if (isNoContentResponse(error.message)) {
-        setEmail(undefined)
-
-        dispatch(
-          showNotification({
-            variant: 'success',
-            groupKey: 'delete-email-complete',
-            message: 'Your email was deleted',
-          }),
-        )
-      }
+      console.log(e)
     }
   }
 

--- a/src/features/recovery/components/RecoveryEmail/useRecoveryEmail.ts
+++ b/src/features/recovery/components/RecoveryEmail/useRecoveryEmail.ts
@@ -1,8 +1,10 @@
+import useRecovery from '@/features/recovery/hooks/useRecovery'
 import {
   changeEmail,
   deleteRegisteredEmail,
   getRegisteredEmail,
   registerEmail,
+  registerRecoveryModule,
   resendEmailVerificationCode,
   verifyEmail,
 } from '@safe-global/safe-gateway-typescript-sdk'
@@ -13,6 +15,7 @@ import { getAssertedChainSigner } from '@/services/tx/tx-sender/sdk'
 const useRecoveryEmail = () => {
   const onboard = useOnboard()
   const { safe, safeAddress } = useSafeInfo()
+  const [recovery] = useRecovery()
 
   const registerEmailAddress = async (emailAddress: string) => {
     if (!onboard) return
@@ -100,6 +103,12 @@ const useRecoveryEmail = () => {
     )
   }
 
+  const registerRecovery = () => {
+    if (!recovery || recovery.length === 0) return
+
+    return registerRecoveryModule(safe.chainId, safeAddress, { moduleAddress: recovery[0].address })
+  }
+
   return {
     getSignerEmailAddress,
     registerEmailAddress,
@@ -107,6 +116,7 @@ const useRecoveryEmail = () => {
     deleteEmailAddress,
     editEmailAddress,
     resendVerification,
+    registerRecovery,
   }
 }
 

--- a/src/tests/mocks/transactions.ts
+++ b/src/tests/mocks/transactions.ts
@@ -43,6 +43,7 @@ export const defaultTx: TransactionSummary = {
     nonce: 1,
     confirmationsRequired: 2,
     confirmationsSubmitted: 2,
+    proposer: null,
   },
 }
 

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -62,6 +62,7 @@ export const makeTxFromDetails = (txDetails: TransactionDetails): Transaction =>
       confirmationsRequired: detailedExecutionInfo.confirmationsRequired,
       confirmationsSubmitted: detailedExecutionInfo.confirmations?.length ?? 0,
       missingSigners: getMissingSigners(detailedExecutionInfo),
+      proposer: null,
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4032,10 +4032,10 @@
     "@safe-global/safe-core-sdk-utils" "^1.7.4"
     ethers "5.7.2"
 
-"@safe-global/safe-gateway-typescript-sdk@3.17.0-alpha.1":
-  version "3.17.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.17.0-alpha.1.tgz#5d224a9fc06cc90568dbaa2ee55c31d2d18db67e"
-  integrity sha512-viDOXzMAjiNGxQCauSQea26wj3lcIrfk4xa/FmqshGwzzCMvn+tjHSzzuK0UV4Br7ApUFrpki4Dnx8Tnzv+vcg==
+"@safe-global/safe-gateway-typescript-sdk@3.18.0-alpha.0":
+  version "3.18.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.18.0-alpha.0.tgz#88cdd16f868d1a6e7d6c705395f28d5954a05b9d"
+  integrity sha512-gOdTX7EtAG+x9u83XTo6E2kqZx42Tunisehb34OS9IX4iN/hpd18SDFzfiKjdw6JaydFXnQqOj/iCSSsPG9etw==
 
 "@safe-global/safe-gateway-typescript-sdk@^3.5.3":
   version "3.12.0"


### PR DESCRIPTION
## What it solves

Part of #3145 

## How this PR fixes it

- Registers the recovery module for Alerts whenever an email address is added

## How to test it

1. Set up recovery
2. Add an email address and verify it
3. Propose a recovery
4. You should receive an email for the recovery proposal

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
