### PR TITLE
fix: move scroll.io from blocked bridges to the warned bridges

### DIFF
--- a/src/features/walletconnect/constants.ts
+++ b/src/features/walletconnect/constants.ts
@@ -52,7 +52,6 @@ export const BlockedBridges = [
   'bridge.zora.energy',
   'bridge.mantle.xyz',
   'bridge.metis.io',
-  'scroll.io',
   'pacific-bridge.manta.network',
   'tokenbridge.rsk.co',
   'canto.io',
@@ -89,6 +88,7 @@ export const WarnedBridges = [
   'portal.txsync.io',
   'bridge.wanchain.org',
   'app.xy.finance',
+  'scroll.io',
 ]
 
 export const WarnedBridgeNames = ['Across Bridge', 'Hop']


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/safe-wallet-web/issues/3435

## How this PR fixes it

Moved scroll.io from BlockedBridges to the WarnedBridges.

## How to test it

1. open WalletConnect widget
2. open https://scroll.io/bridge
3. try to establish a connection from Safe{Wallet} to Scroll Bridge

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
