### PR TITLE
fix: safeTxGas for rejection txs

### DIFF
--- a/src/components/tx-flow/SafeTxProvider.tsx
+++ b/src/components/tx-flow/SafeTxProvider.tsx
@@ -2,7 +2,7 @@ import { createContext, useState, useEffect } from 'react'
 import type { Dispatch, ReactNode, SetStateAction, ReactElement } from 'react'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { createTx } from '@/services/tx/tx-sender'
-import { useRecommendedNonce, useSafeTxGas } from '../tx/SignOrExecuteForm/hooks'
+import { useRecommendedNonce } from '../tx/SignOrExecuteForm/hooks'
 import { Errors, logError } from '@/services/exceptions'
 import type { EIP712TypedData } from '@safe-global/safe-gateway-typescript-sdk'
 
@@ -45,13 +45,12 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
   // Signed txs cannot be updated
   const isSigned = safeTx && safeTx.signatures.size > 0
 
-  // Recommended nonce and safeTxGas
+  // Recommended nonce
   const recommendedNonce = useRecommendedNonce()
-  const recommendedSafeTxGas = useSafeTxGas(safeTx)
 
   // Priority to external nonce, then to the recommended one
   const finalNonce = isSigned ? safeTx?.data.nonce : nonce ?? recommendedNonce ?? safeTx?.data.nonce
-  const finalSafeTxGas = isSigned ? safeTx?.data.safeTxGas : safeTxGas ?? recommendedSafeTxGas ?? safeTx?.data.safeTxGas
+  const finalSafeTxGas = isSigned ? safeTx?.data.safeTxGas : safeTxGas ?? safeTx?.data.safeTxGas
 
   // Update the tx when the nonce or safeTxGas change
   useEffect(() => {

--- a/src/components/tx/SignOrExecuteForm/hooks.ts
+++ b/src/components/tx/SignOrExecuteForm/hooks.ts
@@ -14,7 +14,7 @@ import {
   dispatchTxSigning,
 } from '@/services/tx/tx-sender'
 import { useHasPendingTxs } from '@/hooks/usePendingTxs'
-import { getSafeTxGas, getNonces } from '@/services/tx/tx-sender/recommendedNonce'
+import { getNonces } from '@/services/tx/tx-sender/recommendedNonce'
 import useAsync from '@/hooks/useAsync'
 import { useUpdateBatch } from '@/hooks/useDraftBatch'
 import { type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
@@ -163,30 +163,6 @@ export const useRecommendedNonce = (): number | undefined => {
   )
 
   return recommendedNonce
-}
-
-export const useSafeTxGas = (safeTx: SafeTransaction | undefined): string | undefined => {
-  const { safeAddress, safe } = useSafeInfo()
-
-  // Memoize only the necessary params so that the useAsync hook is not called every time safeTx changes
-  const safeTxParams = useMemo(() => {
-    return !safeTx?.data?.to
-      ? undefined
-      : {
-          to: safeTx?.data.to,
-          value: safeTx?.data?.value,
-          data: safeTx?.data?.data,
-          operation: safeTx?.data?.operation,
-        }
-  }, [safeTx?.data.to, safeTx?.data.value, safeTx?.data.data, safeTx?.data.operation])
-
-  const [safeTxGas] = useAsync(() => {
-    if (!safe.chainId || !safeAddress || !safeTxParams || !safe.version) return
-
-    return getSafeTxGas(safe.chainId, safeAddress, safe.version, safeTxParams)
-  }, [safeAddress, safe.chainId, safe.version, safeTxParams])
-
-  return safeTxGas
 }
 
 export const useAlreadySigned = (safeTx: SafeTransaction | undefined): boolean => {

--- a/src/services/tx/tx-sender/recommendedNonce.ts
+++ b/src/services/tx/tx-sender/recommendedNonce.ts
@@ -1,44 +1,5 @@
-import {
-  Operation,
-  postSafeGasEstimation,
-  getNonces as fetchNonces,
-  type SafeTransactionEstimation,
-} from '@safe-global/safe-gateway-typescript-sdk'
-import type { MetaTransactionData, SafeTransactionDataPartial } from '@safe-global/safe-core-sdk-types'
-import { isLegacyVersion } from '@/hooks/coreSDK/safeCoreSDK'
+import { getNonces as fetchNonces } from '@safe-global/safe-gateway-typescript-sdk'
 import { Errors, logError } from '@/services/exceptions'
-
-const fetchRecommendedParams = async (
-  chainId: string,
-  safeAddress: string,
-  txParams: MetaTransactionData,
-): Promise<SafeTransactionEstimation> => {
-  return postSafeGasEstimation(chainId, safeAddress, {
-    to: txParams.to,
-    value: txParams.value,
-    data: txParams.data,
-    operation: (txParams.operation as unknown as Operation) || Operation.CALL,
-  })
-}
-
-export const getSafeTxGas = async (
-  chainId: string,
-  safeAddress: string,
-  safeVersion: string,
-  safeTxData: SafeTransactionDataPartial,
-): Promise<string | undefined> => {
-  const isSafeTxGasRequired = isLegacyVersion(safeVersion)
-
-  // For 1.3.0+ Safes safeTxGas is not required
-  if (!isSafeTxGasRequired) return '0'
-
-  try {
-    const estimation = await fetchRecommendedParams(chainId, safeAddress, safeTxData)
-    return estimation.safeTxGas
-  } catch (e) {
-    logError(Errors._616, e)
-  }
-}
 
 export const getNonces = async (chainId: string, safeAddress: string) => {
   try {


### PR DESCRIPTION

## What it solves
The protocol-kit estimates the safeTxGas correctly but our SafeTxProvider overrides it with it's own estimation. Therefore this logic is removed with this commit so we only rely on the safeTxGas from the core-sdk.

Resolves #3171 

## How this PR fixes it
Remove all safeTxGas logic from our interface and let the protocol-kit handle it in `createTransaction` (except if the user explicitly overrides it)

## How to test it
- Use a 1.1.1 Safe and create a Rejection tx
- Observe that safeTxGas is 0 and it decodes correctly to a rejection

## Screenshots

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
