### PR TITLE
Feat: Add token symbols to swap transaction summary

### DIFF
--- a/src/components/common/TokenIcon/index.tsx
+++ b/src/components/common/TokenIcon/index.tsx
@@ -1,6 +1,7 @@
 import { type ReactElement } from 'react'
 import ImageFallback from '../ImageFallback'
 import css from './styles.module.css'
+import classNames from 'classnames'
 
 const FALLBACK_ICON = '/images/common/token-placeholder.svg'
 
@@ -9,11 +10,13 @@ const TokenIcon = ({
   tokenSymbol,
   size = 26,
   fallbackSrc,
+  rounded,
 }: {
   logoUri?: string
   tokenSymbol?: string
   size?: number
   fallbackSrc?: string
+  rounded?: boolean
 }): ReactElement => {
   return (
     <ImageFallback
@@ -21,7 +24,7 @@ const TokenIcon = ({
       alt={tokenSymbol}
       fallbackSrc={fallbackSrc || FALLBACK_ICON}
       height={size}
-      className={css.image}
+      className={classNames(css.image, { [css.rounded]: rounded })}
     />
   )
 }

--- a/src/components/common/TokenIcon/styles.module.css
+++ b/src/components/common/TokenIcon/styles.module.css
@@ -8,3 +8,8 @@
   border-radius: 4px;
   padding: 2px;
 }
+
+.rounded {
+  border-radius: 12px !important;
+  background-color: #ffffff;
+}

--- a/src/components/transactions/TxInfo/index.tsx
+++ b/src/components/transactions/TxInfo/index.tsx
@@ -97,11 +97,11 @@ const SwapTx = ({ info }: { info: SwapOrder }): ReactElement => {
       <Typography display="flex" alignItems="center" fontWeight="bold">
         Swap{' '}
         <Box style={{ paddingLeft: 5, paddingRight: 5, display: 'inline-block' }}>
-          <TokenIcon logoUri={info.sellToken.logoUri || undefined} tokenSymbol={info.sellToken.symbol} rounded={true} />
+          <TokenIcon logoUri={info.sellToken.logoUri || undefined} tokenSymbol={info.sellToken.symbol} />
         </Box>
         {info.sellToken.symbol} to
         <Box style={{ paddingLeft: 5, paddingRight: 5, display: 'inline-block' }}>
-          <TokenIcon logoUri={info.buyToken.logoUri || undefined} tokenSymbol={info.buyToken.symbol} rounded={true} />
+          <TokenIcon logoUri={info.buyToken.logoUri || undefined} tokenSymbol={info.buyToken.symbol} />
         </Box>{' '}
         {info.buyToken.symbol}
       </Typography>

--- a/src/components/transactions/TxInfo/index.tsx
+++ b/src/components/transactions/TxInfo/index.tsx
@@ -23,6 +23,8 @@ import {
 } from '@/utils/transaction-guards'
 import { ellipsis, shortenAddress } from '@/utils/formatters'
 import { useCurrentChain } from '@/hooks/useChains'
+import TokenIcon from '@/components/common/TokenIcon'
+import { Box, Typography } from '@mui/material'
 
 export const TransferTx = ({
   info,
@@ -91,9 +93,19 @@ const MultiSendTx = ({ info }: { info: MultiSend }): ReactElement => {
 
 const SwapTx = ({ info }: { info: SwapOrder }): ReactElement => {
   return (
-    <>
-      Swap {info.sellToken.symbol} to {info.buyToken.symbol}
-    </>
+    <Box display="flex">
+      <Typography display="flex" alignItems="center" fontWeight="bold">
+        Swap{' '}
+        <Box style={{ paddingLeft: 5, paddingRight: 5, display: 'inline-block' }}>
+          <TokenIcon logoUri={info.sellToken.logoUri || undefined} tokenSymbol={info.sellToken.symbol} rounded={true} />
+        </Box>
+        {info.sellToken.symbol} to
+        <Box style={{ paddingLeft: 5, paddingRight: 5, display: 'inline-block' }}>
+          <TokenIcon logoUri={info.buyToken.logoUri || undefined} tokenSymbol={info.buyToken.symbol} rounded={true} />
+        </Box>{' '}
+        {info.buyToken.symbol}
+      </Typography>
+    </Box>
   )
 }
 const SettingsChangeTx = ({ info }: { info: SettingsChange }): ReactElement => {


### PR DESCRIPTION
## What it solves

Resolves: https://www.notion.so/safe-global/Display-token-icons-in-the-tx-list-12098c01ba6743b7a3669e6262c9800c?pvs=4

## How this PR fixes it
- display the sell token symbol and then the buy token symbol in the transaction info 

## How to test it
- Excecute a swap
- View the swap tx in transaction history.

## Screenshots
![image](https://github.com/safe-global/safe-wallet-web/assets/17801424/6518353e-44b8-4a12-922d-cdf7f1b9a6d9)


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
