### PR TITLE
Fix: link to the accounts page from the logo

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -33,8 +33,7 @@ const Header = ({ onMenuToggle, onBatchToggle }: HeaderProps): ReactElement => {
   const router = useRouter()
   const enableWc = useHasFeature(FEATURES.NATIVE_WALLETCONNECT)
 
-  // Logo link: if on Dashboard, link to Welcome, otherwise to the root (which redirects to either Dashboard or Welcome)
-  const logoHref = router.pathname === AppRoutes.home ? AppRoutes.welcome.index : AppRoutes.index
+  const logoHref = router.pathname === AppRoutes.welcome.accounts ? AppRoutes.welcome.index : AppRoutes.welcome.accounts
 
   const handleMenuToggle = () => {
     if (onMenuToggle) {

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -1,6 +1,7 @@
 import type { Dispatch, SetStateAction } from 'react'
 import { type ReactElement } from 'react'
 import { useRouter } from 'next/router'
+import type { Url } from 'next/dist/shared/lib/router/router'
 import { IconButton, Paper } from '@mui/material'
 import MenuIcon from '@mui/icons-material/Menu'
 import classnames from 'classnames'
@@ -26,6 +27,14 @@ type HeaderProps = {
   onBatchToggle?: Dispatch<SetStateAction<boolean>>
 }
 
+function getLogoLink(router: ReturnType<typeof useRouter>): Url {
+  return router.pathname === AppRoutes.home || !router.query.safe
+    ? router.pathname === AppRoutes.welcome.accounts
+      ? AppRoutes.welcome.index
+      : AppRoutes.welcome.accounts
+    : { pathname: AppRoutes.home, query: { safe: router.query.safe } }
+}
+
 const Header = ({ onMenuToggle, onBatchToggle }: HeaderProps): ReactElement => {
   const chainId = useChainId()
   const safeAddress = useSafeAddress()
@@ -33,7 +42,8 @@ const Header = ({ onMenuToggle, onBatchToggle }: HeaderProps): ReactElement => {
   const router = useRouter()
   const enableWc = useHasFeature(FEATURES.NATIVE_WALLETCONNECT)
 
-  const logoHref = router.pathname === AppRoutes.welcome.accounts ? AppRoutes.welcome.index : AppRoutes.welcome.accounts
+  // If on the home page, the logo should link to the Accounts or Welcome page, otherwise to the home page
+  const logoHref = getLogoLink(router)
 
   const handleMenuToggle = () => {
     if (onMenuToggle) {


### PR DESCRIPTION
## What it solves

The logo has been historically linking to the Index or Welcome page which is now not so useful anymore.

It will now link to the Home page if on a different Safe page, or to the Accounts page (`/welcome/accounts`) if on Home already.