### PR TITLE
fix: Always poll swap info

### DIFF
--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -163,6 +163,10 @@ const TxDetails = ({
 
   const [txDetailsData, error, loading] = useAsync<TransactionDetails>(
     async () => {
+      if (swapPollCount > 0) {
+        return getTransactionDetails(chainId, txSummary.id)
+      }
+
       return txDetails || getTransactionDetails(chainId, txSummary.id)
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## What it solves

Follow up on [Notion issue](https://www.notion.so/safe-global/Poll-order-status-2442e20147024c3bb69cf49263d1e69c)

## How this PR fixes it

- Always fetches the transaction details for a swap order instead of relying on an existing value

## How to test it

1. Create and execute a swap order
2. Go to the transaction details view or history
3. Expand to see the transaction details
4. Observe the status updating from open to fulfilled after a while

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
