### PR TITLE
fix: hydration error on dashboard

### DIFF
--- a/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
+++ b/src/components/dashboard/GovernanceSection/GovernanceSection.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Typography, Card, Box, Alert, IconButton, Link, SvgIcon } from '@mui/material'
 import { WidgetBody } from '@/components/dashboard/styled'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
@@ -137,6 +137,16 @@ const GovernanceSection = () => {
 // Prevent `GovernanceSection` hooks from needlessly being called
 const GovernanceSectionWrapper = () => {
   const chainId = useChainId()
+  const [isLayoutReady, setIsLayoutReady] = useState(false)
+
+  useEffect(() => {
+    setIsLayoutReady(true)
+  }, [])
+
+  if (!isLayoutReady) {
+    return null
+  }
+
   if (!getSafeTokenAddress(chainId)) {
     return null
   }


### PR DESCRIPTION
When in dev mode and on a chain different than eth or sepolia every refresh display a “Hydration failed error”. It turns out that the governance module is being rendered on the server, where in the client it return null. This is caused by the use of useChainId hook which returns a default chain on the server, but on the client the actual chain the user is on. With the isLayoutReady check we make sure that this component actually only renders when ran on the client.

## What it solves
Hydration error in dev mode

## How this PR fixes it
Prevents rendering of the component on the server

## How to test it
In dev mode switch the chain to something other than mainnet and sepolia. When on the dashboard refresh - you shouldn't see a hydration error.

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
