### PR TITLE
chore: <p> cannot appear as a descendant of <p>.

### DIFF
--- a/src/components/common/WalletInfo/index.tsx
+++ b/src/components/common/WalletInfo/index.tsx
@@ -90,7 +90,7 @@ export const WalletInfo = ({
         ) : (
           <>
             <WalletIdenticon wallet={wallet} size={36} />
-            <Typography variant="body2" className={css.address}>
+            <Typography variant="body2" className={css.address} component="div">
               <EthHashInfo
                 address={wallet.address}
                 name={addressBook[wallet.address] || wallet.ens || wallet.label}

--- a/src/features/walletconnect/components/WcSessionList/WcNoSessions.tsx
+++ b/src/features/walletconnect/components/WcSessionList/WcNoSessions.tsx
@@ -19,7 +19,14 @@ const WcSampleDapps = ({ onUnload }: { onUnload: () => void }) => {
   }, [onUnload])
 
   return (
-    <Typography variant="body2" display="flex" justifyContent="space-between" alignItems="center" mt={3}>
+    <Typography
+      variant="body2"
+      display="flex"
+      justifyContent="space-between"
+      alignItems="center"
+      mt={3}
+      component="div"
+    >
       {SAMPLE_DAPPS.map((item) => (
         <Typography variant="body2" key={item.url}>
           <ExternalLink href={item.url} noIcon px={1}>


### PR DESCRIPTION
note to testers: I can't see this error in production, it seems to only appear with the local dev release, so you'll have to test this locally

fix: Warning: validateDOMNesting(...): <p> cannot appear as a descendant of <p>.

In some locations we had <Typography variant=“body1”> nested inside another <Typography> this renders 2 <p> tags inside of each-other and that is not valid. The other way around was having a <Box> that is nested inside of a Typograpühy which also seems to be not valid.

## How to test it
run the website with 'yarn dev' -> open the wallet box on top -> you shouldn't see:
![grafik](https://github.com/safe-global/safe-wallet-web/assets/693770/1a5514f8-597e-4811-ae3d-245f4405b953)


## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
