### PR TITLE
feat: Add Swap feature flag

### DIFF
--- a/src/components/balances/AssetsTable/index.tsx
+++ b/src/components/balances/AssetsTable/index.tsx
@@ -1,5 +1,8 @@
 import CheckBalance from '@/features/counterfactual/CheckBalance'
+import { useHasFeature } from '@/hooks/useChains'
 import ArrowIconNW from '@/public/images/common/arrow-top-right.svg'
+import { FEATURES } from '@/utils/chains'
+import { formatUnits } from 'ethers'
 import { type ReactElement, useMemo, useContext } from 'react'
 import { Button, Tooltip, Typography, SvgIcon, IconButton, Box, Checkbox, Skeleton } from '@mui/material'
 import type { TokenInfo } from '@safe-global/safe-gateway-typescript-sdk'
@@ -123,7 +126,7 @@ const SendButton = ({
   )
 }
 
-const SwapButton = ({ tokenInfo, amount }: { tokenInfo: TokenInfo; amount: number }): ReactElement => {
+const SwapButton = ({ tokenInfo, amount }: { tokenInfo: TokenInfo; amount: string }): ReactElement => {
   const spendingLimit = useSpendingLimit(tokenInfo)
   const router = useRouter()
 
@@ -167,6 +170,7 @@ const AssetsTable = ({
   const hiddenAssets = useHiddenTokens()
   const { balances, loading } = useBalances()
   const { setTxFlow } = useContext(TxModalContext)
+  const isSwapFeatureEnabled = useHasFeature(FEATURES.NATIVE_SWAPS)
 
   const { isAssetSelected, toggleAsset, hidingAsset, hideAsset, cancel, deselectAll, saveChanges } = useHideAssets(() =>
     setShowHiddenAssets(false),
@@ -258,10 +262,14 @@ const AssetsTable = ({
                 <Box display="flex" flexDirection="row" gap={1} alignItems="center">
                   <>
                     <SendButton tokenInfo={item.tokenInfo} onClick={() => onSendClick(item.tokenInfo.address)} />
-                    <SwapButton
-                      tokenInfo={item.tokenInfo}
-                      amount={Number(item.balance) / 10 ** item.tokenInfo.decimals}
-                    />
+
+                    {isSwapFeatureEnabled && (
+                      <SwapButton
+                        tokenInfo={item.tokenInfo}
+                        amount={formatUnits(item.balance, item.tokenInfo.decimals)}
+                      />
+                    )}
+
                     {showHiddenAssets ? (
                       <Checkbox size="small" checked={isSelected} onClick={() => toggleAsset(item.tokenInfo.address)} />
                     ) : (

--- a/src/components/common/BuyCryptoButton/index.tsx
+++ b/src/components/common/BuyCryptoButton/index.tsx
@@ -1,6 +1,7 @@
+import { useTheme } from '@mui/material/styles'
 import { usePathname, useSearchParams } from 'next/navigation'
 import Link, { type LinkProps } from 'next/link'
-import { Alert, Box, Button, ButtonBase, Typography } from '@mui/material'
+import { Alert, Box, Button, ButtonBase, Typography, useMediaQuery } from '@mui/material'
 import AddIcon from '@mui/icons-material/Add'
 import { SafeAppsTag } from '@/config/constants'
 import { AppRoutes } from '@/config/routes'
@@ -30,7 +31,7 @@ const useBuyCryptoHref = (): LinkProps['href'] | undefined => {
 }
 
 const buttonStyles = {
-  minHeight: '40px',
+  minHeight: '37.5px',
 }
 
 const BuyCryptoOption = ({ name, children }: { name: string; children: ReactNode }) => {
@@ -68,6 +69,9 @@ const _BuyCryptoOptions = ({ rampLink }: { rampLink?: LinkProps['href'] }) => {
 }
 
 const _BuyCryptoButton = ({ href, pagePath }: { href?: LinkProps['href']; pagePath: string }) => {
+  const theme = useTheme()
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'))
+
   if (!href) return null
 
   return (
@@ -76,7 +80,7 @@ const _BuyCryptoButton = ({ href, pagePath }: { href?: LinkProps['href']; pagePa
         <Link href={href} passHref>
           <Button
             variant="contained"
-            size="small"
+            size={isSmallScreen ? 'medium' : 'small'}
             sx={buttonStyles}
             startIcon={<AddIcon />}
             className={css.buyCryptoButton}

--- a/src/components/dashboard/Overview/Overview.tsx
+++ b/src/components/dashboard/Overview/Overview.tsx
@@ -1,24 +1,27 @@
+import BuyCryptoButton from '@/components/common/BuyCryptoButton'
 import TokenAmount from '@/components/common/TokenAmount'
 import Track from '@/components/common/Track'
 import QrCodeButton from '@/components/sidebar/QrCodeButton'
 import { TxModalContext } from '@/components/tx-flow'
 import { NewTxFlow } from '@/components/tx-flow/flows'
+import { AppRoutes } from '@/config/routes'
+import { useHasFeature } from '@/hooks/useChains'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import { useVisibleBalances } from '@/hooks/useVisibleBalances'
+import ArrowIconSE from '@/public/images/common/arrow-se.svg'
+import ArrowIconNW from '@/public/images/common/arrow-top-right.svg'
 import SwapIcon from '@/public/images/sidebar/swap.svg'
 import { OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
 import { useAppSelector } from '@/store'
 import { selectCurrency } from '@/store/settingsSlice'
+import { FEATURES } from '@/utils/chains'
 import { formatCurrency } from '@/utils/formatNumber'
-import { useContext, useMemo, type ReactElement } from 'react'
-import { Button, Grid, Skeleton, Typography } from '@mui/material'
-import { WidgetBody, WidgetContainer } from '../styled'
+import { Button, Grid, Skeleton, Typography, useMediaQuery } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
 import Link from 'next/link'
-import useSafeInfo from '@/hooks/useSafeInfo'
-import { useVisibleBalances } from '@/hooks/useVisibleBalances'
-import ArrowIconNW from '@/public/images/common/arrow-top-right.svg'
-import ArrowIconSE from '@/public/images/common/arrow-se.svg'
-import BuyCryptoButton from '@/components/common/BuyCryptoButton'
-import { AppRoutes } from '@/config/routes'
 import { useRouter } from 'next/router'
+import { type ReactElement, useContext, useMemo } from 'react'
+import { WidgetBody, WidgetContainer } from '../styled'
 
 const SkeletonOverview = (
   <>
@@ -44,6 +47,9 @@ const Overview = (): ReactElement => {
   const { balances, loading: balancesLoading } = useVisibleBalances()
   const { setTxFlow } = useContext(TxModalContext)
   const router = useRouter()
+  const theme = useTheme()
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'))
+  const isSwapFeatureEnabled = useHasFeature(FEATURES.NATIVE_SWAPS)
 
   const fiatTotal = useMemo(
     () => (balances.fiatTotal ? formatCurrency(balances.fiatTotal, currency) : ''),
@@ -57,6 +63,8 @@ const Overview = (): ReactElement => {
     setTxFlow(<NewTxFlow />, undefined, false)
     trackEvent(OVERVIEW_EVENTS.NEW_TRANSACTION)
   }
+
+  const buttonWidth = isSwapFeatureEnabled ? 4 : 6
 
   return (
     <WidgetContainer>
@@ -97,10 +105,10 @@ const Overview = (): ReactElement => {
                     <BuyCryptoButton />
                   </Grid>
 
-                  <Grid item xs={6} sm="auto">
+                  <Grid item xs={buttonWidth} sm="auto">
                     <Button
                       onClick={handleOnSend}
-                      size="small"
+                      size={isSmallScreen ? 'medium' : 'small'}
                       variant="outlined"
                       color="primary"
                       startIcon={<ArrowIconNW />}
@@ -109,23 +117,37 @@ const Overview = (): ReactElement => {
                       Send
                     </Button>
                   </Grid>
-                  <Grid item xs={6} sm="auto">
+                  <Grid item xs={buttonWidth} sm="auto">
                     <Track {...OVERVIEW_EVENTS.SHOW_QR} label="dashboard">
                       <QrCodeButton>
-                        <Button size="small" variant="outlined" color="primary" startIcon={<ArrowIconSE />} fullWidth>
+                        <Button
+                          size={isSmallScreen ? 'medium' : 'small'}
+                          variant="outlined"
+                          color="primary"
+                          startIcon={<ArrowIconSE />}
+                          fullWidth
+                        >
                           Receive
                         </Button>
                       </QrCodeButton>
                     </Track>
                   </Grid>
 
-                  <Grid item xs={6} sm="auto">
-                    <Link href={{ pathname: AppRoutes.swap, query: router.query }} passHref type="button">
-                      <Button size="small" variant="outlined" color="primary" startIcon={<SwapIcon />} fullWidth>
-                        Swap
-                      </Button>
-                    </Link>
-                  </Grid>
+                  {isSwapFeatureEnabled && (
+                    <Grid item xs={buttonWidth} sm="auto">
+                      <Link href={{ pathname: AppRoutes.swap, query: router.query }} passHref type="button">
+                        <Button
+                          size={isSmallScreen ? 'medium' : 'small'}
+                          variant="outlined"
+                          color="primary"
+                          startIcon={<SwapIcon />}
+                          fullWidth
+                        >
+                          Swap
+                        </Button>
+                      </Link>
+                    </Grid>
+                  )}
                 </Grid>
               )}
             </Grid>

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -1,3 +1,4 @@
+import { AppRoutes } from '@/config/routes'
 import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { getExplorerLink } from './gateway'
 
@@ -21,6 +22,12 @@ export enum FEATURES {
   COUNTERFACTUAL = 'COUNTERFACTUAL',
   DELETE_TX = 'DELETE_TX',
   SPEED_UP_TX = 'SPEED_UP_TX',
+  NATIVE_SWAPS = 'NATIVE_SWAPS',
+}
+
+export const FeatureRoutes = {
+  [AppRoutes.apps.index]: FEATURES.SAFE_APPS,
+  [AppRoutes.swap]: FEATURES.NATIVE_SWAPS,
 }
 
 export const hasFeature = (chain: ChainInfo, feature: FEATURES): boolean => {


### PR DESCRIPTION
## What it solves

Adds a new feature flag for Swaps called `NATIVE_SWAPS` and hides UI elements if its not enabled.

## How this PR fixes it

- Hide the Swap button on the dashboard if feature is disabled
- Hide the Swap button in the assets table if feature is disabled
- Hide the Sidebar navigation item for Swaps if feature is disabled
- Use `formatUnits` in the assets table when passing the value for a swap
- Adjust the button layout on the dashboard for mobile view (3 columns, larger buttons)

## How to test it

For now the Swap feature is only enabled on Sepolia

1. Open a Safe on Mainnet
2. There should be no swap button on the dashboard
3. There should be no swap button in the sidebar navigation
4. There should be no swap button in the assets table
5. Open a Safe on Sepolia
6. Switch to a mobile view on the dashboard
7. Observe a three column layout and larger buttons
8. Navigate to the Assets page
9. Press Swap next to an asset
10. Observe the correct max value is still passed to the swap widget

## Screenshots
<img width="1512" alt="Screenshot 2024-04-25 at 14 56 58" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/02bd5f01-15b4-4bc7-a80c-f6271e7e4c02">
<img width="519" alt="Screenshot 2024-04-25 at 14 57 17" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/2f4ad82a-200d-4d9d-9786-b181bcf90b73">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
