### PR TITLE
fix: Disable Execute button for expired swaps

### DIFF
--- a/src/components/transactions/ExecuteTxButton/index.tsx
+++ b/src/components/transactions/ExecuteTxButton/index.tsx
@@ -4,7 +4,7 @@ import { type TransactionSummary } from '@safe-global/safe-gateway-typescript-sd
 import { Button, Tooltip } from '@mui/material'
 
 import useSafeInfo from '@/hooks/useSafeInfo'
-import { isMultisigExecutionInfo } from '@/utils/transaction-guards'
+import { isMultisigExecutionInfo, isSwapTxInfo } from '@/utils/transaction-guards'
 import Track from '@/components/common/Track'
 import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
 import { ReplaceTxHoverContext } from '../GroupedTxListItems/ReplaceTxHoverProvider'
@@ -26,8 +26,10 @@ const ExecuteTxButton = ({
   const { setSelectedTxId } = useContext(ReplaceTxHoverContext)
   const safeSDK = useSafeSDK()
 
+  const isExpiredSwap = isSwapTxInfo(txSummary.txInfo) && txSummary.txInfo.status === 'expired'
+
   const isNext = txNonce !== undefined && txNonce === safe.nonce
-  const isDisabled = !isNext || !safeSDK
+  const isDisabled = !isNext || !safeSDK || isExpiredSwap
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()

--- a/src/components/transactions/ExecuteTxButton/index.tsx
+++ b/src/components/transactions/ExecuteTxButton/index.tsx
@@ -4,7 +4,7 @@ import { type TransactionSummary } from '@safe-global/safe-gateway-typescript-sd
 import { Button, Tooltip } from '@mui/material'
 
 import useSafeInfo from '@/hooks/useSafeInfo'
-import { isMultisigExecutionInfo, isSwapTxInfo } from '@/utils/transaction-guards'
+import { isExpiredSwap, isMultisigExecutionInfo } from '@/utils/transaction-guards'
 import Track from '@/components/common/Track'
 import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
 import { ReplaceTxHoverContext } from '../GroupedTxListItems/ReplaceTxHoverProvider'
@@ -26,10 +26,10 @@ const ExecuteTxButton = ({
   const { setSelectedTxId } = useContext(ReplaceTxHoverContext)
   const safeSDK = useSafeSDK()
 
-  const isExpiredSwap = isSwapTxInfo(txSummary.txInfo) && txSummary.txInfo.status === 'expired'
+  const expiredSwap = isExpiredSwap(txSummary.txInfo)
 
   const isNext = txNonce !== undefined && txNonce === safe.nonce
-  const isDisabled = !isNext || !safeSDK || isExpiredSwap
+  const isDisabled = !isNext || !safeSDK || expiredSwap
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()

--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -1,7 +1,7 @@
 import React, { type ReactElement } from 'react'
 import type { TransactionDetails, TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import { getTransactionDetails, Operation } from '@safe-global/safe-gateway-typescript-sdk'
-import { Box, CircularProgress } from '@mui/material'
+import { Box, CircularProgress, Typography } from '@mui/material'
 
 import TxSigners from '@/components/transactions/TxSigners'
 import Summary from '@/components/transactions/TxDetails/Summary'
@@ -62,6 +62,8 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
     proposer = txDetails.detailedExecutionInfo.proposer?.value
     safeTxHash = txDetails.detailedExecutionInfo.safeTxHash
   }
+
+  const isExpiredSwap = isSwapTxInfo(txSummary.txInfo) && txSummary.txInfo.status === 'expired'
 
   return (
     <>
@@ -129,6 +131,12 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
               {awaitingExecution ? <ExecuteTxButton txSummary={txSummary} /> : <SignTxButton txSummary={txSummary} />}
               <RejectTxButton txSummary={txSummary} safeTxHash={safeTxHash} proposer={proposer} />
             </Box>
+          )}
+
+          {isExpiredSwap && (
+            <Typography color="text.secondary" mt={2}>
+              This order has expired. Reject this transaction and try again.
+            </Typography>
           )}
         </div>
       )}

--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -10,6 +10,7 @@ import useChainId from '@/hooks/useChainId'
 import useAsync from '@/hooks/useAsync'
 import {
   isAwaitingExecution,
+  isExpiredSwap,
   isModuleExecutionInfo,
   isMultiSendTxInfo,
   isMultisigDetailedExecutionInfo,
@@ -63,7 +64,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
     safeTxHash = txDetails.detailedExecutionInfo.safeTxHash
   }
 
-  const isExpiredSwap = isSwapTxInfo(txSummary.txInfo) && txSummary.txInfo.status === 'expired'
+  const expiredSwap = isExpiredSwap(txSummary.txInfo)
 
   return (
     <>
@@ -133,7 +134,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
             </Box>
           )}
 
-          {isExpiredSwap && (
+          {expiredSwap && (
             <Typography color="text.secondary" mt={2}>
               This order has expired. Reject this transaction and try again.
             </Typography>

--- a/src/components/transactions/TxDetails/styles.module.css
+++ b/src/components/transactions/TxDetails/styles.module.css
@@ -68,6 +68,14 @@
   margin-top: var(--space-2);
 }
 
+.buttons > * {
+  flex: 1;
+}
+
+.buttons button {
+  width: 100%;
+}
+
 @media (max-width: 599.95px) {
   .container {
     flex-direction: column;

--- a/src/components/transactions/TxStatusLabel/index.tsx
+++ b/src/components/transactions/TxStatusLabel/index.tsx
@@ -1,10 +1,15 @@
+import { isSwapTxInfo } from '@/utils/transaction-guards'
 import { CircularProgress, type Palette, Typography } from '@mui/material'
 import { TransactionStatus, type TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import useIsPending from '@/hooks/useIsPending'
 import useTransactionStatus from '@/hooks/useTransactionStatus'
 
-const getStatusColor = (value: TransactionStatus, palette: Palette) => {
-  switch (value) {
+const getStatusColor = (tx: TransactionSummary, palette: Palette) => {
+  if (isSwapTxInfo(tx.txInfo) && tx.txInfo.status === 'cancelled') {
+    return palette.error.main
+  }
+
+  switch (tx.txStatus) {
     case TransactionStatus.SUCCESS:
       return palette.success.main
     case TransactionStatus.FAILED:
@@ -29,7 +34,7 @@ const TxStatusLabel = ({ tx }: { tx: TransactionSummary }) => {
       display="flex"
       alignItems="center"
       gap={1}
-      color={({ palette }) => getStatusColor(tx.txStatus, palette)}
+      color={({ palette }) => getStatusColor(tx, palette)}
       data-testid="tx-status-label"
     >
       {isPending && <CircularProgress size={14} color="inherit" />}

--- a/src/components/transactions/TxStatusLabel/index.tsx
+++ b/src/components/transactions/TxStatusLabel/index.tsx
@@ -1,11 +1,11 @@
-import { isSwapTxInfo } from '@/utils/transaction-guards'
+import { isCancelledSwap } from '@/utils/transaction-guards'
 import { CircularProgress, type Palette, Typography } from '@mui/material'
 import { TransactionStatus, type TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import useIsPending from '@/hooks/useIsPending'
 import useTransactionStatus from '@/hooks/useTransactionStatus'
 
 const getStatusColor = (tx: TransactionSummary, palette: Palette) => {
-  if (isSwapTxInfo(tx.txInfo) && tx.txInfo.status === 'cancelled') {
+  if (isCancelledSwap(tx.txInfo)) {
     return palette.error.main
   }
 

--- a/src/components/transactions/TxSummary/index.tsx
+++ b/src/components/transactions/TxSummary/index.tsx
@@ -6,7 +6,7 @@ import { type Transaction } from '@safe-global/safe-gateway-typescript-sdk'
 import css from './styles.module.css'
 import DateTime from '@/components/common/DateTime'
 import TxInfo from '@/components/transactions/TxInfo'
-import { isMultisigExecutionInfo, isSwapTxInfo, isTxQueued } from '@/utils/transaction-guards'
+import { isExpiredSwap, isMultisigExecutionInfo, isTxQueued } from '@/utils/transaction-guards'
 import TxType from '@/components/transactions/TxType'
 import classNames from 'classnames'
 import { isTrustedTx } from '@/utils/transactions'
@@ -32,7 +32,7 @@ const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
   const isTrusted = !hasDefaultTokenlist || isTrustedTx(tx)
   const isPending = useIsPending(tx.id)
   const executionInfo = isMultisigExecutionInfo(tx.executionInfo) ? tx.executionInfo : undefined
-  const isExpiredSwap = isSwapTxInfo(tx.txInfo) && tx.txInfo.status === 'expired'
+  const expiredSwap = isExpiredSwap(tx.txInfo)
 
   return (
     <Box
@@ -83,7 +83,7 @@ const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
         </Box>
       )}
 
-      {isExpiredSwap && (
+      {expiredSwap && (
         <Box gridArea="status" justifyContent="flex-end" display="flex" className={css.status}>
           <StatusLabel status="expired" />
         </Box>

--- a/src/components/transactions/TxSummary/index.tsx
+++ b/src/components/transactions/TxSummary/index.tsx
@@ -1,3 +1,4 @@
+import StatusLabel from '@/features/swap/components/StatusLabel'
 import { Box } from '@mui/material'
 import type { ReactElement } from 'react'
 import { type Transaction } from '@safe-global/safe-gateway-typescript-sdk'
@@ -5,7 +6,7 @@ import { type Transaction } from '@safe-global/safe-gateway-typescript-sdk'
 import css from './styles.module.css'
 import DateTime from '@/components/common/DateTime'
 import TxInfo from '@/components/transactions/TxInfo'
-import { isMultisigExecutionInfo, isTxQueued } from '@/utils/transaction-guards'
+import { isMultisigExecutionInfo, isSwapTxInfo, isTxQueued } from '@/utils/transaction-guards'
 import TxType from '@/components/transactions/TxType'
 import classNames from 'classnames'
 import { isTrustedTx } from '@/utils/transactions'
@@ -31,6 +32,7 @@ const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
   const isTrusted = !hasDefaultTokenlist || isTrustedTx(tx)
   const isPending = useIsPending(tx.id)
   const executionInfo = isMultisigExecutionInfo(tx.executionInfo) ? tx.executionInfo : undefined
+  const isExpiredSwap = isSwapTxInfo(tx.txInfo) && tx.txInfo.status === 'expired'
 
   return (
     <Box
@@ -78,6 +80,12 @@ const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
       {(!isQueue || isPending) && (
         <Box gridArea="status" justifyContent="flex-end" display="flex" className={css.status}>
           <TxStatusLabel tx={tx} />
+        </Box>
+      )}
+
+      {isExpiredSwap && (
+        <Box gridArea="status" justifyContent="flex-end" display="flex" className={css.status}>
+          <StatusLabel status="expired" />
         </Box>
       )}
 

--- a/src/hooks/useTransactionStatus.ts
+++ b/src/hooks/useTransactionStatus.ts
@@ -1,7 +1,7 @@
 import { ReplaceTxHoverContext } from '@/components/transactions/GroupedTxListItems/ReplaceTxHoverProvider'
 import { useAppSelector } from '@/store'
 import { PendingStatus, selectPendingTxById } from '@/store/pendingTxsSlice'
-import { isSignableBy, isSwapTxInfo } from '@/utils/transaction-guards'
+import { isCancelledSwap, isSignableBy } from '@/utils/transaction-guards'
 import type { TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import { TransactionStatus } from '@safe-global/safe-gateway-typescript-sdk'
 import { useContext } from 'react'
@@ -37,8 +37,8 @@ const useTransactionStatus = (txSummary: TransactionSummary): string => {
   const wallet = useWallet()
   const pendingTx = useAppSelector((state) => selectPendingTxById(state, id))
 
-  if (isSwapTxInfo(txSummary.txInfo) && txSummary.txInfo.status === 'cancelled') {
-    return 'Cancelled'
+  if (isCancelledSwap(txSummary.txInfo)) {
+    return STATUS_LABELS['CANCELLED']
   }
 
   if (replacedTxIds.includes(id)) {

--- a/src/hooks/useTransactionStatus.ts
+++ b/src/hooks/useTransactionStatus.ts
@@ -1,7 +1,7 @@
 import { ReplaceTxHoverContext } from '@/components/transactions/GroupedTxListItems/ReplaceTxHoverProvider'
 import { useAppSelector } from '@/store'
 import { PendingStatus, selectPendingTxById } from '@/store/pendingTxsSlice'
-import { isSignableBy } from '@/utils/transaction-guards'
+import { isSignableBy, isSwapTxInfo } from '@/utils/transaction-guards'
 import type { TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import { TransactionStatus } from '@safe-global/safe-gateway-typescript-sdk'
 import { useContext } from 'react'
@@ -36,6 +36,10 @@ const useTransactionStatus = (txSummary: TransactionSummary): string => {
   const { replacedTxIds } = useContext(ReplaceTxHoverContext)
   const wallet = useWallet()
   const pendingTx = useAppSelector((state) => selectPendingTxById(state, id))
+
+  if (isSwapTxInfo(txSummary.txInfo) && txSummary.txInfo.status === 'cancelled') {
+    return 'Cancelled'
+  }
 
   if (replacedTxIds.includes(id)) {
     return STATUS_LABELS[ReplacedStatus]

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -93,6 +93,14 @@ export const isSwapTxInfo = (value: TransactionInfo): value is SwapOrder => {
   return value.type === TransactionInfoType.SWAP_ORDER
 }
 
+export const isExpiredSwap = (value: TransactionInfo) => {
+  return isSwapTxInfo(value) && value.status === 'expired'
+}
+
+export const isCancelledSwap = (value: TransactionInfo) => {
+  return isSwapTxInfo(value) && value.status === 'cancelled'
+}
+
 export const isCancellationTxInfo = (value: TransactionInfo): value is Cancellation => {
   return isCustomTxInfo(value) && value.isCancellation
 }


### PR DESCRIPTION
## What it solves

Resolves [Notion issue](https://www.notion.so/safe-global/View-pending-expired-swap-in-Queue-00dd0e0e820f4040aab6dea6995f4d73)

## How this PR fixes it

- Disables the Execute button if a swap order is expired
- Shows a red Cancelled label for cancelled swaps

## How to test it

1. Create a cow swap and queue it
2. Wait until its expired
3. Observe the Execute button is disabled and a message is shown

## Screenshots

<img width="1268" alt="Screenshot 2024-04-19 at 10 07 17" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/4f15db61-4e62-4300-a7dc-096483f2bf09">
<img width="1261" alt="Screenshot 2024-04-19 at 10 49 49" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/dc3f61f8-aa16-4666-baf8-03231fd7d104">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
