### PR TITLE
fix: Address overflow in read-only inputs

### DIFF
--- a/src/components/common/AddressInputReadOnly/index.tsx
+++ b/src/components/common/AddressInputReadOnly/index.tsx
@@ -1,10 +1,8 @@
 import { type ReactNode, useState, type ReactElement, useId } from 'react'
-import { IconButton, InputAdornment, InputLabel, OutlinedInput, SvgIcon, Typography } from '@mui/material'
+import { InputAdornment, InputLabel, OutlinedInput, Typography } from '@mui/material'
 import EthHashInfo from '@/components/common/EthHashInfo'
-import SaveAddressIcon from '@/public/images/common/save-address.svg'
 import css from './styles.module.css'
 import EntryDialog from '@/components/address-book/EntryDialog'
-import useAddressBook from '@/hooks/useAddressBook'
 
 const AddressInputReadOnly = ({
   label,
@@ -15,14 +13,13 @@ const AddressInputReadOnly = ({
   address: string
   error?: boolean
 }): ReactElement => {
-  const addressBook = useAddressBook()
   const [open, setOpen] = useState(false)
 
   const id = useId()
 
   return (
     <>
-      <div className={css.wrapper}>
+      <div className={css.wrapper} title={address}>
         <InputLabel shrink error={error} htmlFor={id}>
           {label}
         </InputLabel>
@@ -31,20 +28,11 @@ const AddressInputReadOnly = ({
           className={css.input}
           error={error}
           startAdornment={
-            <InputAdornment position="start">
-              <Typography variant="body2" component="div">
+            <InputAdornment position="start" className={css.value}>
+              <Typography variant="body2" component="div" width={1}>
                 <EthHashInfo address={address} shortAddress={false} copyAddress={false} />
               </Typography>
             </InputAdornment>
-          }
-          endAdornment={
-            !addressBook[address] ? (
-              <InputAdornment position="end">
-                <IconButton onClick={() => setOpen(true)}>
-                  <SvgIcon component={SaveAddressIcon} inheritViewBox fontSize="small" />
-                </IconButton>
-              </InputAdornment>
-            ) : null
           }
           label={label}
           readOnly

--- a/src/components/common/AddressInputReadOnly/styles.module.css
+++ b/src/components/common/AddressInputReadOnly/styles.module.css
@@ -42,3 +42,7 @@
   font-weight: bold;
   color: var(--color-text-primary);
 }
+
+.value {
+  width: 100%;
+}


### PR DESCRIPTION
## What it solves

Resolves #3129 

## How this PR fixes it

- Adds ellipsis for long addresses
- Removes unused `endAdornment` in `AddressInputReadOnly`
- Adds the `address` as a title to the element

## How to test it

1. Add some addresses to your address book
2. Create a new safe
3. Assign those addresses as owners
4. Observe the address is cut off at the end with `...` if there is not enough space
5. Hover the address
6. Observe a title showing the whole address

## Screenshots
<img width="806" alt="Screenshot 2024-03-12 at 11 15 39" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/1416369e-d87c-4f3e-a19e-c682acc009e7">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
