### PR TITLE
fix: add query param to settings link

### DIFF
--- a/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
+++ b/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
@@ -53,6 +53,7 @@ import { useAppSelector } from '@/store'
 import { selectBlindSigning } from '@/store/settingsSlice'
 import NextLink from 'next/link'
 import { AppRoutes } from '@/config/routes'
+import { useRouter } from 'next/router'
 
 const createSkeletonMessage = (confirmationsRequired: number): SafeMessage => {
   return {
@@ -155,6 +156,9 @@ const BlindSigningWarning = ({
   isBlindSigningEnabled: boolean
   isBlindSigningPayload: boolean
 }) => {
+  const router = useRouter()
+  const query = router.query.safe ? { safe: router.query.safe } : undefined
+
   if (!isBlindSigningPayload) {
     return null
   }
@@ -162,7 +166,7 @@ const BlindSigningWarning = ({
   return (
     <ErrorMessage level={isBlindSigningEnabled ? 'warning' : 'error'}>
       This request involves{' '}
-      <Link component={NextLink} href={AppRoutes.settings.securityLogin}>
+      <Link component={NextLink} href={{ pathname: AppRoutes.settings.securityLogin, query }}>
         blind signing
       </Link>
       , which can lead to unpredictable outcomes.
@@ -172,7 +176,7 @@ const BlindSigningWarning = ({
       ) : (
         <>
           If you wish to proceed, you must first{' '}
-          <Link component={NextLink} href={AppRoutes.settings.securityLogin}>
+          <Link component={NextLink} href={{ pathname: AppRoutes.settings.securityLogin, query }}>
             enable blind signing
           </Link>
           .


### PR DESCRIPTION
## What it solves
Resolves https://www.notion.so/safe-global/a9aab340d6544cecb2c9be2c654a2c62?v=fe4919f55fb34c82afc07f08552c7967&p=f2a55e3ae651421ba8d673dbc8fcdd4a&pm=s


## How this PR fixes it
- Adds query parameter to settings link

## How to test it
- Receive a blind signing request
- Click on the settings link
- When asked to cancel the flow, cancel and witness no more crash

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
