### PR TITLE
fix: Redirect user to accounts page on social login

### DIFF
--- a/src/components/common/SocialSigner/index.tsx
+++ b/src/components/common/SocialSigner/index.tsx
@@ -62,6 +62,7 @@ export const SocialSigner = ({ socialWalletService, wallet, onLogin, onRequirePa
       setLoginError(error.message)
     } finally {
       setLoginPending(false)
+      onLogin?.()
     }
   }
 

--- a/src/components/welcome/WelcomeLogin/index.tsx
+++ b/src/components/welcome/WelcomeLogin/index.tsx
@@ -69,7 +69,7 @@ const WelcomeLogin = () => {
               </Typography>
             </Divider>
 
-            <SocialSigner />
+            <SocialSigner onLogin={onLogin} />
           </>
         )}
 


### PR DESCRIPTION
## What it solves

Resolves #3428 

## How this PR fixes it

- Passes the `onLogin` handler to `SocialSigner`

## How to test it

1. Open Safe on Gnosis Chain
2. Connect with your Google Account
3. Observe being redirected to the Accounts page

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
