### PR TITLE
Fix: truncated orderId should not contain 0x

### DIFF
--- a/src/features/swap/components/OrderId/index.tsx
+++ b/src/features/swap/components/OrderId/index.tsx
@@ -14,7 +14,8 @@ const OrderId = ({
   length?: number
   showCopyButton?: boolean
 }) => {
-  const truncatedOrderId = orderId.slice(0, length)
+  // CoWSwap doesn't show the 0x at the beginning of a tx
+  const truncatedOrderId = orderId.replace('0x', '').slice(0, length)
 
   return (
     <Stack direction="row">


### PR DESCRIPTION
## What it solves
the truncated orderId for cowswap orders should not contain 0x (it is also shown without it in the cowswap interface)
