### PR TITLE
feat: Auto approve verified WC sessions

### DIFF
--- a/src/features/walletconnect/components/WalletConnectProvider/index.tsx
+++ b/src/features/walletconnect/components/WalletConnectProvider/index.tsx
@@ -19,6 +19,7 @@ enum Errors {
 export enum WCLoadingState {
   APPROVE = 'Approve',
   REJECT = 'Reject',
+  CONNECT = 'Connect',
   DISCONNECT = 'Disconnect',
 }
 

--- a/src/features/walletconnect/components/WcSessionMananger/index.tsx
+++ b/src/features/walletconnect/components/WcSessionMananger/index.tsx
@@ -45,8 +45,11 @@ const WcSessionManager = ({ sessions, uri }: WcSessionManagerProps) => {
       try {
         await walletConnect.approveSession(sessionProposal, chainId, safeAddress)
 
-        // Auto approve future sessions for verified dApps
-        if (sessionProposal.verifyContext.verified.validation === 'VALID') {
+        // Auto approve future sessions for non-malicious dApps
+        if (
+          sessionProposal.verifyContext.verified.validation !== 'INVALID' &&
+          !sessionProposal.verifyContext.verified.isScam
+        ) {
           setAutoApprove((prev) => ({
             ...prev,
             [chainId]: { ...prev?.[chainId], [sessionProposal.verifyContext.verified.origin]: true },
@@ -64,7 +67,7 @@ const WcSessionManager = ({ sessions, uri }: WcSessionManagerProps) => {
       setIsLoading(undefined)
       setProposal(undefined)
     },
-    [proposal, walletConnect, chainId, safeAddress, setIsLoading, setAutoApprove, setError],
+    [proposal, walletConnect, chainId, safeAddress, setIsLoading, setOpen, setAutoApprove, setError],
   )
 
   // Reset error

--- a/src/features/walletconnect/components/WcSessionMananger/index.tsx
+++ b/src/features/walletconnect/components/WcSessionMananger/index.tsx
@@ -1,3 +1,7 @@
+import { WCLoadingState } from '@/features/walletconnect/components/WalletConnectProvider'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import { asError } from '@/services/exceptions/utils'
+import useLocalStorage from '@/services/local-storage/useLocalStorage'
 import { useCallback, useContext, useEffect, useState } from 'react'
 import type { Web3WalletTypes } from '@walletconnect/web3wallet'
 import type { SessionTypes } from '@walletconnect/types'
@@ -14,9 +18,46 @@ type WcSessionManagerProps = {
   uri: string
 }
 
+const WC_AUTO_APPROVE_KEY = 'wcAutoApprove'
+
 const WcSessionManager = ({ sessions, uri }: WcSessionManagerProps) => {
-  const { walletConnect, error, setError, open } = useContext(WalletConnectContext)
+  const [autoApprove = {}, setAutoApprove] = useLocalStorage<Record<string, boolean>>(WC_AUTO_APPROVE_KEY)
+  const { walletConnect, error, setError, open, setIsLoading } = useContext(WalletConnectContext)
+  const { safe, safeAddress } = useSafeInfo()
+  const { chainId } = safe
   const [proposal, setProposal] = useState<Web3WalletTypes.SessionProposal>()
+
+  // On session approve
+  const onApprove = useCallback(
+    async (proposalData?: Web3WalletTypes.SessionProposal) => {
+      const sessionProposal = proposalData || proposal
+
+      if (!walletConnect || !chainId || !safeAddress || !sessionProposal) return
+
+      const label = sessionProposal?.params.proposer.metadata.url
+      trackEvent({ ...WALLETCONNECT_EVENTS.APPROVE_CLICK, label })
+
+      setIsLoading(WCLoadingState.APPROVE)
+
+      try {
+        await walletConnect.approveSession(sessionProposal, chainId, safeAddress)
+
+        // Auto approve future sessions for verified dApps
+        if (sessionProposal.verifyContext.verified.validation === 'VALID') {
+          setAutoApprove((prev) => ({ ...prev, [sessionProposal.verifyContext.verified.origin]: true }))
+        }
+      } catch (e) {
+        setIsLoading(undefined)
+        setError(asError(e))
+        return
+      }
+
+      trackEvent({ ...WALLETCONNECT_EVENTS.CONNECTED, label })
+      setIsLoading(undefined)
+      setProposal(undefined)
+    },
+    [proposal, walletConnect, chainId, safeAddress, setIsLoading, setAutoApprove, setError],
+  )
 
   // Reset error
   const onErrorReset = useCallback(() => {
@@ -28,9 +69,15 @@ const WcSessionManager = ({ sessions, uri }: WcSessionManagerProps) => {
     if (!walletConnect) return
     return walletConnect.onSessionPropose((proposalData) => {
       setError(null)
+
+      if (autoApprove[proposalData.verifyContext.verified.origin]) {
+        onApprove(proposalData)
+        return
+      }
+
       setProposal(proposalData)
     })
-  }, [walletConnect, setError])
+  }, [walletConnect, setError, autoApprove, onApprove])
 
   // Track errors
   useEffect(() => {
@@ -51,7 +98,7 @@ const WcSessionManager = ({ sessions, uri }: WcSessionManagerProps) => {
 
   // Session proposal
   if (proposal) {
-    return <WcProposalForm proposal={proposal} setProposal={setProposal} />
+    return <WcProposalForm proposal={proposal} setProposal={setProposal} onApprove={onApprove} />
   }
 
   // Connection form (initial state)


### PR DESCRIPTION
## What it solves

Resolves #3395 

## How this PR fixes it

- Stores approvals for verified dApps per chain and auto approves future sessions

## How to test it

1. Open a Safe
2. Open a verified dApp (e.g. CowSwap)
3. Connect CowSwap to your Safe
4. A green message should be visible on the Approve screen
6. Press Approve
7. Disconnect the session and connect to CowSwap again
8. Observe no Approve screen and automatically connecting
9. Switch to a different chain and connect with CowSwap again
10. Observe the session is not auto approved
11. Oberve that the dialog closes on approval 

## Screenshots


https://github.com/safe-global/safe-wallet-web/assets/5880855/a302c57d-71d3-4af6-9895-9239014f43e8



## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
