### PR TITLE
Fix: make Connect wallet primary CTA on the Accounts page

### DIFF
--- a/src/components/welcome/MyAccounts/CreateButton.tsx
+++ b/src/components/welcome/MyAccounts/CreateButton.tsx
@@ -4,14 +4,14 @@ import { AppRoutes } from '@/config/routes'
 
 const buttonSx = { width: ['100%', 'auto'] }
 
-const CreateButton = () => {
+const CreateButton = ({ isPrimary }: { isPrimary: boolean }) => {
   return (
     <Link href={AppRoutes.newSafe.create} passHref legacyBehavior>
       <Button
         data-testid="create-safe-btn"
         disableElevation
         size="small"
-        variant="contained"
+        variant={isPrimary ? 'contained' : 'outlined'}
         sx={buttonSx}
         component="a"
       >

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -41,7 +41,7 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
             Safe accounts
           </Typography>
           <Track {...OVERVIEW_EVENTS.CREATE_NEW_SAFE} label={trackingLabel}>
-            <CreateButton />
+            <CreateButton isPrimary={!!wallet} />
           </Track>
         </Box>
 
@@ -56,7 +56,7 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
               <>
                 <Box mb={2}>Connect a wallet to view your Safe Accounts or to create a new one</Box>
                 <Track {...OVERVIEW_EVENTS.OPEN_ONBOARD} label={trackingLabel}>
-                  <ConnectWalletButton text="Connect a wallet" contained={false} />
+                  <ConnectWalletButton text="Connect a wallet" contained />
                 </Track>
               </>
             )


### PR DESCRIPTION
## What it solves

The Connect wallet button was previously a textual button, and now it's a contained button:

Before:
<img width="707" alt="Screenshot 2024-04-09 at 15 06 51" src="https://github.com/safe-global/safe-wallet-web/assets/381895/35e59f13-d3a5-4bb0-bd71-1a438974d92f">

After:
<img width="789" alt="Screenshot 2024-04-09 at 15 04 29" src="https://github.com/safe-global/safe-wallet-web/assets/381895/7c003e6d-9ca7-4c89-bbcc-8aa36ab04683">
