### PR TITLE
fix: Hamburger-icon

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -54,7 +54,7 @@ const Header = ({ onMenuToggle, onBatchToggle }: HeaderProps): ReactElement => {
   return (
     <Paper className={css.container}>
       <div className={classnames(css.element, css.menuButton, !onMenuToggle ? css.hideSidebarMobile : null)}>
-        <IconButton onClick={handleMenuToggle} size="large" edge="start" color="default" aria-label="menu">
+        <IconButton onClick={handleMenuToggle} size="large" color="default" aria-label="menu">
           <MenuIcon />
         </IconButton>
       </div>

--- a/src/components/common/Header/styles.module.css
+++ b/src/components/common/Header/styles.module.css
@@ -51,6 +51,10 @@
   display: none;
 }
 
+.menuButton > Button {
+  padding: var(--space-2);
+}
+
 .networkSelector {
   border-right: none;
 }
@@ -70,10 +74,6 @@
 }
 
 @media (max-width: 599.95px) {
-  .menuButton {
-    padding-left: var(--space-2);
-  }
-
   .hideMobile {
     display: none;
   }

--- a/src/components/common/Header/styles.module.css
+++ b/src/components/common/Header/styles.module.css
@@ -51,10 +51,6 @@
   display: none;
 }
 
-.menuButton > Button {
-  padding: var(--space-2);
-}
-
 .networkSelector {
   border-right: none;
 }


### PR DESCRIPTION
## What it solves
Hamburger icon is not left padded

Resolves #3372
Padding on left of hamburger icon matches that above and below it.

## How this PR fixes it
1. Removing edge="start" which uses a negative margin to counteract the padding on one side (this is often helpful for aligning the left or right side of the icon with content above or below, without ruining the border size and shape).

2. Removing unnecessary padding-left provided to MUI IconButton and adding padding 16 px to the Button child element of IconButton.

## How to test it
As it is a ui/css change you can test the issue with the steps mentioned in reproducing it.

## Screenshots

<img width="501" alt="Screenshot 2024-03-19 at 8 55 51 PM" src="https://github.com/safe-global/safe-wallet-web/assets/13777189/a94809e9-5595-4bd0-a5d1-6a3d290c4032">

<img width="524" alt="Screenshot 2024-03-19 at 8 57 40 PM" src="https://github.com/safe-global/safe-wallet-web/assets/13777189/46f6af26-ff3b-478f-b092-8dc516f14ac7">

<img width="500" alt="Screenshot 2024-03-19 at 8 58 03 PM" src="https://github.com/safe-global/safe-wallet-web/assets/13777189/7d6efbce-23f7-481b-9595-e18caa30b529">


## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
