### PR TITLE
Fix: onboard wallet icon (2)

### DIFF
--- a/src/components/common/WalletIcon/index.tsx
+++ b/src/components/common/WalletIcon/index.tsx
@@ -12,7 +12,12 @@ const WalletIcon = ({
   icon?: string
 }) => {
   return icon ? (
-    <img width={width} height={height} src={icon} alt={`${provider} logo`} />
+    <img
+      width={width}
+      height={height}
+      src={icon.startsWith('data:') ? icon : `data:image/svg+xml;utf8,${encodeURIComponent(icon)}`}
+      alt={`${provider} logo`}
+    />
   ) : (
     <Skeleton variant="circular" width={width} height={height} />
   )


### PR DESCRIPTION
## What it solves

A follow-up on #3527 

## How this PR fixes it

Apparently some icons still come as a data-URI, so we need to support both raw SVG and URIs.

## How to test it
* Connect with MM
* Connect with WC