### PR TITLE
feat: Add OrderId component for swaps

### DIFF
--- a/src/features/swap/components/OrderId/index.stories.tsx
+++ b/src/features/swap/components/OrderId/index.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import OrderId from './index'
+import { Paper } from '@mui/material'
+
+const meta = {
+  component: OrderId,
+  parameters: {
+    componentSubtitle: 'Renders a CowSwap order id with an external link and a copy button',
+  },
+
+  decorators: [
+    (Story) => {
+      return (
+        <Paper sx={{ padding: 2 }}>
+          <Story />
+        </Paper>
+      )
+    },
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof OrderId>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    orderId:
+      '0x1282e32a3a69aeb5a65fcdec0ae40fe16b398d54609bc9a3c8be3eb57d1a0fd07a9af6ef9197041a5841e84cb27873bebd3486e2661510ab',
+  },
+}

--- a/src/features/swap/components/OrderId/index.tsx
+++ b/src/features/swap/components/OrderId/index.tsx
@@ -1,0 +1,30 @@
+import CopyButton from '@/components/common/CopyButton'
+import ExplorerButton from '@/components/common/ExplorerButton'
+import { Box } from '@mui/material'
+import Stack from '@mui/material/Stack'
+
+const COW_EXPLORER_BASE_URL = 'https://explorer.cow.fi/orders/'
+
+const OrderId = ({
+  orderId,
+  length = 8,
+  showCopyButton = true,
+}: {
+  orderId: string
+  length?: number
+  showCopyButton?: boolean
+}) => {
+  const truncatedOrderId = orderId.slice(0, length)
+
+  return (
+    <Stack direction="row">
+      <span>{truncatedOrderId}</span>
+      {showCopyButton && <CopyButton text={orderId} />}
+      <Box color="border.main">
+        <ExplorerButton href={`${COW_EXPLORER_BASE_URL}${orderId}`} />
+      </Box>
+    </Stack>
+  )
+}
+
+export default OrderId


### PR DESCRIPTION
## What it solves

Adds an `OrderId` component for `SwapOrder`

## How to test it

1. Open the Storybook link
2. Compare the OrderId component with the specs

## Screenshots

<img width="1050" alt="Screenshot 2024-04-15 at 12 41 16" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/9fe69fbc-7085-4526-b42e-a3d62add0ae2">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
