### PR TITLE
fix: Show different label for sell orders

### DIFF
--- a/src/components/common/Table/DataTable.tsx
+++ b/src/components/common/Table/DataTable.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react'
-import { Box, Typography } from '@mui/material'
+import { Stack, Typography } from '@mui/material'
 import type { DataRow } from '@/components/common/Table/DataRow'
 
 type DataTableProps = {
@@ -9,13 +9,13 @@ type DataTableProps = {
 
 export const DataTable = ({ header, rows }: DataTableProps): ReactElement | null => {
   return (
-    <Box>
+    <Stack gap="4px">
       <Typography variant="body1">
         <b>{header}</b>
       </Typography>
-      {rows.map((row, index) => {
+      {rows.map((row) => {
         return row
       })}
-    </Box>
+    </Stack>
   )
 }

--- a/src/features/swap/components/SwapOrder/index.tsx
+++ b/src/features/swap/components/SwapOrder/index.tsx
@@ -1,8 +1,10 @@
+import TokenIcon from '@/components/common/TokenIcon'
 import OrderId from '@/features/swap/components/OrderId'
 import StatusLabel from '@/features/swap/components/StatusLabel'
+import { capitalize } from '@/hooks/useMnemonicName'
 import { formatDateTime, formatTimeInWords } from '@/utils/date'
+import Stack from '@mui/material/Stack'
 import type { ReactElement } from 'react'
-import Image from 'next/image'
 import { type SwapOrder as SwapOrderType, type TransactionData } from '@safe-global/safe-gateway-typescript-sdk'
 import { DataRow } from '@/components/common/Table/DataRow'
 import { DataTable } from '@/components/common/Table/DataTable'
@@ -21,6 +23,7 @@ export const SellOrder = ({ order }: { order: SwapOrderType }) => {
     buyToken,
     sellToken,
     orderUid,
+    orderKind,
     expiresTimestamp,
     status,
     executionPriceLabel,
@@ -32,26 +35,30 @@ export const SellOrder = ({ order }: { order: SwapOrderType }) => {
   const expires = new Date(expiresTimestamp * 1000)
   const now = new Date()
 
+  const orderKindLabel = capitalize(orderKind)
+  const isSellOrder = orderKind === 'sell'
+
   return (
     <DataTable
-      header="Sell order"
+      header={`${orderKindLabel} order`}
       rows={[
         <DataRow key="Amount" title="Amount">
-          <div>
+          <Stack flexDirection={isSellOrder ? 'column' : 'column-reverse'}>
             <div>
               <span className={css.value}>
-                Sell {sellToken.logo && <Image src={sellToken.logo} alt={sellToken.symbol} width={24} height={24} />}{' '}
-                {sellToken.amount} {sellToken.symbol}
+                {isSellOrder ? 'Sell' : 'For at most'}{' '}
+                {sellToken.logo && <TokenIcon logoUri={sellToken.logo} size={24} />} {sellToken.amount}{' '}
+                {sellToken.symbol}
               </span>
             </div>
             <div>
               <span className={css.value}>
-                For at least{' '}
-                {buyToken.logo && <Image src={buyToken.logo} alt={buyToken.symbol} width={24} height={24} />}
+                {isSellOrder ? 'for at least' : 'Buy'}{' '}
+                {buyToken.logo && <TokenIcon logoUri={buyToken.logo} size={24} />}
                 {buyToken.amount} {buyToken.symbol}
               </span>
             </div>
-          </div>
+          </Stack>
         </DataRow>,
         status === 'fulfilled' ? (
           <DataRow key="Execution price" title="Execution price">
@@ -69,19 +76,23 @@ export const SellOrder = ({ order }: { order: SwapOrderType }) => {
         ) : (
           <></>
         ),
-        compareAsc(now, expires) !== 1 ? (
-          <DataRow key="Expiry" title="Expiry">
-            <Typography>
-              <Typography fontWeight={700} component="span">
-                {formatTimeInWords(expiresTimestamp * 1000)}
-              </Typography>{' '}
-              ({formatDateTime(expiresTimestamp * 1000)})
-            </Typography>
-          </DataRow>
+        status !== 'fulfilled' ? (
+          compareAsc(now, expires) !== 1 ? (
+            <DataRow key="Expiry" title="Expiry">
+              <Typography>
+                <Typography fontWeight={700} component="span">
+                  {formatTimeInWords(expiresTimestamp * 1000)}
+                </Typography>{' '}
+                ({formatDateTime(expiresTimestamp * 1000)})
+              </Typography>
+            </DataRow>
+          ) : (
+            <DataRow key="Expiry" title="Expiry">
+              {formatDateTime(expiresTimestamp * 1000)}
+            </DataRow>
+          )
         ) : (
-          <DataRow key="Expiry" title="Expiry">
-            {formatDateTime(expiresTimestamp * 1000)}
-          </DataRow>
+          <></>
         ),
         <DataRow key="Order ID" title="Order ID">
           <OrderId orderId={orderUid} href={explorerUrl} />

--- a/src/hooks/useMnemonicName/index.ts
+++ b/src/hooks/useMnemonicName/index.ts
@@ -5,7 +5,7 @@ import { animalsDict, adjectivesDict } from './dict'
 const animals: string[] = animalsDict.trim().split(/\s+/)
 const adjectives: string[] = adjectivesDict.trim().split(/\s+/)
 
-const capitalize = (word: string) => (word.length > 0 ? `${word.charAt(0).toUpperCase()}${word.slice(1)}` : word)
+export const capitalize = (word: string) => (word.length > 0 ? `${word.charAt(0).toUpperCase()}${word.slice(1)}` : word)
 
 const getRandomItem = <T>(arr: T[]): T => {
   return arr[Math.floor(arr.length * Math.random())]


### PR DESCRIPTION
## What it solves

Show different labels and a different order of swaps when its a sell or buy order.

## How this PR fixes it

- Adds a small gap for the `DataTable`
- Uses `TokenIcon` component so there is a fallback image

## How to test it

1. Create a buy and sell order
2. Observe the different orders and labels

## Screenshots
<img width="628" alt="Screenshot 2024-04-17 at 16 59 35" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/a10aeb33-2178-4e90-84c2-75e900338e76">

<img width="678" alt="Screenshot 2024-04-17 at 16 59 51" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/56cf4464-e2ff-4dc6-b0a4-296067ebd3cb">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻


