### PR TITLE
Fix: always redirect index route to accounts page when there are safes in localstorage

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,7 +10,7 @@ const IndexPage: NextPage = () => {
   const { hasSafes } = useHasSafes()
 
   useEffect(() => {
-    if (!router.isReady || router.pathname !== AppRoutes.index) {
+    if (!router.isReady || router.pathname !== AppRoutes.index || hasSafes === undefined) {
       return
     }
 


### PR DESCRIPTION
## What it solves

Resolves [notion](https://www.notion.so/safe-global/4cbe48f69de44fd3ae8682b2c45cdcbe?v=d1599a9fe4ff413a9b7ccdd1af19b9cb&p=9c5d6c1fe1bc4928b5c5e33313aa2ab3&pm=s)

## How this PR fixes it
When landing on the index route for the first time, the redirect to the welcome page happens before the check for local safes is complete. Make sure the check for local safes has completed **before**  redirecting.
