### PR TITLE
fix: Propose signed transaction when relaying from the queue

### DIFF
--- a/src/components/tx/SignOrExecuteForm/hooks.test.ts
+++ b/src/components/tx/SignOrExecuteForm/hooks.test.ts
@@ -540,8 +540,7 @@ describe('SignOrExecute hooks', () => {
         'Cannot relay an unsigned transaction from a smart contract wallet',
       )
 
-      // We are proposing before signing
-      expect(proposeSpy).toHaveBeenCalled()
+      expect(proposeSpy).not.toHaveBeenCalled()
       expect(signSpy).not.toHaveBeenCalled()
       expect(relaySpy).not.toHaveBeenCalled()
     })

--- a/src/components/tx/SignOrExecuteForm/hooks.ts
+++ b/src/components/tx/SignOrExecuteForm/hooks.ts
@@ -102,9 +102,16 @@ export const useTxActions = (): TxActions => {
       let tx: TransactionDetails | undefined
       // Relayed transactions must be fully signed, so request a final signature if needed
       if (isRelayed && safeTx.signatures.size < safe.threshold) {
+        if (txId) {
+          safeTx = await signRelayedTx(safeTx)
+        }
+
         tx = await proposeTx(wallet.address, safeTx, txId, origin)
-        safeTx = await signRelayedTx(safeTx)
         txId = tx.txId
+
+        if (!txId) {
+          safeTx = await signRelayedTx(safeTx)
+        }
       }
 
       // Propose the tx if there's no id yet ("immediate execution")

--- a/src/components/tx/SignOrExecuteForm/hooks.ts
+++ b/src/components/tx/SignOrExecuteForm/hooks.ts
@@ -104,14 +104,12 @@ export const useTxActions = (): TxActions => {
       if (isRelayed && safeTx.signatures.size < safe.threshold) {
         if (txId) {
           safeTx = await signRelayedTx(safeTx)
-        }
-
-        tx = await proposeTx(wallet.address, safeTx, txId, origin)
-        txId = tx.txId
-
-        if (!txId) {
+          tx = await proposeTx(wallet.address, safeTx, txId, origin)
+        } else {
+          tx = await proposeTx(wallet.address, safeTx, txId, origin)
           safeTx = await signRelayedTx(safeTx)
         }
+        txId = tx.txId
       }
 
       // Propose the tx if there's no id yet ("immediate execution")


### PR DESCRIPTION
## What it solves

Part of #3422 

## How this PR fixes it

This is a follow up to #3457 which solved the issue for immediately executed relay transactions but in case a user queued a transaction first and then decided to relay it would fail. We now check for the `txId` when relaying:

- If there is a `txId` it means the transaction has already been created and is queued so we propose the signed transaction
- If there is no `txId` it means it is an immediate execution so we propose the unsigned transaction

## ToDo

- [ ] Write more tests for hooks.ts

## How to test it

1. Open a 1/1 Safe on Sepolia
2. Create a new transaction to your own Safe (so that relaying fails)
3. Upon execution there should be an error message visible
4. There should not be a transaction in the queue

---

1. Switch to a 2/n Safe on Sepolia
2. Create a new transaction to your own Safe (so that relaying fails)
3. Sign that transaction
4. Switch to a different Owner
6. Go to the queue and Confirm the transaction
7. Upon relaying there should be an error
8. Close the tx dialog and observe that the queued transaction has one more signature now
9. It can be executed without relaying

---

1. Switch to a 2/n Safe on Sepolia
2. Create a new transaction that would not fail relay (e.g. transfer something out of your Safe)
3. Sign the transaction
4. Switch to a different Owner
5. Go to the queue and Confirm the transaction
6. Observe no error during relaying
7. Observe that the transaction executes correctly

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
