### PR TITLE
Feat: Make swap link in CF first transaction modal lead to native swap feature

### DIFF
--- a/src/features/counterfactual/FirstTxFlow.tsx
+++ b/src/features/counterfactual/FirstTxFlow.tsx
@@ -53,7 +53,7 @@ const FirstTxFlow = ({ open, onClose }: { open: boolean; onClose: () => void }) 
 
   const onSwap = () => {
     trackEvent({ ...OVERVIEW_EVENTS.CHOOSE_TRANSACTION_TYPE, label: 'swap' })
-    router.push({ pathname: AppRoutes.apps.index, query: { ...router.query, categories: 'Aggregator' } })
+    router.push({ pathname: AppRoutes.swap, query: { ...router.query } })
   }
 
   const onCustomTransaction = () => {


### PR DESCRIPTION
## What it solves

Resolves: https://www.notion.so/safe-global/Create-your-first-transaction-8eb9359fcfd943fcaf1a401500458e43?pvs=4

## How this PR fixes it
- Link now leads to the native swap feature instead of the safe apps page.

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
