### PR TITLE
feat: add a redux store decorator for stories

### DIFF
--- a/src/components/common/EthHashInfo/index.stories.tsx
+++ b/src/components/common/EthHashInfo/index.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import EthHashInfo from './index'
+import { Paper } from '@mui/material'
+
+import { StoreDecorator } from '@/stories/storeDecorator'
+
+const meta = {
+  component: EthHashInfo,
+  parameters: {
+    componentSubtitle: 'Renders a hash address with options for copy and explorer link',
+  },
+
+  decorators: [
+    (Story) => {
+      return (
+        <StoreDecorator initialState={{}}>
+          <Paper sx={{ padding: 2 }}>
+            <Story />
+          </Paper>
+        </StoreDecorator>
+      )
+    },
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof EthHashInfo>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    address: '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552',
+  },
+}

--- a/src/stories/storeDecorator.tsx
+++ b/src/stories/storeDecorator.tsx
@@ -1,0 +1,13 @@
+import { makeStore } from '@/store'
+import { Provider } from 'react-redux'
+import { type ReactNode } from 'react'
+
+type StoreDecoratorProps = {
+  initialState: Record<string, any>
+  children: ReactNode
+}
+
+export const StoreDecorator = ({ initialState, children }: StoreDecoratorProps) => {
+  const store = makeStore(initialState)
+  return <Provider store={store}>{children}</Provider>
+}


### PR DESCRIPTION
## What it solves
If you were trying to create a story for a component that uses redux state storybook was throwing an error

## How this PR fixes it
Ads a decorator that can wrap a story if testing a component that requires state.


