### PR TITLE
feat: Add SwapProgress component

### DIFF
--- a/src/features/swap/components/SwapProgress/index.stories.tsx
+++ b/src/features/swap/components/SwapProgress/index.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import SwapProgress from './index'
+import { Paper } from '@mui/material'
+
+const meta = {
+  component: SwapProgress,
+  parameters: {
+    componentSubtitle: 'Renders a linear progress bar with % of a token sold',
+  },
+
+  decorators: [
+    (Story) => {
+      return (
+        <Paper sx={{ padding: 2 }}>
+          <Story />
+        </Paper>
+      )
+    },
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof SwapProgress>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const PartiallyFilled: Story = {
+  args: {
+    progress: '40.00',
+    tokenAmount: '1',
+    tokenSymbol: 'ETH',
+  },
+}
+
+export const Filled: Story = {
+  args: {
+    progress: '100.00',
+    tokenAmount: '1',
+    tokenSymbol: 'ETH',
+  },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/VyA38zUPbJ2zflzCIYR6Nu/Swap?node-id=5974%3A14487&mode=dev',
+    },
+  },
+}

--- a/src/features/swap/components/SwapProgress/index.stories.tsx
+++ b/src/features/swap/components/SwapProgress/index.stories.tsx
@@ -23,14 +23,6 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const PartiallyFilled: Story = {
-  args: {
-    progress: '40.00',
-    tokenAmount: '1',
-    tokenSymbol: 'ETH',
-  },
-}
-
 export const Filled: Story = {
   args: {
     progress: '100.00',
@@ -42,5 +34,21 @@ export const Filled: Story = {
       type: 'figma',
       url: 'https://www.figma.com/file/VyA38zUPbJ2zflzCIYR6Nu/Swap?node-id=5974%3A14487&mode=dev',
     },
+  },
+}
+
+export const PartiallyFilled: Story = {
+  args: {
+    progress: '40.00',
+    tokenAmount: '1',
+    tokenSymbol: 'ETH',
+  },
+}
+
+export const NotFilled: Story = {
+  args: {
+    progress: '0.00',
+    tokenAmount: '1',
+    tokenSymbol: 'ETH',
   },
 }

--- a/src/features/swap/components/SwapProgress/index.tsx
+++ b/src/features/swap/components/SwapProgress/index.tsx
@@ -1,0 +1,31 @@
+import { LinearProgress, Stack, Typography } from '@mui/material'
+
+const SwapProgress = ({
+  progress,
+  tokenAmount,
+  tokenSymbol,
+}: {
+  progress: string
+  tokenAmount: string
+  tokenSymbol: string
+}) => {
+  const progressValue = Math.min(Math.max(Number(progress), 0), 100)
+  const isFilled = progressValue >= 100
+  const soldAmount = Number(tokenAmount) * (progressValue / 100)
+  const color = isFilled ? 'success' : 'warning'
+
+  return (
+    <Stack direction="row" alignItems="center" gap={1}>
+      <LinearProgress variant="determinate" value={progressValue} sx={{ flex: 1, borderRadius: '6px' }} color={color} />
+      <Typography color={`${color}.main`}>{progressValue} %</Typography>
+      <Typography>
+        <Typography component="span" fontWeight="bold">
+          {soldAmount} {tokenSymbol}
+        </Typography>{' '}
+        sold
+      </Typography>
+    </Stack>
+  )
+}
+
+export default SwapProgress


### PR DESCRIPTION
## What it solves

Adds `SwapProgress` component to be used in `SellOrder` according to the [Design](https://www.figma.com/file/VyA38zUPbJ2zflzCIYR6Nu/Swap?node-id=5974%3A14487&mode=dev)

## How to test it

1. Check the component in Storybook

## Screenshots

<img width="1064" alt="Screenshot 2024-04-17 at 15 27 06" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/2745d488-0725-4746-b135-7ad65e27aa26">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
