### PR TITLE
Fix: don't show onboard popup on reconnect for MetaMask, Rabby and Zerion

### DIFF
--- a/src/utils/wallets.ts
+++ b/src/utils/wallets.ts
@@ -48,10 +48,10 @@ export const isSmartContractWallet = memoize(
 
 /* Check if the wallet is unlocked. */
 export const isWalletUnlocked = async (walletName: string): Promise<boolean | undefined> => {
-  const METAMASK = 'MetaMask'
+  const METAMASK_LIKE = ['MetaMask', 'Rabby Wallet', 'Zerion']
 
   // Only MetaMask exposes a method to check if the wallet is unlocked
-  if (walletName === METAMASK) {
+  if (METAMASK_LIKE.includes(walletName)) {
     if (typeof window === 'undefined' || !window.ethereum?._metamask) return false
     try {
       return await window.ethereum?._metamask.isUnlocked()


### PR DESCRIPTION
## What it solves

Resolves #3508

## How this PR fixes it

Rabby and Zerion expose the same `window.ethereum._metamask` API as MetaMask itself, so it's possible to check if they are unlocked. If they are, we won't show a reconnect modal.