### PR TITLE
feat: Add SwapTxInfo, extend EthHashInfo

### DIFF
--- a/src/components/common/EthHashInfo/SrcEthHashInfo/index.stories.tsx
+++ b/src/components/common/EthHashInfo/SrcEthHashInfo/index.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import SrcEthHashInfo from './index'
+import { Paper } from '@mui/material'
+
+const meta = {
+  component: SrcEthHashInfo,
+  parameters: {
+    componentSubtitle: 'Renders a hash address with options for copy and explorer link',
+  },
+
+  decorators: [
+    (Story) => {
+      return (
+        <Paper sx={{ padding: 2 }}>
+          <Story />
+        </Paper>
+      )
+    },
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof SrcEthHashInfo>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    address: '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552',
+  },
+}
+
+export const WithName: Story = {
+  args: {
+    address: '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552',
+    name: 'Real OG',
+  },
+}
+
+export const WithOnlyName: Story = {
+  args: {
+    address: '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552',
+    name: 'Real OG',
+    onlyName: true,
+  },
+}
+
+export const WithAvatar: Story = {
+  args: {
+    address: '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552',
+    name: 'Real OG',
+    showAvatar: true,
+    avatarSize: 30,
+  },
+}

--- a/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames'
 import type { ReactNode, ReactElement, SyntheticEvent } from 'react'
 import { isAddress } from 'ethers'
 import { useTheme } from '@mui/material/styles'
@@ -15,6 +16,7 @@ export type EthHashInfoProps = {
   chainId?: string
   name?: string | null
   showAvatar?: boolean
+  onlyName?: boolean
   showCopyButton?: boolean
   prefix?: string
   showPrefix?: boolean
@@ -40,6 +42,7 @@ const SrcEthHashInfo = ({
   shortAddress = true,
   copyAddress = true,
   showAvatar = true,
+  onlyName = false,
   avatarSize,
   name,
   showCopyButton,
@@ -76,23 +79,25 @@ const SrcEthHashInfo = ({
         </div>
       )}
 
-      <Box overflow="hidden">
+      <Box overflow="hidden" className={onlyName ? css.inline : undefined}>
         {name && (
           <Box textOverflow="ellipsis" overflow="hidden" title={name}>
             {name}
           </Box>
         )}
 
-        <div className={css.addressContainer}>
-          <Box fontWeight="inherit" fontSize="inherit" overflow="hidden" textOverflow="ellipsis">
-            {copyAddress ? (
-              <CopyAddressButton prefix={prefix} address={address} copyPrefix={shouldCopyPrefix} trusted={trusted}>
-                {addressElement}
-              </CopyAddressButton>
-            ) : (
-              addressElement
-            )}
-          </Box>
+        <div className={classnames(css.addressContainer, { [css.inline]: onlyName })}>
+          {(!onlyName || !name) && (
+            <Box fontWeight="inherit" fontSize="inherit" overflow="hidden" textOverflow="ellipsis">
+              {copyAddress ? (
+                <CopyAddressButton prefix={prefix} address={address} copyPrefix={shouldCopyPrefix} trusted={trusted}>
+                  {addressElement}
+                </CopyAddressButton>
+              ) : (
+                addressElement
+              )}
+            </Box>
+          )}
 
           {showCopyButton && (
             <CopyAddressButton prefix={prefix} address={address} copyPrefix={shouldCopyPrefix} trusted={trusted} />

--- a/src/components/common/EthHashInfo/SrcEthHashInfo/styles.module.css
+++ b/src/components/common/EthHashInfo/SrcEthHashInfo/styles.module.css
@@ -22,3 +22,8 @@
   gap: 0.25em;
   white-space: nowrap;
 }
+
+.inline {
+  display: flex;
+  align-items: center;
+}

--- a/src/components/transactions/TxDetails/TxData/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/index.tsx
@@ -1,4 +1,5 @@
 import SettingsChangeTxInfo from '@/components/transactions/TxDetails/TxData/SettingsChange'
+import SwapTxInfo from '@/features/swap/components/SwapTxInfo'
 import type { SpendingLimitMethods } from '@/utils/transaction-guards'
 import {
   isCancellationTxInfo,
@@ -8,6 +9,7 @@ import {
   isSettingsChangeTxInfo,
   isSpendingLimitMethod,
   isSupportedSpendingLimitAddress,
+  isSwapTxInfo,
   isTransferTxInfo,
 } from '@/utils/transaction-guards'
 import { SpendingLimits } from '@/components/transactions/TxDetails/TxData/SpendingLimits'
@@ -42,6 +44,10 @@ const TxData = ({ txDetails, trusted }: { txDetails: TransactionDetails; trusted
   const method = txDetails.txData?.dataDecoded?.method as SpendingLimitMethods
   if (isCustomTxInfo(txInfo) && isSupportedSpendingLimitAddress(txInfo, chainId) && isSpendingLimitMethod(method)) {
     return <SpendingLimits txData={txDetails.txData} txInfo={txInfo} type={method} />
+  }
+
+  if (isSwapTxInfo(txInfo)) {
+    return <SwapTxInfo txData={txDetails.txData} />
   }
 
   return <DecodedData txData={txDetails.txData} txInfo={txInfo} />

--- a/src/features/swap/components/SwapTxInfo/index.tsx
+++ b/src/features/swap/components/SwapTxInfo/index.tsx
@@ -1,0 +1,24 @@
+import type { TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
+import EthHashInfo from '@/components/common/EthHashInfo'
+import { Box, Typography } from '@mui/material'
+
+const SwapTxInfo = ({ txData }: { txData: TransactionDetails['txData'] }) => {
+  if (!txData) return null
+
+  return (
+    <Typography component="div" display="flex" alignItems="center" fontWeight="bold" gap={1}>
+      <Box flexShrink="0">Interact with</Box>
+      <EthHashInfo
+        address={txData.to.value}
+        name={txData.to.name ?? undefined}
+        customAvatar={txData.to.logoUri ?? undefined}
+        avatarSize={24}
+        shortAddress={false}
+        hasExplorer
+        onlyName
+      />
+    </Typography>
+  )
+}
+
+export default SwapTxInfo


### PR DESCRIPTION
## What it solves

We want to display a reduced `TxData` section for `SwapOrders` according to the [design specs](https://www.figma.com/file/VyA38zUPbJ2zflzCIYR6Nu/Swap?node-id=5807%3A29679&mode=dev)

## How this PR fixes it

- Extends `EthHashInfo` with a new prop `onlyName`
- Adds `SwapTxInfo` component

## How to test it

1. Execute a swap
2. Observe the new "Interact with" block

## Screenshots

<img width="843" alt="Screenshot 2024-04-15 at 15 59 49" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/6c7d8323-fb7f-4017-9485-519092c54465">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
