### PR TITLE
Fix: Safari CSS - conflicting txs line

### DIFF
--- a/src/components/transactions/GroupedTxListItems/styles.module.css
+++ b/src/components/transactions/GroupedTxListItems/styles.module.css
@@ -1,4 +1,5 @@
 .container {
+  position: relative;
   padding: var(--space-2);
   border: 1px solid var(--color-warning-light);
   display: grid;
@@ -33,7 +34,9 @@
   border-bottom: 1px solid var(--color-border-light);
   border-radius: 0 0 0 4px;
   height: calc(100% - 29px);
-  margin-top: -30px;
+  width: 100%;
+  position: absolute;
+  top: 0;
   margin-left: 9px;
 }
 


### PR DESCRIPTION
Fixes a CSS bug in Safari that made conflicting tx groups look like this:

![Screenshot 2024-03-26 at 16 37 36](https://github.com/safe-global/safe-wallet-web/assets/381895/eb8b8215-411f-45fb-86e0-c0241730afc0)
