### PR TITLE
fix: show input error if chosen nonce is not an integer

### DIFF
--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -101,7 +101,7 @@ enum ErrorMessages {
   NONCE_TOO_HIGH = 'Nonce is too high',
   NONCE_TOO_FAR = 'Nonce is much higher than the current nonce',
   NONCE_GT_RECOMMENDED = 'Nonce is higher than the recommended nonce',
-  NONCE_MUST_BE_INTEGER = 'Nonce must be an integer',
+  NONCE_MUST_BE_INTEGER = "Nonce can't contain decimals",
 }
 
 const MAX_NONCE_DIFFERENCE = 100

--- a/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/src/components/tx-flow/common/TxNonce/index.tsx
@@ -101,6 +101,7 @@ enum ErrorMessages {
   NONCE_TOO_HIGH = 'Nonce is too high',
   NONCE_TOO_FAR = 'Nonce is much higher than the current nonce',
   NONCE_GT_RECOMMENDED = 'Nonce is higher than the recommended nonce',
+  NONCE_MUST_BE_INTEGER = 'Nonce must be an integer',
 }
 
 const MAX_NONCE_DIFFERENCE = 100
@@ -166,6 +167,10 @@ const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNo
 
           if (newNonce >= Number.MAX_SAFE_INTEGER) {
             return ErrorMessages.NONCE_TOO_HIGH
+          }
+
+          if (!Number.isInteger(newNonce)) {
+            return ErrorMessages.NONCE_MUST_BE_INTEGER
           }
 
           // Update context with valid nonce


### PR DESCRIPTION
## What it solves

Resolves #3159 

## How this PR fixes it
Show an error when user inputs a non integer number

## How to test it
- On the execute transaction screen, try to change the nonce to a number with a decimal point.
- It should show an error.
- Changing to an integer should work as before.

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
