### PR TITLE
feat: hide finish button on success screen for swaps

### DIFF
--- a/src/components/tx-flow/flows/SuccessScreen/index.tsx
+++ b/src/components/tx-flow/flows/SuccessScreen/index.tsx
@@ -29,7 +29,7 @@ const SuccessScreen = ({ txId, safeTx }: { txId: string; safeTx?: SafeTransactio
   const { status } = pendingTx || {}
   const txHash = pendingTx && 'txHash' in pendingTx ? pendingTx.txHash : undefined
   const txLink = chain && getTxLink(txId, chain, safeAddress)
-  const [decodedData, decodedDataError, decodedDataLoading] = useDecodeTx(safeTx)
+  const [decodedData] = useDecodeTx(safeTx)
   const isSwapOrder = isSwapConfirmationViewOrder(decodedData)
 
   useEffect(() => {

--- a/src/components/tx-flow/flows/SuccessScreen/index.tsx
+++ b/src/components/tx-flow/flows/SuccessScreen/index.tsx
@@ -95,6 +95,12 @@ const SuccessScreen = ({ txId, safeTx }: { txId: string; safeTx?: SafeTransactio
       <Divider />
 
       <div className={classnames(css.row, css.buttons)}>
+        {isSwapOrder && (
+          <Button data-testid="finish-transaction-btn" variant="outlined" size="small" onClick={onClose}>
+            Back to Swap
+          </Button>
+        )}
+
         {txLink && (
           <Link {...txLink} passHref target="_blank" rel="noreferrer" legacyBehavior>
             <Button

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -112,7 +112,7 @@ export const ExecuteForm = ({
 
     // On success
     onSubmit?.(executedTxId, true)
-    setTxFlow(<SuccessScreenFlow txId={executedTxId} />, undefined, false)
+    setTxFlow(<SuccessScreenFlow txId={executedTxId} safeTx={safeTx} />, undefined, false)
   }
 
   const walletCanPay = useWalletCanPay({


### PR DESCRIPTION
## What it solves
This is an attempt to make the swap a bit less confusing after performing a swap. We incentivise the user to go to "view transaction" instead of staying on the swap page. This way he won't be on the swap page that just displays "order submitted" with no further information about the order itself. 

Resolves
https://www.notion.so/safe-global/Submit-order-redirect-5e826c01903249fdb3cfc116811fa472?pvs=4

## How this PR fixes it
Hides the "Finish" button on the Success screen

## How to test it
Perform a swap. On the success screen you should only see "view transaction"

## Screenshots
<img width="858" alt="grafik" src="https://github.com/safe-global/safe-wallet-web/assets/693770/af04a2d2-add9-4e14-9c87-43b2e1f25934">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
