### PR TITLE
Fix: close Notifications popup after navigation

### DIFF
--- a/src/components/notification-center/NotificationCenter/index.tsx
+++ b/src/components/notification-center/NotificationCenter/index.tsx
@@ -86,6 +86,10 @@ const NotificationCenter = (): ReactElement => {
     dispatch(deleteAllNotifications())
   }
 
+  const onSettingsClick = () => {
+    setTimeout(handleClose, 300)
+  }
+
   const ExpandIcon = showAll ? ExpandLessIcon : ExpandMoreIcon
 
   return (
@@ -170,7 +174,7 @@ const NotificationCenter = (): ReactElement => {
               passHref
               legacyBehavior
             >
-              <MuiLink className={css.settingsLink} variant="body2" onClick={handleClose}>
+              <MuiLink className={css.settingsLink} variant="body2" onClick={onSettingsClick}>
                 <SvgIcon component={SettingsIcon} inheritViewBox fontSize="small" /> Push notifications settings
               </MuiLink>
             </Link>


### PR DESCRIPTION
## What it solves

Resolves #3465

## How this PR fixes it

The popup should be closed _after_ a navigation happens, not before. An MUI quirk. So I just added a simple timeout on link click.