### PR TITLE
fix: Add loading states to WC

### DIFF
--- a/src/features/walletconnect/WalletConnectContext.tsx
+++ b/src/features/walletconnect/WalletConnectContext.tsx
@@ -1,3 +1,4 @@
+import type { WCLoadingState } from '@/features/walletconnect/components/WalletConnectProvider'
 import { createContext, type Dispatch, type SetStateAction } from 'react'
 import type WalletConnectWallet from '@/features/walletconnect/services/WalletConnectWallet'
 
@@ -7,6 +8,8 @@ type WalletConnectContextType = {
   setError: Dispatch<SetStateAction<Error | null>>
   open: boolean
   setOpen: (open: boolean) => void
+  isLoading: WCLoadingState | undefined
+  setIsLoading: Dispatch<SetStateAction<WCLoadingState | undefined>>
 }
 
 export const WalletConnectContext = createContext<WalletConnectContextType>({
@@ -15,4 +18,6 @@ export const WalletConnectContext = createContext<WalletConnectContextType>({
   setError: () => {},
   open: false,
   setOpen: (_open: boolean) => {},
+  isLoading: undefined,
+  setIsLoading: () => {},
 })

--- a/src/features/walletconnect/components/WalletConnectProvider/index.tsx
+++ b/src/features/walletconnect/components/WalletConnectProvider/index.tsx
@@ -16,6 +16,12 @@ enum Errors {
   WRONG_CHAIN = '%%dappName%% made a request on a different chain than the one you are connected to',
 }
 
+export enum WCLoadingState {
+  APPROVE = 'Approve',
+  REJECT = 'Reject',
+  DISCONNECT = 'Disconnect',
+}
+
 const WalletConnectSafeApp = IS_PRODUCTION ? WC_APP_PROD : WC_APP_DEV
 
 const walletConnectSingleton = new WalletConnectWallet()
@@ -34,6 +40,7 @@ export const WalletConnectProvider = ({ children }: { children: ReactNode }) => 
   const open = wcPopupStore.useStore() ?? false
   const setOpen = wcPopupStore.setStore
   const [error, setError] = useState<Error | null>(null)
+  const [isLoading, setIsLoading] = useState<WCLoadingState>()
   const safeWalletProvider = useSafeWalletProvider()
 
   // Init WalletConnect
@@ -102,7 +109,7 @@ export const WalletConnectProvider = ({ children }: { children: ReactNode }) => 
   }, [walletConnect, chainId, safeWalletProvider])
 
   return (
-    <WalletConnectContext.Provider value={{ walletConnect, error, setError, open, setOpen }}>
+    <WalletConnectContext.Provider value={{ walletConnect, error, setError, open, setOpen, isLoading, setIsLoading }}>
       {children}
     </WalletConnectContext.Provider>
   )

--- a/src/features/walletconnect/components/WcConnectionForm/index.tsx
+++ b/src/features/walletconnect/components/WcConnectionForm/index.tsx
@@ -15,15 +15,7 @@ import { WALLETCONNECT_EVENTS } from '@/services/analytics/events/walletconnect'
 
 const WC_HINTS_KEY = 'wcHints'
 
-export const WcConnectionForm = ({
-  sessions,
-  onDisconnect,
-  uri,
-}: {
-  sessions: SessionTypes.Struct[]
-  onDisconnect: (session: SessionTypes.Struct) => Promise<void>
-  uri: string
-}): ReactElement => {
+export const WcConnectionForm = ({ sessions, uri }: { sessions: SessionTypes.Struct[]; uri: string }): ReactElement => {
   const [showHints = true, setShowHints] = useLocalStorage<boolean>(WC_HINTS_KEY)
   const { safeLoaded } = useSafeInfo()
 
@@ -72,7 +64,7 @@ export const WcConnectionForm = ({
       <Divider flexItem />
 
       <Grid item>
-        <WcSessionList sessions={sessions} onDisconnect={onDisconnect} />
+        <WcSessionList sessions={sessions} />
       </Grid>
 
       {showHints && (

--- a/src/features/walletconnect/components/WcProposalForm/index.tsx
+++ b/src/features/walletconnect/components/WcProposalForm/index.tsx
@@ -1,5 +1,8 @@
-import { Button, Checkbox, Divider, FormControlLabel, Typography } from '@mui/material'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { WalletConnectContext } from '@/features/walletconnect/WalletConnectContext'
+
+import { asError } from '@/services/exceptions/utils'
+import { Button, Checkbox, CircularProgress, Divider, FormControlLabel, Typography } from '@mui/material'
+import { type Dispatch, type SetStateAction, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import type { ReactElement, ChangeEvent } from 'react'
 import type { Web3WalletTypes } from '@walletconnect/web3wallet'
 
@@ -20,13 +23,16 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 
 type ProposalFormProps = {
   proposal: Web3WalletTypes.SessionProposal
-  onApprove?: () => void
-  onReject?: () => void
+  setProposal: Dispatch<SetStateAction<Web3WalletTypes.SessionProposal | undefined>>
 }
 
-const WcProposalForm = ({ proposal, onApprove, onReject }: ProposalFormProps): ReactElement => {
+const WcProposalForm = ({ proposal, setProposal }: ProposalFormProps): ReactElement => {
+  const { walletConnect, setError } = useContext(WalletConnectContext)
+  const [isApproving, setIsApproving] = useState<boolean>(false)
+  const [isRejecting, setIsRejecting] = useState<boolean>(false)
+
   const { configs } = useChains()
-  const { safeLoaded, safe } = useSafeInfo()
+  const { safeLoaded, safe, safeAddress } = useSafeInfo()
   const { chainId } = safe
   const [understandsRisk, setUnderstandsRisk] = useState(false)
   const { proposer } = proposal.params
@@ -39,7 +45,49 @@ const WcProposalForm = ({ proposal, onApprove, onReject }: ProposalFormProps): R
   const name = getPeerName(proposer) || 'Unknown dApp'
   const isHighRisk = proposal.verifyContext.verified.validation === 'INVALID' || isWarnedBridge(origin, name)
   const isBlocked = isScam || isBlockedBridge(origin)
-  const disabled = !safeLoaded || isUnsupportedChain || isBlocked || (isHighRisk && !understandsRisk)
+  const disabled = !safeLoaded || isUnsupportedChain || isBlocked || (isHighRisk && !understandsRisk) || isApproving
+
+  // On session approve
+  const onApprove = useCallback(async () => {
+    if (!walletConnect || !chainId || !safeAddress || !proposal) return
+
+    const label = proposal?.params.proposer.metadata.url
+    trackEvent({ ...WALLETCONNECT_EVENTS.APPROVE_CLICK, label })
+
+    setIsApproving(true)
+
+    try {
+      await walletConnect.approveSession(proposal, chainId, safeAddress)
+    } catch (e) {
+      setIsApproving(false)
+      setError(asError(e))
+      return
+    }
+
+    trackEvent({ ...WALLETCONNECT_EVENTS.CONNECTED, label })
+    setIsApproving(false)
+    setProposal(undefined)
+  }, [walletConnect, chainId, safeAddress, proposal, setProposal, setError])
+
+  // On session reject
+  const onReject = useCallback(async () => {
+    if (!walletConnect || !proposal) return
+
+    const label = proposal?.params.proposer.metadata.url
+    trackEvent({ ...WALLETCONNECT_EVENTS.REJECT_CLICK, label })
+
+    setIsRejecting(true)
+
+    try {
+      await walletConnect.rejectSession(proposal)
+    } catch (e) {
+      setIsRejecting(false)
+      setError(asError(e))
+    }
+
+    setIsRejecting(false)
+    setProposal(undefined)
+  }, [walletConnect, proposal, setProposal, setError])
 
   const onCheckboxClick = useCallback(
     (_: ChangeEvent, checked: boolean) => {
@@ -112,12 +160,12 @@ const WcProposalForm = ({ proposal, onApprove, onReject }: ProposalFormProps): R
       <Divider flexItem className={css.divider} />
 
       <div className={css.buttons}>
-        <Button variant="danger" onClick={onReject} className={css.button}>
-          Reject
+        <Button variant="danger" onClick={onReject} className={css.button} disabled={isRejecting}>
+          {isRejecting ? <CircularProgress size={20} /> : 'Reject'}
         </Button>
 
         <Button variant="contained" onClick={onApprove} className={css.button} disabled={disabled}>
-          Approve
+          {isApproving ? <CircularProgress size={20} /> : 'Approve'}
         </Button>
       </div>
     </div>

--- a/src/features/walletconnect/components/WcSessionList/index.tsx
+++ b/src/features/walletconnect/components/WcSessionList/index.tsx
@@ -1,17 +1,24 @@
+import { WalletConnectContext } from '@/features/walletconnect/WalletConnectContext'
+import { trackEvent } from '@/services/analytics'
+import { WALLETCONNECT_EVENTS } from '@/services/analytics/events/walletconnect'
+import { asError } from '@/services/exceptions/utils'
 import type { SessionTypes } from '@walletconnect/types'
-import { Button, List, ListItem, ListItemAvatar, ListItemIcon, ListItemText } from '@mui/material'
+import { Button, CircularProgress, List, ListItem, ListItemAvatar, ListItemIcon, ListItemText } from '@mui/material'
 import SafeAppIconCard from '@/components/safe-apps/SafeAppIconCard'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { getPeerName } from '@/features/walletconnect/services/utils'
+import { useCallback, useContext, useState } from 'react'
 import WcNoSessions from './WcNoSessions'
 import css from './styles.module.css'
 
 type WcSesstionListProps = {
   sessions: SessionTypes.Struct[]
-  onDisconnect: (session: SessionTypes.Struct) => void
 }
 
-const WcSessionListItem = ({ session, onDisconnect }: { session: SessionTypes.Struct; onDisconnect: () => void }) => {
+const WcSessionListItem = ({ session }: { session: SessionTypes.Struct }) => {
+  const { walletConnect, setError } = useContext(WalletConnectContext)
+  const [isDisconnecting, setIsDisconnecting] = useState<boolean>(false)
+
   const MAX_NAME_LENGTH = 23
   const { safeLoaded } = useSafeInfo()
   let name = getPeerName(session.peer) || 'Unknown dApp'
@@ -19,6 +26,24 @@ const WcSessionListItem = ({ session, onDisconnect }: { session: SessionTypes.St
   if (name.length > MAX_NAME_LENGTH + 1) {
     name = `${name.slice(0, MAX_NAME_LENGTH)}…`
   }
+
+  const onDisconnect = useCallback(async () => {
+    if (!walletConnect) return
+
+    const label = session.peer.metadata.url
+    trackEvent({ ...WALLETCONNECT_EVENTS.DISCONNECT_CLICK, label })
+
+    setIsDisconnecting(true)
+
+    try {
+      await walletConnect.disconnectSession(session)
+    } catch (error) {
+      setIsDisconnecting(false)
+      setError(asError(error))
+    }
+
+    setIsDisconnecting(false)
+  }, [walletConnect, setError, session])
 
   return (
     <ListItem className={css.sessionListItem}>
@@ -31,15 +56,15 @@ const WcSessionListItem = ({ session, onDisconnect }: { session: SessionTypes.St
       <ListItemText primary={name} primaryTypographyProps={{ color: safeLoaded ? undefined : 'text.secondary' }} />
 
       <ListItemIcon className={css.sessionListSecondaryAction}>
-        <Button variant="danger" onClick={onDisconnect} className={css.button}>
-          Disconnect
+        <Button variant="danger" onClick={onDisconnect} className={css.button} disabled={isDisconnecting}>
+          {isDisconnecting ? <CircularProgress size={20} /> : 'Disconnect'}
         </Button>
       </ListItemIcon>
     </ListItem>
   )
 }
 
-const WcSessionList = ({ sessions, onDisconnect }: WcSesstionListProps) => {
+const WcSessionList = ({ sessions }: WcSesstionListProps) => {
   if (sessions.length === 0) {
     return <WcNoSessions />
   }
@@ -47,7 +72,7 @@ const WcSessionList = ({ sessions, onDisconnect }: WcSesstionListProps) => {
   return (
     <List className={css.sessionList}>
       {Object.values(sessions).map((session) => (
-        <WcSessionListItem key={session.topic} session={session} onDisconnect={() => onDisconnect(session)} />
+        <WcSessionListItem key={session.topic} session={session} />
       ))}
     </List>
   )

--- a/src/features/walletconnect/components/WcSessionMananger/index.tsx
+++ b/src/features/walletconnect/components/WcSessionMananger/index.tsx
@@ -1,13 +1,10 @@
-import { useCallback, useContext, useEffect, useRef, useState } from 'react'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import type { Web3WalletTypes } from '@walletconnect/web3wallet'
 import type { SessionTypes } from '@walletconnect/types'
-import useSafeInfo from '@/hooks/useSafeInfo'
 import { WalletConnectContext } from '@/features/walletconnect/WalletConnectContext'
-import { asError } from '@/services/exceptions/utils'
 import WcConnectionForm from '../WcConnectionForm'
 import WcErrorMessage from '../WcErrorMessage'
 import WcProposalForm from '../WcProposalForm'
-import WcConnectionState from '../WcConnectionState'
 import { trackEvent } from '@/services/analytics'
 import { WALLETCONNECT_EVENTS } from '@/services/analytics/events/walletconnect'
 import { splitError } from '@/features/walletconnect/services/utils'
@@ -17,85 +14,9 @@ type WcSessionManagerProps = {
   uri: string
 }
 
-const SESSION_INFO_TIMEOUT = 1000
-
 const WcSessionManager = ({ sessions, uri }: WcSessionManagerProps) => {
-  const { safe, safeAddress } = useSafeInfo()
-  const { chainId } = safe
-  const { walletConnect, error, setError, open, setOpen } = useContext(WalletConnectContext)
+  const { walletConnect, error, setError, open } = useContext(WalletConnectContext)
   const [proposal, setProposal] = useState<Web3WalletTypes.SessionProposal>()
-  const [changedSession, setChangedSession] = useState<SessionTypes.Struct>()
-  const isResponded = useRef<boolean>(false)
-
-  // On session approve
-  const onApprove = useCallback(async () => {
-    if (!walletConnect || !chainId || !safeAddress || !proposal) return
-
-    isResponded.current = true
-
-    const label = proposal?.params.proposer.metadata.url
-    trackEvent({ ...WALLETCONNECT_EVENTS.APPROVE_CLICK, label })
-
-    try {
-      await walletConnect.approveSession(proposal, chainId, safeAddress)
-    } catch (e) {
-      setError(asError(e))
-      return
-    }
-
-    trackEvent({ ...WALLETCONNECT_EVENTS.CONNECTED, label })
-
-    setProposal(undefined)
-  }, [walletConnect, setError, chainId, safeAddress, proposal])
-
-  // On session reject
-  const onReject = useCallback(async () => {
-    if (!walletConnect || !proposal) return
-
-    isResponded.current = true
-    const label = proposal?.params.proposer.metadata.url
-    trackEvent({ ...WALLETCONNECT_EVENTS.REJECT_CLICK, label })
-
-    try {
-      await walletConnect.rejectSession(proposal)
-    } catch (e) {
-      setError(asError(e))
-    }
-
-    // Always clear the proposal, even if the rejection fails
-    setProposal(undefined)
-  }, [proposal, walletConnect, setError])
-
-  // Try to clean-up when the user has open proposal,
-  // but for whatever reason refreshes the browser without rejecting/accepting it
-  // if we don't do this we often get "No matching key: session"
-  useEffect(() => {
-    const handleBeforeUnload = async () => {
-      if (proposal && isResponded.current === false) {
-        await onReject()
-      }
-    }
-
-    window.addEventListener('beforeunload', handleBeforeUnload)
-
-    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
-  }, [proposal, onReject])
-
-  // On session disconnect
-  const onDisconnect = useCallback(
-    async (session: SessionTypes.Struct) => {
-      const label = session.peer.metadata.url
-      trackEvent({ ...WALLETCONNECT_EVENTS.DISCONNECT_CLICK, label })
-
-      if (!walletConnect) return
-      try {
-        await walletConnect.disconnectSession(session)
-      } catch (error) {
-        setError(asError(error))
-      }
-    },
-    [walletConnect, setError],
-  )
 
   // Reset error
   const onErrorReset = useCallback(() => {
@@ -108,32 +29,8 @@ const WcSessionManager = ({ sessions, uri }: WcSessionManagerProps) => {
     return walletConnect.onSessionPropose((proposalData) => {
       setError(null)
       setProposal(proposalData)
-      isResponded.current = false
     })
   }, [walletConnect, setError])
-
-  // On session add
-  useEffect(() => {
-    return walletConnect?.onSessionAdd(setChangedSession)
-  }, [walletConnect])
-
-  // On session delete
-  useEffect(() => {
-    return walletConnect?.onSessionDelete(setChangedSession)
-  }, [walletConnect])
-
-  // Hide session info after timeout
-  useEffect(() => {
-    if (!changedSession) return
-
-    setOpen(true)
-
-    const timer = setTimeout(() => {
-      setChangedSession(undefined)
-    }, SESSION_INFO_TIMEOUT)
-
-    return () => clearTimeout(timer)
-  }, [changedSession, setOpen])
 
   // Track errors
   useEffect(() => {
@@ -144,10 +41,6 @@ const WcSessionManager = ({ sessions, uri }: WcSessionManagerProps) => {
     }
   }, [error])
 
-  //
-  // UI states
-  //
-
   // Nothing to show
   if (!open) return null
 
@@ -156,23 +49,13 @@ const WcSessionManager = ({ sessions, uri }: WcSessionManagerProps) => {
     return <WcErrorMessage error={error} onClose={onErrorReset} />
   }
 
-  // Session info
-  if (changedSession) {
-    return (
-      <WcConnectionState
-        metadata={changedSession.peer?.metadata}
-        isDelete={!sessions.some((s) => s.topic === changedSession.topic)}
-      />
-    )
-  }
-
   // Session proposal
   if (proposal) {
-    return <WcProposalForm proposal={proposal} onApprove={onApprove} onReject={onReject} />
+    return <WcProposalForm proposal={proposal} setProposal={setProposal} />
   }
 
   // Connection form (initial state)
-  return <WcConnectionForm sessions={sessions} onDisconnect={onDisconnect} uri={uri} />
+  return <WcConnectionForm sessions={sessions} uri={uri} />
 }
 
 export default WcSessionManager

--- a/src/features/walletconnect/hooks/__tests__/useWalletConnectSessions.test.tsx
+++ b/src/features/walletconnect/hooks/__tests__/useWalletConnectSessions.test.tsx
@@ -32,7 +32,15 @@ describe('useWalletConnectSessions', () => {
 
     const wrapper = ({ children }: any) => (
       <WalletConnectContext.Provider
-        value={{ walletConnect: mockWalletConnect, error: null, setError: () => {}, open: false, setOpen: () => {} }}
+        value={{
+          walletConnect: mockWalletConnect,
+          error: null,
+          setError: () => {},
+          open: false,
+          setOpen: () => {},
+          isLoading: undefined,
+          setIsLoading: () => {},
+        }}
       >
         {children}
       </WalletConnectContext.Provider>
@@ -52,7 +60,15 @@ describe('useWalletConnectSessions', () => {
 
     const wrapper = ({ children }: any) => (
       <WalletConnectContext.Provider
-        value={{ walletConnect: mockWalletConnect, error: null, setError: () => {}, open: false, setOpen: () => {} }}
+        value={{
+          walletConnect: mockWalletConnect,
+          error: null,
+          setError: () => {},
+          open: false,
+          setOpen: () => {},
+          isLoading: undefined,
+          setIsLoading: () => {},
+        }}
       >
         {children}
       </WalletConnectContext.Provider>
@@ -102,7 +118,15 @@ describe('useWalletConnectSessions', () => {
 
     const wrapper = ({ children }: any) => (
       <WalletConnectContext.Provider
-        value={{ walletConnect: mockWalletConnect, error: null, setError: () => {}, open: false, setOpen: () => {} }}
+        value={{
+          walletConnect: mockWalletConnect,
+          error: null,
+          setError: () => {},
+          open: false,
+          setOpen: () => {},
+          isLoading: undefined,
+          setIsLoading: () => {},
+        }}
       >
         {children}
       </WalletConnectContext.Provider>

--- a/src/features/walletconnect/services/WalletConnectWallet.ts
+++ b/src/features/walletconnect/services/WalletConnectWallet.ts
@@ -126,6 +126,7 @@ class WalletConnectWallet {
     await this.chainChanged(session.topic, currentChainId)
 
     // Workaround: WalletConnect doesn't have a session_add event
+    // and we want to update our state inside the useWalletConnectSessions hook
     this.web3Wallet?.events.emit(SESSION_ADD_EVENT, session)
 
     // Return updated session as it may have changed
@@ -256,7 +257,8 @@ class WalletConnectWallet {
     })
 
     // Workaround: WalletConnect doesn't emit session_delete event when disconnecting from the wallet side
-    this.web3Wallet?.events.emit('session_delete', session)
+    // and we want to update the state inside the useWalletConnectSessions hook
+    this.web3Wallet.events.emit('session_delete', session)
   }
 
   /**


### PR DESCRIPTION
## What it solves

Resolves #3200

## How this PR fixes it

- Adds loading indicators for `disconnect`, `reject` and `approve`
- Moves the `onDisconnect`, `onReject` and `onApprove` handler to the components where they are used instead of prop drilling them

Other changes:

💡 These aim to reduce complexity and improve the UX. We should discuss if we want to keep them or not. 💡 

- Removes the `handleBeforeUnload` call as there is no error and no such handling in the [example app](https://react-wallet.walletconnect.com/pairings). Reloading the page during an approval doesn't show any errors either, just an "Unknown" pairing but no active session. Using the same uri again establishes a session and updates the "Unknown" pairing which is expected.
- Removes `WcConnectionState` and associated logic. Switching back and forth with the dialogs when approving/rejecting takes the user out of the current context which is confusing imo. We should rather keep the user in the current dialog and display a loading state there.

## How to test it

1. Open the app, open the WC widget and paste a uri
2. Press Reject or Approve
3. Observe a loading indicator
4. Press Disconnect
5. Observe a loading indicator 

We should check that after pasting the URI into the input field and reloading the page before pressing reject and approve doesn't cause any errors.

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
