### PR TITLE
analytics: add event handlers for speedup tx feature

### DIFF
--- a/src/features/speedup/components/SpeedUpMonitor.tsx
+++ b/src/features/speedup/components/SpeedUpMonitor.tsx
@@ -2,12 +2,14 @@ import { Alert, AlertTitle, Box, Button, SvgIcon, Typography } from '@mui/materi
 import { SpeedUpModal } from '@/features/speedup/components/SpeedUpModal'
 import Rocket from '@/public/images/common/rocket.svg'
 import { useCounter } from '@/components/common/Notifications/useCounter'
+import type { MouseEventHandler } from 'react'
 import { useState } from 'react'
 import type { PendingProcessingTx } from '@/store/pendingTxsSlice'
 import useAsync from '@/hooks/useAsync'
 import { isSmartContract, useWeb3ReadOnly } from '@/hooks/wallets/web3'
 import useWallet from '@/hooks/wallets/useWallet'
 import { isSpeedableTx } from '@/features/speedup/utils/IsSpeedableTx'
+import { MODALS_EVENTS, trackEvent } from '@/services/analytics'
 
 type SpeedUpMonitorProps = {
   txId: string
@@ -36,6 +38,12 @@ export const SpeedUpMonitor = ({ txId, pendingTx, modalTrigger = 'alertBox' }: S
     return null
   }
 
+  const onOpen: MouseEventHandler = (e) => {
+    e.stopPropagation()
+    setOpenSpeedUpModal(true)
+    trackEvent(MODALS_EVENTS.OPEN_SPEEDUP_MODAL)
+  }
+
   return (
     <>
       <Box>
@@ -53,14 +61,7 @@ export const SpeedUpMonitor = ({ txId, pendingTx, modalTrigger = 'alertBox' }: S
           <Alert
             severity="warning"
             icon={<SvgIcon component={Rocket} />}
-            action={
-              <Button
-                onClick={(e) => {
-                  e.stopPropagation()
-                  setOpenSpeedUpModal(true)
-                }}
-              >{`Speed up >`}</Button>
-            }
+            action={<Button onClick={onOpen}>{`Speed up >`}</Button>}
           >
             <AlertTitle>
               <Typography textAlign="left">Taking too long?</Typography>
@@ -68,15 +69,7 @@ export const SpeedUpMonitor = ({ txId, pendingTx, modalTrigger = 'alertBox' }: S
             Try to speed up with better gas parameters.
           </Alert>
         ) : (
-          <Button
-            variant="outlined"
-            size="small"
-            sx={{ py: 0.6 }}
-            onClick={(e) => {
-              e.stopPropagation()
-              setOpenSpeedUpModal(true)
-            }}
-          >
+          <Button variant="outlined" size="small" sx={{ py: 0.6 }} onClick={onOpen}>
             Speed up
           </Button>
         )}

--- a/src/services/analytics/events/modals.ts
+++ b/src/services/analytics/events/modals.ts
@@ -53,6 +53,16 @@ export const MODALS_EVENTS = {
     category: MODALS_CATEGORY,
     event: EventType.META,
   },
+  OPEN_SPEEDUP_MODAL: {
+    action: 'Open speed-up modal',
+    category: MODALS_CATEGORY,
+    event: EventType.CLICK,
+  },
+  CANCEL_SPEEDUP: {
+    action: 'Cancel speed-up',
+    category: MODALS_CATEGORY,
+    event: EventType.CLICK,
+  },
 }
 
 export enum MODAL_NAVIGATION {

--- a/src/services/analytics/events/transactions.ts
+++ b/src/services/analytics/events/transactions.ts
@@ -46,4 +46,9 @@ export const TX_EVENTS = {
     action: 'Execute transaction',
     category: TX_CATEGORY,
   },
+  SPEED_UP: {
+    event: EventType.TX_EXECUTED,
+    action: 'Speedup transaction',
+    category: TX_CATEGORY,
+  },
 }


### PR DESCRIPTION
## What it solves
The Speedup transaction feature is still missing tracking events.

Resolves #3107 

## How this PR fixes it
- Adds events for
  - Opening the modal
  - Closing the modal
  - speeding up transactions

## How to test it
- Execute a tx with low gas price
- Speed it up and observe the logged events

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
