### PR TITLE
Update eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,8 @@
         "additionalHooks": "useAsync"
       }
     ],
-    "no-only-tests/no-only-tests": "error"
+    "no-only-tests/no-only-tests": "error",
+    "object-shorthand": ["error", "properties"]
   },
   "ignorePatterns": ["node_modules/", ".next/", ".github/"],
   "plugins": ["unused-imports", "@typescript-eslint", "no-only-tests"]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,9 @@
       }
     ],
     "no-only-tests/no-only-tests": "error",
-    "object-shorthand": ["error", "properties"]
+    "object-shorthand": ["error", "properties"],
+    "jsx-quotes": ["error", "prefer-double"],
+    "react/jsx-curly-brace-presence": ["error", { "props": "never", "children": "never" }]
   },
   "ignorePatterns": ["node_modules/", ".next/", ".github/"],
   "plugins": ["unused-imports", "@typescript-eslint", "no-only-tests"]

--- a/cypress/e2e/pages/address_book.page.js
+++ b/cypress/e2e/pages/address_book.page.js
@@ -223,7 +223,7 @@ export function verifyEditedNameNotExists(name) {
 }
 
 export function clickOnWhatsNewBtn(force = false) {
-  cy.contains(whatsNewBtnStr).click({ force: force })
+  cy.contains(whatsNewBtnStr).click({ force })
 }
 
 export function acceptBeamerCookies() {

--- a/cypress/e2e/pages/safeapps.pages.js
+++ b/cypress/e2e/pages/safeapps.pages.js
@@ -140,7 +140,7 @@ export function clearSearchAppInput() {
 }
 
 export function verifyLinkName(name) {
-  cy.findAllByRole('link', { name: name }).should('have.length', 1)
+  cy.findAllByRole('link', { name }).should('have.length', 1)
 }
 
 export function clickOnApp(app) {

--- a/src/components/batch/BatchIndicator/index.tsx
+++ b/src/components/batch/BatchIndicator/index.tsx
@@ -15,7 +15,7 @@ const BatchIndicator = ({ onClick }: { onClick?: () => void }) => {
           <Badge
             variant="standard"
             badgeContent={length}
-            color={'secondary'}
+            color="secondary"
             anchorOrigin={{
               vertical: 'bottom',
               horizontal: 'right',

--- a/src/components/common/EthHashInfo/index.test.tsx
+++ b/src/components/common/EthHashInfo/index.test.tsx
@@ -253,7 +253,7 @@ describe('EthHashInfo', () => {
       )
 
       const { container } = render(
-        <EthHashInfo address={'0xe26920604f9a02c5a877d449faa71b7504f0c2508dcc7c0384078a024b8e592f'} showCopyButton />,
+        <EthHashInfo address="0xe26920604f9a02c5a877d449faa71b7504f0c2508dcc7c0384078a024b8e592f" showCopyButton />,
       )
 
       const button = container.querySelector('button')

--- a/src/components/new-safe/create/logic/address-book.ts
+++ b/src/components/new-safe/create/logic/address-book.ts
@@ -14,9 +14,9 @@ export const updateAddressBook = (
   return (dispatch) => {
     dispatch(
       upsertAddressBookEntry({
-        chainId: chainId,
-        address: address,
-        name: name,
+        chainId,
+        address,
+        name,
       }),
     )
 
@@ -37,7 +37,7 @@ export const updateAddressBook = (
             value: owner.address,
             name: owner.name || owner.ens,
           })),
-          chainId: chainId,
+          chainId,
           nonce: 0,
         },
       }),

--- a/src/components/new-safe/create/logic/index.ts
+++ b/src/components/new-safe/create/logic/index.ts
@@ -164,7 +164,7 @@ export const estimateSafeCreationGas = async (
   const encodedSafeCreationTx = await encodeSafeCreationTx({ ...safeParams, chain })
 
   const gas = await provider.estimateGas({
-    from: from,
+    from,
     to: await readOnlyProxyFactoryContract.getAddress(),
     data: encodedSafeCreationTx,
   })

--- a/src/components/nfts/NftCollections/index.tsx
+++ b/src/components/nfts/NftCollections/index.tsx
@@ -86,7 +86,7 @@ const NftCollections = (): ReactElement => {
       )}
 
       {/* NFT preview */}
-      {<NftPreviewModal onClose={() => setPreviewNft(undefined)} nft={previewNft} />}
+      <NftPreviewModal onClose={() => setPreviewNft(undefined)} nft={previewNft} />
     </>
   )
 }

--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -107,9 +107,9 @@ const AppFrame = ({ appUrl, allowedFeaturesList, safeAppFromManifest }: AppFrame
       const data = {
         app: safeAppFromManifest,
         appId: remoteApp ? String(remoteApp.id) : undefined,
-        requestId: requestId,
-        txs: txs,
-        params: params,
+        requestId,
+        txs,
+        params,
       }
 
       setCurrentRequestId(requestId)

--- a/src/components/safe-apps/SafeAppCard/index.tsx
+++ b/src/components/safe-apps/SafeAppCard/index.tsx
@@ -84,7 +84,7 @@ const SafeAppCardGridView = ({
   openPreviewDrawer,
 }: SafeAppCardViewProps) => {
   return (
-    <SafeAppCardContainer safeAppUrl={safeAppUrl} onClickSafeApp={onClickSafeApp} height={'100%'}>
+    <SafeAppCardContainer safeAppUrl={safeAppUrl} onClickSafeApp={onClickSafeApp} height="100%">
       {/* Safe App Header */}
       <CardHeader
         className={css.safeAppHeader}

--- a/src/components/safe-apps/SafeAppSocialLinksCard/index.tsx
+++ b/src/components/safe-apps/SafeAppSocialLinksCard/index.tsx
@@ -85,7 +85,7 @@ const SafeAppSocialLinksCard = ({ safeApp }: SafeAppSocialLinksCardProps) => {
         )}
 
         {hasSocialLinks && developerWebsite && (
-          <Divider sx={{ height: '40px' }} orientation="vertical" component={'div'} />
+          <Divider sx={{ height: '40px' }} orientation="vertical" component="div" />
         )}
 
         {/* Developer website section */}

--- a/src/components/safe-apps/SafeAppsFilters/index.tsx
+++ b/src/components/safe-apps/SafeAppsFilters/index.tsx
@@ -118,7 +118,7 @@ const SafeAppsFilters = ({
             ) : (
               <MenuItem disabled sx={{ padding: '0 6px 2px 6px', height: CATEGORY_OPTION_HEIGHT }} disableGutters>
                 <ListItemText
-                  primary={'No categories defined'}
+                  primary="No categories defined"
                   primaryTypographyProps={{ fontSize: 14, paddingLeft: '5px' }}
                 />
               </MenuItem>

--- a/src/components/safe-messages/MsgSigners/index.tsx
+++ b/src/components/safe-messages/MsgSigners/index.tsx
@@ -121,7 +121,7 @@ export const MsgSigners = ({
             <ListItemText>
               <Box display="flex" flexDirection="row" alignItems="center" gap={1}>
                 <Skeleton variant="circular" width={36} height={36} />
-                <Typography variant="body2" color={'text.secondary'}>
+                <Typography variant="body2" color="text.secondary">
                   Confirmation #{idx + 1 + confirmationsSubmitted}
                 </Typography>
               </Box>

--- a/src/components/safe-messages/MsgSigners/index.tsx
+++ b/src/components/safe-messages/MsgSigners/index.tsx
@@ -102,7 +102,7 @@ export const MsgSigners = ({
         ))}
       {!showOnlyConfirmations && confirmations.length > 0 && (
         <ListItem>
-          <ListItemIcon sx={{ backgroundColor: backgroundColor }}>
+          <ListItemIcon sx={{ backgroundColor }}>
             <Dot />
           </ListItemIcon>
           <ListItemText>

--- a/src/components/settings/PushNotifications/hooks/__tests__/useNotificationPreferences.test.ts
+++ b/src/components/settings/PushNotifications/hooks/__tests__/useNotificationPreferences.test.ts
@@ -289,8 +289,8 @@ describe('useNotificationPreferences', () => {
 
         const preferences = {
           [`${chainId}:${safeAddress}`]: {
-            chainId: chainId,
-            safeAddress: safeAddress,
+            chainId,
+            safeAddress,
             preferences: DEFAULT_NOTIFICATION_PREFERENCES,
           },
         }
@@ -307,8 +307,8 @@ describe('useNotificationPreferences', () => {
         await waitFor(() => {
           expect(result.current.getAllPreferences()).toEqual({
             [`${chainId}:${safeAddress}`]: {
-              chainId: chainId,
-              safeAddress: safeAddress,
+              chainId,
+              safeAddress,
               preferences: {
                 ...DEFAULT_NOTIFICATION_PREFERENCES,
                 [WebhookType.CONFIRMATION_REQUEST]: false,

--- a/src/components/settings/owner/EditOwnerDialog/index.tsx
+++ b/src/components/settings/owner/EditOwnerDialog/index.tsx
@@ -25,8 +25,8 @@ export const EditOwnerDialog = ({ chainId, address, name }: { chainId: string; a
     if (data.name !== name) {
       dispatch(
         upsertAddressBookEntry({
-          chainId: chainId,
-          address: address,
+          chainId,
+          address,
           name: data.name,
         }),
       )

--- a/src/components/sidebar/WatchlistAddButton/index.tsx
+++ b/src/components/sidebar/WatchlistAddButton/index.tsx
@@ -25,7 +25,7 @@ const WatchlistAddButton = () => {
       pathname: AppRoutes.newSafe.load,
       query: {
         chain: chain?.shortName,
-        address: address,
+        address,
       },
     })
   }

--- a/src/components/transactions/UntrustedTxWarning/index.tsx
+++ b/src/components/transactions/UntrustedTxWarning/index.tsx
@@ -3,7 +3,7 @@ import WarningIcon from '@/public/images/notifications/warning.svg'
 
 const UntrustedTxWarning = () => {
   return (
-    <Tooltip title={`This token is unfamiliar and may pose risks when interacting with it or involved addresses`}>
+    <Tooltip title="This token is unfamiliar and may pose risks when interacting with it or involved addresses">
       <Box
         lineHeight="16px"
         sx={{

--- a/src/components/tx-flow/flows/AddOwner/ReviewOwner.tsx
+++ b/src/components/tx-flow/flows/AddOwner/ReviewOwner.tsx
@@ -44,7 +44,7 @@ export const ReviewOwner = ({ params }: { params: AddOwnerFlowProps | ReplaceOwn
     if (typeof newOwner.name !== 'undefined') {
       dispatch(
         upsertAddressBookEntry({
-          chainId: chainId,
+          chainId,
           address: newOwner.address,
           name: newOwner.name,
         }),

--- a/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
+++ b/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
@@ -87,7 +87,7 @@ export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowPr
               >
                 {existingAmount}
               </Typography>
-              {'→'}
+              →
             </>
           )}
         </SendAmountBlock>

--- a/src/components/tx/ApprovalEditor/hooks/useApprovalInfos.ts
+++ b/src/components/tx/ApprovalEditor/hooks/useApprovalInfos.ts
@@ -56,7 +56,7 @@ export const useApprovalInfos = (payload: {
               ? PSEUDO_APPROVAL_VALUES.UNLIMITED
               : formatUnits(approval.amount, tokenInfo?.decimals)
 
-          return { ...approval, tokenInfo: tokenInfo, amountFormatted }
+          return { ...approval, tokenInfo, amountFormatted }
         }),
       )
     },

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -162,7 +162,7 @@ export const ExecuteForm = ({
             Cannot execute a transaction from the Safe Account itself, please connect a different account.
           </ErrorMessage>
         ) : !walletCanPay && !willRelay ? (
-          <ErrorMessage level={'info'}>
+          <ErrorMessage level="info">
             Your connected wallet doesn&apos;t have enough funds to execute this transaction.
           </ErrorMessage>
         ) : (

--- a/src/components/tx/SignOrExecuteForm/__tests__/SignOrExecute.test.tsx
+++ b/src/components/tx/SignOrExecuteForm/__tests__/SignOrExecute.test.tsx
@@ -81,7 +81,7 @@ describe('SignOrExecute', () => {
         safeTx={safeTxBuilder().build()}
         onSubmit={jest.fn()}
         safeTxError={undefined}
-        txId={'someid'}
+        txId="someid"
         isExecutable={true}
         chainId="1"
       />,

--- a/src/components/tx/SignOrExecuteForm/hooks.test.ts
+++ b/src/components/tx/SignOrExecuteForm/hooks.test.ts
@@ -111,7 +111,7 @@ describe('SignOrExecute hooks', () => {
       jest.spyOn(wallet, 'default').mockReturnValue({
         chainId: '1',
         label: 'MetaMask',
-        address: address,
+        address,
       } as ConnectedWallet)
 
       const { result } = renderHook(() => useIsExecutionLoop())

--- a/src/features/counterfactual/hooks/usePendingSafeStatuses.ts
+++ b/src/features/counterfactual/hooks/usePendingSafeStatuses.ts
@@ -132,7 +132,7 @@ const usePendingSafeStatus = (): void => {
             chainId: safe.chainId,
             address: safeAddress,
             status: {
-              status: status,
+              status,
               txHash: 'txHash' in detail ? detail.txHash : undefined,
               taskId: 'taskId' in detail ? detail.taskId : undefined,
               startBlock: await provider?.getBlockNumber(),

--- a/src/features/recovery/hooks/useRecoveryTxNotification.ts
+++ b/src/features/recovery/hooks/useRecoveryTxNotification.ts
@@ -66,7 +66,7 @@ export function useRecoveryTxNotifications(): void {
             title,
             message,
             detailedMessage: isError ? detail.error.message : undefined,
-            groupKey: groupKey,
+            groupKey,
             variant: isError ? 'error' : isSuccess ? 'success' : 'info',
             link,
           }),

--- a/src/features/recovery/services/recovery-sender.ts
+++ b/src/features/recovery/services/recovery-sender.ts
@@ -119,14 +119,14 @@ export async function dispatchRecoveryProposal({
       recoveryDispatch(RecoveryEvent.PROCESSING_BY_SMART_CONTRACT_WALLET, {
         moduleAddress: delayModifierAddress,
         recoveryTxHash,
-        txType: txType,
+        txType,
         txHash: tx.hash,
       })
     } else {
       waitForRecoveryTx({
         moduleAddress: delayModifierAddress,
         recoveryTxHash,
-        txType: txType,
+        txType,
         tx,
       })
     }
@@ -134,7 +134,7 @@ export async function dispatchRecoveryProposal({
     recoveryDispatch(RecoveryEvent.FAILED, {
       moduleAddress: delayModifierAddress,
       recoveryTxHash,
-      txType: txType,
+      txType,
       error: asError(error),
     })
 
@@ -168,14 +168,14 @@ export async function dispatchRecoveryExecution({
       recoveryDispatch(RecoveryEvent.PROCESSING_BY_SMART_CONTRACT_WALLET, {
         moduleAddress: delayModifierAddress,
         recoveryTxHash: args.txHash,
-        txType: txType,
+        txType,
         txHash: tx.hash,
       })
     } else {
       waitForRecoveryTx({
         moduleAddress: delayModifierAddress,
         recoveryTxHash: args.txHash,
-        txType: txType,
+        txType,
         tx,
       })
     }
@@ -183,7 +183,7 @@ export async function dispatchRecoveryExecution({
     recoveryDispatch(RecoveryEvent.FAILED, {
       moduleAddress: delayModifierAddress,
       recoveryTxHash: args.txHash,
-      txType: txType,
+      txType,
       error: asError(error),
     })
 

--- a/src/hooks/__tests__/usePendingActions.test.ts
+++ b/src/hooks/__tests__/usePendingActions.test.ts
@@ -192,7 +192,7 @@ describe('usePendingActions hook', () => {
     const mockPage = {
       error: undefined,
       loading: false,
-      page: page,
+      page,
     }
     jest.spyOn(useTxQueue, 'default').mockReturnValue(mockPage)
 

--- a/src/hooks/coreSDK/safeCoreSDK.ts
+++ b/src/hooks/coreSDK/safeCoreSDK.ts
@@ -97,7 +97,7 @@ export const initSafeSDK = async ({
   if (undeployedSafe) {
     return Safe.create({
       ethAdapter: createReadOnlyEthersAdapter(provider),
-      isL1SafeSingleton: isL1SafeSingleton,
+      isL1SafeSingleton,
       predictedSafe: undeployedSafe.props,
     })
   }
@@ -105,7 +105,7 @@ export const initSafeSDK = async ({
   return Safe.create({
     ethAdapter: createReadOnlyEthersAdapter(provider),
     safeAddress: address,
-    isL1SafeSingleton: isL1SafeSingleton,
+    isL1SafeSingleton,
   })
 }
 

--- a/src/hooks/messages/useSafeMessages.ts
+++ b/src/hooks/messages/useSafeMessages.ts
@@ -34,7 +34,7 @@ const useSafeMessages = (
       {
         page,
         error: error?.message,
-        loading: loading,
+        loading,
       }
     : // Stored page
       {

--- a/src/hooks/useGasPrice.ts
+++ b/src/hooks/useGasPrice.ts
@@ -59,7 +59,7 @@ const parseEtherscanOracleResult = (result: EtherscanResult, gweiFactor: string)
   const baseFee = BigInt(Number(result.suggestBaseFee) * Number(gweiFactor))
 
   return {
-    maxFeePerGas: maxFeePerGas,
+    maxFeePerGas,
     maxPriorityFeePerGas: maxFeePerGas - baseFee,
   }
 }

--- a/src/hooks/useTxQueue.ts
+++ b/src/hooks/useTxQueue.ts
@@ -30,7 +30,7 @@ const useTxQueue = (
     ? {
         page,
         error: error?.message,
-        loading: loading,
+        loading,
       }
     : {
         page: queueState.data,

--- a/src/store/txQueueSlice.ts
+++ b/src/store/txQueueSlice.ts
@@ -61,7 +61,7 @@ export const txQueueListener = (listenerMiddleware: typeof listenerMiddlewareIns
             sameAddress(address.value, awaitingSigner),
           )
         ) {
-          txDispatch(TxEvent.SIGNATURE_INDEXED, { txId: txId })
+          txDispatch(TxEvent.SIGNATURE_INDEXED, { txId })
         }
       }
     },

--- a/src/tests/test-utils.tsx
+++ b/src/tests/test-utils.tsx
@@ -128,7 +128,7 @@ const mockWeb3Provider = (
       return Promise.resolve(50_000n)
     }),
     _isProvider: true,
-    resolveName: resolveName,
+    resolveName,
   } as unknown as JsonRpcProvider
   jest.spyOn(web3, 'useWeb3ReadOnly').mockReturnValue(mockWeb3ReadOnly)
   return mockWeb3ReadOnly

--- a/src/utils/gateway.ts
+++ b/src/utils/gateway.ts
@@ -44,7 +44,7 @@ const signTxServiceMessage = async (
   const domain = {
     name: 'Safe Transaction Service',
     version: '1.0',
-    chainId: chainId,
+    chainId,
     verifyingContract: safeAddress,
   }
   const types = {
@@ -54,7 +54,7 @@ const signTxServiceMessage = async (
     ],
   }
   const message = {
-    safeTxHash: safeTxHash,
+    safeTxHash,
     totp: Math.floor(Date.now() / 3600e3),
   }
 

--- a/src/utils/providers/UncheckedJsonRpcSigner.ts
+++ b/src/utils/providers/UncheckedJsonRpcSigner.ts
@@ -17,7 +17,7 @@ export class UncheckedJsonRpcSigner extends JsonRpcSigner {
   async sendTransaction(transaction: TransactionRequest): Promise<TransactionResponse> {
     return this.sendUncheckedTransaction(transaction).then((hash) => {
       return <TransactionResponse>(<unknown>{
-        hash: hash,
+        hash,
         nonce: null,
         gasLimit: null,
         gasPrice: null,

--- a/src/utils/safe-messages.ts
+++ b/src/utils/safe-messages.ts
@@ -58,7 +58,7 @@ export const generateSafeMessageTypedData = (
   return {
     domain: isHandledByFallbackHandler
       ? {
-          chainId: chainId,
+          chainId,
           verifyingContract: address.value,
         }
       : { verifyingContract: address.value },


### PR DESCRIPTION
## What it solves
Reduces nitpicking on syntax during reviews.

Ads rules for enforcing shortharnd object notation and removing curly brace when having a single prop e.g.
`something={"somtihng"}` becomes `sometihng="something"`

I also tried adding jsx-newline, but it conflicts with prettier and there doesn't seem to be a setting that can make those 2 co-exist. So I gues nitpicking on non-readable jsx syntax is fine there :). 
 