### PR TITLE
fix: Only show status label in queue if transaction is pending

### DIFF
--- a/src/components/transactions/TxStatusLabel/index.tsx
+++ b/src/components/transactions/TxStatusLabel/index.tsx
@@ -30,6 +30,7 @@ const TxStatusLabel = ({ tx }: { tx: TransactionSummary }) => {
       alignItems="center"
       gap={1}
       color={({ palette }) => getStatusColor(tx.txStatus, palette)}
+      data-testid="tx-status-label"
     >
       {isPending && <CircularProgress size={14} color="inherit" />}
       {txStatusLabel}

--- a/src/components/transactions/TxSummary/index.test.tsx
+++ b/src/components/transactions/TxSummary/index.test.tsx
@@ -1,0 +1,111 @@
+import TxSummary from '@/components/transactions/TxSummary/index'
+import * as pending from '@/hooks/useIsPending'
+import { render } from '@/tests/test-utils'
+import {
+  ConflictType,
+  DetailedExecutionInfoType,
+  type Transaction,
+  TransactionListItemType,
+  TransactionStatus,
+  type TransactionSummary,
+} from '@safe-global/safe-gateway-typescript-sdk'
+import {
+  TransactionInfoType,
+  TransactionTokenType,
+  TransferDirection,
+} from '@safe-global/safe-gateway-typescript-sdk/dist/types/transactions'
+
+const mockTransaction: Transaction = {
+  type: TransactionListItemType.TRANSACTION,
+  transaction: {
+    timestamp: Date.now(),
+    executionInfo: {
+      type: DetailedExecutionInfoType.MULTISIG,
+      nonce: 7,
+      confirmationsRequired: 3,
+      confirmationsSubmitted: 1,
+      missingSigners: [
+        { value: '0x6a5602335a878ADDCa4BF63a050E34946B56B5bC' },
+        { value: '0x0000000000000000000000000000000000000789' },
+      ],
+    },
+    txInfo: {
+      type: TransactionInfoType.TRANSFER,
+      direction: TransferDirection.OUTGOING,
+      transferInfo: {
+        value: '1000000',
+        type: TransactionTokenType.NATIVE_COIN,
+      },
+    },
+    txStatus: TransactionStatus.AWAITING_CONFIRMATIONS,
+  } as unknown as TransactionSummary,
+  conflictType: ConflictType.HAS_NEXT,
+}
+
+const mockTransactionWithoutExecutionInfo = {
+  ...mockTransaction,
+  transaction: { ...mockTransaction.transaction, executionInfo: undefined },
+}
+
+const mockTransactionInHistory = {
+  ...mockTransaction,
+  transaction: { ...mockTransaction.transaction, txStatus: TransactionStatus.SUCCESS },
+}
+
+describe('TxSummary', () => {
+  it('should display a nonce if transaction is not grouped', () => {
+    const { getByText } = render(<TxSummary item={mockTransaction} isGrouped={false} />)
+
+    expect(getByText('7')).toBeInTheDocument()
+  })
+
+  it('should not display a nonce if transaction is grouped', () => {
+    const { queryByText } = render(<TxSummary item={mockTransaction} isGrouped={true} />)
+
+    expect(queryByText('7')).not.toBeInTheDocument()
+  })
+
+  it('should not display a nonce if there is no executionInfo', () => {
+    const { queryByText } = render(<TxSummary item={mockTransactionWithoutExecutionInfo} isGrouped={true} />)
+
+    expect(queryByText('7')).not.toBeInTheDocument()
+  })
+
+  it('should display confirmations if transactions is in queue', () => {
+    const { getByText } = render(<TxSummary item={mockTransaction} isGrouped={false} />)
+
+    expect(getByText('1 out of 3')).toBeInTheDocument()
+  })
+
+  it('should not display confirmations if transactions is already executed', () => {
+    const { queryByText } = render(<TxSummary item={mockTransactionInHistory} isGrouped={false} />)
+
+    expect(queryByText('1 out of 3')).not.toBeInTheDocument()
+  })
+
+  it('should not display confirmations if there is no executionInfo', () => {
+    const { queryByText } = render(<TxSummary item={mockTransactionWithoutExecutionInfo} isGrouped={false} />)
+
+    expect(queryByText('1 out of 3')).not.toBeInTheDocument()
+  })
+
+  it('should display a Sign button if confirmations are missing', () => {
+    const { getByText } = render(<TxSummary item={mockTransaction} isGrouped={false} />)
+
+    expect(getByText('Confirm')).toBeInTheDocument()
+  })
+
+  it('should display a status label if transaction is in queue and pending', () => {
+    jest.spyOn(pending, 'default').mockReturnValue(true)
+    const { getByTestId } = render(<TxSummary item={mockTransaction} isGrouped={false} />)
+
+    expect(getByTestId('tx-status-label')).toBeInTheDocument()
+  })
+
+  it('should not display a status label if transaction is in queue and not pending', () => {
+    jest.spyOn(pending, 'default').mockReturnValue(false)
+    const { queryByTestId } = render(<TxSummary item={mockTransaction} isGrouped={false} />)
+
+    expect(queryByTestId('tx-status-label')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/transactions/TxSummary/index.test.tsx
+++ b/src/components/transactions/TxSummary/index.test.tsx
@@ -102,6 +102,13 @@ describe('TxSummary', () => {
     expect(getByTestId('tx-status-label')).toBeInTheDocument()
   })
 
+  it('should display a status label if transaction is not in queue', () => {
+    jest.spyOn(pending, 'default').mockReturnValue(true)
+    const { getByTestId } = render(<TxSummary item={mockTransactionInHistory} isGrouped={false} />)
+
+    expect(getByTestId('tx-status-label')).toBeInTheDocument()
+  })
+
   it('should not display a status label if transaction is in queue and not pending', () => {
     jest.spyOn(pending, 'default').mockReturnValue(false)
     const { queryByTestId } = render(<TxSummary item={mockTransaction} isGrouped={false} />)

--- a/src/components/transactions/TxSummary/index.tsx
+++ b/src/components/transactions/TxSummary/index.tsx
@@ -75,9 +75,11 @@ const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
         </Box>
       )}
 
-      <Box gridArea="status" justifyContent="flex-end" display="flex" mr={5}>
-        {(!isQueue || isPending) && <TxStatusLabel tx={tx} />}
-      </Box>
+      {(!isQueue || isPending) && (
+        <Box gridArea="status" justifyContent="flex-end" display="flex" mr={5}>
+          <TxStatusLabel tx={tx} />
+        </Box>
+      )}
 
       {isQueue && (
         <Box gridArea="actions">

--- a/src/components/transactions/TxSummary/index.tsx
+++ b/src/components/transactions/TxSummary/index.tsx
@@ -76,7 +76,7 @@ const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
       )}
 
       <Box gridArea="status" justifyContent="flex-end" display="flex" mr={5}>
-        <TxStatusLabel tx={tx} />
+        {(!isQueue || isPending) && <TxStatusLabel tx={tx} />}
       </Box>
 
       {isQueue && (


### PR DESCRIPTION
## What it solves

Resolves [Issue in QA Board](https://www.notion.so/safe-global/Tx-status-is-displayed-as-a-text-in-addition-to-n-of-M-5202a7c1373c4f5cb30fa42e2882cc30)

## How this PR fixes it

- Adds previous condition back to only render `TxStatusLabel` if the transaction is either not in the queue or if it is pending

## How to test it

1. Queue a transaction
2. Observe no status label in the queue
3. Execute the transaction
4. Observe a processing status label
5. Go to the history after execution
6. Observe a Success status label

## Screenshots
<img width="1264" alt="Screenshot 2024-04-08 at 14 43 34" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/8796df8e-d8b7-41c2-9714-1c305075f2db">
<img width="1269" alt="Screenshot 2024-04-08 at 14 44 08" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/56520fbd-64d8-4d6e-aebd-4cef3eff5d4a">
<img width="1257" alt="Screenshot 2024-04-08 at 14 44 22" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/9bab2fab-0c1e-400d-98c2-02b6bd036ab1">


<img width="1260" alt="Screenshot 2024-04-08 at 14 43 42" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/6110e8d9-a75c-438d-87e6-96d8d4f2a0b8">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
