### PR TITLE
fix: Use feature flag for swaps widget

### DIFF
--- a/src/pages/swap.tsx
+++ b/src/pages/swap.tsx
@@ -14,6 +14,7 @@ const Swap: NextPage = () => {
       amount: String(amount),
     }
   }
+
   return (
     <>
       <Head>


### PR DESCRIPTION
## What it solves

Shows the user a message instead of the native swaps widget in case they try to open the swaps route on an unsupported chain.

## How this PR fixes it

- Removes hard-coded supported chains for swaps and uses the feature flag instead

## How to test it

1. Open the `/swaps` route on an unsupported chain
2. Observe the message showing instead of the widget

## Screenshots
<img width="1512" alt="Screenshot 2024-05-02 at 10 11 28" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/1cfbd048-af39-40e1-bb4b-1685f6741ac1">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
