### PR TITLE
Fix: always switch wallet chain before signing/executing

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@web3-onboard/keystone": "^2.3.7",
     "@web3-onboard/ledger": "2.3.2",
     "@web3-onboard/trezor": "^2.4.2",
-    "@web3-onboard/walletconnect": "^2.5.3",
+    "@web3-onboard/walletconnect": "^2.5.4-alpha.1",
     "@web3auth/mpc-core-kit": "^1.1.3",
     "blo": "^1.1.1",
     "bn.js": "^5.2.1",

--- a/src/hooks/wallets/useOnboard.ts
+++ b/src/hooks/wallets/useOnboard.ts
@@ -13,9 +13,7 @@ import { E2E_WALLET_NAME } from '@/tests/e2e-wallet'
 import { ONBOARD_MPC_MODULE_LABEL } from '@/services/mpc/SocialLoginModule'
 import { formatAmount } from '@/utils/formatNumber'
 import { localItem } from '@/services/local-storage/local'
-import { isWalletUnlocked } from '@/utils/wallets'
-
-const WALLETCONNECT = 'WalletConnect'
+import { isWalletConnect, isWalletUnlocked } from '@/utils/wallets'
 
 export type ConnectedWallet = {
   label: string
@@ -83,9 +81,7 @@ export const getConnectedWallet = (wallets: WalletState[]): ConnectedWallet | nu
 
 const getWalletConnectLabel = async (wallet: ConnectedWallet): Promise<string | undefined> => {
   const UNKNOWN_PEER = 'Unknown'
-  const { label } = wallet
-  const isWalletConnect = label.startsWith(WALLETCONNECT)
-  if (!isWalletConnect) return
+  if (!isWalletConnect(wallet)) return
   const { connector } = wallet.provider as unknown as any
   const peerWalletV2 = connector.session?.peer?.metadata?.name
   return peerWalletV2 || UNKNOWN_PEER

--- a/src/services/tx/tx-sender/sdk.ts
+++ b/src/services/tx/tx-sender/sdk.ts
@@ -3,7 +3,7 @@ import type Safe from '@safe-global/protocol-kit'
 import { EthersAdapter, SigningMethod } from '@safe-global/protocol-kit'
 import type { JsonRpcSigner } from 'ethers'
 import { ethers } from 'ethers'
-import { isWalletRejection, isHardwareWallet } from '@/utils/wallets'
+import { isWalletRejection, isHardwareWallet, isWalletConnect } from '@/utils/wallets'
 import { OperationType, type SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { SAFE_FEATURES } from '@safe-global/protocol-kit/dist/src/utils/safeVersions'
@@ -28,26 +28,21 @@ export const getAndValidateSafeSDK = (): Safe => {
 
 export const switchWalletChain = async (onboard: OnboardAPI, chainId: string): Promise<ConnectedWallet | null> => {
   const currentWallet = getConnectedWallet(onboard.state.get().wallets)
+  if (!currentWallet) return null
 
-  if (!currentWallet) {
-    return null
-  }
-
-  if (isHardwareWallet(currentWallet)) {
-    await onboard.disconnectWallet({ label: currentWallet.label })
-    const wallets = await connectWallet(onboard, { autoSelect: currentWallet.label })
-
-    return wallets ? getConnectedWallet(wallets) : null
-  }
-
-  const didSwitch = await onboard.setChain({ chainId: toQuantity(parseInt(chainId)) })
-  if (!didSwitch) {
+  // Onboard incorrectly returns WalletConnect's chainId, so it needs to be switched uncnoditionally
+  if (currentWallet.chainId === chainId && !isWalletConnect(currentWallet)) {
     return currentWallet
   }
 
-  /**
-   * Onboard doesn't update immediately and otherwise returns a stale wallet if we directly get its state
-   */
+  // Hardware wallets cannot switch chains
+  if (isHardwareWallet(currentWallet)) {
+    await onboard.disconnectWallet({ label: currentWallet.label })
+    const wallets = await connectWallet(onboard, { autoSelect: currentWallet.label })
+    return wallets ? getConnectedWallet(wallets) : null
+  }
+
+  // Onboard doesn't update immediately and otherwise returns a stale wallet if we directly get its state
   return new Promise((resolve) => {
     const source$ = onboard.state.select('wallets').subscribe((newWallets) => {
       const newWallet = getConnectedWallet(newWallets)
@@ -56,6 +51,17 @@ export const switchWalletChain = async (onboard: OnboardAPI, chainId: string): P
         resolve(newWallet)
       }
     })
+
+    // Switch chain for all other wallets
+    currentWallet.provider
+      .request({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: toQuantity(parseInt(chainId)) }],
+      })
+      .catch(() => {
+        source$.unsubscribe()
+        resolve(currentWallet)
+      })
   })
 }
 
@@ -64,10 +70,6 @@ export const assertWalletChain = async (onboard: OnboardAPI, chainId: string): P
 
   if (!wallet) {
     throw new Error('No wallet connected.')
-  }
-
-  if (wallet.chainId === chainId) {
-    return wallet
   }
 
   const newWallet = await switchWalletChain(onboard, chainId)

--- a/src/services/tx/tx-sender/sdk.ts
+++ b/src/services/tx/tx-sender/sdk.ts
@@ -30,7 +30,7 @@ export const switchWalletChain = async (onboard: OnboardAPI, chainId: string): P
   const currentWallet = getConnectedWallet(onboard.state.get().wallets)
   if (!currentWallet) return null
 
-  // Onboard incorrectly returns WalletConnect's chainId, so it needs to be switched uncnoditionally
+  // Onboard incorrectly returns WalletConnect's chainId, so it needs to be switched unconditionally
   if (currentWallet.chainId === chainId && !isWalletConnect(currentWallet)) {
     return currentWallet
   }

--- a/src/utils/wallets.ts
+++ b/src/utils/wallets.ts
@@ -5,6 +5,8 @@ import { WALLET_KEYS } from '@/hooks/wallets/consts'
 import memoize from 'lodash/memoize'
 import { ONBOARD_MPC_MODULE_LABEL } from '@/services/mpc/SocialLoginModule'
 
+const WALLETCONNECT = 'WalletConnect'
+
 const isWCRejection = (err: Error): boolean => {
   return /rejected/.test(err?.message)
 }
@@ -22,7 +24,7 @@ export const isLedger = (wallet: ConnectedWallet): boolean => {
 }
 
 export const isWalletConnect = (wallet: ConnectedWallet): boolean => {
-  return wallet.label.toUpperCase() === WALLET_KEYS.WALLETCONNECT_V2
+  return wallet.label.toLowerCase().startsWith(WALLETCONNECT.toLowerCase())
 }
 
 export const isHardwareWallet = (wallet: ConnectedWallet): boolean => {

--- a/src/utils/wallets.ts
+++ b/src/utils/wallets.ts
@@ -21,6 +21,10 @@ export const isLedger = (wallet: ConnectedWallet): boolean => {
   return wallet.label.toUpperCase() === WALLET_KEYS.LEDGER
 }
 
+export const isWalletConnect = (wallet: ConnectedWallet): boolean => {
+  return wallet.label.toUpperCase() === WALLET_KEYS.WALLETCONNECT_V2
+}
+
 export const isHardwareWallet = (wallet: ConnectedWallet): boolean => {
   return [WALLET_KEYS.LEDGER, WALLET_KEYS.TREZOR, WALLET_KEYS.KEYSTONE].includes(
     wallet.label.toUpperCase() as WALLET_KEYS,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5860,7 +5860,7 @@
   dependencies:
     tslib "1.14.1"
 
-"@walletconnect/ethereum-provider@^2.11.0", "@walletconnect/ethereum-provider@^2.11.2":
+"@walletconnect/ethereum-provider@^2.11.2":
   version "2.11.2"
   resolved "https://registry.yarnpkg.com/@walletconnect/ethereum-provider/-/ethereum-provider-2.11.2.tgz#914f773e37a879bc00cf367437c4e98a826247b1"
   integrity sha512-BUDqee0Uy2rCZVkW5Ao3q6Ado/3fePYnFdryVF+YL6bPhj+xQZ5OfKodl+uvs7Rwq++O5wTX2RqOTzpW7+v+Mg==
@@ -6288,12 +6288,12 @@
     ethereumjs-util "^7.1.3"
     hdkey "^2.0.1"
 
-"@web3-onboard/walletconnect@^2.5.3":
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/@web3-onboard/walletconnect/-/walletconnect-2.5.3.tgz#b8f71ee93de8cf151dd31732715bff250fcda293"
-  integrity sha512-ENrUwXBbja6gXWfF4G2pxhwOodT9MAMPum0E1KPyphzcs+QxjrC+aaXnYUpLLhZsjlAcIWcGrgpmtLP2NDhRXg==
+"@web3-onboard/walletconnect@^2.5.4-alpha.1":
+  version "2.5.4-alpha.1"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/walletconnect/-/walletconnect-2.5.4-alpha.1.tgz#ba44b74d277ed310f63afb9f7b55f9b66fae4789"
+  integrity sha512-mhlzDAduTolTn9s2qSYiD0fSlMWt1VCxLXBeQQUuypIencDYTF+GsFTjZSbLAfYx6sclRvAIb4/PGIM5d5mLNQ==
   dependencies:
-    "@walletconnect/ethereum-provider" "^2.11.0"
+    "@walletconnect/ethereum-provider" "^2.11.2"
     "@web3-onboard/common" "^2.3.3"
     joi "17.9.1"
     rxjs "^7.5.2"


### PR DESCRIPTION
## What it solves

The Zerion Wallet mobile app, when connected via WalletConnect, connects to the wrong chain but onboard thinks it's on the right chain. In addition to that, `onboard.setChain` doesn't work for WalletConnect (probably because onboard thinks there's no need to switch the chain). Not sure on whose side is the bug, but this fixes it for us.

Basically, if we detect WalletConnect, it will always attempt to switch the chain even if it's seemingly already on the right one.

## How to test

1. Connect Zerion to Safe as a signer
2. Attempt to sign or execute a tx
3. On prod, it would show a "Safe contract not deployed on this network" error

---

Other cases:
1. Switch MetaMask to some chain
2. Connect it to a Safe on another chain
3. Try to sign or execute a tx
4. It should offer to switch the chain in MM and correctly sign afterwards

---

1. Connect to MetaMask on the same chain as Safe
2. It should sign/execute w/o switching the chain

---

1. Connect some other WalletConnect wallet
2. Try all signing/executing on different chains
