### PR TITLE
fix: status|speed up button too cramped up

### DIFF
--- a/src/components/transactions/TxSummary/QueueActions.tsx
+++ b/src/components/transactions/TxSummary/QueueActions.tsx
@@ -20,7 +20,7 @@ const QueueActions = ({ tx }: { tx: TransactionSummary }) => {
   }
 
   return (
-    <Box data-testid="tx-actions" my={-1} mr={2} display="flex" justifyContent="center">
+    <Box data-testid="tx-actions" mr={2} display="flex" justifyContent="center">
       {ExecutionComponent}
       {pendingTx && pendingTx.status === PendingStatus.PROCESSING && (
         <SpeedUpMonitor txId={tx.id} pendingTx={pendingTx} modalTrigger="alertButton" />

--- a/src/components/transactions/TxSummary/index.tsx
+++ b/src/components/transactions/TxSummary/index.tsx
@@ -76,7 +76,7 @@ const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
       )}
 
       {(!isQueue || isPending) && (
-        <Box gridArea="status" justifyContent="flex-end" display="flex" mr={5}>
+        <Box gridArea="status" justifyContent="flex-end" display="flex" className={css.status}>
           <TxStatusLabel tx={tx} />
         </Box>
       )}

--- a/src/components/transactions/TxSummary/styles.module.css
+++ b/src/components/transactions/TxSummary/styles.module.css
@@ -63,6 +63,6 @@
   }
 
   .status {
-    margin: 0  var(--space-1);
+    margin: 0 var(--space-1);
   }
 }

--- a/src/components/transactions/TxSummary/styles.module.css
+++ b/src/components/transactions/TxSummary/styles.module.css
@@ -39,6 +39,10 @@
   opacity: 0.4;
 }
 
+.gridContainer .status {
+  margin-right: var(--space-3);
+}
+
 .date {
   color: var(--color-text-secondary);
 }
@@ -56,5 +60,9 @@
 
   .date {
     width: 100%;
+  }
+
+  .status {
+    margin: 0  var(--space-1);
   }
 }


### PR DESCRIPTION
## What it solves
![grafik](https://github.com/safe-global/safe-wallet-web/assets/693770/df48e478-6743-4427-96b8-f532f6ef28d6)

Resolves #

## How this PR fixes it
![grafik](https://github.com/safe-global/safe-wallet-web/assets/693770/2abac8be-65ea-4115-a796-0073a22673d2)

## How to test it
Have a look at a pending transaction in the queue - both execute and speed up should have enough space from the elements above them.

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
