### PR TITLE
fix: Poll swap order details

### DIFF
--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -1,3 +1,5 @@
+import { POLLING_INTERVAL } from '@/config/constants'
+import useIntervalCounter from '@/hooks/useIntervalCounter'
 import React, { type ReactElement } from 'react'
 import type { TransactionDetails, TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import { getTransactionDetails, Operation } from '@safe-global/safe-gateway-typescript-sdk'
@@ -15,6 +17,7 @@ import {
   isMultiSendTxInfo,
   isMultisigDetailedExecutionInfo,
   isMultisigExecutionInfo,
+  isOpenSwap,
   isSwapTxInfo,
   isTxQueued,
 } from '@/utils/transaction-guards'
@@ -155,12 +158,15 @@ const TxDetails = ({
   const chainId = useChainId()
   const { safe } = useSafeInfo()
 
+  const [pollCount] = useIntervalCounter(POLLING_INTERVAL)
+  const swapPollCount = isOpenSwap(txSummary.txInfo) ? pollCount : 0
+
   const [txDetailsData, error, loading] = useAsync<TransactionDetails>(
     async () => {
       return txDetails || getTransactionDetails(chainId, txSummary.id)
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [txDetails, chainId, txSummary.id, safe.txQueuedTag],
+    [txDetails, chainId, txSummary.id, safe.txQueuedTag, swapPollCount],
     false,
   )
 

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -101,6 +101,10 @@ export const isCancelledSwap = (value: TransactionInfo) => {
   return isSwapTxInfo(value) && value.status === 'cancelled'
 }
 
+export const isOpenSwap = (value: TransactionInfo) => {
+  return isSwapTxInfo(value) && value.status === 'open'
+}
+
 export const isCancellationTxInfo = (value: TransactionInfo): value is Cancellation => {
   return isCustomTxInfo(value) && value.isCancellation
 }


### PR DESCRIPTION
## What it solves

Resolves [Notion issue](https://www.notion.so/safe-global/Poll-order-status-2442e20147024c3bb69cf49263d1e69c)

## How this PR fixes it

- Polls `txDetails` every 15 seconds if its a swap order and the status of the swap is `open`

## How to test it

1. Create a Swap
2. Execute the transaction
3. Open the transaction in the history
4. Observe the status switching from `open` to `fulfilled`

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
