### PR TITLE
Fix: [Tx Deletion] signTypedData fallback for Ledger

### DIFF
--- a/src/utils/__tests__/web3.test.ts
+++ b/src/utils/__tests__/web3.test.ts
@@ -1,0 +1,66 @@
+import type { JsonRpcSigner } from 'ethers'
+import { signTypedData } from '../web3'
+
+describe('web3', () => {
+  describe('signTypedData', () => {
+    const mockSignature =
+      '0xe658c4de8780d5f2182ad364e8be4b1a63f59a2abf53fab05113ab1087ccf7fe50a9ae164517b24b8c886432a7fddf18bd73b0d6d43b8a5077c0f26e982a63b91b'
+
+    it('should sign typed data', async () => {
+      const signer = {
+        signTypedData: jest.fn().mockResolvedValue(mockSignature),
+      }
+      const typedData = {
+        domain: {
+          chainId: 1,
+          name: 'name',
+          version: '1',
+        },
+        types: {
+          EIP712Domain: [],
+        },
+        message: {},
+      }
+      const result = await signTypedData(signer as unknown as JsonRpcSigner, typedData)
+      expect(result).toBe(mockSignature)
+    })
+
+    it('should throw an error if signTypedData fails', async () => {
+      const signer = {
+        signTypedData: jest.fn().mockRejectedValue(new Error('error')),
+      }
+      const typedData = {
+        domain: {
+          chainId: 1,
+          name: 'name',
+          version: '1',
+        },
+        types: {
+          EIP712Domain: [],
+        },
+        message: {},
+      }
+      await expect(signTypedData(signer as unknown as JsonRpcSigner, typedData)).rejects.toThrow('error')
+    })
+
+    it('should fall back to signTypedData if signTypedData_v4 is not available', async () => {
+      const signer = {
+        signTypedData_v4: undefined,
+        signTypedData: jest.fn().mockResolvedValue(mockSignature),
+      }
+      const typedData = {
+        domain: {
+          chainId: 1,
+          name: 'name',
+          version: '1',
+        },
+        types: {
+          EIP712Domain: [],
+        },
+        message: {},
+      }
+      const result = await signTypedData(signer as unknown as JsonRpcSigner, typedData)
+      expect(result).toBe(mockSignature)
+    })
+  })
+})

--- a/src/utils/gateway.ts
+++ b/src/utils/gateway.ts
@@ -1,8 +1,7 @@
 import type { JsonRpcSigner } from 'ethers'
 import { type ChainInfo, deleteTransaction } from '@safe-global/safe-gateway-typescript-sdk'
 import { WC_APP_PROD, WC_APP_DEV } from '@/config/constants'
-import { adjustVInSignature } from '@safe-global/protocol-kit/dist/src/utils/signatures'
-import { SigningMethod } from '@safe-global/protocol-kit'
+import { signTypedData } from './web3'
 
 export const _replaceTemplate = (uri: string, data: Record<string, string>): string => {
   // Template syntax returned from gateway is {{this}}
@@ -41,25 +40,24 @@ const signTxServiceMessage = async (
   safeTxHash: string,
   signer: JsonRpcSigner,
 ): Promise<string> => {
-  const domain = {
-    name: 'Safe Transaction Service',
-    version: '1.0',
-    chainId,
-    verifyingContract: safeAddress,
-  }
-  const types = {
-    DeleteRequest: [
-      { name: 'safeTxHash', type: 'bytes32' },
-      { name: 'totp', type: 'uint256' },
-    ],
-  }
-  const message = {
-    safeTxHash,
-    totp: Math.floor(Date.now() / 3600e3),
-  }
-
-  const signature = await signer.signTypedData(domain, types, message)
-  return adjustVInSignature(SigningMethod.ETH_SIGN_TYPED_DATA, signature)
+  return await signTypedData(signer, {
+    types: {
+      DeleteRequest: [
+        { name: 'safeTxHash', type: 'bytes32' },
+        { name: 'totp', type: 'uint256' },
+      ],
+    },
+    domain: {
+      name: 'Safe Transaction Service',
+      version: '1.0',
+      chainId,
+      verifyingContract: safeAddress,
+    },
+    message: {
+      safeTxHash,
+      totp: Math.floor(Date.now() / 3600e3),
+    },
+  })
 }
 
 export const deleteTx = async ({

--- a/src/utils/safe-messages.ts
+++ b/src/utils/safe-messages.ts
@@ -1,8 +1,8 @@
-import { getBytes, hashMessage, type TypedDataDomain, type JsonRpcSigner } from 'ethers'
+import { getBytes, hashMessage, type JsonRpcSigner } from 'ethers'
 import { gte } from 'semver'
 import { adjustVInSignature } from '@safe-global/protocol-kit/dist/src/utils/signatures'
 
-import { hashTypedData } from '@/utils/web3'
+import { hashTypedData, signTypedData } from '@/utils/web3'
 import { isValidAddress } from './validation'
 import { isWalletRejection } from '@/utils/wallets'
 import { getSupportedSigningMethods } from '@/services/tx/tx-sender/sdk'
@@ -117,14 +117,7 @@ export const tryOffChainMsgSigning = async (
     try {
       if (signingMethod === 'eth_signTypedData') {
         const typedData = generateSafeMessageTypedData(safe, message)
-        const signature = await signer.signTypedData(
-          typedData.domain as TypedDataDomain,
-          typedData.types,
-          typedData.message,
-        )
-
-        // V needs adjustment when signing with ledger / trezor through metamask
-        return adjustVInSignature(signingMethod, signature)
+        return signTypedData(signer, typedData)
       }
 
       if (signingMethod === 'eth_sign') {

--- a/src/utils/safe-messages.ts
+++ b/src/utils/safe-messages.ts
@@ -1,8 +1,8 @@
-import { getBytes, hashMessage, type JsonRpcSigner } from 'ethers'
+import { getBytes, hashMessage, type TypedDataDomain, type JsonRpcSigner } from 'ethers'
 import { gte } from 'semver'
 import { adjustVInSignature } from '@safe-global/protocol-kit/dist/src/utils/signatures'
 
-import { hashTypedData, signTypedData } from '@/utils/web3'
+import { hashTypedData } from '@/utils/web3'
 import { isValidAddress } from './validation'
 import { isWalletRejection } from '@/utils/wallets'
 import { getSupportedSigningMethods } from '@/services/tx/tx-sender/sdk'
@@ -117,7 +117,14 @@ export const tryOffChainMsgSigning = async (
     try {
       if (signingMethod === 'eth_signTypedData') {
         const typedData = generateSafeMessageTypedData(safe, message)
-        return signTypedData(signer, typedData)
+        const signature = await signer.signTypedData(
+          typedData.domain as TypedDataDomain,
+          typedData.types,
+          typedData.message,
+        )
+
+        // V needs adjustment when signing with ledger / trezor through metamask
+        return adjustVInSignature(signingMethod, signature)
       }
 
       if (signingMethod === 'eth_sign') {

--- a/src/utils/web3.ts
+++ b/src/utils/web3.ts
@@ -38,13 +38,17 @@ const signTypedDataFallback = async (signer: JsonRpcSigner, typedData: EIP712Typ
 }
 
 export const signTypedData = async (signer: JsonRpcSigner, typedData: EIP712TypedData): Promise<string> => {
-  const { domain, types, message } = typedData
-
+  const UNSUPPORTED_OPERATION = 'UNSUPPORTED_OPERATION'
   let signature = ''
   try {
+    const { domain, types, message } = typedData
     signature = await signer.signTypedData(domain as TypedDataDomain, types, message)
-  } catch {
-    signature = await signTypedDataFallback(signer, typedData)
+  } catch (e) {
+    if ((e as Error & { code: string }).code === UNSUPPORTED_OPERATION) {
+      signature = await signTypedDataFallback(signer, typedData)
+    } else {
+      throw e
+    }
   }
   return adjustVInSignature(SigningMethod.ETH_SIGN_TYPED_DATA, signature)
 }


### PR DESCRIPTION
## What it solves

In Ethers v6, the signTypedData method unconditionally calls `eth_signTypedData_v4` that Ledger (and probably also Trezor) doesn't support. So I've added a fallback that calls `eth_signTypedData` if `eth_signTypedData_v4` fails.

## How to test it

Case 1:
* Propose a transaction with Ledger
* Delete that transaction with Ledger

Case 2:
* Sign a message with one of the signers being a Ledger
