### PR TITLE
fix: Add wrap on queue tx button container

### DIFF
--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -109,7 +109,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
           <TxSigners txDetails={txDetails} txSummary={txSummary} />
 
           {isQueue && (
-            <Box display="flex" alignItems="center" justifyContent="center" gap={1} mt={2}>
+            <Box className={`${css.buttons}`}>
               {awaitingExecution ? <ExecuteTxButton txSummary={txSummary} /> : <SignTxButton txSummary={txSummary} />}
               <RejectTxButton txSummary={txSummary} />
             </Box>

--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -95,7 +95,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
         </div>
 
         {isMultiSendTxInfo(txDetails.txInfo) && (
-          <div className={`${css.multiSend}`}>
+          <div className={css.multiSend}>
             <ErrorBoundary fallback={<div>Error parsing data</div>}>
               <Multisend txData={txDetails.txData} />
             </ErrorBoundary>
@@ -109,7 +109,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
           <TxSigners txDetails={txDetails} txSummary={txSummary} />
 
           {isQueue && (
-            <Box className={`${css.buttons}`}>
+            <Box className={css.buttons}>
               {awaitingExecution ? <ExecuteTxButton txSummary={txSummary} /> : <SignTxButton txSummary={txSummary} />}
               <RejectTxButton txSummary={txSummary} />
             </Box>

--- a/src/components/transactions/TxDetails/styles.module.css
+++ b/src/components/transactions/TxDetails/styles.module.css
@@ -56,6 +56,15 @@
   border-top: 1px solid var(--color-border-light);
 }
 
+.buttons {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  margin-top: var(--space-2);
+}
+
 @media (max-width: 599.95px) {
   .container {
     flex-direction: column;


### PR DESCRIPTION
## What it solves

Resolves #3386

## How this PR fixes it
It adds the flex-wrap property to the button container. I have also moved the styles of the Box container from inline properties to the corresponding css file for better maintenance.
 
## How to test it
Open http://localhost:3000/transactions/queue?safe=oeth%3A0x773D7c58941295aF412092efF5Aa3d188525e81a , open up the transation modal and check Execute and Replace buttons. 

## Screenshots
![image](https://github.com/safe-global/safe-wallet-web/assets/34529009/5c9345dd-c167-4ab4-8bd5-8bdbb756f98a)

