### PR TITLE
Feat: spam filter for incoming txs

### DIFF
--- a/src/hooks/useTxHistory.ts
+++ b/src/hooks/useTxHistory.ts
@@ -22,6 +22,7 @@ const useTxHistory = (
   const [filter] = useTxFilter()
   const { showOnlyTrustedTransactions } = useAppSelector(selectSettings)
   const hasDefaultTokenlist = useHasFeature(FEATURES.DEFAULT_TOKENLIST)
+  const onlyTrusted = (hasDefaultTokenlist && showOnlyTrustedTransactions) || false
 
   const {
     safe: { chainId },
@@ -34,10 +35,10 @@ const useTxHistory = (
       if (!(filter || pageUrl)) return
 
       return filter
-        ? fetchFilteredTxHistory(chainId, safeAddress, filter, pageUrl)
-        : getTxHistory(chainId, safeAddress, hasDefaultTokenlist && showOnlyTrustedTransactions, pageUrl)
+        ? fetchFilteredTxHistory(chainId, safeAddress, filter, onlyTrusted, pageUrl)
+        : getTxHistory(chainId, safeAddress, onlyTrusted, pageUrl)
     },
-    [chainId, safeAddress, pageUrl, filter, hasDefaultTokenlist, showOnlyTrustedTransactions],
+    [chainId, safeAddress, pageUrl, filter, onlyTrusted],
     false,
   )
 

--- a/src/utils/__tests__/tx-history-filter.test.ts
+++ b/src/utils/__tests__/tx-history-filter.test.ts
@@ -380,7 +380,13 @@ describe('tx-history-filter', () => {
     })
 
     it('should get incoming transfers relevant to `type`', () => {
-      fetchFilteredTxHistory('4', '0x123', { type: 'Incoming' as TxFilterType, filter: { value: '123' } }, 'pageUrl1')
+      fetchFilteredTxHistory(
+        '4',
+        '0x123',
+        { type: 'Incoming' as TxFilterType, filter: { value: '123' } },
+        false,
+        'pageUrl1',
+      )
 
       expect(getIncomingTransfers).toHaveBeenCalledWith(
         '4',
@@ -401,6 +407,7 @@ describe('tx-history-filter', () => {
           type: 'Outgoing' as TxFilterType,
           filter: { execution_date__gte: '1970-01-01T00:00:00.000Z', executed: 'true' },
         },
+        false,
         'pageUrl2',
       )
 
@@ -425,6 +432,7 @@ describe('tx-history-filter', () => {
         '1',
         '0x789',
         { type: 'Module-based' as TxFilterType, filter: { to: '0x123' } },
+        false,
         'pageUrl3',
       )
 
@@ -447,6 +455,7 @@ describe('tx-history-filter', () => {
           type: 'Test' as TxFilterType,
           filter: { token_address: '0x123' },
         },
+        false,
         'pageUrl3',
       )
 

--- a/src/utils/tx-history-filter.ts
+++ b/src/utils/tx-history-filter.ts
@@ -119,13 +119,14 @@ export const fetchFilteredTxHistory = async (
   chainId: string,
   safeAddress: string,
   filterData: TxFilter,
+  onlyTrusted: boolean,
   pageUrl?: string,
 ): Promise<TransactionListPage> => {
   const fetchPage = () => {
     const query = {
       ...filterData.filter,
       timezone_offset: getTimezoneOffset(),
-      trusted: false, // load all transactions, mark untrusted in the UI
+      trusted: onlyTrusted ?? false,
       executed: filterData.type === TxFilterType.MULTISIG ? 'true' : undefined,
     }
 


### PR DESCRIPTION
## What it solves

Resolves #3334

## How this PR fixes it

Passes the trusted flag to the filtered history endpoints (although it only works for the incoming tx filter).

## How to test it

* Open https://filter_incoming--walletweb.review-wallet-web.5afe.dev/transactions/history?safe=eth:0x220866b1a2219f40e72f5c628b65d54268ca3a9d&type=Incoming
* Press "Hide unknown transactions"
* The tx list should be filtered

---

Note: this PR is based off of the Tx Deletion PR because it requires an updated Gateway SDK.