### PR TITLE
fix: Set swap widget to full height

### DIFF
--- a/src/features/swap/index.tsx
+++ b/src/features/swap/index.tsx
@@ -16,6 +16,8 @@ import { useCustomAppCommunicator } from '@/hooks/safe-apps/useCustomAppCommunic
 import { showNotification } from '@/store/notificationsSlice'
 import { useAppDispatch } from '@/store'
 
+import css from './styles.module.css'
+
 const supportedChains = [1, 100, 11155111]
 
 const isSupportedChainForSwap = (chainId: number) => supportedChains.includes(chainId)
@@ -124,7 +126,7 @@ const SwapWidget = ({ sell }: Params) => {
       height: '860px',
       // provider: safeAppWeb3Provider, // Ethereum EIP-1193 provider. For a quick test, you can pass `window.ethereum`, but consider using something like https://web3modal.com
       chainId, // 1 (Mainnet), 5 (Goerli), 100 (Gnosis)
-      // standaloneMode: false,
+      standaloneMode: true,
       disableToastMessages: true,
       disablePostedOrderConfirmationModal: true,
       hideLogo: true,
@@ -198,7 +200,7 @@ const SwapWidget = ({ sell }: Params) => {
   console.log('params', params, listeners)
 
   return (
-    <Box sx={{ height: '100%' }} id="swapWidget">
+    <Box className={css.swapWidget} id="swapWidget">
       <CowSwapWidget params={params} listeners={listeners} />
     </Box>
   )

--- a/src/features/swap/index.tsx
+++ b/src/features/swap/index.tsx
@@ -126,7 +126,7 @@ const SwapWidget = ({ sell }: Params) => {
       height: '860px',
       // provider: safeAppWeb3Provider, // Ethereum EIP-1193 provider. For a quick test, you can pass `window.ethereum`, but consider using something like https://web3modal.com
       chainId, // 1 (Mainnet), 5 (Goerli), 100 (Gnosis)
-      standaloneMode: true,
+      standaloneMode: false,
       disableToastMessages: true,
       disablePostedOrderConfirmationModal: true,
       hideLogo: true,

--- a/src/features/swap/styles.module.css
+++ b/src/features/swap/styles.module.css
@@ -1,0 +1,5 @@
+.swapWidget,
+.swapWidget > div,
+.swapWidget > div > iframe {
+  height: 100% !important;
+}

--- a/src/pages/swap.tsx
+++ b/src/pages/swap.tsx
@@ -20,7 +20,7 @@ const Swap: NextPage = () => {
         <title>{'Safe{Wallet} – Swap'}</title>
       </Head>
 
-      <main>
+      <main className="swapWrapper">
         <SwapWidget sell={sell} />
       </main>
     </>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -14,6 +14,10 @@ main {
   width: 100%;
 }
 
+main.swapWrapper {
+  height: calc(100vh - 48px);
+}
+
 a {
   color: inherit;
   text-decoration: none;


### PR DESCRIPTION
## What it solves

Sets the swap widget page to full height so that the widget is not cut off

## How to test it

1. Open the Swap page
2. Click "My orders"
3. Observe the overlay taking up the available space

## Screenshots

<img width="1512" alt="Screenshot 2024-04-22 at 12 36 52" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/7fb1317a-bb19-4bd2-9ca1-35bdcfb5ab51">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
