### PR TITLE
feat: redesign approval editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@safe-global/protocol-kit": "^3.0.2",
     "@safe-global/safe-apps-sdk": "^9.0.0-next.1",
     "@safe-global/safe-deployments": "^1.34.0",
-    "@safe-global/safe-gateway-typescript-sdk": "3.19.0",
+    "@safe-global/safe-gateway-typescript-sdk": "3.21.0",
     "@safe-global/safe-modules-deployments": "^1.2.0",
     "@sentry/react": "^7.91.0",
     "@spindl-xyz/attribution-lite": "^1.4.0",

--- a/src/components/theme/safeTheme.ts
+++ b/src/components/theme/safeTheme.ts
@@ -57,6 +57,12 @@ declare module '@mui/material/Button' {
   }
 }
 
+declare module '@mui/material/IconButton' {
+  export interface IconButtonPropsColorOverrides {
+    border: true
+  }
+}
+
 const createSafeTheme = (mode: PaletteMode): Theme => {
   const isDarkMode = mode === 'dark'
   const colors = isDarkMode ? darkPalette : palette

--- a/src/components/tx/ApprovalEditor/ApprovalEditor.test.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalEditor.test.tsx
@@ -5,6 +5,8 @@ import { TokenType } from '@safe-global/safe-gateway-typescript-sdk'
 import { OperationType } from '@safe-global/safe-core-sdk-types'
 import * as approvalInfos from '@/components/tx/ApprovalEditor/hooks/useApprovalInfos'
 import { createMockSafeTransaction } from '@/tests/transactions'
+import { faker } from '@faker-js/faker'
+import { shortenAddress } from '@/utils/formatters'
 
 describe('ApprovalEditor', () => {
   beforeEach(() => {
@@ -18,7 +20,11 @@ describe('ApprovalEditor', () => {
   })
 
   it('returns null if there are no approvals', () => {
-    const mockSafeTx = createMockSafeTransaction({ to: '0x1', data: '0x', operation: OperationType.DelegateCall })
+    const mockSafeTx = createMockSafeTransaction({
+      to: faker.finance.ethereumAddress(),
+      data: '0x',
+      operation: OperationType.DelegateCall,
+    })
     jest.spyOn(approvalInfos, 'useApprovalInfos').mockReturnValue([[], undefined, false])
     const result = render(<ApprovalEditor safeTransaction={mockSafeTx} />)
 
@@ -29,7 +35,11 @@ describe('ApprovalEditor', () => {
     jest
       .spyOn(approvalInfos, 'useApprovalInfos')
       .mockReturnValue([undefined, new Error('Error parsing approvals'), false])
-    const mockSafeTx = createMockSafeTransaction({ to: '0x1', data: '0x', operation: OperationType.DelegateCall })
+    const mockSafeTx = createMockSafeTransaction({
+      to: faker.finance.ethereumAddress(),
+      data: '0x',
+      operation: OperationType.DelegateCall,
+    })
 
     const result = render(<ApprovalEditor safeTransaction={mockSafeTx} />)
 
@@ -46,18 +56,21 @@ describe('ApprovalEditor', () => {
   })
 
   it('renders a read-only view if the transaction contains signatures', async () => {
+    const tokenAddress = faker.finance.ethereumAddress()
+    const spenderAddress = faker.finance.ethereumAddress()
     const mockApprovalInfo = {
-      tokenInfo: { symbol: 'TST', decimals: 18, address: '0x3', type: TokenType.ERC20 },
-      tokenAddress: '0x1',
-      spender: '0x2',
+      tokenInfo: { symbol: 'TST', decimals: 18, address: tokenAddress, type: TokenType.ERC20 },
+      tokenAddress,
+      spender: spenderAddress,
       amount: '4200000',
       amountFormatted: '420.0',
       method: 'approve',
+      transactionIndex: 0,
     } as const
     jest.spyOn(approvalInfos, 'useApprovalInfos').mockReturnValue([[mockApprovalInfo], undefined, false])
     const mockSafeTx = safeTxBuilder()
       .with({
-        signatures: new Map().set('0x1', safeSignatureBuilder().build()),
+        signatures: new Map().set(faker.finance.ethereumAddress(), safeSignatureBuilder().build()),
       })
       .build()
 
@@ -66,22 +79,29 @@ describe('ApprovalEditor', () => {
     const amountInput = result.container.querySelector('input[name="approvals.0"]') as HTMLInputElement
 
     expect(amountInput).not.toBeInTheDocument()
-    expect(result.getByText('TST'))
-    expect(result.getByText('420'))
-    expect(result.getByText('0x2'))
+    expect(result.getByText('TST', { exact: false }))
+    expect(result.getByText('420', { exact: false }))
+    expect(result.getByText(shortenAddress(spenderAddress)))
   })
 
   it('renders a form if there are no signatures', async () => {
+    const tokenAddress = faker.finance.ethereumAddress()
+    const spenderAddress = faker.finance.ethereumAddress()
     const mockApprovalInfo = {
-      tokenInfo: { symbol: 'TST', decimals: 18, address: '0x3', type: TokenType.ERC20 },
-      tokenAddress: '0x1',
-      spender: '0x2',
+      tokenInfo: { symbol: 'TST', decimals: 18, address: tokenAddress, type: TokenType.ERC20 },
+      tokenAddress,
+      spender: spenderAddress,
       amount: '4200000',
       amountFormatted: '420.0',
       method: 'approve',
+      transactionIndex: 0,
     } as const
     jest.spyOn(approvalInfos, 'useApprovalInfos').mockReturnValue([[mockApprovalInfo], undefined, false])
-    const mockSafeTx = createMockSafeTransaction({ to: '0x1', data: '0x', operation: OperationType.DelegateCall })
+    const mockSafeTx = createMockSafeTransaction({
+      to: tokenAddress,
+      data: '0x',
+      operation: OperationType.DelegateCall,
+    })
 
     const result = render(<ApprovalEditor safeTransaction={mockSafeTx} />)
 
@@ -90,21 +110,28 @@ describe('ApprovalEditor', () => {
     expect(amountInput1).toBeInTheDocument
 
     expect(amountInput1).toHaveValue('420.0')
-    expect(result.getByText('TST'))
-    expect(result.getByText('0x2'))
+    expect(result.getByText('TST', { exact: false }))
+    expect(result.getByText(shortenAddress(spenderAddress)))
   })
 
   it('renders a form if there is an update callback', async () => {
+    const tokenAddress = faker.finance.ethereumAddress()
+    const spenderAddress = faker.finance.ethereumAddress()
     const mockApprovalInfo = {
-      tokenInfo: { symbol: 'TST', decimals: 18, address: '0x3', type: TokenType.ERC20 },
-      tokenAddress: '0x1',
-      spender: '0x2',
+      tokenInfo: { symbol: 'TST', decimals: 18, address: tokenAddress, type: TokenType.ERC20 },
+      tokenAddress,
+      spender: spenderAddress,
       amount: '4200000',
       amountFormatted: '420.0',
       method: 'approve',
+      transactionIndex: 0,
     } as const
     jest.spyOn(approvalInfos, 'useApprovalInfos').mockReturnValue([[mockApprovalInfo], undefined, false])
-    const mockSafeTx = createMockSafeTransaction({ to: '0x1', data: '0x', operation: OperationType.DelegateCall })
+    const mockSafeTx = createMockSafeTransaction({
+      to: tokenAddress,
+      data: '0x',
+      operation: OperationType.DelegateCall,
+    })
 
     const result = render(<ApprovalEditor safeTransaction={mockSafeTx} />)
 

--- a/src/components/tx/ApprovalEditor/ApprovalEditor.test.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalEditor.test.tsx
@@ -1,5 +1,5 @@
 import { safeSignatureBuilder, safeTxBuilder } from '@/tests/builders/safeTx'
-import { render } from '@/tests/test-utils'
+import { act, fireEvent, getAllByTitle, render, waitFor } from '@/tests/test-utils'
 import ApprovalEditor from '.'
 import { TokenType } from '@safe-global/safe-gateway-typescript-sdk'
 import { OperationType } from '@safe-global/safe-core-sdk-types'
@@ -7,10 +7,30 @@ import * as approvalInfos from '@/components/tx/ApprovalEditor/hooks/useApproval
 import { createMockSafeTransaction } from '@/tests/transactions'
 import { faker } from '@faker-js/faker'
 import { shortenAddress } from '@/utils/formatters'
+import { encodeMultiSendData } from '@safe-global/protocol-kit'
+import { ERC20__factory, Multi_send__factory } from '@/types/contracts'
+import { getAndValidateSafeSDK } from '@/services/tx/tx-sender/sdk'
+import { parseUnits } from 'ethers'
+import { checksumAddress } from '@/utils/addresses'
+
+jest.mock('@/services/tx/tx-sender/sdk', () => ({
+  getAndValidateSafeSDK: jest.fn().mockReturnValue({
+    createTransaction: jest.fn(),
+  }),
+}))
+
+jest.mock('@safe-global/safe-gateway-typescript-sdk', () => ({
+  ...jest.requireActual('@safe-global/safe-gateway-typescript-sdk'),
+  getContract: jest.fn(() => undefined),
+  __esModule: true,
+}))
+
+const ERC20_INTERFACE = ERC20__factory.createInterface()
+const MULTISEND_INTERFACE = Multi_send__factory.createInterface()
 
 describe('ApprovalEditor', () => {
   beforeEach(() => {
-    jest.clearAllMocks()
+    jest.restoreAllMocks()
   })
 
   it('returns null if there is no safe transaction', () => {
@@ -25,7 +45,6 @@ describe('ApprovalEditor', () => {
       data: '0x',
       operation: OperationType.DelegateCall,
     })
-    jest.spyOn(approvalInfos, 'useApprovalInfos').mockReturnValue([[], undefined, false])
     const result = render(<ApprovalEditor safeTransaction={mockSafeTx} />)
 
     expect(result.container).toBeEmptyDOMElement()
@@ -114,29 +133,217 @@ describe('ApprovalEditor', () => {
     expect(result.getByText(shortenAddress(spenderAddress)))
   })
 
-  it('renders a form if there is an update callback', async () => {
-    const tokenAddress = faker.finance.ethereumAddress()
-    const spenderAddress = faker.finance.ethereumAddress()
-    const mockApprovalInfo = {
-      tokenInfo: { symbol: 'TST', decimals: 18, address: tokenAddress, type: TokenType.ERC20 },
-      tokenAddress,
-      spender: spenderAddress,
-      amount: '4200000',
-      amountFormatted: '420.0',
-      method: 'approve',
-      transactionIndex: 0,
-    } as const
-    jest.spyOn(approvalInfos, 'useApprovalInfos').mockReturnValue([[mockApprovalInfo], undefined, false])
+  it('should modify approvals on save', async () => {
+    const tokenAddress = checksumAddress(faker.finance.ethereumAddress())
+    const multiSendAddress = checksumAddress(faker.finance.ethereumAddress())
+    const spenderAddress = checksumAddress(faker.finance.ethereumAddress())
+
     const mockSafeTx = createMockSafeTransaction({
-      to: tokenAddress,
-      data: '0x',
+      to: multiSendAddress,
+      data: MULTISEND_INTERFACE.encodeFunctionData('multiSend', [
+        encodeMultiSendData([
+          {
+            to: tokenAddress,
+            data: ERC20_INTERFACE.encodeFunctionData('approve', [spenderAddress, '420000000000000000000']),
+            value: '0',
+            operation: OperationType.Call,
+          },
+          {
+            to: tokenAddress,
+            data: ERC20_INTERFACE.encodeFunctionData('transfer', [spenderAddress, '25']),
+            value: '0',
+            operation: OperationType.Call,
+          },
+          {
+            to: tokenAddress,
+            data: ERC20_INTERFACE.encodeFunctionData('increaseAllowance', [spenderAddress, '690000000000']),
+            value: '0',
+            operation: OperationType.Call,
+          },
+        ]),
+      ]),
       operation: OperationType.DelegateCall,
     })
 
-    const result = render(<ApprovalEditor safeTransaction={mockSafeTx} />)
+    const result = render(<ApprovalEditor safeTransaction={mockSafeTx} />, {
+      initialReduxState: {
+        balances: {
+          loading: false,
+          data: {
+            fiatTotal: '0',
+            items: [
+              {
+                balance: '10',
+                tokenInfo: {
+                  address: tokenAddress,
+                  decimals: 18,
+                  logoUri: 'someurl',
+                  name: 'Test token',
+                  symbol: 'TST',
+                  type: TokenType.ERC20,
+                },
+                fiatBalance: '10',
+                fiatConversion: '1',
+              },
+            ],
+          },
+        },
+      },
+    })
 
-    const amountInput = result.container.querySelector('input[name="approvals.0"]') as HTMLInputElement
+    await waitFor(() => {
+      const amountInput1 = result.container.querySelector('input[name="approvals.0"]') as HTMLInputElement
+      const amountInput2 = result.container.querySelector('input[name="approvals.1"]') as HTMLInputElement
+      expect(amountInput1).toBeInTheDocument()
+      expect(amountInput2).toBeInTheDocument()
+    })
 
-    expect(amountInput).toBeInTheDocument()
+    // One edit button for each approval
+    const editButtons = getAllByTitle(result.container, 'Edit')
+    expect(editButtons).toHaveLength(2)
+
+    // Edit and Save first value
+    act(() => {
+      fireEvent.click(editButtons[0])
+      const amountInput1 = result.container.querySelector('input[name="approvals.0"]') as HTMLInputElement
+      fireEvent.change(amountInput1!, { target: { value: '100' } })
+    })
+
+    let saveButton = result.getByTitle('Save')
+    await waitFor(() => {
+      expect(saveButton).toBeEnabled()
+    })
+
+    act(() => {
+      fireEvent.click(saveButton)
+    })
+    const mockSafe = getAndValidateSafeSDK()
+    expect(mockSafe.createTransaction).toHaveBeenCalledWith({
+      onlyCalls: true,
+      transactions: [
+        {
+          to: tokenAddress,
+          data: ERC20_INTERFACE.encodeFunctionData('approve', [spenderAddress, parseUnits('100', 18)]),
+          value: '0',
+        },
+        {
+          to: tokenAddress,
+          data: ERC20_INTERFACE.encodeFunctionData('transfer', [spenderAddress, '25']),
+          value: '0',
+        },
+        {
+          to: tokenAddress,
+          data: ERC20_INTERFACE.encodeFunctionData('increaseAllowance', [spenderAddress, '690000000000']),
+          value: '0',
+        },
+      ],
+    })
+  })
+
+  it('should modify increaseAllowance on save', async () => {
+    const tokenAddress = checksumAddress(faker.finance.ethereumAddress())
+    const multiSendAddress = checksumAddress(faker.finance.ethereumAddress())
+    const spenderAddress = checksumAddress(faker.finance.ethereumAddress())
+
+    const mockSafeTx = createMockSafeTransaction({
+      to: multiSendAddress,
+      data: MULTISEND_INTERFACE.encodeFunctionData('multiSend', [
+        encodeMultiSendData([
+          {
+            to: tokenAddress,
+            data: ERC20_INTERFACE.encodeFunctionData('approve', [spenderAddress, '420000000000000000000']),
+            value: '0',
+            operation: OperationType.Call,
+          },
+          {
+            to: tokenAddress,
+            data: ERC20_INTERFACE.encodeFunctionData('transfer', [spenderAddress, '25']),
+            value: '0',
+            operation: OperationType.Call,
+          },
+          {
+            to: tokenAddress,
+            data: ERC20_INTERFACE.encodeFunctionData('increaseAllowance', [spenderAddress, '690000000000']),
+            value: '0',
+            operation: OperationType.Call,
+          },
+        ]),
+      ]),
+      operation: OperationType.DelegateCall,
+    })
+
+    const result = render(<ApprovalEditor safeTransaction={mockSafeTx} />, {
+      initialReduxState: {
+        balances: {
+          loading: false,
+          data: {
+            fiatTotal: '0',
+            items: [
+              {
+                balance: '10',
+                tokenInfo: {
+                  address: tokenAddress,
+                  decimals: 18,
+                  logoUri: 'someurl',
+                  name: 'Test token',
+                  symbol: 'TST',
+                  type: TokenType.ERC20,
+                },
+                fiatBalance: '10',
+                fiatConversion: '1',
+              },
+            ],
+          },
+        },
+      },
+    })
+
+    await waitFor(() => {
+      const amountInput1 = result.container.querySelector('input[name="approvals.0"]') as HTMLInputElement
+      const amountInput2 = result.container.querySelector('input[name="approvals.1"]') as HTMLInputElement
+      expect(amountInput1).toBeInTheDocument()
+      expect(amountInput2).toBeInTheDocument()
+    })
+
+    // One edit button for each approval
+    const editButtons = getAllByTitle(result.container, 'Edit')
+    expect(editButtons).toHaveLength(2)
+
+    // Edit and Save second value
+    act(() => {
+      fireEvent.click(editButtons[1])
+      const amountInput2 = result.container.querySelector('input[name="approvals.1"]') as HTMLInputElement
+      fireEvent.change(amountInput2!, { target: { value: '300' } })
+    })
+
+    let saveButton = result.getByTitle('Save')
+    await waitFor(() => {
+      expect(saveButton).toBeEnabled()
+    })
+
+    act(() => {
+      fireEvent.click(saveButton)
+    })
+    const mockSafe = getAndValidateSafeSDK()
+    expect(mockSafe.createTransaction).toHaveBeenCalledWith({
+      onlyCalls: true,
+      transactions: [
+        {
+          to: tokenAddress,
+          data: ERC20_INTERFACE.encodeFunctionData('approve', [spenderAddress, '420000000000000000000']),
+          value: '0',
+        },
+        {
+          to: tokenAddress,
+          data: ERC20_INTERFACE.encodeFunctionData('transfer', [spenderAddress, '25']),
+          value: '0',
+        },
+        {
+          to: tokenAddress,
+          data: ERC20_INTERFACE.encodeFunctionData('increaseAllowance', [spenderAddress, parseUnits('300', 18)]),
+          value: '0',
+        },
+      ],
+    })
   })
 })

--- a/src/components/tx/ApprovalEditor/ApprovalEditor.test.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalEditor.test.tsx
@@ -6,7 +6,6 @@ import { OperationType } from '@safe-global/safe-core-sdk-types'
 import * as approvalInfos from '@/components/tx/ApprovalEditor/hooks/useApprovalInfos'
 import { createMockSafeTransaction } from '@/tests/transactions'
 import { faker } from '@faker-js/faker'
-import { shortenAddress } from '@/utils/formatters'
 import { encodeMultiSendData } from '@safe-global/protocol-kit'
 import { ERC20__factory, Multi_send__factory } from '@/types/contracts'
 import { getAndValidateSafeSDK } from '@/services/tx/tx-sender/sdk'
@@ -100,7 +99,7 @@ describe('ApprovalEditor', () => {
     expect(amountInput).not.toBeInTheDocument()
     expect(result.getByText('TST', { exact: false }))
     expect(result.getByText('420', { exact: false }))
-    expect(result.getByText(shortenAddress(spenderAddress)))
+    expect(result.getByText(spenderAddress))
   })
 
   it('renders a form if there are no signatures', async () => {
@@ -130,7 +129,7 @@ describe('ApprovalEditor', () => {
 
     expect(amountInput1).toHaveValue('420.0')
     expect(result.getByText('TST', { exact: false }))
-    expect(result.getByText(shortenAddress(spenderAddress)))
+    expect(result.getByText(spenderAddress))
   })
 
   it('should modify approvals on save', async () => {

--- a/src/components/tx/ApprovalEditor/ApprovalEditorForm.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalEditorForm.tsx
@@ -1,4 +1,4 @@
-import { Divider, List, ListItem, Stack } from '@mui/material'
+import { Box, Divider, List, ListItem, Stack } from '@mui/material'
 import { FormProvider, useForm } from 'react-hook-form'
 import css from './styles.module.css'
 import type { ApprovalInfo } from './hooks/useApprovalInfos'
@@ -30,11 +30,7 @@ export const ApprovalEditorForm = ({
     mode: 'onChange',
   })
 
-  const {
-    formState: { errors, dirtyFields },
-    getValues,
-    reset,
-  } = formMethods
+  const { getValues, reset } = formMethods
 
   const onSave = () => {
     const formData = getValues('approvals')
@@ -48,8 +44,8 @@ export const ApprovalEditorForm = ({
     <FormProvider {...formMethods}>
       <List className={css.approvalsList}>
         {Object.entries(groupedApprovals).map(([spender, approvals], spenderIdx) => (
-          <>
-            <Stack key={spender} gap={2}>
+          <Box key={spender}>
+            <Stack gap={2}>
               <SpenderField address={spender} />
               {approvals.map((tx) => (
                 <ListItem
@@ -63,7 +59,7 @@ export const ApprovalEditorForm = ({
               ))}
             </Stack>
             {spenderIdx !== Object.keys(groupedApprovals).length - 1 && <Divider />}
-          </>
+          </Box>
         ))}
       </List>
     </FormProvider>

--- a/src/components/tx/ApprovalEditor/ApprovalEditorForm.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalEditorForm.tsx
@@ -1,13 +1,12 @@
-import { IconButton, SvgIcon, List, ListItem } from '@mui/material'
+import { Divider, List, ListItem, Stack } from '@mui/material'
 import { FormProvider, useForm } from 'react-hook-form'
 import css from './styles.module.css'
-import CheckIcon from '@mui/icons-material/Check'
 import type { ApprovalInfo } from './hooks/useApprovalInfos'
-import { ApprovalValueField } from './ApprovalValueField'
-import { MODALS_EVENTS } from '@/services/analytics'
-import Track from '@/components/common/Track'
+
 import { useMemo } from 'react'
-import ApprovalItem from '@/components/tx/ApprovalEditor/ApprovalItem'
+import EditableApprovalItem from './EditableApprovalItem'
+import { groupBy } from 'lodash'
+import { SpenderField } from './SpenderField'
 
 export type ApprovalEditorFormData = {
   approvals: string[]
@@ -20,6 +19,8 @@ export const ApprovalEditorForm = ({
   approvalInfos: ApprovalInfo[]
   updateApprovals: (newApprovals: string[]) => void
 }) => {
+  const groupedApprovals = useMemo(() => groupBy(approvalInfos, (approval) => approval.spender), [approvalInfos])
+
   const initialApprovals = useMemo(() => approvalInfos.map((info) => info.amountFormatted), [approvalInfos])
 
   const formMethods = useForm<ApprovalEditorFormData>({
@@ -41,32 +42,28 @@ export const ApprovalEditorForm = ({
     reset({ approvals: formData })
   }
 
+  let fieldIndex = 0
+
   return (
     <FormProvider {...formMethods}>
       <List className={css.approvalsList}>
-        {approvalInfos.map((tx, idx) => (
-          <ListItem
-            key={tx.tokenAddress + tx.spender}
-            className={0n === tx.amount ? css.zeroValueApproval : undefined}
-            disablePadding
-            data-testid="approval-item"
-          >
-            <ApprovalItem spender={tx.spender} method={tx.method}>
-              <>
-                <ApprovalValueField name={`approvals.${idx}`} tx={tx} />
-                <Track {...MODALS_EVENTS.EDIT_APPROVALS}>
-                  <IconButton
-                    className={css.iconButton}
-                    onClick={onSave}
-                    disabled={!!errors.approvals || !dirtyFields.approvals?.[idx]}
-                    title="Save"
-                  >
-                    <SvgIcon component={CheckIcon} />
-                  </IconButton>
-                </Track>
-              </>
-            </ApprovalItem>
-          </ListItem>
+        {Object.entries(groupedApprovals).map(([spender, approvals], spenderIdx) => (
+          <>
+            <Stack key={spender} gap={2}>
+              <SpenderField address={spender} />
+              {approvals.map((tx) => (
+                <ListItem
+                  key={tx.tokenAddress + tx.spender}
+                  className={0n === tx.amount ? css.zeroValueApproval : undefined}
+                  disablePadding
+                  data-testid="approval-item"
+                >
+                  <EditableApprovalItem approval={tx} name={`approvals.${fieldIndex++}`} onSave={onSave} />
+                </ListItem>
+              ))}
+            </Stack>
+            {spenderIdx !== Object.keys(groupedApprovals).length - 1 && <Divider />}
+          </>
         ))}
       </List>
     </FormProvider>

--- a/src/components/tx/ApprovalEditor/ApprovalEditorForm.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalEditorForm.tsx
@@ -57,8 +57,8 @@ export const ApprovalEditorForm = ({
                   <EditableApprovalItem approval={tx} name={`approvals.${fieldIndex++}`} onSave={onSave} />
                 </ListItem>
               ))}
+              {spenderIdx !== Object.keys(groupedApprovals).length - 1 && <Divider />}
             </Stack>
-            {spenderIdx !== Object.keys(groupedApprovals).length - 1 && <Divider />}
           </Box>
         ))}
       </List>

--- a/src/components/tx/ApprovalEditor/ApprovalItem.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalItem.tsx
@@ -32,9 +32,7 @@ const ApprovalItem = ({
         {amount === PSEUDO_APPROVAL_VALUES.UNLIMITED ? (
           <Typography>{PSEUDO_APPROVAL_VALUES.UNLIMITED}</Typography>
         ) : (
-          <Typography data-testid="token-amount">
-            {formatAmountPrecise(amount, tokenInfo.decimals)} {tokenInfo.symbol && `of ${tokenInfo.symbol}`}
-          </Typography>
+          <Typography data-testid="token-amount">{formatAmountPrecise(amount, tokenInfo.decimals)}</Typography>
         )}
       </Box>
     </Stack>

--- a/src/components/tx/ApprovalEditor/ApprovalItem.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalItem.tsx
@@ -1,49 +1,45 @@
-import { type ReactElement } from 'react'
-import { Alert, Grid, Typography } from '@mui/material'
+import { Box, Stack, Typography } from '@mui/material'
 import css from '@/components/tx/ApprovalEditor/styles.module.css'
-import EthHashInfo from '@/components/common/EthHashInfo'
 import type { Approval } from '@/services/security/modules/ApprovalModule'
+import type { ApprovalInfo } from './hooks/useApprovalInfos'
+import TokenIcon from '@/components/common/TokenIcon'
+import { PSEUDO_APPROVAL_VALUES } from './utils/approvals'
+import { formatAmountPrecise } from '@/utils/formatNumber'
 
-const approvalMethodDescription: Record<Approval['method'], string> = {
+export const approvalMethodDescription: Record<Approval['method'], string> = {
   approve: 'Set allowance to',
   increaseAllowance: 'Increase allowance by',
   Permit2: 'Give permission to spend',
 }
 
 const ApprovalItem = ({
-  spender,
   method,
-  children,
+  amount,
+  tokenInfo,
 }: {
   spender: string
+  amount: string
+  tokenInfo: NonNullable<ApprovalInfo['tokenInfo']>
   method: Approval['method']
-  children: ReactElement
 }) => {
   return (
-    <Alert icon={false} variant="outlined" severity="warning" className={css.alert}>
-      <Grid container gap={1} justifyContent="space-between">
-        <Grid item xs={12}>
-          <Typography variant="caption">{approvalMethodDescription[method]}</Typography>
-        </Grid>
-        <Grid item display="flex" xs={12} flexDirection="row" alignItems="center" gap={1}>
-          {children}
-        </Grid>
-
-        <Grid item container display="flex" xs={12} alignItems="center" gap={1}>
-          <Grid item xs={2}>
-            <Typography color="text.secondary" variant="body2">
-              Spender
-            </Typography>
-          </Grid>
-
-          <Grid item>
-            <Typography fontSize="14px">
-              <EthHashInfo address={spender} hasExplorer showAvatar={false} shortAddress={false} />
-            </Typography>
-          </Grid>
-        </Grid>
-      </Grid>
-    </Alert>
+    <Stack direction="row" alignItems="center" gap={2} className={css.approvalField}>
+      <TokenIcon logoUri={tokenInfo?.logoUri} tokenSymbol={tokenInfo?.symbol} />
+      <Box>
+        <Typography variant="body2" color="text.secondary">
+          {approvalMethodDescription[method]}
+        </Typography>
+        {amount === PSEUDO_APPROVAL_VALUES.UNLIMITED ? (
+          <Typography>
+            {PSEUDO_APPROVAL_VALUES.UNLIMITED} {tokenInfo.symbol && `of ${tokenInfo.symbol}`}
+          </Typography>
+        ) : (
+          <Typography data-testid="token-amount">
+            {formatAmountPrecise(amount, tokenInfo.decimals)} {tokenInfo.symbol && `of ${tokenInfo.symbol}`}
+          </Typography>
+        )}
+      </Box>
+    </Stack>
   )
 }
 

--- a/src/components/tx/ApprovalEditor/ApprovalItem.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalItem.tsx
@@ -6,10 +6,10 @@ import TokenIcon from '@/components/common/TokenIcon'
 import { PSEUDO_APPROVAL_VALUES } from './utils/approvals'
 import { formatAmountPrecise } from '@/utils/formatNumber'
 
-export const approvalMethodDescription: Record<Approval['method'], string> = {
-  approve: 'Set allowance to',
-  increaseAllowance: 'Increase allowance by',
-  Permit2: 'Give permission to spend',
+export const approvalMethodDescription: Record<Approval['method'], (symbol: string) => string> = {
+  approve: (symbol: string) => `Set ${symbol} allowance to`,
+  increaseAllowance: (symbol: string) => `Increase ${symbol} allowance by`,
+  Permit2: (symbol: string) => `Give permission to spend ${symbol}`,
 }
 
 const ApprovalItem = ({
@@ -24,15 +24,13 @@ const ApprovalItem = ({
 }) => {
   return (
     <Stack direction="row" alignItems="center" gap={2} className={css.approvalField}>
-      <TokenIcon logoUri={tokenInfo?.logoUri} tokenSymbol={tokenInfo?.symbol} />
+      <TokenIcon size={32} logoUri={tokenInfo?.logoUri} tokenSymbol={tokenInfo?.symbol} />
       <Box>
         <Typography variant="body2" color="text.secondary">
-          {approvalMethodDescription[method]}
+          {approvalMethodDescription[method](tokenInfo.symbol ?? '')}
         </Typography>
         {amount === PSEUDO_APPROVAL_VALUES.UNLIMITED ? (
-          <Typography>
-            {PSEUDO_APPROVAL_VALUES.UNLIMITED} {tokenInfo.symbol && `of ${tokenInfo.symbol}`}
-          </Typography>
+          <Typography>{PSEUDO_APPROVAL_VALUES.UNLIMITED}</Typography>
         ) : (
           <Typography data-testid="token-amount">
             {formatAmountPrecise(amount, tokenInfo.decimals)} {tokenInfo.symbol && `of ${tokenInfo.symbol}`}

--- a/src/components/tx/ApprovalEditor/ApprovalValueField.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalValueField.tsx
@@ -36,7 +36,8 @@ export const ApprovalValueField = ({ name, tx, readOnly }: { name: string; tx: A
     },
   })
 
-  const helperText = fieldState.error?.message ?? fieldState.isDirty ? 'Save to apply changes' : ''
+  const helperText = fieldState.error?.message ?? (fieldState.isDirty ? 'Save to apply changes' : '')
+
   const label = `${approvalMethodDescription[tx.method](tx.tokenInfo?.symbol ?? '')}`
   const options = selectValues
 

--- a/src/components/tx/ApprovalEditor/ApprovalValueField.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalValueField.tsx
@@ -37,7 +37,7 @@ export const ApprovalValueField = ({ name, tx, readOnly }: { name: string; tx: A
   })
 
   const helperText = fieldState.error?.message ?? fieldState.isDirty ? 'Save to apply changes' : ''
-  const label = approvalMethodDescription[tx.method]
+  const label = `${approvalMethodDescription[tx.method](tx.tokenInfo?.symbol ?? '')}`
   const options = selectValues
 
   return (
@@ -73,7 +73,7 @@ export const ApprovalValueField = ({ name, tx, readOnly }: { name: string; tx: A
               }
             }}
             margin="dense"
-            variant="filled"
+            variant="standard"
             error={!!fieldState.error}
             size="small"
             onBlur={onBlur}
@@ -81,9 +81,6 @@ export const ApprovalValueField = ({ name, tx, readOnly }: { name: string; tx: A
             InputProps={{
               ...params.InputProps,
               sx: {
-                paddingTop: '4px',
-                paddingBottom: '4px',
-                paddingLeft: 1,
                 flexWrap: 'nowrap !important',
                 '&::before': {
                   border: 'none !important',

--- a/src/components/tx/ApprovalEditor/ApprovalValueField.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalValueField.tsx
@@ -45,7 +45,7 @@ export const ApprovalValueField = ({ name, tx, readOnly }: { name: string; tx: A
       freeSolo
       fullWidth
       options={options}
-      renderOption={(props, value: string) => <ApprovalOption menuItemProps={props} value={value} />}
+      renderOption={(props, value: string) => <ApprovalOption key={value} menuItemProps={props} value={value} />}
       value={value}
       // On option select or free text entry
       onInputChange={(_, value) => {

--- a/src/components/tx/ApprovalEditor/ApprovalValueField.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalValueField.tsx
@@ -85,6 +85,9 @@ export const ApprovalValueField = ({ name, tx, readOnly }: { name: string; tx: A
                 '&::before': {
                   border: 'none !important',
                 },
+                '&::after': {
+                  display: readOnly ? 'none' : undefined,
+                },
                 border: 'none !important',
               },
             }}
@@ -95,6 +98,9 @@ export const ApprovalValueField = ({ name, tx, readOnly }: { name: string; tx: A
             InputLabelProps={{
               ...params.InputLabelProps,
               shrink: true,
+              sx: {
+                color: (theme) => (readOnly ? `${theme.palette.text.secondary} !important` : undefined),
+              },
             }}
           />
         )

--- a/src/components/tx/ApprovalEditor/ApprovalValueField.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalValueField.tsx
@@ -1,12 +1,11 @@
 import NumberField from '@/components/common/NumberField'
-import TokenIcon from '@/components/common/TokenIcon'
-import { shortenAddress } from '@/utils/formatters'
 import { validateAmount, validateDecimalLength } from '@/utils/validation'
-import { Autocomplete, Box, type MenuItemProps, Typography, MenuItem } from '@mui/material'
+import { Autocomplete, type MenuItemProps, MenuItem } from '@mui/material'
 import { useController, useFormContext } from 'react-hook-form'
 import type { ApprovalInfo } from './hooks/useApprovalInfos'
 import css from './styles.module.css'
 import { PSEUDO_APPROVAL_VALUES } from './utils/approvals'
+import { approvalMethodDescription } from './ApprovalItem'
 
 const ApprovalOption = ({ menuItemProps, value }: { menuItemProps: MenuItemProps; value: string }) => {
   return (
@@ -16,10 +15,9 @@ const ApprovalOption = ({ menuItemProps, value }: { menuItemProps: MenuItemProps
   )
 }
 
-export const ApprovalValueField = ({ name, tx }: { name: string; tx: ApprovalInfo }) => {
+export const ApprovalValueField = ({ name, tx, readOnly }: { name: string; tx: ApprovalInfo; readOnly: boolean }) => {
   const { control } = useFormContext()
   const selectValues = Object.values(PSEUDO_APPROVAL_VALUES)
-
   const {
     field: { ref, onBlur, onChange, value },
     fieldState,
@@ -38,7 +36,8 @@ export const ApprovalValueField = ({ name, tx }: { name: string; tx: ApprovalInf
     },
   })
 
-  const label = fieldState.error?.message || 'Token'
+  const helperText = fieldState.error?.message ?? fieldState.isDirty ? 'Save to apply changes' : ''
+  const label = approvalMethodDescription[tx.method]
   const options = selectValues
 
   return (
@@ -53,7 +52,8 @@ export const ApprovalValueField = ({ name, tx }: { name: string; tx: ApprovalInf
         onChange(value)
       }}
       disableClearable
-      selectOnFocus
+      selectOnFocus={!readOnly}
+      readOnly={readOnly}
       componentsProps={{
         paper: {
           elevation: 2,
@@ -66,6 +66,14 @@ export const ApprovalValueField = ({ name, tx }: { name: string; tx: ApprovalInf
             label={label}
             name={name}
             fullWidth
+            helperText={helperText}
+            onFocus={(field) => {
+              if (!readOnly) {
+                field.target.select()
+              }
+            }}
+            margin="dense"
+            variant="filled"
             error={!!fieldState.error}
             size="small"
             onBlur={onBlur}
@@ -77,13 +85,11 @@ export const ApprovalValueField = ({ name, tx }: { name: string; tx: ApprovalInf
                 paddingBottom: '4px',
                 paddingLeft: 1,
                 flexWrap: 'nowrap !important',
+                '&::before': {
+                  border: 'none !important',
+                },
+                border: 'none !important',
               },
-              startAdornment: (
-                <Box display="flex" flexDirection="row" alignItems="center" gap="4px">
-                  <TokenIcon size={32} logoUri={tx.tokenInfo?.logoUri} tokenSymbol={tx.tokenInfo?.symbol} />
-                  <Typography>{tx.tokenInfo?.symbol || shortenAddress(tx.tokenAddress)}</Typography>
-                </Box>
-              ),
             }}
             inputProps={{
               ...params.inputProps,

--- a/src/components/tx/ApprovalEditor/Approvals.tsx
+++ b/src/components/tx/ApprovalEditor/Approvals.tsx
@@ -1,31 +1,41 @@
-import { Grid, List, ListItem } from '@mui/material'
+import { List, ListItem, Stack } from '@mui/material'
 
 import { type ApprovalInfo } from '@/components/tx/ApprovalEditor/hooks/useApprovalInfos'
 import css from './styles.module.css'
-import SendAmountBlock from '@/components/tx-flow/flows/TokenTransfer/SendAmountBlock'
 import ApprovalItem from '@/components/tx/ApprovalEditor/ApprovalItem'
+import { groupBy } from 'lodash'
+import { useMemo } from 'react'
+import { SpenderField } from './SpenderField'
 
 const Approvals = ({ approvalInfos }: { approvalInfos: ApprovalInfo[] }) => {
+  const groupedApprovals = useMemo(() => groupBy(approvalInfos, (approval) => approval.spender), [approvalInfos])
+
   return (
     <List className={css.approvalsList}>
-      {approvalInfos.map((tx) => {
-        if (!tx.tokenInfo) return <></>
+      {Object.entries(groupedApprovals).map(([spender, approvals]) => (
+        <Stack key={spender} gap={2}>
+          <SpenderField address={spender} />
+          {approvals.map((tx) => {
+            if (!tx.tokenInfo) return <></>
 
-        return (
-          <ListItem
-            key={tx.tokenAddress + tx.spender}
-            className={BigInt(0) === BigInt(tx.amount) ? css.zeroValueApproval : undefined}
-            disablePadding
-            data-testid="approval-item"
-          >
-            <ApprovalItem spender={tx.spender} method={tx.method}>
-              <Grid container gap={1} alignItems="center">
-                <SendAmountBlock amount={tx.amountFormatted} tokenInfo={tx.tokenInfo} title="Token" />
-              </Grid>
-            </ApprovalItem>
-          </ListItem>
-        )
-      })}
+            return (
+              <ListItem
+                key={tx.tokenAddress + tx.spender}
+                className={BigInt(0) === BigInt(tx.amount) ? css.zeroValueApproval : undefined}
+                disablePadding
+                data-testid="approval-item"
+              >
+                <ApprovalItem
+                  spender={tx.spender}
+                  method={tx.method}
+                  amount={tx.amountFormatted}
+                  tokenInfo={tx.tokenInfo}
+                />
+              </ListItem>
+            )
+          })}
+        </Stack>
+      ))}
     </List>
   )
 }

--- a/src/components/tx/ApprovalEditor/EditableApprovalItem.tsx
+++ b/src/components/tx/ApprovalEditor/EditableApprovalItem.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, IconButton, Stack, SvgIcon, Typography } from '@mui/material'
+import { Box, Button, IconButton, Stack, SvgIcon } from '@mui/material'
 import css from '@/components/tx/ApprovalEditor/styles.module.css'
 import type { ApprovalInfo } from './hooks/useApprovalInfos'
 
@@ -9,7 +9,6 @@ import { useFormContext } from 'react-hook-form'
 import { get } from 'lodash'
 import { EditOutlined } from '@mui/icons-material'
 import TokenIcon from '@/components/common/TokenIcon'
-import { shortenAddress } from '@/utils/formatters'
 import { useState } from 'react'
 
 const EditableApprovalItem = ({
@@ -45,7 +44,6 @@ const EditableApprovalItem = ({
     <Stack direction="row" alignItems="center" gap={2} className={css.approvalField}>
       <Box display="flex" flexDirection="row" alignItems="center" gap="4px">
         <TokenIcon size={32} logoUri={approval.tokenInfo?.logoUri} tokenSymbol={approval.tokenInfo?.symbol} />
-        <Typography>{approval.tokenInfo?.symbol || shortenAddress(approval.tokenAddress)}</Typography>
       </Box>
       <ApprovalValueField name={name} tx={approval} readOnly={readOnly} />
       <Track {...MODALS_EVENTS.EDIT_APPROVALS}>

--- a/src/components/tx/ApprovalEditor/EditableApprovalItem.tsx
+++ b/src/components/tx/ApprovalEditor/EditableApprovalItem.tsx
@@ -1,0 +1,66 @@
+import { Box, Button, IconButton, Stack, SvgIcon, Typography } from '@mui/material'
+import css from '@/components/tx/ApprovalEditor/styles.module.css'
+import type { ApprovalInfo } from './hooks/useApprovalInfos'
+
+import { ApprovalValueField } from './ApprovalValueField'
+import Track from '@/components/common/Track'
+import { MODALS_EVENTS } from '@/services/analytics'
+import { useFormContext } from 'react-hook-form'
+import { get } from 'lodash'
+import { EditOutlined } from '@mui/icons-material'
+import TokenIcon from '@/components/common/TokenIcon'
+import { shortenAddress } from '@/utils/formatters'
+import { useState } from 'react'
+
+const EditableApprovalItem = ({
+  approval,
+  name,
+  onSave,
+}: {
+  approval: ApprovalInfo
+  onSave: () => void
+  name: string
+}) => {
+  const { formState, setFocus, trigger } = useFormContext()
+
+  const { errors, dirtyFields } = formState
+
+  const fieldErrors = get(errors, name)
+  const isDirty = get(dirtyFields, name)
+
+  const [readOnly, setReadOnly] = useState(true)
+
+  const handleSave = () => {
+    onSave()
+    setReadOnly(true)
+  }
+
+  const handleEditMode = () => {
+    setReadOnly(false)
+    // We need to rerender such that select on focus triggers
+    setTimeout(() => setFocus(name), 0)
+  }
+
+  return (
+    <Stack direction="row" alignItems="center" gap={2} className={css.approvalField}>
+      <Box display="flex" flexDirection="row" alignItems="center" gap="4px">
+        <TokenIcon size={32} logoUri={approval.tokenInfo?.logoUri} tokenSymbol={approval.tokenInfo?.symbol} />
+        <Typography>{approval.tokenInfo?.symbol || shortenAddress(approval.tokenAddress)}</Typography>
+      </Box>
+      <ApprovalValueField name={name} tx={approval} readOnly={readOnly} />
+      <Track {...MODALS_EVENTS.EDIT_APPROVALS}>
+        {readOnly ? (
+          <IconButton color="border" size="small" onClick={handleEditMode} title="Save">
+            <SvgIcon width="16px" height="16px" component={EditOutlined} inheritViewBox />
+          </IconButton>
+        ) : (
+          <Button variant="text" size="small" onClick={handleSave} disabled={!!fieldErrors || !isDirty}>
+            Save
+          </Button>
+        )}
+      </Track>
+    </Stack>
+  )
+}
+
+export default EditableApprovalItem

--- a/src/components/tx/ApprovalEditor/EditableApprovalItem.tsx
+++ b/src/components/tx/ApprovalEditor/EditableApprovalItem.tsx
@@ -48,8 +48,8 @@ const EditableApprovalItem = ({
       <ApprovalValueField name={name} tx={approval} readOnly={readOnly} />
       <Track {...MODALS_EVENTS.EDIT_APPROVALS}>
         {readOnly ? (
-          <IconButton color="border" size="small" onClick={handleEditMode} title="Edit">
-            <SvgIcon width="16px" height="16px" component={EditOutlined} inheritViewBox />
+          <IconButton color="border" onClick={handleEditMode} title="Edit">
+            <SvgIcon fontSize="small" component={EditOutlined} inheritViewBox />
           </IconButton>
         ) : (
           <Button title="Save" variant="text" size="small" onClick={handleSave} disabled={!!fieldErrors || !isDirty}>

--- a/src/components/tx/ApprovalEditor/EditableApprovalItem.tsx
+++ b/src/components/tx/ApprovalEditor/EditableApprovalItem.tsx
@@ -21,7 +21,7 @@ const EditableApprovalItem = ({
   onSave: () => void
   name: string
 }) => {
-  const { formState, setFocus, trigger } = useFormContext()
+  const { formState, setFocus } = useFormContext()
 
   const { errors, dirtyFields } = formState
 
@@ -50,11 +50,11 @@ const EditableApprovalItem = ({
       <ApprovalValueField name={name} tx={approval} readOnly={readOnly} />
       <Track {...MODALS_EVENTS.EDIT_APPROVALS}>
         {readOnly ? (
-          <IconButton color="border" size="small" onClick={handleEditMode} title="Save">
+          <IconButton color="border" size="small" onClick={handleEditMode} title="Edit">
             <SvgIcon width="16px" height="16px" component={EditOutlined} inheritViewBox />
           </IconButton>
         ) : (
-          <Button variant="text" size="small" onClick={handleSave} disabled={!!fieldErrors || !isDirty}>
+          <Button title="Save" variant="text" size="small" onClick={handleSave} disabled={!!fieldErrors || !isDirty}>
             Save
           </Button>
         )}

--- a/src/components/tx/ApprovalEditor/SpenderField.tsx
+++ b/src/components/tx/ApprovalEditor/SpenderField.tsx
@@ -3,8 +3,8 @@ import { Stack, Typography } from '@mui/material'
 
 import css from './styles.module.css'
 import useAsync from '@/hooks/useAsync'
-import { getContract } from '@safe-global/safe-gateway-typescript-sdk'
 import useChainId from '@/hooks/useChainId'
+import { getContract } from '@safe-global/safe-gateway-typescript-sdk'
 export const SpenderField = ({ address }: { address: string }) => {
   const chainId = useChainId()
   const [spendingContract] = useAsync(() => getContract(chainId, address), [chainId, address])

--- a/src/components/tx/ApprovalEditor/SpenderField.tsx
+++ b/src/components/tx/ApprovalEditor/SpenderField.tsx
@@ -1,0 +1,29 @@
+import EthHashInfo from '@/components/common/EthHashInfo'
+import { Stack, Typography } from '@mui/material'
+
+import css from './styles.module.css'
+import useAsync from '@/hooks/useAsync'
+import { getContract } from '@safe-global/safe-gateway-typescript-sdk'
+import useChainId from '@/hooks/useChainId'
+export const SpenderField = ({ address }: { address: string }) => {
+  const chainId = useChainId()
+  const [spendingContract] = useAsync(() => getContract(chainId, address), [chainId, address])
+
+  return (
+    <Stack direction="row" justifyContent="space-between" alignItems="center" gap={2} className={css.approvalField}>
+      <Typography variant="body2" color="text.secondary">
+        Spender
+      </Typography>
+      <div>
+        {/* TODO: set to name only once merged with swap changes */}
+        <EthHashInfo
+          avatarSize={24}
+          address={address}
+          name={spendingContract?.displayName || spendingContract?.name}
+          customAvatar={spendingContract?.logoUri}
+          hasExplorer
+        />
+      </div>
+    </Stack>
+  )
+}

--- a/src/components/tx/ApprovalEditor/SpenderField.tsx
+++ b/src/components/tx/ApprovalEditor/SpenderField.tsx
@@ -1,13 +1,16 @@
 import EthHashInfo from '@/components/common/EthHashInfo'
-import { Stack, Typography } from '@mui/material'
+import { Stack, Typography, useMediaQuery, useTheme } from '@mui/material'
 
 import css from './styles.module.css'
 import useAsync from '@/hooks/useAsync'
 import useChainId from '@/hooks/useChainId'
 import { getContract } from '@safe-global/safe-gateway-typescript-sdk'
+
 export const SpenderField = ({ address }: { address: string }) => {
   const chainId = useChainId()
   const [spendingContract] = useAsync(() => getContract(chainId, address), [chainId, address])
+  const { breakpoints } = useTheme()
+  const isSmallScreen = useMediaQuery(breakpoints.down('md'))
 
   return (
     <Stack direction="row" justifyContent="space-between" alignItems="center" gap={2} className={css.approvalField}>
@@ -15,12 +18,12 @@ export const SpenderField = ({ address }: { address: string }) => {
         Spender
       </Typography>
       <div>
-        {/* TODO: set to name only once merged with swap changes */}
         <EthHashInfo
           avatarSize={24}
           address={address}
           name={spendingContract?.displayName || spendingContract?.name}
           customAvatar={spendingContract?.logoUri}
+          shortAddress={isSmallScreen}
           hasExplorer
         />
       </div>

--- a/src/components/tx/ApprovalEditor/hooks/useApprovalInfos.ts
+++ b/src/components/tx/ApprovalEditor/hooks/useApprovalInfos.ts
@@ -16,6 +16,8 @@ export type ApprovalInfo = {
   amount: any
   amountFormatted: string
   method: Approval['method']
+  /** Index of approval transaction within (batch) transaction */
+  transactionIndex: number
 }
 
 const ApprovalModuleInstance = new ApprovalModule()

--- a/src/components/tx/ApprovalEditor/index.tsx
+++ b/src/components/tx/ApprovalEditor/index.tsx
@@ -15,9 +15,7 @@ const Title = () => {
   return (
     <div>
       <Typography fontWeight={700}>Allow access to tokens?</Typography>
-      <Typography variant="body2">
-        It will give access to third parties to use and spend the set amount of your tokens.
-      </Typography>
+      <Typography variant="body2">This allows the spender to spend the specified amount of your tokens.</Typography>
     </div>
   )
 }

--- a/src/components/tx/ApprovalEditor/index.tsx
+++ b/src/components/tx/ApprovalEditor/index.tsx
@@ -1,6 +1,6 @@
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { createMultiSendCallOnlyTx, createTx } from '@/services/tx/tx-sender'
-import { Alert, Box, Divider, Skeleton, SvgIcon, Typography } from '@mui/material'
+import { Alert, Box, Skeleton, Typography } from '@mui/material'
 import { type SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { useContext } from 'react'
 import css from './styles.module.css'
@@ -8,23 +8,16 @@ import { ApprovalEditorForm } from './ApprovalEditorForm'
 import { updateApprovalTxs } from './utils/approvals'
 import { useApprovalInfos } from './hooks/useApprovalInfos'
 import { decodeSafeTxToBaseTransactions } from '@/utils/transactions'
-import EditIcon from '@/public/images/common/edit.svg'
-import commonCss from '@/components/tx-flow/common/styles.module.css'
 import Approvals from '@/components/tx/ApprovalEditor/Approvals'
 import { type EIP712TypedData } from '@safe-global/safe-gateway-typescript-sdk'
 
 const Title = () => {
   return (
-    <div className={css.wrapper}>
-      <div className={css.icon}>
-        <SvgIcon component={EditIcon} inheritViewBox fontSize="small" />
-      </div>
-      <div>
-        <Typography fontWeight={700}>Approve access to</Typography>
-        <Typography variant="body2">
-          This allows contracts to spend the selected amounts of your asset balance.
-        </Typography>
-      </div>
+    <div>
+      <Typography fontWeight={700}>Allow access to tokens?</Typography>
+      <Typography variant="body2">
+        It will give access to third parties to use and spend the set amount of your tokens.
+      </Typography>
     </div>
   )
 }
@@ -63,7 +56,7 @@ export const ApprovalEditor = ({
   const isReadOnly = (safeTransaction && safeTransaction.signatures.size > 0) || safeMessage !== undefined
 
   return (
-    <Box display="flex" flexDirection="column" gap={2} mb={3}>
+    <Box display="flex" flexDirection="column" gap={2} mb={3} className={css.container}>
       <Title />
       {error ? (
         <Alert severity="error">Error while decoding approval transactions.</Alert>
@@ -74,10 +67,6 @@ export const ApprovalEditor = ({
       ) : (
         <ApprovalEditorForm approvalInfos={readableApprovals} updateApprovals={updateApprovals} />
       )}
-
-      <Box mt={2}>
-        <Divider className={commonCss.nestedDivider} />
-      </Box>
     </Box>
   )
 }

--- a/src/components/tx/ApprovalEditor/styles.module.css
+++ b/src/components/tx/ApprovalEditor/styles.module.css
@@ -1,3 +1,9 @@
+.container {
+  background-color: var(--color-warning-background);
+  border-radius: 4px;
+  padding: var(--space-2);
+}
+
 .warningAccordion {
   border: 1px var(--color-warning-main) solid !important;
   margin-bottom: var(--space-2) !important;
@@ -15,6 +21,13 @@
   width: 100%;
 }
 
+.approvalField {
+  background-color: var(--color-background-paper);
+  border-radius: 6px;
+  padding: 12px 16px;
+  width: 100%;
+}
+
 .alert :global .MuiAlert-message {
   width: 100%;
 }
@@ -24,32 +37,7 @@
 }
 
 .approvalAmount {
-  text-align: right !important;
   padding-left: var(--space-1);
-}
-
-.iconButton {
-  border-radius: 4px;
-  padding: 6px;
-  width: 52px;
-  height: 52px;
-  background-color: var(--color-primary-main);
-}
-
-.iconButton:hover {
-  background-color: var(--color-primary-dark);
-}
-
-.iconButton svg {
-  color: var(--color-background-paper);
-}
-
-.iconButton:disabled {
-  background-color: var(--color-text-disabled);
-}
-
-.iconButton:disabled svg {
-  color: var(--color-border-dark);
 }
 
 .approvalsList {

--- a/src/components/tx/ApprovalEditor/utils/approvals.ts
+++ b/src/components/tx/ApprovalEditor/utils/approvals.ts
@@ -81,20 +81,22 @@ export const extractTxs: (txs: BaseTransaction[] | (DecodedDataResponse & { to: 
 }
 
 export const updateApprovalTxs = (
-  approvals: string[],
+  approvalFormValues: string[],
   approvalInfos: ApprovalInfo[] | undefined,
   txs: BaseTransaction[],
 ) => {
-  let approvalID = 0
-  const updatedTxs = txs.map((tx) => {
+  const updatedTxs = txs.map((tx, txIndex) => {
+    const approvalIndex = approvalInfos?.findIndex((approval) => approval.transactionIndex === txIndex)
+    if (approvalIndex === undefined) {
+      return tx
+    }
     if (tx.data.startsWith(APPROVAL_SIGNATURE_HASH)) {
-      const newApproval = approvals[approvalID]
-      const approvalInfo = approvalInfos?.[approvalID]
+      const newApproval = approvalFormValues[approvalIndex]
+      const approvalInfo = approvalInfos?.[approvalIndex]
       if (!approvalInfo || !approvalInfo.tokenInfo) {
         // Without decimals and spender we cannot create a new tx
         return tx
       }
-      approvalID++
       const decimals = approvalInfo.tokenInfo.decimals
       const newAmountWei = parseApprovalAmount(newApproval, decimals)
       return {

--- a/src/components/tx/ApprovalEditor/utils/approvals.ts
+++ b/src/components/tx/ApprovalEditor/utils/approvals.ts
@@ -90,7 +90,7 @@ export const updateApprovalTxs = (
     if (approvalIndex === undefined) {
       return tx
     }
-    if (tx.data.startsWith(APPROVAL_SIGNATURE_HASH)) {
+    if (tx.data.startsWith(APPROVAL_SIGNATURE_HASH) || tx.data.startsWith(INCREASE_ALLOWANCE_SIGNATURE_HASH)) {
       const newApproval = approvalFormValues[approvalIndex]
       const approvalInfo = approvalInfos?.[approvalIndex]
       if (!approvalInfo || !approvalInfo.tokenInfo) {
@@ -99,10 +99,18 @@ export const updateApprovalTxs = (
       }
       const decimals = approvalInfo.tokenInfo.decimals
       const newAmountWei = parseApprovalAmount(newApproval, decimals)
-      return {
-        to: approvalInfo.tokenAddress,
-        value: '0',
-        data: ERC20_INTERFACE.encodeFunctionData(APPROVE_METHOD, [approvalInfo.spender, newAmountWei]),
+      if (tx.data.startsWith(APPROVAL_SIGNATURE_HASH)) {
+        return {
+          to: approvalInfo.tokenAddress,
+          value: '0',
+          data: ERC20_INTERFACE.encodeFunctionData('approve', [approvalInfo.spender, newAmountWei]),
+        }
+      } else {
+        return {
+          to: approvalInfo.tokenAddress,
+          value: '0',
+          data: ERC20_INTERFACE.encodeFunctionData('increaseAllowance', [approvalInfo.spender, newAmountWei]),
+        }
       }
     }
     return tx

--- a/src/components/tx/ApprovalEditor/utils/approvals.ts
+++ b/src/components/tx/ApprovalEditor/utils/approvals.ts
@@ -21,7 +21,7 @@ const UINT256_TYPE = 'uint256'
 const ERC20_INTERFACE = ERC20__factory.createInterface()
 
 export enum PSEUDO_APPROVAL_VALUES {
-  UNLIMITED = 'Unlimited (not recommended)',
+  UNLIMITED = 'Unlimited amount',
 }
 
 const parseApprovalAmount = (amount: string, decimals: number) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4246,7 +4246,12 @@
   dependencies:
     semver "^7.3.7"
 
-"@safe-global/safe-gateway-typescript-sdk@3.19.0", "@safe-global/safe-gateway-typescript-sdk@^3.5.3":
+"@safe-global/safe-gateway-typescript-sdk@3.21.0":
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.21.0.tgz#1c27a811762af74d9939a1c88ecc7dd0cdd98d64"
+  integrity sha512-q68R8j80EcUa5qLB2+lVfCYIDvK2/wE0UhFF7++4KQXDLX2AUolBWL4wsr9G44TpsiIj3fS2Bv/TrlWk8mrtTQ==
+
+"@safe-global/safe-gateway-typescript-sdk@^3.5.3":
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.19.0.tgz#18637c205c83bfc0a6be5fddbf202d6bb4927302"
   integrity sha512-TRlP05KY6t3wjLJ74FiirWlEt3xTclnUQM2YdYto1jx5G1o0meMnugIUZXhzm7Bs3rDEDNhz/aDf2KMSZtoCFg==


### PR DESCRIPTION
## What it solves

Resolves #3607 

## TODO
- [x] Maintain order of approvals as they are in the transaction or fix update function

## How this PR fixes it
- Changes layout / design of approval editor
- Groups approvals by spender address
- Fetches and displays contract name for spender address

## How to test it
- Use any app that requires approvals OR transaction builder to craft specific approval payloads
- Observe the approval editor


## Screenshots
<img width="449" alt="Screenshot 2024-04-25 at 13 46 12" src="https://github.com/safe-global/safe-wallet-web/assets/2670790/3f9ec297-ab11-4f79-82d0-632c851951a7">
<img width="449" alt="Screenshot 2024-04-25 at 13 46 19" src="https://github.com/safe-global/safe-wallet-web/assets/2670790/49b24e11-c3f9-43a7-a2c1-e97cb8b94284">
<img width="449" alt="Screenshot 2024-04-25 at 13 46 26" src="https://github.com/safe-global/safe-wallet-web/assets/2670790/7723eccf-5b06-47cc-b44f-95732f76ed23">
<img width="587" alt="Screenshot 2024-04-25 at 13 28 17" src="https://github.com/safe-global/safe-wallet-web/assets/2670790/6b62c02c-1c5f-4c98-a6cb-9811ba82f5d8">


## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [] I've written a unit/e2e test for it (if applicable) 🧑‍💻
