### PR TITLE
fix: Overlapping buttons when signing a transaction

### DIFF
--- a/src/components/tx-flow/common/TxLayout/index.tsx
+++ b/src/components/tx-flow/common/TxLayout/index.tsx
@@ -82,6 +82,7 @@ const TxLayout = ({
 
   const theme = useTheme()
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'))
+  const isDesktop = useMediaQuery(theme.breakpoints.down('lg'))
 
   const steps = Array.isArray(children) ? children : [children]
   const progress = Math.round(((step + 1) / steps.length) * 100)
@@ -143,7 +144,7 @@ const TxLayout = ({
                     {onBack && step > 0 && (
                       <Button
                         data-testid="modal-back-btn"
-                        variant="contained"
+                        variant={isDesktop ? 'text' : 'contained'}
                         onClick={onBack}
                         className={css.backButton}
                       >

--- a/src/components/tx-flow/common/TxLayout/styles.module.css
+++ b/src/components/tx-flow/common/TxLayout/styles.module.css
@@ -108,7 +108,15 @@
   /* Height of transaction type title */
   margin-top: 46px;
 }
-
+@media (max-width: 1199.95px) {
+  .backButton {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+  .step :global(.MuiCardActions-root) {
+    margin-bottom: var(--space-8);
+  }
+}
 @media (max-width: 899.95px) {
   .widget {
     position: absolute;

--- a/src/components/tx/SignOrExecuteForm/BatchButton.tsx
+++ b/src/components/tx/SignOrExecuteForm/BatchButton.tsx
@@ -1,5 +1,5 @@
 import { type SyntheticEvent } from 'react'
-import { Box, Button, SvgIcon, Tooltip } from '@mui/material'
+import { Box, Button, Divider, SvgIcon, Tooltip } from '@mui/material'
 import PlusIcon from '@/public/images/common/plus.svg'
 import Track from '@/components/common/Track'
 import { BATCH_EVENTS } from '@/services/analytics'
@@ -17,7 +17,12 @@ const BatchButton = ({
     <Tooltip title={tooltip} placement="top">
       <span>
         <Track {...BATCH_EVENTS.BATCH_APPEND}>
-          <Button variant="outlined" onClick={onClick} disabled={disabled} sx={{ display: ['none', 'flex'] }}>
+          <Button
+            variant="outlined"
+            onClick={onClick}
+            disabled={disabled}
+            sx={{ display: ['none', 'flex'], width: ['100%', '100%', '100%', 'auto'] }}
+          >
             <SvgIcon component={PlusIcon} inheritViewBox fontSize="small" sx={{ mr: 1 }} />
             Add to batch
           </Button>
@@ -26,7 +31,15 @@ const BatchButton = ({
     </Tooltip>
     <Box display={['none', 'flex']} flexDirection="column" justifyContent="center" color="border.main">
       {' '}
-      or
+      <Divider
+        sx={{
+          '&:before': {
+            display: { sx: 'block', lg: 'none' },
+          },
+        }}
+      >
+        or
+      </Divider>
     </Box>
   </>
 )

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -1,7 +1,7 @@
 import madProps from '@/utils/mad-props'
 import { type ReactElement, type SyntheticEvent, useContext, useState } from 'react'
 import { CircularProgress, Box, Button, CardActions, Divider } from '@mui/material'
-
+import Stack from '@mui/system/Stack'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import { trackError, Errors } from '@/services/exceptions'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
@@ -114,7 +114,13 @@ export const SignForm = ({
       <Divider className={commonCss.nestedDivider} sx={{ pt: 3 }} />
 
       <CardActions>
-        <Box display="flex" gap={2}>
+        <Stack
+          sx={{
+            width: ['100%', '100%', '100%', 'auto'],
+          }}
+          direction={{ xs: 'column-reverse', lg: 'row' }}
+          spacing={{ xs: 2, md: 2 }}
+        >
           {/* Batch button */}
           {isCreation && !isBatch && (
             <BatchButton
@@ -132,13 +138,13 @@ export const SignForm = ({
                 variant="contained"
                 type="submit"
                 disabled={!isOk || submitDisabled}
-                sx={{ minWidth: '82px' }}
+                sx={{ minWidth: '82px', order: '1', width: ['100%', '100%', '100%', 'auto'] }}
               >
                 {!isSubmittable ? <CircularProgress size={20} /> : 'Sign'}
               </Button>
             )}
           </CheckWallet>
-        </Box>
+        </Stack>
       </CardActions>
     </form>
   )


### PR DESCRIPTION
## What it solves
Overlapping buttons when signing a transaction #3403

Resolves #3403

## How this PR fixes it: 
As per the designs provided removed box component and used stack component to achieve the responsive design for different screen widths.  Added media queries for respective screen sizes to render the buttons as asked in the design.

## How to test it
Tested on various devices, screen sizes also by resizing the window.

## Screenshots

<img width="1022" alt="Screenshot 2024-03-25 at 1 54 14 PM" src="https://github.com/safe-global/safe-wallet-web/assets/15044077/08e3af26-f4dd-4a21-aba0-82dbbca2c365">
<img width="1249" alt="Screenshot 2024-03-25 at 2 00 17 PM" src="https://github.com/safe-global/safe-wallet-web/assets/15044077/5e2ca65e-36df-45b1-9534-2810e671bd85">
<img width="630" alt="Screenshot 2024-03-25 at 1 54 30 PM" src="https://github.com/safe-global/safe-wallet-web/assets/15044077/03df7f6a-aa66-4bd9-be13-d1c68bc42b08">

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
