### PR TITLE
fix: detect native transfers

### DIFF
--- a/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.test.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.test.tsx
@@ -1,0 +1,111 @@
+import { render } from '@/tests/test-utils'
+import SingleTxDecoded from '.'
+import { Operation } from '@safe-global/safe-gateway-typescript-sdk'
+import { faker } from '@faker-js/faker'
+import { parseUnits } from 'ethers'
+import { ERC20__factory } from '@/types/contracts'
+
+describe('SingleTxDecoded', () => {
+  it('should show native transfers', () => {
+    const receiver = faker.finance.ethereumAddress()
+    const result = render(
+      <SingleTxDecoded
+        actionTitle="0"
+        showDelegateCallWarning
+        tx={{
+          data: '0x',
+          operation: Operation.CALL,
+          to: receiver,
+          value: parseUnits('1').toString(),
+        }}
+        txData={{
+          to: { value: receiver },
+          operation: Operation.CALL,
+          trustedDelegateCallTarget: false,
+          addressInfoIndex: {},
+          value: parseUnits('1').toString(),
+        }}
+      />,
+    )
+
+    expect(result.queryByText('native transfer')).not.toBeNull()
+  })
+
+  it('should show unknown contract interactions', () => {
+    const unknownToken = faker.finance.ethereumAddress()
+    const spender = faker.finance.ethereumAddress()
+    const result = render(
+      <SingleTxDecoded
+        actionTitle="0"
+        showDelegateCallWarning
+        tx={{
+          data: ERC20__factory.createInterface().encodeFunctionData('approve', [spender, '100000']),
+          operation: Operation.CALL,
+          to: unknownToken,
+        }}
+        txData={{
+          to: { value: unknownToken },
+          operation: Operation.CALL,
+          trustedDelegateCallTarget: false,
+          addressInfoIndex: {},
+        }}
+      />,
+    )
+
+    expect(result.queryByText('Unknown contract interaction')).not.toBeNull()
+  })
+
+  it('should show decoded data ', () => {
+    const unknownToken = faker.finance.ethereumAddress()
+    const spender = faker.finance.ethereumAddress()
+    const result = render(
+      <SingleTxDecoded
+        actionTitle="0"
+        showDelegateCallWarning
+        tx={{
+          data: ERC20__factory.createInterface().encodeFunctionData('approve', [spender, '100000']),
+          operation: Operation.CALL,
+          to: unknownToken,
+          dataDecoded: {
+            method: 'approve',
+            parameters: [
+              {
+                name: 'spender',
+                type: 'address',
+                value: spender,
+              },
+              {
+                name: 'value',
+                type: 'uint256',
+                value: '100000',
+              },
+            ],
+          },
+        }}
+        txData={{
+          to: { value: unknownToken },
+          operation: Operation.CALL,
+          trustedDelegateCallTarget: false,
+          addressInfoIndex: {},
+          dataDecoded: {
+            method: 'approve',
+            parameters: [
+              {
+                name: 'spender',
+                type: 'address',
+                value: spender,
+              },
+              {
+                name: 'value',
+                type: 'uint256',
+                value: '100000',
+              },
+            ],
+          },
+        }}
+      />,
+    )
+
+    expect(result.queryAllByText('approve')).not.toHaveLength(0)
+  })
+})

--- a/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
@@ -35,7 +35,7 @@ export const SingleTxDecoded = ({
   onChange,
 }: SingleTxDecodedProps) => {
   const chain = useCurrentChain()
-  const isNativeTransfer = tx.value !== '0' && tx.data && isEmptyHexData(tx.data)
+  const isNativeTransfer = tx.value !== '0' && (!tx.data || isEmptyHexData(tx.data))
   const method = tx.dataDecoded?.method || (isNativeTransfer ? 'native transfer' : 'Unknown contract interaction')
   const { decimals, symbol } = chain?.nativeCurrency || {}
   const amount = tx.value ? formatVisualAmount(tx.value, decimals) : 0


### PR DESCRIPTION
## What it solves

Resolves [Notion issue](https://www.notion.so/safe-global/NativeToken-transfer-ETH-is-marked-as-Unknown-contract-interaction-1f5ed836073245cbb9962daf47485c41)

## How this PR fixes it
Does not require tx.data to be defined when checking for native transfers.

## How to test it
- Send a multisend with native transfers
- Observe that they are shown correctly

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
