### PR TITLE
fix: Override handlers in new app communicator

### DIFF
--- a/src/hooks/safe-apps/useCustomAppCommunicator.tsx
+++ b/src/hooks/safe-apps/useCustomAppCommunicator.tsx
@@ -1,11 +1,10 @@
 import { useState, useEffect, useContext, type MutableRefObject } from 'react'
 import type { UseAppCommunicatorHandlers } from '@/components/safe-apps/AppFrame/useAppCommunicator'
 import useAppCommunicator, { CommunicatorMessages } from '@/components/safe-apps/AppFrame/useAppCommunicator'
+import type { Methods } from '@safe-global/safe-apps-sdk'
 import {
-  type AddressBookItem,
   type BaseTransaction,
   type EIP712TypedData,
-  Methods,
   type RequestId,
   type SafeSettings,
   type SendTransactionRequestParams,
@@ -30,8 +29,6 @@ import { trackSafeAppEvent, SAFE_APPS_EVENTS } from '@/services/analytics'
 import { safeMsgSubscribe, SafeMsgEvent } from '@/services/safe-messages/safeMsgEvents'
 import { txSubscribe, TxEvent } from '@/services/tx/txEvents'
 import type { ChainInfo as WebCoreChainInfo } from '@safe-global/safe-gateway-typescript-sdk/dist/types/chains'
-import { useSafePermissions } from '@/hooks/safe-apps/permissions'
-import useAddressBook from '@/hooks/useAddressBook'
 import useChainId from '@/hooks/useChainId'
 import type AppCommunicator from '@/services/safe-apps/AppCommunicator'
 import useBalances from '@/hooks/useBalances'
@@ -50,9 +47,6 @@ export const useCustomAppCommunicator = (
   const [settings, setSettings] = useState<SafeSettings>({
     offChainSigning: true,
   })
-  const { getPermissions, hasPermission, permissionsRequest, setPermissionsRequest, confirmPermissionRequest } =
-    useSafePermissions()
-  const addressBook = useAddressBook()
   const appData = app
   const onTxFlowClose = () => {
     setCurrentRequestId((prevId) => {
@@ -115,15 +109,9 @@ export const useCustomAppCommunicator = (
         )
       }
     },
-    onGetPermissions: getPermissions,
-    onSetPermissions: setPermissionsRequest,
-    onRequestAddressBook: (origin: string): AddressBookItem[] => {
-      if (hasPermission(origin, Methods.requestAddressBook)) {
-        return Object.entries(addressBook).map(([address, name]) => ({ address, name, chainId }))
-      }
-
-      return []
-    },
+    onGetPermissions: () => [],
+    onSetPermissions: () => {},
+    onRequestAddressBook: () => [],
     onGetTxBySafeTxHash: (safeTxHash) => getTransactionDetails(chainId, safeTxHash),
     onGetEnvironmentInfo: () => ({
       origin: document.location.origin,


### PR DESCRIPTION
## What it solves

We extracted the app communicator handlers into a new hook called `useCustomAppCommunicator`. It also uses the `useSafePermissions` hook but now this hooks is used in two places but the data is only updated in one. This results in the `AppFrame` not having the data for e.g. `permissionsRequest` so safe apps won't see a dialog when requesting permissions for the address book.

## How this PR fixes it

Uses `overrideHandlers` to keep the handlers in `AppFrame`

## How to test it

1. 

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
