### PR TITLE
fix: Conflicting transaction color in dark mode

### DIFF
--- a/src/components/transactions/GroupedTxListItems/styles.module.css
+++ b/src/components/transactions/GroupedTxListItems/styles.module.css
@@ -15,7 +15,6 @@
 
 .disclaimerContainer {
   background-color: var(--color-warning-background);
-  color: var(--color-static-main);
   padding: var(--space-1) var(--space-2);
   border-radius: var(--space-1);
   flex: 1;


### PR DESCRIPTION
## What it solves

Resolves [Notion](https://www.notion.so/safe-global/63420452940c454b809f3b5872e678ef?v=7044dcf36cdb4656b7b00878ede3974a&p=bbe5b688230e45cb8aaadd291fa2d573&pm=s)

## How this PR fixes it

- Removes the static color

## How to test it

1. Open a Safe
2. Queue two transactions with the same nonce
3. Check that the Conflicting transactions message is readable in both light and dark mode

## Screenshots

<img width="1269" alt="Screenshot 2024-03-27 at 10 12 20" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/d3ce70e3-3a13-4578-aff6-e1933e192a82">
<img width="1269" alt="Screenshot 2024-03-27 at 10 12 31" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/0f5d2d38-fe4f-4de3-9870-e508b7e377fd">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
