### PR TITLE
Fix: onboard wallet icon

### DIFF
--- a/src/components/common/WalletIcon/index.tsx
+++ b/src/components/common/WalletIcon/index.tsx
@@ -12,12 +12,7 @@ const WalletIcon = ({
   icon?: string
 }) => {
   return icon ? (
-    <img
-      width={width}
-      height={height}
-      src={`data:image/svg+xml;utf8,${encodeURIComponent(icon)}`}
-      alt={`${provider} logo`}
-    />
+    <img width={width} height={height} src={icon} alt={`${provider} logo`} />
   ) : (
     <Skeleton variant="circular" width={width} height={height} />
   )


### PR DESCRIPTION
## What it solves

Resolves https://www.notion.so/safe-global/FF-no-connected-MM-icon-in-the-app-2963f2ca97ab4c51ad6832943004c8a1

## How this PR fixes it

Looks like the latest version of onboard suddenly started returning SVG icons with the data: URI prefix already appended, so we should not append it ourselves.

## How to test it

Check that the connected wallet icon is displayed correctly in different browsers.

We display the same component in two places:
* Account popup
* Execution gas selector (Sponsored or Wallet)