### PR TITLE
fix: Propose relay transactions without a signature

### DIFF
--- a/src/components/tx/SignOrExecuteForm/hooks.test.ts
+++ b/src/components/tx/SignOrExecuteForm/hooks.test.ts
@@ -539,7 +539,9 @@ describe('SignOrExecute hooks', () => {
       await expect(executeTx({ gasPrice: 1 }, tx, '123', 'origin.com', true)).rejects.toThrowError(
         'Cannot relay an unsigned transaction from a smart contract wallet',
       )
-      expect(proposeSpy).not.toHaveBeenCalled()
+
+      // We are proposing before signing
+      expect(proposeSpy).toHaveBeenCalled()
       expect(signSpy).not.toHaveBeenCalled()
       expect(relaySpy).not.toHaveBeenCalled()
     })

--- a/src/components/tx/SignOrExecuteForm/hooks.ts
+++ b/src/components/tx/SignOrExecuteForm/hooks.ts
@@ -102,8 +102,8 @@ export const useTxActions = (): TxActions => {
       let tx: TransactionDetails | undefined
       // Relayed transactions must be fully signed, so request a final signature if needed
       if (isRelayed && safeTx.signatures.size < safe.threshold) {
-        safeTx = await signRelayedTx(safeTx)
         tx = await proposeTx(wallet.address, safeTx, txId, origin)
+        safeTx = await signRelayedTx(safeTx)
         txId = tx.txId
       }
 


### PR DESCRIPTION
## What it solves

Resolves #3422

Relaying a transaction first prompts the user to sign and then proposes the signed transaction to the backend which makes it appear in the queue with one signature but in case the call to the relay service fails, the tx dialog is still open and the user can either Execute the transaction again or only sign if the recommended nonce updated fast enough. This is confusing because the same transaction is already in the queue. Instead the transaction should not be queued unless the relay call succeeds.

## How this PR fixes it

Propose the unsigned transaction to the backend in case the user tries to relay. That way it doesn't show up in the queue unless executed and the recommended nonce also won't increase in case there is an error from the relay call.

## How to test it

1. Open a Safe on Sepolia
2. Create a transfer to the same Safe
3. Try to relay
4. Observe an error
5. Observe no transaction in the queue
6. Create a transfer to a different Account
7. Try to relay
8. Observe no error and the transaction showing up in the queue

## Screenshots
<img width="1265" alt="Screenshot 2024-03-19 at 16 32 51" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/09e1c1ff-b78c-47e0-9787-fff2ed342da3">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
