### PR TITLE
PoC: server-sent events service

### DIFF
--- a/src/hook/useTxServiceEvents.ts
+++ b/src/hook/useTxServiceEvents.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react'
+import useSafeAddress from '@/hooks/useSafeAddress'
+
+const API_URL = 'https://sse-proxy.ivan-dbc.workers.dev/'
+
+export function useTxServiceEvents() {
+  const safeAddress = useSafeAddress()
+
+  useEffect(() => {
+    if (!safeAddress) {
+      return
+    }
+    const eventSource = new EventSource(API_URL + safeAddress)
+
+    eventSource.onmessage = (e) => {
+      console.log('TX SERVICE EVENT:', JSON.parse(e.data))
+    }
+
+    return () => {
+      eventSource.close()
+    }
+  }, [safeAddress])
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -44,6 +44,7 @@ import { useNotificationTracking } from '@/components/settings/PushNotifications
 import Recovery from '@/features/recovery/components/Recovery'
 import WalletProvider from '@/components/common/WalletProvider'
 import CounterfactualHooks from '@/features/counterfactual/CounterfactualHooks'
+import { useTxServiceEvents } from '@/hook/useTxServiceEvents'
 
 const GATEWAY_URL = IS_PRODUCTION || cgwDebugStorage.get() ? GATEWAY_URL_PRODUCTION : GATEWAY_URL_STAGING
 
@@ -69,6 +70,7 @@ const InitApp = (): null => {
   useSafeMsgTracking()
   useBeamer()
   useRehydrateSocialWallet()
+  useTxServiceEvents()
 
   return null
 }


### PR DESCRIPTION
## What it solves

Uxio created an experimental Server-Sent Events API for tx-service events.

This PR implements a hook for it that for now just logs the events.

As the API requires Basic Auth, I had to create a proxy for it using a CloudFlare Worker. Here's the code for the proxy: https://gist.github.com/katspaugh/b5816d8462808962bd923e51b854d737

![Screenshot 2024-04-05 at 16 14 47](https://github.com/safe-global/safe-wallet-web/assets/381895/55e23ce5-1285-4f37-8f37-ca39f230b3aa)