### PR TITLE
feat: implement better swap notifications

### DIFF
--- a/src/features/swap/index.tsx
+++ b/src/features/swap/index.tsx
@@ -59,8 +59,8 @@ const SwapWidget = ({ sell }: Params) => {
             case 'ORDER_CREATED':
               dispatch(
                 showNotification({
-                  title: 'Order created',
-                  message: 'Order created but waiting for presignature',
+                  title: 'Swap transaction created',
+                  message: 'Waiting for confirmation from signers of your Safe',
                   groupKey,
                   variant: 'info',
                 }),
@@ -70,8 +70,8 @@ const SwapWidget = ({ sell }: Params) => {
             case 'ORDER_PRESIGNED':
               dispatch(
                 showNotification({
-                  title: 'Order presigned waiting for fullfillment',
-                  message: 'Order was presigned and waiting for match',
+                  title: 'Swap transaction confirmed',
+                  message: 'Waiting for swap execution by the CoW Protocol',
                   groupKey,
                   variant: 'info',
                 }),
@@ -81,8 +81,8 @@ const SwapWidget = ({ sell }: Params) => {
             case 'ORDER_FULFILLED':
               dispatch(
                 showNotification({
-                  title: 'Order fullfilled',
-                  message: 'Order was fullfilled',
+                  title: 'Swap executed',
+                  message: 'Your swap has been successful',
                   groupKey,
                   variant: 'info',
                 }),
@@ -92,8 +92,8 @@ const SwapWidget = ({ sell }: Params) => {
             case 'ORDER_EXPIRED':
               dispatch(
                 showNotification({
-                  title: 'Order expired',
-                  message,
+                  title: 'Swap expired',
+                  message: 'Your swap has reached the expiry time and has become invalid',
                   groupKey,
                   variant: 'warning',
                 }),
@@ -103,8 +103,8 @@ const SwapWidget = ({ sell }: Params) => {
             case 'ORDER_CANCELLED':
               dispatch(
                 showNotification({
-                  title: 'Order cancelled',
-                  message,
+                  title: 'Swap cancelled',
+                  message: 'Your swap has been cancelled',
                   groupKey,
                   variant: 'warning',
                 }),


### PR DESCRIPTION
## What it solves
Renders better notifications about the swap status

## Resolves
https://www.notion.so/safe-global/8f5927d10d3643f3a0d2ebc02c8eb425?v=1ddb11e4f9454c5d85bc9b50cde32640&p=e3f19e8ddcaf4263ab4164a4eb95e333&pm=s


## How this PR fixes it
Changed the notification title and text to the agreed ones.

## How to test it
Create a cow swap and watch the notifications that are output. (You need to be on the swap page to see all of them)


## Screenshots
![grafik](https://github.com/safe-global/safe-wallet-web/assets/693770/08fe7def-eb9e-4a1f-9bb7-f9465b18b843)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
