### PR TITLE
fix: Set default owner on safe creation when entering step

### DIFF
--- a/src/components/new-safe/create/index.tsx
+++ b/src/components/new-safe/create/index.tsx
@@ -9,7 +9,6 @@ import SetNameStep from '@/components/new-safe/create/steps/SetNameStep'
 import OwnerPolicyStep from '@/components/new-safe/create/steps/OwnerPolicyStep'
 import ReviewStep from '@/components/new-safe/create/steps/ReviewStep'
 import { CreateSafeStatus } from '@/components/new-safe/create/steps/StatusStep'
-import useAddressBook from '@/hooks/useAddressBook'
 import { CardStepper } from '@/components/new-safe/CardStepper'
 import { AppRoutes } from '@/config/routes'
 import { CREATE_SAFE_CATEGORY } from '@/services/analytics'
@@ -100,12 +99,6 @@ const staticHints: Record<
 const CreateSafe = () => {
   const router = useRouter()
   const wallet = useWallet()
-  const addressBook = useAddressBook()
-  const defaultOwnerAddressBookName = wallet?.address ? addressBook[wallet.address] : undefined
-  const defaultOwner: NamedAddress = {
-    name: defaultOwnerAddressBookName || wallet?.ens || '',
-    address: wallet?.address || '',
-  }
 
   const [safeName, setSafeName] = useState('')
   const [dynamicHint, setDynamicHint] = useState<CreateSafeInfoItem>()
@@ -166,7 +159,7 @@ const CreateSafe = () => {
 
   const initialData: NewSafeFormData = {
     name: isSocialLogin ? mnemonicSafeName : '',
-    owners: [defaultOwner],
+    owners: [],
     threshold: 1,
     saltNonce: Date.now(),
   }

--- a/src/components/new-safe/create/steps/OwnerPolicyStep/index.tsx
+++ b/src/components/new-safe/create/steps/OwnerPolicyStep/index.tsx
@@ -1,4 +1,6 @@
 import CounterfactualHint from '@/features/counterfactual/CounterfactualHint'
+import useAddressBook from '@/hooks/useAddressBook'
+import useWallet from '@/hooks/wallets/useWallet'
 import { Button, SvgIcon, MenuItem, Tooltip, Typography, Divider, Box, Grid, TextField } from '@mui/material'
 import { Controller, FormProvider, useFieldArray, useForm } from 'react-hook-form'
 import type { ReactElement } from 'react'
@@ -37,12 +39,19 @@ const OwnerPolicyStep = ({
 }: StepRenderProps<NewSafeFormData> & {
   setDynamicHint: (hints: CreateSafeInfoItem | undefined) => void
 }): ReactElement => {
+  const wallet = useWallet()
+  const addressBook = useAddressBook()
+  const defaultOwnerAddressBookName = wallet?.address ? addressBook[wallet.address] : undefined
+  const defaultOwner: NamedAddress = {
+    name: defaultOwnerAddressBookName || wallet?.ens || '',
+    address: wallet?.address || '',
+  }
   useSyncSafeCreationStep(setStep)
 
   const formMethods = useForm<OwnerPolicyStepForm>({
     mode: 'onChange',
     defaultValues: {
-      [OwnerPolicyStepFields.owners]: data.owners,
+      [OwnerPolicyStepFields.owners]: data.owners.length > 0 ? data.owners : [defaultOwner],
       [OwnerPolicyStepFields.threshold]: data.threshold,
     },
   })


### PR DESCRIPTION
## What it solves

Resolves #3571

## How this PR fixes it

- Moves the defaultOwner logic from the parent component to the owner step so that it updates if the wallet was changed during one of the steps

## How to test it

1. Go to safe creation with wallet 1
2. Switch to wallet 2 in the first step
3. Go to the owner step
4. Observe wallet 2 is the default owner
5. Switch back to wallet 1
6. Observe wallet 2 is still the default owner
7. Go back one step and forth again
8. Observe wallet 2 is still the default owner

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
