### PR TITLE
Fix: adjust bridge warning wording

### DIFF
--- a/src/features/walletconnect/components/WcProposalForm/__tests__/useCompatibilityWarning.test.ts
+++ b/src/features/walletconnect/components/WcProposalForm/__tests__/useCompatibilityWarning.test.ts
@@ -56,7 +56,7 @@ describe('useCompatibilityWarning', () => {
 
       expect(result.current).toEqual({
         message:
-          'While using Fake Bridge, please make sure that the desination address you send funds to matches the Safe address you have on the respective chain. Otherwise, the funds will be lost.',
+          'While bridging via Fake Bridge, please make sure that the desination address you send funds to matches the Safe address you have on the respective chain. Otherwise, the funds will be lost.',
         severity: 'warning',
       })
     })
@@ -74,7 +74,7 @@ describe('useCompatibilityWarning', () => {
 
       expect(result.current).toEqual({
         message:
-          'While using this dApp, please make sure that the desination address you send funds to matches the Safe address you have on the respective chain. Otherwise, the funds will be lost.',
+          'While bridging via this dApp, please make sure that the desination address you send funds to matches the Safe address you have on the respective chain. Otherwise, the funds will be lost.',
         severity: 'warning',
       })
     })

--- a/src/features/walletconnect/components/WcProposalForm/useCompatibilityWarning.ts
+++ b/src/features/walletconnect/components/WcProposalForm/useCompatibilityWarning.ts
@@ -17,7 +17,7 @@ const Warnings: Record<string, { severity: AlertColor; message: string }> = {
   },
   WARNED_BRIDGE: {
     severity: 'warning',
-    message: `While using ${NAME_PLACEHOLDER}, please make sure that the desination address you send funds to matches the Safe address you have on the respective chain. Otherwise, the funds will be lost.`,
+    message: `While bridging via ${NAME_PLACEHOLDER}, please make sure that the desination address you send funds to matches the Safe address you have on the respective chain. Otherwise, the funds will be lost.`,
   },
   UNSUPPORTED_CHAIN: {
     severity: 'error',


### PR DESCRIPTION
## What it solves

Make the warning more specifically refer to bridging as opposed to using a dapp.