### PR TITLE
fix: open info page in new tab

### DIFF
--- a/src/components/dashboard/ActivityRewardsSection/index.tsx
+++ b/src/components/dashboard/ActivityRewardsSection/index.tsx
@@ -86,7 +86,7 @@ const ActivityRewardsSection = () => {
               <NextLink href={appUrl} passHref rel="noreferrer" onClick={onClick}>
                 <Button variant="contained">{'Get Safe{Pass}'}</Button>
               </NextLink>
-              <NextLink href="https://safe.global/pass" passHref rel="noreferrer" onClick={onClick}>
+              <NextLink href="https://safe.global/pass" target="_blank" passHref rel="noreferrer" onClick={onClick}>
                 <Button variant="outlined">Learn more</Button>
               </NextLink>
             </Box>


### PR DESCRIPTION
## What it solves
The Learn more button in the Safe Pass banner did not open in a new tab.

## How this PR fixes it
- Sets `target` to `_blank`

## How to test it
- Click on Learn more

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
