### PR TITLE
fix: Track Create new Safe click once, disable onboarding buttons for non-owners

### DIFF
--- a/src/components/dashboard/FirstSteps/index.tsx
+++ b/src/components/dashboard/FirstSteps/index.tsx
@@ -1,4 +1,5 @@
 import { BuyCryptoOptions } from '@/components/common/BuyCryptoButton'
+import CheckWallet from '@/components/common/CheckWallet'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import ModalDialog from '@/components/common/ModalDialog'
 import QRCode from '@/components/common/QRCode'
@@ -81,11 +82,21 @@ const AddFundsWidget = ({ completed }: { completed: boolean }) => {
       {!completed && (
         <>
           <Box mt={2}>
-            <Track {...OVERVIEW_EVENTS.ADD_FUNDS}>
-              <Button onClick={toggleDialog} variant="contained" size="small" sx={{ minHeight: '40px' }}>
-                Add funds
-              </Button>
-            </Track>
+            <CheckWallet>
+              {(isOk) => (
+                <Track {...OVERVIEW_EVENTS.ADD_FUNDS}>
+                  <Button
+                    onClick={toggleDialog}
+                    variant="contained"
+                    size="small"
+                    sx={{ minHeight: '40px' }}
+                    disabled={!isOk}
+                  >
+                    Add funds
+                  </Button>
+                </Track>
+              )}
+            </CheckWallet>
           </Box>
           <ModalDialog
             open={open}
@@ -159,11 +170,21 @@ const FirstTransactionWidget = ({ completed }: { completed: boolean }) => {
     <>
       <StatusCard badge="First interaction" title={title} content={content} completed={completed}>
         {!completed && (
-          <Track {...OVERVIEW_EVENTS.NEW_TRANSACTION} label="onboarding">
-            <Button onClick={() => setOpen(true)} variant="outlined" size="small" sx={{ mt: 2, minHeight: '40px' }}>
-              Create transaction
-            </Button>
-          </Track>
+          <CheckWallet>
+            {(isOk) => (
+              <Track {...OVERVIEW_EVENTS.NEW_TRANSACTION} label="onboarding">
+                <Button
+                  onClick={() => setOpen(true)}
+                  variant="outlined"
+                  size="small"
+                  sx={{ mt: 2, minHeight: '40px' }}
+                  disabled={!isOk}
+                >
+                  Create transaction
+                </Button>
+              </Track>
+            )}
+          </CheckWallet>
         )}
       </StatusCard>
       <FirstTxFlow open={open} onClose={() => setOpen(false)} />

--- a/src/components/welcome/MyAccounts/CreateButton.tsx
+++ b/src/components/welcome/MyAccounts/CreateButton.tsx
@@ -1,19 +1,10 @@
 import { Button } from '@mui/material'
 import Link from 'next/link'
 import { AppRoutes } from '@/config/routes'
-import { useRouter } from 'next/router'
-import { OVERVIEW_EVENTS, OVERVIEW_LABELS, trackEvent } from '@/services/analytics'
 
 const buttonSx = { width: ['100%', 'auto'] }
 
 const CreateButton = () => {
-  const router = useRouter()
-  const trackingLabel =
-    router.pathname === AppRoutes.welcome.accounts ? OVERVIEW_LABELS.login_page : OVERVIEW_LABELS.sidebar
-
-  const onClick = () => {
-    trackEvent({ ...OVERVIEW_EVENTS.CREATE_NEW_SAFE, label: trackingLabel })
-  }
   return (
     <Link href={AppRoutes.newSafe.create} passHref legacyBehavior>
       <Button
@@ -23,7 +14,6 @@ const CreateButton = () => {
         variant="contained"
         sx={buttonSx}
         component="a"
-        onClick={onClick}
       >
         Create account
       </Button>


### PR DESCRIPTION
## What it solves

Resolves https://www.notion.so/safe-global/GTM-tracking-Create-safe-tracked-twice-af995523863541778b0dcb69726ad157

Resolves https://www.notion.so/safe-global/Create-tx-button-shouldn-t-be-available-for-non-owners-disconnected-users-0dd990edb6bd4cdf9e816423911af51e

## How this PR fixes it

The `CreateButton` is already wrapped in a `Track` so I removed the onClick handler

## How to test it

1. Go to the accounts page
2. Press the Create button
3. Observe only one event
4. Create a counterfactual safe
5. Go to the dashboard
6. Disconnect your wallet or switch to a non-owner
7. Observe the Add funds and Create transaction buttons are disabled

## Screenshots

<img width="857" alt="Screenshot 2024-03-06 at 12 30 34" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/47ff87de-7b4c-46c3-b8fd-1cd5a0f4774c">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
