### PR TITLE
fix: max button not applying correct value

### DIFF
--- a/src/components/tx-flow/flows/TokenTransfer/SpendingLimitRow/index.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/SpendingLimitRow/index.tsx
@@ -11,7 +11,7 @@ import { HelpCenterArticle } from '@/config/constants'
 
 import css from './styles.module.css'
 import { TokenAmountFields } from '@/components/common/TokenAmountInput'
-import { useContext } from 'react'
+import { useContext, useEffect } from 'react'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 
 const SpendingLimitRow = ({
@@ -21,11 +21,18 @@ const SpendingLimitRow = ({
   availableAmount: bigint
   selectedToken: TokenInfo | undefined
 }) => {
-  const { control, trigger } = useFormContext()
+  const { control, trigger, resetField } = useFormContext()
   const isOnlySpendLimitBeneficiary = useIsOnlySpendingLimitBeneficiary()
   const { setNonceNeeded } = useContext(SafeTxContext)
 
   const formattedAmount = safeFormatUnits(availableAmount, selectedToken?.decimals)
+
+  useEffect(() => {
+    return () => {
+      // reset the field value to default when the component is unmounted
+      resetField(TokenTransferFields.type)
+    }
+  }, [resetField])
 
   return (
     <FormControl>


### PR DESCRIPTION
## What it solves
fixes #3326

If you have a token that has a spending limit, select it, then switch to another token that doesn't have a spending limit set then the "Max" button would update the amount field to 0 instead of the max available.


## How this PR fixes it
The whole problem stems from the fact that we watch for the type of the transfer with react-hook-form, but if we just unmount the component that displays those limit controls the watch doesn't know that the type has to be reset back to default.

## How to test it
follow the steps in #3326

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
