### PR TITLE
fix: Hide "add to address book" when address already in the address book

### DIFF
--- a/src/components/common/AddressBookInput/index.tsx
+++ b/src/components/common/AddressBookInput/index.tsx
@@ -35,6 +35,11 @@ const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canA
     [addressBookEntries, addressValue],
   )
 
+  const isInAddressBook = useMemo(
+    () => addressBookEntries.some((entry) => entry.label === addressValue),
+    [addressBookEntries, addressValue],
+  )
+
   const customFilterOptions = (options: any, state: any) => {
     // Don't show suggestions from the address book once a valid address has been entered.
     if (isValidAddress(addressValue)) return []
@@ -94,7 +99,7 @@ const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canA
         )}
       />
 
-      {canAdd ? (
+      {canAdd && !isInAddressBook ? (
         <Typography variant="body2" className={css.unknownAddress}>
           <SvgIcon component={InfoIcon} fontSize="small" />
           <span>

--- a/src/components/common/AddressBookInput/index.tsx
+++ b/src/components/common/AddressBookInput/index.tsx
@@ -10,6 +10,7 @@ import EntryDialog from '@/components/address-book/EntryDialog'
 import css from './styles.module.css'
 import inputCss from '@/styles/inputs.module.css'
 import { isValidAddress } from '@/utils/validation'
+import { sameAddress } from '@/utils/addresses'
 
 const abFilterOptions = createFilterOptions({
   stringify: (option: { label: string; name: string }) => option.name + ' ' + option.label,
@@ -36,7 +37,7 @@ const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canA
   )
 
   const isInAddressBook = useMemo(
-    () => addressBookEntries.some((entry) => entry.label === addressValue),
+    () => addressBookEntries.some((entry) => sameAddress(entry.label, addressValue)),
     [addressBookEntries, addressValue],
   )
 


### PR DESCRIPTION
## What it solves

Resolves #3531 

## How this PR fixes it
It adds a memo function value (isInAddressBook) to find address in address book (returns true if found) and adds this check before displaying the message (if not isInAddressBook then display message).
## How to test it
1. Go to a safe you own
2. Add an address to the address book
3. Start a send funds tx
4. Copy/paste that address in the input
5. Check that "add to address book" is not showing anymore.

## Screenshots
![image](https://github.com/safe-global/safe-wallet-web/assets/34529009/6834d1c0-77a3-47ad-9d7f-349a4d6420fc)
