### PR TITLE
fix: Remove counterfactual backup option

### DIFF
--- a/cypress/e2e/pages/create_wallet.pages.js
+++ b/cypress/e2e/pages/create_wallet.pages.js
@@ -26,7 +26,6 @@ const networkFeeSection = '[data-tetid="network-fee-section"]'
 const nextBtn = '[data-testid="next-btn"]'
 const backBtn = '[data-testid="back-btn"]'
 const cancelBtn = '[data-testid="cancel-btn"]'
-const safeBackupAlert = '[data-testid="safe-backup-alert"]'
 const dialogConfirmBtn = '[data-testid="dialog-confirm-btn"]'
 const safeActivationSection = '[data-testid="activation-section"]'
 const addressAutocompleteOptions = '[data-testid="address-item"]'
@@ -41,7 +40,7 @@ export const defaultSepoliaPlaceholder = 'Sepolia Safe'
 const welcomeToSafeStr = 'Welcome to Safe'
 
 export function verifyNewSafeDialogModal() {
-  main.verifyElementsIsVisible([safeBackupAlert, dialogConfirmBtn])
+  main.verifyElementsIsVisible([dialogConfirmBtn])
 }
 //
 export function verifyCFSafeCreated() {

--- a/src/components/dashboard/CreationDialog/index.tsx
+++ b/src/components/dashboard/CreationDialog/index.tsx
@@ -1,12 +1,5 @@
-import { selectUndeployedSafe, type UndeployedSafe } from '@/features/counterfactual/store/undeployedSafesSlice'
-import useChainId from '@/hooks/useChainId'
-import useSafeInfo from '@/hooks/useSafeInfo'
-import { trackEvent } from '@/services/analytics'
-import { COUNTERFACTUAL_EVENTS } from '@/services/analytics/events/counterfactual'
-import { useAppSelector } from '@/store'
-import type { PredictedSafeProps } from '@safe-global/protocol-kit'
-import React, { type ElementType, type MouseEvent } from 'react'
-import { Alert, Box, Button, Dialog, DialogContent, Grid, Link, SvgIcon, Typography } from '@mui/material'
+import React, { type ElementType } from 'react'
+import { Box, Button, Dialog, DialogContent, Grid, SvgIcon, Typography } from '@mui/material'
 import { useRouter } from 'next/router'
 
 import HomeIcon from '@/public/images/sidebar/home.svg'
@@ -34,43 +27,17 @@ const HintItem = ({ Icon, title, description }: { Icon: ElementType; title: stri
   )
 }
 
-const getExportFileName = () => {
-  const today = new Date().toISOString().slice(0, 10)
-  return `safe-backup-${today}.json`
-}
-
-const backupSafe = (chainId: string, safeAddress: string, undeployedSafe: PredictedSafeProps) => {
-  const data = JSON.stringify({ chainId, safeAddress, safeProps: undeployedSafe }, null, 2)
-
-  const blob = new Blob([data], { type: 'text/json' })
-  const link = document.createElement('a')
-
-  link.download = getExportFileName()
-  link.href = window.URL.createObjectURL(blob)
-  link.dataset.downloadurl = ['text/json', link.download, link.href].join(':')
-  link.dispatchEvent(new MouseEvent('click'))
-}
-
 const CreationDialog = () => {
   const router = useRouter()
   const [open, setOpen] = React.useState(true)
   const [remoteSafeApps = []] = useRemoteSafeApps()
   const chain = useCurrentChain()
-  const chainId = useChainId()
-  const { safeAddress } = useSafeInfo()
-  const undeployedSafe = useAppSelector((state) => selectUndeployedSafe(state, chainId, safeAddress))
 
   const onClose = () => {
     const { [CREATION_MODAL_QUERY_PARM]: _, ...query } = router.query
     router.replace({ pathname: router.pathname, query })
 
     setOpen(false)
-  }
-
-  const onBackup = (e: MouseEvent<HTMLAnchorElement>, undeployedSafe: UndeployedSafe) => {
-    e.preventDefault()
-    trackEvent(COUNTERFACTUAL_EVENTS.BACKUP_COUNTERFACTUAL_SAFE)
-    backupSafe(chainId, safeAddress, undeployedSafe.props)
   }
 
   return (
@@ -107,16 +74,6 @@ const CreationDialog = () => {
             description="Have any questions? Check out our collection of articles."
           />
         </Grid>
-
-        {undeployedSafe && (
-          <Alert data-testid="safe-backup-alert" severity="info" sx={{ mb: 2 }}>
-            We recommend{' '}
-            <Link href="#" onClick={(e) => onBackup(e, undeployedSafe)}>
-              backing up your Safe Account
-            </Link>{' '}
-            in case you lose access to this device.
-          </Alert>
-        )}
 
         <Box display="flex" justifyContent="center">
           <Button data-testid="dialog-confirm-btn" onClick={onClose} variant="contained" size="stretched">

--- a/src/services/analytics/events/counterfactual.ts
+++ b/src/services/analytics/events/counterfactual.ts
@@ -3,11 +3,6 @@ import { EventType } from '@/services/analytics'
 const COUNTERFACTUAL_CATEGORY = 'counterfactual'
 
 export const COUNTERFACTUAL_EVENTS = {
-  BACKUP_COUNTERFACTUAL_SAFE: {
-    action: 'Backup counterfactual safe',
-    category: COUNTERFACTUAL_CATEGORY,
-    event: EventType.CLICK,
-  },
   CHECK_BALANCES: {
     action: 'Check balances on block explorer',
     category: COUNTERFACTUAL_CATEGORY,


### PR DESCRIPTION
## What it solves

Follow up on #3203 

Less than 4% of users who created a counterfactual safe did a backup according to our analytics. Furthermore we received feedback that this option is confusing. As there is currently no strategy to restore those backups this option seems more confusing than it is useful. In case users with an existing backup reach out to us we can still handle those manually.

## How to test it

1. Create a new counterfactual safe
2. Observe no Backup option

## Screenshots
<img width="710" alt="Screenshot 2024-03-15 at 15 13 47" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/72e2dd01-5ee4-4aa0-b116-05abdc75d2dc">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
