### PR TITLE
fix: Revert warning.background color in dark mode

### DIFF
--- a/src/components/theme/darkPalette.ts
+++ b/src/components/theme/darkPalette.ts
@@ -42,7 +42,7 @@ const darkPalette = {
     dark: '#C04C32',
     main: '#FF8061',
     light: '#FFBC9F',
-    background: '#FFF1E0',
+    background: '#2F2318',
   },
   background: {
     default: '#121312',

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -81,7 +81,7 @@
   --color-warning-dark: #c04c32;
   --color-warning-main: #ff8061;
   --color-warning-light: #ffbc9f;
-  --color-warning-background: #fff1e0;
+  --color-warning-background: #2f2318;
   --color-background-default: #121312;
   --color-background-main: #121312;
   --color-background-paper: #1c1c1c;
@@ -123,7 +123,7 @@
     --color-warning-dark: #c04c32;
     --color-warning-main: #ff8061;
     --color-warning-light: #ffbc9f;
-    --color-warning-background: #fff1e0;
+    --color-warning-background: #2f2318;
     --color-background-default: #121312;
     --color-background-main: #121312;
     --color-background-paper: #1c1c1c;


### PR DESCRIPTION
## What it solves

Resolves #3464

## How this PR fixes it

Reverts back to the previous `warning.background` color in dark mode

## How to test it

1. Open a Safe
2. Switch to dark mode
3. Go to the Settings and create a recovery
4. Observe that the warning text is readable

## Screenshots
<img width="718" alt="Screenshot 2024-03-22 at 10 57 30" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/16b70054-5c9d-4f81-8688-9402ac4bf3fe">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
