### PR TITLE
fix: cannot connect with WC to Opensea

### DIFF
--- a/src/features/walletconnect/services/WalletConnectWallet.ts
+++ b/src/features/walletconnect/services/WalletConnectWallet.ts
@@ -89,7 +89,8 @@ class WalletConnectWallet {
 
     const supportedChainIds = [currentChainId].concat(
       requiredChains.map(stripEip155Prefix),
-      optionalChains.map(stripEip155Prefix),
+      // disable optional chains for now as some dapps end up sending request after the session is approved to the wrong chain
+      // optionalChains.map(stripEip155Prefix),
     )
 
     const eip155ChainIds = supportedChainIds.map(getEip155ChainId)

--- a/src/features/walletconnect/services/__tests__/WalletConnectWallet.test.ts
+++ b/src/features/walletconnect/services/__tests__/WalletConnectWallet.test.ts
@@ -105,7 +105,9 @@ describe('WalletConnectWallet', () => {
   describe('approveSession', () => {
     it('should approve the session with proposed required/optional chains/methods and required events', async () => {
       const approveSessionSpy = jest.spyOn((wallet as any).web3Wallet as IWeb3Wallet, 'approveSession')
+      const updateSessionSpy = jest.spyOn((wallet as any).web3Wallet as IWeb3Wallet, 'updateSession')
       approveSessionSpy.mockResolvedValue({
+        topic: 'abc',
         namespaces: {
           eip155: {},
         },
@@ -159,7 +161,23 @@ describe('WalletConnectWallet', () => {
         toBeHex('0x123', 20),
       )
 
-      const namespaces = {
+      const namespaceWithOnlyRequired = {
+        eip155: {
+          chains: ['eip155:1'],
+          methods: [
+            'eth_sendTransaction',
+            'personal_sign',
+            'eth_accounts',
+            'eth_sign',
+            'eth_signTypedData',
+            'eth_signTypedData_v4',
+            'wallet_switchEthereumChain',
+          ],
+          events: ['chainChanged', 'accountsChanged'],
+          accounts: [`eip155:1:${toBeHex('0x123', 20)}`],
+        },
+      }
+      const namespacesWithOptional = {
         eip155: {
           chains: [
             'eip155:1',
@@ -194,7 +212,12 @@ describe('WalletConnectWallet', () => {
 
       expect(approveSessionSpy).toHaveBeenCalledWith({
         id: 123,
-        namespaces,
+        namespaces: namespaceWithOnlyRequired,
+      })
+
+      expect(updateSessionSpy).toHaveBeenCalledWith({
+        topic: 'abc',
+        namespaces: namespacesWithOptional,
       })
     })
 
@@ -230,25 +253,50 @@ describe('WalletConnectWallet', () => {
         toBeHex('0x123', 20),
       )
 
+      let chains = ['eip155:43114', 'eip155:42161', 'eip155:8453', 'eip155:100', 'eip155:137', 'eip155:1101']
+      let accounts = [
+        `eip155:43114:${toBeHex('0x123', 20)}`,
+        `eip155:42161:${toBeHex('0x123', 20)}`,
+        `eip155:8453:${toBeHex('0x123', 20)}`,
+        `eip155:100:${toBeHex('0x123', 20)}`,
+        `eip155:137:${toBeHex('0x123', 20)}`,
+        `eip155:1101:${toBeHex('0x123', 20)}`,
+      ]
       const namespaces = {
         eip155: {
-          chains: ['eip155:43114', 'eip155:42161', 'eip155:8453', 'eip155:100', 'eip155:137', 'eip155:1101'],
+          chains: [],
           methods: ['eth_accounts', 'personal_sign', 'eth_sendTransaction'],
           events: ['chainChanged', 'accountsChanged'],
-          accounts: [
-            `eip155:43114:${toBeHex('0x123', 20)}`,
-            `eip155:42161:${toBeHex('0x123', 20)}`,
-            `eip155:8453:${toBeHex('0x123', 20)}`,
-            `eip155:100:${toBeHex('0x123', 20)}`,
-            `eip155:137:${toBeHex('0x123', 20)}`,
-            `eip155:1101:${toBeHex('0x123', 20)}`,
-          ],
+          accounts: [],
         },
       }
+
+      await wallet.approveSession(
+        proposal,
+        '69420', // not in proposal, therefore not supported
+        toBeHex('0x123', 20),
+      )
 
       expect(approveSessionSpy).toHaveBeenCalledWith({
         id: 123,
         namespaces,
+      })
+
+      await wallet.approveSession(
+        proposal,
+        '42161', // in proposal, therefore supported
+        toBeHex('0x123', 20),
+      )
+      expect(approveSessionSpy).toHaveBeenCalledWith({
+        id: 123,
+        namespaces: {
+          ...namespaces,
+          eip155: {
+            ...namespaces.eip155,
+            chains: [chains[1]],
+            accounts: [accounts[1]],
+          },
+        },
       })
     })
 


### PR DESCRIPTION
If the user is trying to connect with WC to Opensea and the user is on a chain other than mainnet the first connection attempt fails. The second one succeeds. This is because when opensea sees the list of optional chains, after establishing a session it sends a request, but the request is for the optional chain and not for the required one and we end up blocking it. By giving up on the optional namespace Opensea sends the request to the requried chain.

## How to test it
Go to opensea to a collection that is on let's say OP. Try to establish WC connection to your safe that is also on OP. Establishing a connection should work.

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
