### PR TITLE
fix: [Counterfactual] Call onSubmit handler when submitting a transaction

### DIFF
--- a/src/features/counterfactual/CounterfactualForm.tsx
+++ b/src/features/counterfactual/CounterfactualForm.tsx
@@ -66,7 +66,7 @@ export const CounterfactualForm = ({
   // On modal submit
   const handleSubmit = async (e: SyntheticEvent) => {
     e.preventDefault()
-    onSubmit?.('mockId')
+    onSubmit?.(Math.random().toString())
 
     if (needsRiskConfirmation && !isRiskConfirmed) {
       setIsRiskIgnored(true)

--- a/src/features/counterfactual/CounterfactualForm.tsx
+++ b/src/features/counterfactual/CounterfactualForm.tsx
@@ -38,6 +38,7 @@ export const CounterfactualForm = ({
   isOwner,
   isExecutionLoop,
   txSecurity,
+  onSubmit,
 }: SignOrExecuteProps & {
   isOwner: ReturnType<typeof useIsSafeOwner>
   isExecutionLoop: ReturnType<typeof useIsExecutionLoop>
@@ -65,6 +66,7 @@ export const CounterfactualForm = ({
   // On modal submit
   const handleSubmit = async (e: SyntheticEvent) => {
     e.preventDefault()
+    onSubmit?.('mockId')
 
     if (needsRiskConfirmation && !isRiskConfirmed) {
       setIsRiskIgnored(true)


### PR DESCRIPTION
## What it solves

We didn't call the `onSubmit` handler in `CounterfactualForm` so safe apps didn't receive a `safeTxHash` when submitting transactions.

## How this PR fixes it

- Call `onSubmit` when submitting in `CounterfactualForm`

## How to test it

1. Create a counterfactual safe
2. Send some WETH to it
3. Open the CowSwap safe app
4. Create a TWAP order
5. Submit the transaction in the tx-flow
6. Observe that CowSwap shows a success message and is not stuck

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
