### PR TITLE
Feat: for swap orders with custom recipient, display recipient address in order details

### DIFF
--- a/src/features/swap/components/SwapOrder/index.tsx
+++ b/src/features/swap/components/SwapOrder/index.tsx
@@ -16,6 +16,8 @@ import { Typography } from '@mui/material'
 import { formatAmount } from '@/utils/formatNumber'
 import { formatVisualAmount } from '@/utils/formatters'
 import { getExecutionPrice, getLimitPrice, getOrderClass, getSurplusPrice } from '@/features/swap/helpers/utils'
+import EthHashInfo from '@/components/common/EthHashInfo'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 type SwapOrderProps = {
   txData?: TransactionData
@@ -23,7 +25,8 @@ type SwapOrderProps = {
 }
 
 export const SellOrder = ({ order }: { order: SwapOrderType }) => {
-  const { uid, kind, validUntil, status, sellToken, buyToken, sellAmount, buyAmount, explorerUrl } = order
+  const { safeAddress } = useSafeInfo()
+  const { uid, kind, validUntil, status, sellToken, buyToken, sellAmount, buyAmount, explorerUrl, receiver } = order
 
   const executionPrice = getExecutionPrice(order)
   const limitPrice = getLimitPrice(order)
@@ -104,6 +107,13 @@ export const SellOrder = ({ order }: { order: SwapOrderType }) => {
         <DataRow key="Status" title="Status">
           <StatusLabel status={status} />
         </DataRow>,
+        receiver && receiver !== safeAddress ? (
+          <DataRow key="Recipient" title="Recipient">
+            <EthHashInfo address={receiver} showAvatar={false} />
+          </DataRow>
+        ) : (
+          <></>
+        ),
       ]}
     />
   )


### PR DESCRIPTION
## What it solves

Resolves: https://www.notion.so/safe-global/Show-swap-recipient-in-history-ad9368d5f2ee4de191e49315e9cb4251?pvs=4

## How this PR fixes it
- adds a new row for custom recipient orders showing the recipient address

## How to test it
- Example tx: `/transactions/tx?safe=sep:0xC62CBc9d49ba64EC27a1c27fAA9c7f2ce5D583C8&id=multisig_0xC62CBc9d49ba64EC27a1c27fAA9c7f2ce5D583C8_0xf32095000c4cbb67f0b24b45533422fc7f9ed009b92ed2e60348b3ba49baf42e`

## Screenshots
<img width="505" alt="image" src="https://github.com/safe-global/safe-wallet-web/assets/17801424/41dae70c-1a7b-4a51-a9ea-72eac030d874">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
