### PR TITLE
fix: block new social login creations

### DIFF
--- a/src/services/exceptions/ErrorCodes.ts
+++ b/src/services/exceptions/ErrorCodes.ts
@@ -18,6 +18,7 @@ enum ErrorCodes {
   _304 = '304: Error enabling MFA',
   _305 = '305: Error exporting account key',
   _306 = '306: Error logging in',
+  _307 = '307: Error attempted new account creation',
 
   _400 = '400: Error requesting browser notification permissions',
   _401 = '401: Error tracking push notifications',

--- a/src/services/mpc/SocialWalletService.ts
+++ b/src/services/mpc/SocialWalletService.ts
@@ -10,6 +10,8 @@ import { asError } from '../exceptions/utils'
 import { type ISocialWalletService } from './interfaces'
 import { isSocialWalletOptions, SOCIAL_WALLET_OPTIONS } from './config'
 
+const ERROR_MSG_NO_NEW_ACCOUNTS = 'No new account creations are allowed as this feature will be deprecated soon.'
+
 /**
  * Singleton Service for accessing the social login wallet
  */
@@ -29,6 +31,36 @@ class SocialWalletService implements ISocialWalletService {
   isMFAEnabled() {
     const { shareDescriptions } = this.mpcCoreKit.getKeyDetails()
     return !Object.values(shareDescriptions).some((value) => value[0]?.includes('hashedShare'))
+  }
+
+  /**
+   *
+   * An Account is considered new if
+   * - It has no MFA setup
+   * - the hashedShare was created in the past 5 minutes
+   *
+   * @returns true if account is new, false otherwise
+   */
+  isAccountNew() {
+    const { shareDescriptions } = this.mpcCoreKit.getKeyDetails()
+    const hashedShare = Object.values(shareDescriptions).find((value) => value[0]?.includes('hashedShare'))
+
+    if (!hashedShare || hashedShare.length > 1) {
+      return false
+    }
+
+    try {
+      const firstShare = hashedShare[0]
+      const data = JSON.parse(firstShare)
+      if ('dateAdded' in data) {
+        const dateAdded = Number(data.dateAdded)
+        const timeDiff = Date.now() - dateAdded
+        if (timeDiff < 1000 * 5 * 60) {
+          return true
+        }
+      }
+    } catch (e) {}
+    return false
   }
 
   isRecoveryPasswordSet() {
@@ -102,6 +134,10 @@ class SocialWalletService implements ISocialWalletService {
       return this.mpcCoreKit.status
     } catch (err) {
       const error = asError(err)
+      if (error.message === ERROR_MSG_NO_NEW_ACCOUNTS) {
+        logError(ErrorCodes._307, error)
+        throw err
+      }
       logError(ErrorCodes._306, error)
       throw new Error('Something went wrong. Please try to login again.')
     }
@@ -109,6 +145,9 @@ class SocialWalletService implements ISocialWalletService {
 
   private async finalizeLogin() {
     if (this.mpcCoreKit.status === COREKIT_STATUS.LOGGED_IN) {
+      if (this.isAccountNew()) {
+        throw new Error(ERROR_MSG_NO_NEW_ACCOUNTS)
+      }
       await this.mpcCoreKit.commitChanges()
       await this.mpcCoreKit.provider?.request({ method: 'eth_accounts', params: [] })
       await this.onConnect()

--- a/src/services/mpc/__tests__/SocialWalletService.test.ts
+++ b/src/services/mpc/__tests__/SocialWalletService.test.ts
@@ -32,16 +32,23 @@ class MockMPCCoreKit {
   private stateAfterLogin: COREKIT_STATUS
   private userInfoAfterLogin: UserInfo | undefined
   private expectedFactorKey: BN
+  private expectedKeyDetails: { shareDescriptions: Record<string, string[]> }
   /**
    *
    * @param stateAfterLogin State after loginWithOauth resolves
    * @param userInfoAfterLogin  User info to set in the state after loginWithOauth resolves
    * @param expectedFactorKey For MFA login flow the expected factor key. If inputFactorKey gets called with the expected factor key the state switches to logged in
    */
-  constructor(stateAfterLogin: COREKIT_STATUS, userInfoAfterLogin: UserInfo, expectedFactorKey: BN = new BN(-1)) {
+  constructor(
+    stateAfterLogin: COREKIT_STATUS,
+    userInfoAfterLogin: UserInfo,
+    expectedFactorKey: BN = new BN(-1),
+    expectedKeyDetails = { shareDescriptions: {} },
+  ) {
     this.stateAfterLogin = stateAfterLogin
     this.userInfoAfterLogin = userInfoAfterLogin
     this.expectedFactorKey = expectedFactorKey
+    this.expectedKeyDetails = expectedKeyDetails
   }
 
   loginWithOauth(params: OauthLoginParams): Promise<void> {
@@ -69,6 +76,10 @@ class MockMPCCoreKit {
   getUserInfo() {
     return this.state.userInfo
   }
+
+  getKeyDetails() {
+    return this.expectedKeyDetails
+  }
 }
 
 describe('useMPCWallet', () => {
@@ -87,10 +98,24 @@ describe('useMPCWallet', () => {
     it('should handle successful log in for SFA account', async () => {
       const mockOnConnect = jest.fn()
 
-      const mockCoreKit = new MockMPCCoreKit(COREKIT_STATUS.LOGGED_IN, {
-        email: 'test@test.com',
-        name: 'Test',
-      } as unknown as UserInfo) as unknown as Web3AuthMPCCoreKit
+      const mockCoreKit = new MockMPCCoreKit(
+        COREKIT_STATUS.LOGGED_IN,
+        {
+          email: 'test@test.com',
+          name: 'Test',
+        } as unknown as UserInfo,
+        new BN(-1),
+        {
+          shareDescriptions: {
+            1: [
+              JSON.stringify({
+                dateAdded: Date.now() - 30 * 24 * 60 * 60 * 60 * 1000,
+                module: 'hashedShare',
+              }),
+            ],
+          },
+        },
+      ) as unknown as Web3AuthMPCCoreKit
 
       const testService = new SocialWalletService(mockCoreKit)
       testService.setOnConnect(mockOnConnect)
@@ -112,6 +137,53 @@ describe('useMPCWallet', () => {
         expect(status).resolves.toEqual(COREKIT_STATUS.LOGGED_IN)
         expect(mockOnConnect).toHaveBeenCalled()
         expect(mockCoreKit.commitChanges).toHaveBeenCalled()
+      })
+    })
+
+    it('should not allow logins to newly created SFA accounts', async () => {
+      const mockOnConnect = jest.fn()
+
+      const mockCoreKit = new MockMPCCoreKit(
+        COREKIT_STATUS.LOGGED_IN,
+        {
+          email: 'test@test.com',
+          name: 'Test',
+        } as unknown as UserInfo,
+        new BN(-1),
+        {
+          shareDescriptions: {
+            1: [
+              JSON.stringify({
+                dateAdded: Date.now() - 5,
+                module: 'hashedShare',
+              }),
+            ],
+          },
+        },
+      ) as unknown as Web3AuthMPCCoreKit
+
+      const testService = new SocialWalletService(mockCoreKit)
+      testService.setOnConnect(mockOnConnect)
+
+      let status: Promise<COREKIT_STATUS>
+      act(() => {
+        status = testService.loginAndCreate()
+      })
+
+      expect(mockOnConnect).not.toHaveBeenCalled()
+
+      // Resolve mock login
+      act(() => {
+        jest.advanceTimersByTime(MOCK_LOGIN_TIME)
+      })
+
+      // We should be logged in and onboard should get connected
+      await waitFor(() => {
+        expect(status).rejects.toEqual(
+          new Error('No new account creations are allowed as this feature will be deprecated soon.'),
+        )
+        expect(mockOnConnect).not.toHaveBeenCalled()
+        expect(mockCoreKit.commitChanges).not.toHaveBeenCalled()
       })
     })
 


### PR DESCRIPTION
## What it solves
Approaching the deprecation of Social logins, we do not want new users to sign up with social signers.

## How this PR fixes it
If a single factor (initial setup) account it younger than 5 minutes we error out of the login / social signer creation.

## How to test it
- If you have an old account, delete it first
- Login with an unused google login
- observe new error

## Screenshots
![Screenshot 2024-03-12 at 15 21 51](https://github.com/safe-global/safe-wallet-web/assets/2670790/299d5bc8-c4c3-441a-9c21-339e9f1550ba)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
