### PR TITLE
Revert "fix: safeTxGas for rejection txs (#3452)"

### DIFF
--- a/src/components/tx-flow/SafeTxProvider.tsx
+++ b/src/components/tx-flow/SafeTxProvider.tsx
@@ -2,7 +2,7 @@ import { createContext, useState, useEffect } from 'react'
 import type { Dispatch, ReactNode, SetStateAction, ReactElement } from 'react'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { createTx } from '@/services/tx/tx-sender'
-import { useRecommendedNonce } from '../tx/SignOrExecuteForm/hooks'
+import { useRecommendedNonce, useSafeTxGas } from '../tx/SignOrExecuteForm/hooks'
 import { Errors, logError } from '@/services/exceptions'
 import type { EIP712TypedData } from '@safe-global/safe-gateway-typescript-sdk'
 
@@ -45,12 +45,13 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
   // Signed txs cannot be updated
   const isSigned = safeTx && safeTx.signatures.size > 0
 
-  // Recommended nonce
+  // Recommended nonce and safeTxGas
   const recommendedNonce = useRecommendedNonce()
+  const recommendedSafeTxGas = useSafeTxGas(safeTx)
 
   // Priority to external nonce, then to the recommended one
   const finalNonce = isSigned ? safeTx?.data.nonce : nonce ?? recommendedNonce ?? safeTx?.data.nonce
-  const finalSafeTxGas = isSigned ? safeTx?.data.safeTxGas : safeTxGas ?? safeTx?.data.safeTxGas
+  const finalSafeTxGas = isSigned ? safeTx?.data.safeTxGas : safeTxGas ?? recommendedSafeTxGas ?? safeTx?.data.safeTxGas
 
   // Update the tx when the nonce or safeTxGas change
   useEffect(() => {

--- a/src/services/tx/tx-sender/recommendedNonce.ts
+++ b/src/services/tx/tx-sender/recommendedNonce.ts
@@ -1,5 +1,44 @@
-import { getNonces as fetchNonces } from '@safe-global/safe-gateway-typescript-sdk'
+import {
+  Operation,
+  postSafeGasEstimation,
+  getNonces as fetchNonces,
+  type SafeTransactionEstimation,
+} from '@safe-global/safe-gateway-typescript-sdk'
+import type { MetaTransactionData, SafeTransactionDataPartial } from '@safe-global/safe-core-sdk-types'
+import { isLegacyVersion } from '@/hooks/coreSDK/safeCoreSDK'
 import { Errors, logError } from '@/services/exceptions'
+
+const fetchRecommendedParams = async (
+  chainId: string,
+  safeAddress: string,
+  txParams: MetaTransactionData,
+): Promise<SafeTransactionEstimation> => {
+  return postSafeGasEstimation(chainId, safeAddress, {
+    to: txParams.to,
+    value: txParams.value,
+    data: txParams.data,
+    operation: (txParams.operation as unknown as Operation) || Operation.CALL,
+  })
+}
+
+export const getSafeTxGas = async (
+  chainId: string,
+  safeAddress: string,
+  safeVersion: string,
+  safeTxData: SafeTransactionDataPartial,
+): Promise<string | undefined> => {
+  const isSafeTxGasRequired = isLegacyVersion(safeVersion)
+
+  // For 1.3.0+ Safes safeTxGas is not required
+  if (!isSafeTxGasRequired) return '0'
+
+  try {
+    const estimation = await fetchRecommendedParams(chainId, safeAddress, safeTxData)
+    return estimation.safeTxGas
+  } catch (e) {
+    logError(Errors._616, e)
+  }
+}
 
 export const getNonces = async (chainId: string, safeAddress: string) => {
   try {


### PR DESCRIPTION
This reverts commit 1dc5e3ea1aa0e37b2126b4c270b5e8be9f82323a.

The commit caused `safeTxGas is NaN` errors for transactions from SafeApps.