### PR TITLE
Fix: remove dynamic sorting for safe lists

### DIFF
--- a/src/components/welcome/MyAccounts/useAllSafes.ts
+++ b/src/components/welcome/MyAccounts/useAllSafes.ts
@@ -45,7 +45,7 @@ const useAllSafes = (): SafeItems => {
   const undeployedSafes = useAppSelector(selectUndeployedSafes)
 
   return useMemo<SafeItems>(() => {
-    const chains = uniq([currentChainId].concat(Object.keys(allAdded)).concat(Object.keys(allOwned)))
+    const chains = uniq(Object.keys(allAdded).concat(Object.keys(allOwned)))
 
     return chains.flatMap((chainId) => {
       if (!configs.some((item) => item.chainId === chainId)) return []

--- a/src/components/welcome/MyAccounts/useAllSafes.ts
+++ b/src/components/welcome/MyAccounts/useAllSafes.ts
@@ -68,7 +68,7 @@ const useAllSafes = (): SafeItems => {
         }
       })
     })
-  }, [currentChainId, allAdded, allOwned, configs, undeployedSafes, walletAddress])
+  }, [allAdded, allOwned, configs, undeployedSafes, walletAddress])
 }
 
 export default useAllSafes

--- a/src/components/welcome/MyAccounts/useAllSafes.ts
+++ b/src/components/welcome/MyAccounts/useAllSafes.ts
@@ -5,7 +5,6 @@ import { useAppSelector } from '@/store'
 import { selectAllAddedSafes } from '@/store/addedSafesSlice'
 import useAllOwnedSafes from './useAllOwnedSafes'
 import useChains from '@/hooks/useChains'
-import useChainId from '@/hooks/useChainId'
 import useWallet from '@/hooks/wallets/useWallet'
 import { selectUndeployedSafes } from '@/store/slices'
 import { sameAddress } from '@/utils/addresses'
@@ -41,7 +40,6 @@ const useAllSafes = (): SafeItems => {
   const [allOwned = {}] = useAllOwnedSafes(walletAddress)
   const allAdded = useAddedSafes()
   const { configs } = useChains()
-  const currentChainId = useChainId()
   const undeployedSafes = useAppSelector(selectUndeployedSafes)
 
   return useMemo<SafeItems>(() => {


### PR DESCRIPTION
## What it solves
For users with a lot of safes it is disorienting for the order of their accounts to change after selecting a different safe. Make the list order persistent.

Resolves #

## How this PR fixes it
- Remove sorting by current chain, so that the list order does not change after selecting a new safe.
- Now it is ordered primarily by chains you have added safes on, and secondarily by chainId.