### PR TITLE
fix: map `to` and `value` of `SwapOrder` type transactions

### DIFF
--- a/src/services/tx/__tests__/extractTxInfo.test.ts
+++ b/src/services/tx/__tests__/extractTxInfo.test.ts
@@ -112,4 +112,114 @@ describe('extractTxInfo', () => {
       },
     })
   })
+
+  it('should extract tx info for a swap order', () => {
+    const txDetails = {
+      safeAddress: '0xF979f34D16d865f51e2eC7baDEde4f3735DaFb7d',
+      txId: 'multisig_0xF979f34D16d865f51e2eC7baDEde4f3735DaFb7d_0x8061c0374937f7c1722e3e305d9e364c84e06fadda806e36c0e09a110b806f42',
+      executedAt: null,
+      txStatus: 'AWAITING_EXECUTION',
+      txInfo: {
+        type: 'SwapOrder',
+        humanDescription: null,
+        richDecodedInfo: null,
+        orderUid:
+          '0xc062b80afd6bd050f3edc555c7e9c6af73432c5037ac4b579a244dfefd6d4a92f979f34d16d865f51e2ec7badede4f3735dafb7d662110c6',
+        status: 'expired',
+        orderKind: 'buy',
+        sellToken: {
+          logo: 'https://safe-transaction-assets.staging.5afe.dev/tokens/logos/0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14.png',
+          symbol: 'WETH',
+          amount: '0.00895526057385569',
+        },
+        buyToken: {
+          logo: 'https://safe-transaction-assets.staging.5afe.dev/tokens/logos/0x0625aFB445C3B6B7B929342a04A22599fd5dBB59.png',
+          symbol: 'COW',
+          amount: '0.254',
+        },
+        expiresTimestamp: 1713443014,
+        filledPercentage: '0.00',
+        explorerUrl:
+          'https://explorer.cow.fi/orders/0xc062b80afd6bd050f3edc555c7e9c6af73432c5037ac4b579a244dfefd6d4a92f979f34d16d865f51e2ec7badede4f3735dafb7d662110c6',
+        limitPriceLabel: '1 WETH = 0.035256931393132636 COW',
+      },
+      txData: {
+        hexData:
+          '0xec6cb13f000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000038c062b80afd6bd050f3edc555c7e9c6af73432c5037ac4b579a244dfefd6d4a92f979f34d16d865f51e2ec7badede4f3735dafb7d662110c60000000000000000',
+        dataDecoded: {
+          method: 'setPreSignature',
+          parameters: [
+            {
+              name: 'orderUid',
+              type: 'bytes',
+              value:
+                '0xc062b80afd6bd050f3edc555c7e9c6af73432c5037ac4b579a244dfefd6d4a92f979f34d16d865f51e2ec7badede4f3735dafb7d662110c6',
+            },
+            { name: 'signed', type: 'bool', value: 'True' },
+          ],
+        },
+        to: { value: '0x9008D19f58AAbD9eD0D60971565AA8510560ab41', name: null, logoUri: null },
+        value: '0',
+        operation: 0,
+        trustedDelegateCallTarget: null,
+        addressInfoIndex: null,
+      },
+      txHash: null,
+      detailedExecutionInfo: {
+        type: 'MULTISIG',
+        submittedAt: 1713441228191,
+        nonce: 19,
+        safeTxGas: '0',
+        baseGas: '0',
+        gasPrice: '0',
+        gasToken: '0x0000000000000000000000000000000000000000',
+        refundReceiver: { value: '0x0000000000000000000000000000000000000000', name: null, logoUri: null },
+        safeTxHash: '0x8061c0374937f7c1722e3e305d9e364c84e06fadda806e36c0e09a110b806f42',
+        executor: null,
+        signers: [
+          { value: '0x3326c5D84bd462Ec1CadA0B5bBa9b2B85059FCba', name: null, logoUri: null },
+          { value: '0xbbeedB6d8e56e23f5812e59d1b6602F15957271F', name: null, logoUri: null },
+        ],
+        confirmationsRequired: 1,
+        confirmations: [
+          {
+            signer: { value: '0xbbeedB6d8e56e23f5812e59d1b6602F15957271F', name: null, logoUri: null },
+            signature:
+              '0xb10e0605bd27c42af87ff36d690a5594d13a4a7029ea5f080dde917d0781f97901958195d0d99c7805419adb636ccdc579e9aa200ee0443dd10c4f5885f37f081b',
+            submittedAt: 1713441228230,
+          },
+        ],
+        rejectors: [],
+        gasTokenInfo: null,
+        trusted: true,
+        proposer: { value: '0xbbeedB6d8e56e23f5812e59d1b6602F15957271F', name: null, logoUri: null },
+      },
+      safeAppInfo: {
+        name: 'CowSwap',
+        url: 'https://cowswap.exchange/',
+        logoUri: 'https://safe-transaction-assets.staging.5afe.dev/safe_apps/58/icon.png',
+      },
+    } as unknown as TransactionDetails
+
+    const safeAddress = '0xF979f34D16d865f51e2eC7baDEde4f3735DaFb7d'
+
+    expect(extractTxInfo(txDetails, safeAddress)).toEqual({
+      signatures: {
+        '0xbbeedB6d8e56e23f5812e59d1b6602F15957271F':
+          '0xb10e0605bd27c42af87ff36d690a5594d13a4a7029ea5f080dde917d0781f97901958195d0d99c7805419adb636ccdc579e9aa200ee0443dd10c4f5885f37f081b',
+      },
+      txParams: {
+        baseGas: '0',
+        data: '0xec6cb13f000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000038c062b80afd6bd050f3edc555c7e9c6af73432c5037ac4b579a244dfefd6d4a92f979f34d16d865f51e2ec7badede4f3735dafb7d662110c60000000000000000',
+        gasPrice: '0',
+        gasToken: '0x0000000000000000000000000000000000000000',
+        nonce: 19,
+        operation: 0,
+        refundReceiver: '0x0000000000000000000000000000000000000000',
+        safeTxGas: '0',
+        to: '0x9008D19f58AAbD9eD0D60971565AA8510560ab41',
+        value: '0',
+      },
+    })
+  })
 })

--- a/src/services/tx/extractTxInfo.ts
+++ b/src/services/tx/extractTxInfo.ts
@@ -57,12 +57,16 @@ const extractTxInfo = (
         } else {
           return txDetails.txData?.value ?? '0'
         }
+      case 'SwapOrder':
+        return txDetails.txData?.value ?? '0'
       case 'Custom':
         return txDetails.txInfo.value
       case 'Creation':
       case 'SettingsChange':
-      default:
         return '0'
+      default: {
+        throw new Error(`Unknown transaction type: ${txDetails.txInfo.type}`)
+      }
     }
   })()
 
@@ -74,12 +78,21 @@ const extractTxInfo = (
         } else {
           return txDetails.txInfo.transferInfo.tokenAddress
         }
+      case 'SwapOrder':
+        const swapOrderTo = txDetails.txData?.to.value
+        // TODO: Remove assertion after type is corrected
+        if (!swapOrderTo) {
+          throw new Error('SwapOrder tx data does not have a `to` field')
+        }
+        return swapOrderTo
       case 'Custom':
         return txDetails.txInfo.to.value
       case 'Creation':
       case 'SettingsChange':
-      default:
         return safeAddress
+      default: {
+        throw new Error(`Unknown transaction type: ${txDetails.txInfo.type}`)
+      }
     }
   })()
 


### PR DESCRIPTION
## What it solves

Inability to execute queued CoW Swap orders.

## How this PR fixes it

The `to` and `value` of `SwapOrder`-typed transactions were not being mapped correctly for the SDK. New mapping cases have been added to cover them accordingly, as well as test coverage.

Associated error prevention has also been included, should other transaction types be added in the future.

## How to test it

1. Queue a CoW Swap order.
2. Observe ability to successfully execute the order.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
