### PR TITLE
fix: Dashboard widget color in dark mode

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,7 @@
     "plugin:prettier/recommended",
     "plugin:storybook/recommended"
   ],
+  "parser": "@typescript-eslint/parser",
   "rules": {
     "@next/next/no-img-element": "off",
     "@next/next/google-font-display": "off",

--- a/src/components/dashboard/FirstSteps/index.tsx
+++ b/src/components/dashboard/FirstSteps/index.tsx
@@ -91,16 +91,7 @@ const UsefulHintsWidget = () => {
   return (
     <StatusCard
       badge={
-        <Typography
-          variant="body2"
-          sx={{
-            backgroundColor: 'info.main',
-            borderRadius: '0 0 4px 4px',
-            padding: '4px 8px',
-            display: 'flex',
-            alignItems: 'center',
-          }}
-        >
+        <Typography variant="body2" className={classnames(css.badgeText, css.badgeTextInfo)}>
           <LightbulbOutlinedIcon fontSize="small" sx={{ mr: 0.5 }} />
           Did you know
         </Typography>
@@ -131,10 +122,7 @@ const AddFundsWidget = ({ completed }: { completed: boolean }) => {
   return (
     <StatusCard
       badge={
-        <Typography
-          variant="body2"
-          sx={{ backgroundColor: 'secondary.light', borderRadius: '0 0 4px 4px', padding: '4px 8px' }}
-        >
+        <Typography variant="body2" className={css.badgeText}>
           First interaction
         </Typography>
       }
@@ -233,10 +221,7 @@ const FirstTransactionWidget = ({ completed }: { completed: boolean }) => {
     <>
       <StatusCard
         badge={
-          <Typography
-            variant="body2"
-            sx={{ backgroundColor: 'secondary.light', borderRadius: '0 0 4px 4px', padding: '4px 8px' }}
-          >
+          <Typography variant="body2" className={css.badgeText}>
             First interaction
           </Typography>
         }

--- a/src/components/dashboard/FirstSteps/styles.module.css
+++ b/src/components/dashboard/FirstSteps/styles.module.css
@@ -22,6 +22,19 @@
   border-radius: 0 0 4px 4px;
 }
 
+.badgeText {
+  background-color: var(--color-secondary-light);
+  color: var(--color-static-main);
+  border-radius: 0 0 4px 4px;
+  padding: 4px 8px;
+  display: flex;
+  align-items: center;
+}
+
+.badgeTextInfo {
+  background-color: var(--color-info-main);
+}
+
 .status {
   align-self: flex-start;
   margin-bottom: auto;


### PR DESCRIPTION
## What it solves

Follow up on #3495 

## How this PR fixes it

- Adds back the `static.main` color to the badge

## How to test it

1. Create a counterfactual Safe
2. Go to the dashboard
3. Switch to dark mode
4. Observe the badges are readable

## Screenshots
<img width="1278" alt="Screenshot 2024-04-16 at 14 18 40" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/28b58c7b-a057-495d-aef1-b8b90f14449d">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
