### PR TITLE
Fix: use correct values for swap order surplus calculation

### DIFF
--- a/src/features/swap/helpers/__tests__/utils.test.ts
+++ b/src/features/swap/helpers/__tests__/utils.test.ts
@@ -141,5 +141,38 @@ describe('Swap helpers', () => {
 
       expect(result).toEqual('0')
     })
+
+    // eslint-disable-next-line no-only-tests/no-only-tests
+    it('returns the surplus amount for buy orders', () => {
+      const mockOrder = {
+        executedSellAmount: '10000000000000000000', //10
+        executedBuyAmount: '50',
+        buyToken: { decimals: 8 },
+        sellToken: { decimals: 18 },
+        sellAmount: '15000000000000000000', //15
+        buyAmount: '5000000000',
+        kind: 'buy',
+      } as unknown as SwapOrder
+
+      const result = getSurplusPrice(mockOrder)
+
+      expect(result).toEqual(5)
+    })
+
+    it('returns the surplus amount for sell orders', () => {
+      const mockOrder = {
+        executedSellAmount: '100000000000000000000',
+        executedBuyAmount: '10000000000', //100
+        buyToken: { decimals: 8 },
+        sellToken: { decimals: 18 },
+        sellAmount: '100000000000000000000',
+        buyAmount: '5000000000', //50
+        kind: 'sell',
+      } as unknown as SwapOrder
+
+      const result = getSurplusPrice(mockOrder)
+
+      expect(result).toEqual(50)
+    })
   })
 })

--- a/src/features/swap/helpers/utils.ts
+++ b/src/features/swap/helpers/utils.ts
@@ -7,6 +7,11 @@ type Quantity = {
   decimals: number
 }
 
+enum OrderKind {
+  SELL = 'sell',
+  BUY = 'buy',
+}
+
 function asDecimal(amount: number | bigint, decimals: number): number {
   return Number(formatUnits(amount, decimals))
 }
@@ -47,13 +52,20 @@ const calculateRatio = (a: Quantity, b: Quantity) => {
   return asDecimal(BigInt(a.amount), a.decimals) / asDecimal(BigInt(b.amount), b.decimals)
 }
 
-export const getSurplusPrice = (order: Pick<SwapOrder, 'executedBuyAmount' | 'buyAmount' | 'buyToken'>): number => {
-  const { executedBuyAmount, buyAmount, buyToken } = order
-
-  const surplus =
-    asDecimal(BigInt(executedBuyAmount), buyToken.decimals) - asDecimal(BigInt(buyAmount), buyToken.decimals)
-
-  return surplus
+export const getSurplusPrice = (
+  order: Pick<
+    SwapOrder,
+    'executedBuyAmount' | 'buyAmount' | 'buyToken' | 'executedSellAmount' | 'sellAmount' | 'sellToken' | 'kind'
+  >,
+): number => {
+  const { kind, executedSellAmount, sellAmount, sellToken, executedBuyAmount, buyAmount, buyToken } = order
+  if (kind === 'sell') {
+    return asDecimal(BigInt(executedBuyAmount), buyToken.decimals) - asDecimal(BigInt(buyAmount), buyToken.decimals)
+  } else if (kind === 'buy') {
+    return asDecimal(BigInt(sellAmount), sellToken.decimals) - asDecimal(BigInt(executedSellAmount), sellToken.decimals)
+  } else {
+    return 0
+  }
 }
 
 export const getFilledPercentage = (

--- a/src/features/swap/helpers/utils.ts
+++ b/src/features/swap/helpers/utils.ts
@@ -59,10 +59,10 @@ export const getSurplusPrice = (
   >,
 ): number => {
   const { kind, executedSellAmount, sellAmount, sellToken, executedBuyAmount, buyAmount, buyToken } = order
-  if (kind === OrderKind.SELL) {
-    return asDecimal(BigInt(executedBuyAmount), buyToken.decimals) - asDecimal(BigInt(buyAmount), buyToken.decimals)
-  } else if (kind === OrderKind.BUY) {
+  if (kind === OrderKind.BUY) {
     return asDecimal(BigInt(sellAmount), sellToken.decimals) - asDecimal(BigInt(executedSellAmount), sellToken.decimals)
+  } else if (kind === OrderKind.SELL) {
+    return asDecimal(BigInt(executedBuyAmount), buyToken.decimals) - asDecimal(BigInt(buyAmount), buyToken.decimals)
   } else {
     return 0
   }

--- a/src/features/swap/helpers/utils.ts
+++ b/src/features/swap/helpers/utils.ts
@@ -59,9 +59,9 @@ export const getSurplusPrice = (
   >,
 ): number => {
   const { kind, executedSellAmount, sellAmount, sellToken, executedBuyAmount, buyAmount, buyToken } = order
-  if (kind === 'sell') {
+  if (kind === OrderKind.SELL) {
     return asDecimal(BigInt(executedBuyAmount), buyToken.decimals) - asDecimal(BigInt(buyAmount), buyToken.decimals)
-  } else if (kind === 'buy') {
+  } else if (kind === OrderKind.BUY) {
     return asDecimal(BigInt(sellAmount), sellToken.decimals) - asDecimal(BigInt(executedSellAmount), sellToken.decimals)
   } else {
     return 0
@@ -74,10 +74,10 @@ export const getFilledPercentage = (
   let executed: number
   let total: number
 
-  if (order.kind === 'buy') {
+  if (order.kind === OrderKind.BUY) {
     executed = Number(order.executedBuyAmount)
     total = Number(order.buyAmount)
-  } else if (order.kind === 'sell') {
+  } else if (order.kind === OrderKind.SELL) {
     executed = Number(order.executedSellAmount)
     total = Number(order.sellAmount)
   } else {
@@ -90,9 +90,9 @@ export const getFilledPercentage = (
 export const getFilledAmount = (
   order: Pick<SwapOrder, 'kind' | 'executedBuyAmount' | 'executedSellAmount' | 'buyToken' | 'sellToken'>,
 ): string => {
-  if (order.kind === 'buy') {
+  if (order.kind === OrderKind.BUY) {
     return formatUnits(order.executedBuyAmount, order.buyToken.decimals)
-  } else if (order.kind === 'sell') {
+  } else if (order.kind === OrderKind.SELL) {
     return formatUnits(order.executedSellAmount, order.sellToken.decimals)
   } else {
     return '0'

--- a/src/features/swap/helpers/utils.ts
+++ b/src/features/swap/helpers/utils.ts
@@ -16,6 +16,10 @@ function asDecimal(amount: number | bigint, decimals: number): number {
   return Number(formatUnits(amount, decimals))
 }
 
+function calculateDifference(amountA: string, amountB: string, decimals: number): number {
+  return asDecimal(BigInt(amountA), decimals) - asDecimal(BigInt(amountB), decimals)
+}
+
 export const getExecutionPrice = (
   order: Pick<SwapOrder, 'executedSellAmount' | 'executedBuyAmount' | 'buyToken' | 'sellToken'>,
 ): number => {
@@ -60,9 +64,9 @@ export const getSurplusPrice = (
 ): number => {
   const { kind, executedSellAmount, sellAmount, sellToken, executedBuyAmount, buyAmount, buyToken } = order
   if (kind === OrderKind.BUY) {
-    return asDecimal(BigInt(sellAmount), sellToken.decimals) - asDecimal(BigInt(executedSellAmount), sellToken.decimals)
+    return calculateDifference(sellAmount, executedSellAmount, sellToken.decimals)
   } else if (kind === OrderKind.SELL) {
-    return asDecimal(BigInt(executedBuyAmount), buyToken.decimals) - asDecimal(BigInt(buyAmount), buyToken.decimals)
+    return calculateDifference(executedBuyAmount, buyAmount, buyToken.decimals)
   } else {
     return 0
   }


### PR DESCRIPTION
## What it solves

Resolves: https://www.notion.so/safe-global/Check-surplus-calculation-31c4ea517ab74a2a8c8f1555a6447fb1?pvs=4

## How this PR fixes it
- use the correct values to calculate surplus depending on the order type
    - for buy orders: (executed sell amount) - (order sell amount)
    - for sell orders: (order buy amount) - (executed sell amount)

## How to test it
- Compare the surplus value in the safe tx to the surplus value given in the cowswap order, and ensure the values are the same. For both transaction types: `buy` and `sell`
- example buy order
    - https://fix_surplus_calc--walletweb.review-wallet-web.5afe.dev/transactions/tx?safe=sep:0x8FAb71C0d4272698A3B2d1F3Ed5FC3c1B9b3E531&id=multisig_0x8FAb71C0d4272698A3B2d1F3Ed5FC3c1B9b3E531_0x3e84f6c60d81a710328ab141f595ea0fb4275ca5da4b7d019a7a0cc98cf67f7d
    - https://explorer.cow.fi/orders/0x3a2cab43e3d58a6458824625fde1d6d3a4fa6b57200c6f04d12b91aa259e660fd3a484faea53313ef85b5916c9302a3e304ae622662fb4dc?tab=overview


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
