### PR TITLE
Fix: extend bridge warnings list

### DIFF
--- a/src/features/walletconnect/constants.ts
+++ b/src/features/walletconnect/constants.ts
@@ -64,6 +64,7 @@ export const BlockedBridges = [
 
 // Bridges that initially select the same address on the destination chain but allow changing it
 export const WarnedBridges = [
+  'core.app',
   'across.to', // doesn't send their URL in the session proposal
   'app.allbridge.io',
   'bridge.arbitrum.io',


### PR DESCRIPTION
## What it solves

Resolves #3499

## How this PR fixes it

Adds core.app to the list of warned bridges as it doesn't support specifying a different recepient address.