### PR TITLE
Tests: reduce number of machines for recovery tests

### DIFF
--- a/.github/workflows/e2e-hp-ondemand.yml
+++ b/.github/workflows/e2e-hp-ondemand.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [1]
+        containers: [1, 2, 3]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/e2e-hp-ondemand.yml
+++ b/.github/workflows/e2e-hp-ondemand.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [1, 2, 3, 4, 5]
+        containers: [1]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## What it solves

## How this PR fixes it

- Reduce number of machines for execution in recovery tests

## How to test it

- Run Cypress tests and observe outcome