### PR TITLE
fix: wrong orderClass used

### DIFF
--- a/src/features/swap/components/SwapOrder/index.stories.tsx
+++ b/src/features/swap/components/SwapOrder/index.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { SellOrder as SellOrderComponent } from './index'
 import { Paper } from '@mui/material'
-import type { OrderStatuses, SwapOrder } from '@safe-global/safe-gateway-typescript-sdk'
-import { orderTokenBuilder, swapOrderBuilder } from '@/features/swap/helpers/swapOrderBuilder'
+import type { OrderStatuses } from '@safe-global/safe-gateway-typescript-sdk'
+import { appDataBuilder, orderTokenBuilder, swapOrderBuilder } from '@/features/swap/helpers/swapOrderBuilder'
 
-const FulfilledSwapOrder: SwapOrder = swapOrderBuilder()
+const FulfilledSwapOrder = swapOrderBuilder()
   .with({
     uid: '0x03a5d561ad2452d719a0d075573f4bed68217c696b52f151122c30e3e4426f1b05e6b5eb1d0e6aabab082057d5bb91f2ee6d11be66223d88',
   })
@@ -34,10 +34,14 @@ const FulfilledSwapOrder: SwapOrder = swapOrderBuilder()
     explorerUrl:
       'https://explorer.cow.fi/orders/0x03a5d561ad2452d719a0d075573f4bed68217c696b52f151122c30e3e4426f1b05e6b5eb1d0e6aabab082057d5bb91f2ee6d11be66223d88',
   })
-  .build()
+  .with({
+    fullAppData: appDataBuilder('market').build(),
+  })
+
+console.log(FulfilledSwapOrder)
 
 const NonFulfilledSwapOrder = {
-  ...FulfilledSwapOrder,
+  ...FulfilledSwapOrder.build(),
   status: 'open' as OrderStatuses,
   expiresTimestamp: new Date().getTime() / 1000 + 28 * 60,
   executedSellAmount: '0',
@@ -65,9 +69,20 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Executed: Story = {
+export const ExecutedMarket: Story = {
   args: {
-    order: FulfilledSwapOrder,
+    order: FulfilledSwapOrder.build(),
+  },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/VyA38zUPbJ2zflzCIYR6Nu/Swap?type=design&node-id=5813-37759&mode=design&t=cJDGDQGZFqccSTaB-4',
+    },
+  },
+}
+export const ExecutedLimit: Story = {
+  args: {
+    order: FulfilledSwapOrder.with({ fullAppData: appDataBuilder('limit').build() }).build(),
   },
   parameters: {
     design: {
@@ -77,10 +92,11 @@ export const Executed: Story = {
   },
 }
 
-export const Pending: Story = {
+export const PendingMarket: Story = {
   args: {
     order: {
       ...NonFulfilledSwapOrder,
+      fullAppData: appDataBuilder('market').build(),
       status: 'presignaturePending' as OrderStatuses,
       validUntil: new Date().getTime() / 1000 + 28 * 60,
     },
@@ -93,7 +109,24 @@ export const Pending: Story = {
   },
 }
 
-export const Open: Story = {
+export const PendingLimit: Story = {
+  args: {
+    order: {
+      ...NonFulfilledSwapOrder,
+      fullAppData: appDataBuilder('limit').build(),
+      status: 'presignaturePending' as OrderStatuses,
+      validUntil: new Date().getTime() / 1000 + 28 * 60,
+    },
+  },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/VyA38zUPbJ2zflzCIYR6Nu/Swap?type=design&node-id=5974-14391&mode=design&t=cJDGDQGZFqccSTaB-4',
+    },
+  },
+}
+
+export const OpenMarket: Story = {
   args: {
     order: {
       ...NonFulfilledSwapOrder,
@@ -106,11 +139,25 @@ export const Open: Story = {
     },
   },
 }
-
-export const Cancelled: Story = {
+export const OpenLimit: Story = {
   args: {
     order: {
       ...NonFulfilledSwapOrder,
+      fullAppData: appDataBuilder('limit').build(),
+    },
+  },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/VyA38zUPbJ2zflzCIYR6Nu/Swap?type=design&node-id=5813-37808&mode=design&t=cJDGDQGZFqccSTaB-4',
+    },
+  },
+}
+export const CancelledMarket: Story = {
+  args: {
+    order: {
+      ...NonFulfilledSwapOrder,
+      fullAppData: appDataBuilder('market').build(),
       status: 'cancelled' as OrderStatuses,
       validUntil: new Date().getTime() / 1000 - 28 * 60,
     },
@@ -123,10 +170,45 @@ export const Cancelled: Story = {
   },
 }
 
-export const Expired: Story = {
+export const CancelledLimit: Story = {
   args: {
     order: {
       ...NonFulfilledSwapOrder,
+      fullAppData: appDataBuilder('limit').build(),
+      status: 'cancelled' as OrderStatuses,
+      validUntil: new Date().getTime() / 1000 - 28 * 60,
+    },
+  },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/VyA38zUPbJ2zflzCIYR6Nu/Swap?type=design&node-id=5813-37924&mode=design&t=cJDGDQGZFqccSTaB-4',
+    },
+  },
+}
+
+export const ExpiredSwap: Story = {
+  args: {
+    order: {
+      ...NonFulfilledSwapOrder,
+      fullAppData: appDataBuilder('market').build(),
+      status: 'expired' as OrderStatuses,
+      validUntil: new Date().getTime() / 1000 - 28 * 60,
+    },
+  },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/VyA38zUPbJ2zflzCIYR6Nu/Swap?type=design&node-id=5813-37987&mode=design&t=cJDGDQGZFqccSTaB-4',
+    },
+  },
+}
+
+export const ExpiredLimit: Story = {
+  args: {
+    order: {
+      ...NonFulfilledSwapOrder,
+      fullAppData: appDataBuilder('limit').build(),
       status: 'expired' as OrderStatuses,
       validUntil: new Date().getTime() / 1000 - 28 * 60,
     },

--- a/src/features/swap/components/SwapOrder/index.tsx
+++ b/src/features/swap/components/SwapOrder/index.tsx
@@ -15,7 +15,7 @@ import css from './styles.module.css'
 import { Typography } from '@mui/material'
 import { formatAmount } from '@/utils/formatNumber'
 import { formatVisualAmount } from '@/utils/formatters'
-import { getExecutionPrice, getLimitPrice, getSurplusPrice } from '@/features/swap/helpers/utils'
+import { getExecutionPrice, getLimitPrice, getOrderClass, getSurplusPrice } from '@/features/swap/helpers/utils'
 
 type SwapOrderProps = {
   txData?: TransactionData
@@ -23,13 +23,14 @@ type SwapOrderProps = {
 }
 
 export const SellOrder = ({ order }: { order: SwapOrderType }) => {
-  const { uid, kind, validUntil, status, sellToken, buyToken, sellAmount, buyAmount, orderClass, explorerUrl } = order
+  const { uid, kind, validUntil, status, sellToken, buyToken, sellAmount, buyAmount, explorerUrl } = order
 
   const executionPrice = getExecutionPrice(order)
   const limitPrice = getLimitPrice(order)
   const surplusPrice = getSurplusPrice(order)
   const expires = new Date(validUntil * 1000)
   const now = new Date()
+  const orderClass = getOrderClass(order)
 
   const orderKindLabel = capitalize(kind)
   const isSellOrder = kind === 'sell'

--- a/src/features/swap/helpers/swapOrderBuilder.ts
+++ b/src/features/swap/helpers/swapOrderBuilder.ts
@@ -7,12 +7,14 @@ import type {
   CowSwapConfirmationView,
 } from '@safe-global/safe-gateway-typescript-sdk'
 
-export function appDataBuilder(): IBuilder<Record<string, unknown>> {
+export function appDataBuilder(
+  orderClass: 'limit' | 'market' | 'liquidity' = 'limit',
+): IBuilder<Record<string, unknown>> {
   return Builder.new<Record<string, unknown>>().with({
     appCode: 'Safe Wallet Swaps',
     metadata: {
       orderClass: {
-        orderClass: faker.helpers.arrayElement(['limit', 'market', 'liquidity']),
+        orderClass,
       },
       partnerFee: {
         bps: 50,
@@ -29,6 +31,7 @@ export function appDataBuilder(): IBuilder<Record<string, unknown>> {
     version: '1.1.0',
   })
 }
+
 export function orderTokenBuilder(): IBuilder<OrderToken> {
   return Builder.new<OrderToken>().with({
     address: faker.finance.ethereumAddress(),

--- a/src/features/swap/helpers/utils.ts
+++ b/src/features/swap/helpers/utils.ts
@@ -93,3 +93,8 @@ export const getSlippageInPercent = (order: Pick<SwapOrder, 'fullAppData'>): str
 
   return (Number(slippageBips) / 100).toFixed(2)
 }
+
+export const getOrderClass = (order: Pick<SwapOrder, 'fullAppData'>): latest.OrderClass1 => {
+  const fullAppData = order.fullAppData as AnyAppDataDocVersion
+  return (fullAppData.metadata.orderClass as latest.OrderClass).orderClass
+}


### PR DESCRIPTION
The cowswap API was returning an unexpected value for the orderClass:
context:
Trust the appData.metadata.orderClass.orderClass to match the form used (Swap->market, Limit->limit, Twap->twap). More context:
The the order class in the API is what the order was considered during placement. Before, there was a difference between SWAP and LIMIT. Basically SWAP had a fee, LIMIT did not.
When we moved all orders to not have a pre-defined fee, everything became a LIMIT order from the protocol point of view.
