### PR TITLE
fix: Recovery not visible on settings page

### DIFF
--- a/src/features/recovery/services/delay-modifier.ts
+++ b/src/features/recovery/services/delay-modifier.ts
@@ -1,7 +1,7 @@
 import { ContractVersions, getModuleInstance, KnownContracts } from '@gnosis.pm/zodiac'
 import { SENTINEL_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 import type { Delay, SupportedNetworks } from '@gnosis.pm/zodiac'
-import type { JsonRpcProvider } from 'ethers'
+import { type JsonRpcProvider, isAddress } from 'ethers'
 import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 
 import { sameAddress } from '@/utils/addresses'
@@ -13,6 +13,8 @@ export async function _getZodiacContract(
   moduleAddress: string,
   provider: JsonRpcProvider,
 ): Promise<string | undefined> {
+  if (!isAddress(moduleAddress)) return
+
   const bytecode = await provider.getCode(moduleAddress)
 
   if (isGenericProxy(bytecode)) {


### PR DESCRIPTION
## What it solves

Resolves #3413 

## How this PR fixes it

- For some safe proxy contracts (e.g. on mainnet), the function `getGnosisProxyMasterCopy` returns `0` since the public masterCopy function is missing ([Example](https://etherscan.io/address/0x651bBd829a7cBD32F35dFC099cBde1E04789393c#code))
- Check `isAddress` for a given `moduleAddress` before running `_getZodiacContract`

## How to test it

1. Open a safe on mainnet that added another safe as the recoverer
2. Navigate to the settings page
3. Observe the Recovery setup is visible

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
