### PR TITLE
Feat: make gas estimation error more prominent

### DIFF
--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -1,8 +1,9 @@
 import { getTotalFee } from '@/hooks/useGasPrice'
 import type { ReactElement, SyntheticEvent } from 'react'
-import { Accordion, AccordionDetails, AccordionSummary, Skeleton, Typography, Link, Grid } from '@mui/material'
+import { Accordion, AccordionDetails, AccordionSummary, Skeleton, Typography, Link, Grid, SvgIcon } from '@mui/material'
 import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import WarningIcon from '@/public/images/notifications/warning.svg'
 import { useCurrentChain } from '@/hooks/useChains'
 import { formatVisualAmount } from '@/utils/formatters'
 import { type AdvancedParameters } from '../AdvancedParams/types'
@@ -67,68 +68,80 @@ export const _GasParams = ({
   }
 
   return (
-    <Accordion
-      elevation={0}
-      onChange={onChangeExpand}
-      className={classnames({ [css.withExecutionMethod]: isExecution })}
-    >
-      <AccordionSummary expandIcon={<ExpandMoreIcon />} className={accordionCss.accordion}>
-        {isExecution ? (
-          <Typography display="flex" alignItems="center" justifyContent="space-between" width={1}>
-            <span>Estimated fee </span>
-            {gasLimitError ? null : isLoading ? (
-              <Skeleton variant="text" sx={{ display: 'inline-block', minWidth: '7em' }} />
-            ) : (
-              <span>{willRelay ? 'Free' : `${totalFee} ${chain?.nativeCurrency.symbol}`}</span>
-            )}
-          </Typography>
-        ) : (
-          <Typography>
-            Signing the transaction with nonce&nbsp;
-            {nonce !== undefined ? (
-              nonce
-            ) : (
-              <Skeleton variant="text" sx={{ display: 'inline-block', minWidth: '2em' }} />
-            )}
-          </Typography>
-        )}
-      </AccordionSummary>
+    <div className={classnames({ [css.error]: gasLimitError })}>
+      <Accordion
+        elevation={0}
+        onChange={onChangeExpand}
+        className={classnames({ [css.withExecutionMethod]: isExecution })}
+      >
+        <AccordionSummary expandIcon={<ExpandMoreIcon />} className={accordionCss.accordion}>
+          {isExecution ? (
+            <Typography display="flex" alignItems="center" width={1}>
+              <span style={{ flex: '1' }}>Estimated fee </span>
+              {gasLimitError ? (
+                <>
+                  <SvgIcon
+                    component={WarningIcon}
+                    inheritViewBox
+                    fontSize="small"
+                    sx={{ color: 'var(--color-error-main)', mr: 'var(--space-1)' }}
+                  />
+                  <span style={{ fontWeight: 'normal' }}>Cannot Estimate</span>
+                </>
+              ) : isLoading ? (
+                <Skeleton variant="text" sx={{ display: 'inline-block', minWidth: '7em' }} />
+              ) : (
+                <span>{willRelay ? 'Free' : `${totalFee} ${chain?.nativeCurrency.symbol}`}</span>
+              )}
+            </Typography>
+          ) : (
+            <Typography>
+              Signing the transaction with nonce&nbsp;
+              {nonce !== undefined ? (
+                nonce
+              ) : (
+                <Skeleton variant="text" sx={{ display: 'inline-block', minWidth: '2em' }} />
+              )}
+            </Typography>
+          )}
+        </AccordionSummary>
 
-      <AccordionDetails>
-        {nonce !== undefined && (
-          <GasDetail isLoading={false} name="Safe Account transaction nonce" value={nonce.toString()} />
-        )}
+        <AccordionDetails>
+          {nonce !== undefined && (
+            <GasDetail isLoading={false} name="Safe Account transaction nonce" value={nonce.toString()} />
+          )}
 
-        {safeTxGas !== undefined && <GasDetail isLoading={false} name="safeTxGas" value={safeTxGas.toString()} />}
+          {safeTxGas !== undefined && <GasDetail isLoading={false} name="safeTxGas" value={safeTxGas.toString()} />}
 
-        {isExecution && (
-          <>
-            {userNonce !== undefined && (
-              <GasDetail isLoading={false} name="Wallet nonce" value={userNonce.toString()} />
-            )}
+          {isExecution && (
+            <>
+              {userNonce !== undefined && (
+                <GasDetail isLoading={false} name="Wallet nonce" value={userNonce.toString()} />
+              )}
 
-            <GasDetail isLoading={isLoading} name="Gas limit" value={isError ? 'Cannot estimate' : gasLimitString} />
+              <GasDetail isLoading={isLoading} name="Gas limit" value={isError ? 'Cannot estimate' : gasLimitString} />
 
-            {isEIP1559 ? (
-              <>
-                <GasDetail isLoading={isLoading} name="Max priority fee (Gwei)" value={maxPrioGasGwei} />
-                <GasDetail isLoading={isLoading} name="Max fee (Gwei)" value={maxFeePerGasGwei} />
-              </>
-            ) : (
-              <GasDetail isLoading={isLoading} name="Gas price (Gwei)" value={maxFeePerGasGwei} />
-            )}
-          </>
-        )}
+              {isEIP1559 ? (
+                <>
+                  <GasDetail isLoading={isLoading} name="Max priority fee (Gwei)" value={maxPrioGasGwei} />
+                  <GasDetail isLoading={isLoading} name="Max fee (Gwei)" value={maxFeePerGasGwei} />
+                </>
+              ) : (
+                <GasDetail isLoading={isLoading} name="Gas price (Gwei)" value={maxFeePerGasGwei} />
+              )}
+            </>
+          )}
 
-        {gasLimitError || !isExecution || (isExecution && !isLoading) ? (
-          <Link component="button" onClick={onEditClick} sx={{ mt: 2 }} fontSize="medium">
-            Edit
-          </Link>
-        ) : (
-          <Skeleton variant="text" sx={{ display: 'inline-block', minWidth: '2em', mt: 2 }} />
-        )}
-      </AccordionDetails>
-    </Accordion>
+          {gasLimitError || !isExecution || (isExecution && !isLoading) ? (
+            <Link component="button" onClick={onEditClick} sx={{ mt: 2 }} fontSize="medium">
+              Edit
+            </Link>
+          ) : (
+            <Skeleton variant="text" sx={{ display: 'inline-block', minWidth: '2em', mt: 2 }} />
+          )}
+        </AccordionDetails>
+      </Accordion>
+    </div>
   )
 }
 

--- a/src/components/tx/GasParams/styles.module.css
+++ b/src/components/tx/GasParams/styles.module.css
@@ -2,3 +2,16 @@
   border-bottom-left-radius: 0px;
   border-bottom-right-radius: 0px;
 }
+
+.error :global .MuiAccordion-root.Mui-expanded {
+  border-color: var(--color-error-light);
+}
+
+.error :global .MuiAccordionSummary-root.Mui-expanded {
+  background-color: var(--color-error-background);
+  border-bottom: 1px solid var(--color-error-light);
+}
+
+.error :global .MuiAccordionSummary-expandIconWrapper {
+  margin-left: var(--space-1);
+}


### PR DESCRIPTION
## What it solves

Resolves #1764 

[Figma](https://www.figma.com/file/cMDccuR9aZFqAiBd4dKsKg/Transaction-flow?type=design&mode=design&t=v9TzJ1qgynHjd0QP-0)

## How this PR fixes it
- Add extra warning to the 'estimated fee' accordion
- On expanding, change the background color of the accordion summary and border color of the whole accordion.

## How to test it
- Review a transaction that will fail.
- Check that the gas estimation component matches the designs.

## Screenshots
<img width="666" alt="image" src="https://github.com/safe-global/safe-wallet-web/assets/17801424/a68dc4f3-bd1f-43c8-b585-2d9e286e02bf">

<img width="666" alt="image" src="https://github.com/safe-global/safe-wallet-web/assets/17801424/deaa33d4-5bb2-44aa-bd8e-9e1eae529246">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
