### PR TITLE
Test: detect duplicated signer in safe creation

### DIFF
--- a/cypress/e2e/pages/create_wallet.pages.js
+++ b/cypress/e2e/pages/create_wallet.pages.js
@@ -29,6 +29,7 @@ const cancelBtn = '[data-testid="cancel-btn"]'
 const safeBackupAlert = '[data-testid="safe-backup-alert"]'
 const dialogConfirmBtn = '[data-testid="dialog-confirm-btn"]'
 const safeActivationSection = '[data-testid="activation-section"]'
+const addressAutocompleteOptions = '[data-testid="address-item"]'
 
 const sponsorStr = 'Your account is sponsored by Goerli'
 const safeCreationProcessing = 'Transaction is being executed'
@@ -177,6 +178,14 @@ export function verifyOwnerAddress(address, index) {
 
 export function verifyThreshold(number) {
   cy.get(thresholdInput).should('have.value', number)
+}
+
+export function clickOnSignerAddressInput(index) {
+  cy.get(getOwnerAddressInput(index)).clear()
+}
+
+export function selectSignerOnAutocomplete(index) {
+  cy.get(addressAutocompleteOptions).eq(index).click()
 }
 
 export function typeOwnerName(name, index) {

--- a/cypress/e2e/regression/create_safe_simple.cy.js
+++ b/cypress/e2e/regression/create_safe_simple.cy.js
@@ -2,6 +2,7 @@ import * as constants from '../../support/constants'
 import * as main from '../../e2e/pages/main.page'
 import * as createwallet from '../pages/create_wallet.pages'
 import * as owner from '../pages/owners.pages'
+import * as ls from '../../support/localstorage_data.js'
 
 describe('Safe creation tests', () => {
   beforeEach(() => {
@@ -127,5 +128,21 @@ describe('Safe creation tests', () => {
 
     createwallet.typeOwnerAddress(constants.ENS_TEST_SEPOLIA_INVALID, 1)
     owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.failedResolve)
+  })
+
+  it('Verify duplicated signer error using the autocomplete feature', () => {
+    cy.visit(constants.createNewSafeSepoliaUrl + '?chain=sep')
+    main
+      .addToLocalStorage(constants.localStorageKeys.SAFE_v2__addressBook, ls.addressBookData.sameOwnerName)
+      .then(() => {
+        owner.waitForConnectionStatus()
+        createwallet.clickOnContinueWithWalletBtn()
+        createwallet.clickOnCreateNewSafeBtn()
+        createwallet.clickOnNextBtn()
+        createwallet.clickOnAddNewOwnerBtn()
+        createwallet.clickOnSignerAddressInput(1)
+        createwallet.selectSignerOnAutocomplete(2)
+        owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.ownerAdded)
+      })
   })
 })


### PR DESCRIPTION
## What it solves
Ticket #3427 fixed an issue of duplicated owner in safe creation in a specific scenario. This is an e2e-test that prevents that issue for happening again

## How this PR fixes it
Adds an address of the currently connected owner to the LS (like if it was added to the address book)
Uses the autocomplete feature in the safe creation owners' step to selecte the address added to the LS
Makes sure the "Duplicated signer" error shows up for that scenario

## How to test it
Run the test "Verify duplicated signer error using the autocomplete feature" in the "create_test_simple" file. It should run fine
No other tests should be affected, so they all should run fine as well

## Screenshots
![image](https://github.com/safe-global/safe-wallet-web/assets/4503659/7be59a0d-12b0-44bb-b32c-627dce215e9d)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
