### PR TITLE
fix: show watchlist when disconnected from wallet

### DIFF
--- a/src/components/welcome/MyAccounts/useAllSafes.ts
+++ b/src/components/welcome/MyAccounts/useAllSafes.ts
@@ -43,13 +43,12 @@ const useAllSafes = (): SafeItems | undefined => {
   const undeployedSafes = useAppSelector(selectUndeployedSafes)
 
   return useMemo<SafeItems | undefined>(() => {
-    if (!allOwned) return
-    const chains = uniq(Object.keys(allAdded).concat(Object.keys(allOwned)))
+    const chains = uniq(Object.keys(allAdded).concat(Object.keys(allOwned || {})))
 
     return chains.flatMap((chainId) => {
       if (!configs.some((item) => item.chainId === chainId)) return []
       const addedOnChain = Object.keys(allAdded[chainId] || {})
-      const ownedOnChain = allOwned[chainId]
+      const ownedOnChain = (allOwned || {})[chainId]
       const undeployedOnChain = Object.keys(undeployedSafes[chainId] || {})
       const uniqueAddresses = uniq(addedOnChain.concat(ownedOnChain)).filter(Boolean)
 


### PR DESCRIPTION
## What it solves
Watchlist safes were not showing up when disconnected from wallet. 

Always show watchlist safes wether connected or not.
