### PR TITLE
fix: Remove display version on unsupported contract

### DIFF
--- a/src/components/settings/ContractVersion/index.tsx
+++ b/src/components/settings/ContractVersion/index.tsx
@@ -33,10 +33,10 @@ export const ContractVersion = () => {
       </Typography>
 
       <Typography variant="body1" fontWeight={400}>
-        {safeLoaded ? safe.version ? safe.version : 'Unsupported contract' : <Skeleton width="60px" />}
+        {safeLoaded ? safe.version ?? 'Unsupported contract' : <Skeleton width="60px" />}
       </Typography>
       <Box mt={2}>
-        {safeLoaded ? (
+        {safeLoaded && safe.version ? (
           showUpdateDialog ? (
             <Alert
               sx={{ borderRadius: '2px', borderColor: '#B0FFC9' }}


### PR DESCRIPTION
## What it solves

Resolves #3436

## How this PR fixes it
It adds an additional check on safe.version before displaying version tag (green mark and label).

## How to test it
Open https://localhost:3000/settings/setup?safe=matic:0x68d231A531BcF34199a825AE568aa79b695f7965 and check there is no "Latest Version" label

## Screenshots
![image](https://github.com/safe-global/safe-wallet-web/assets/34529009/10434606-81ab-4080-b0a5-a0bd5aed62f9)

