### PR TITLE
Fix: CF first transaction swap link goes to safe apps page if native swaps is not enabled

### DIFF
--- a/src/features/counterfactual/FirstTxFlow.tsx
+++ b/src/features/counterfactual/FirstTxFlow.tsx
@@ -57,7 +57,7 @@ const FirstTxFlow = ({ open, onClose }: { open: boolean; onClose: () => void }) 
   const onSwap = () => {
     trackEvent({ ...OVERVIEW_EVENTS.CHOOSE_TRANSACTION_TYPE, label: 'swap' })
     if (isSwapFeatureEnabled) {
-      router.push({ pathname: AppRoutes.swap, query: { ...router.query } })
+      router.push({ pathname: AppRoutes.swap, query: router.query })
     } else {
       router.push({ pathname: AppRoutes.apps.index, query: { ...router.query, categories: 'Aggregator' } })
     }

--- a/src/features/counterfactual/FirstTxFlow.tsx
+++ b/src/features/counterfactual/FirstTxFlow.tsx
@@ -18,6 +18,8 @@ import RecoveryPlus from '@/public/images/common/recovery-plus.svg'
 import SwapIcon from '@/public/images/common/swap.svg'
 import SafeLogo from '@/public/images/logo-no-text.svg'
 import HandymanOutlinedIcon from '@mui/icons-material/HandymanOutlined'
+import { useHasFeature } from '@/hooks/useChains'
+import { FEATURES } from '@/utils/chains'
 
 const FirstTxFlow = ({ open, onClose }: { open: boolean; onClose: () => void }) => {
   const txBuilder = useTxBuilderApp()
@@ -25,6 +27,7 @@ const FirstTxFlow = ({ open, onClose }: { open: boolean; onClose: () => void }) 
   const { setTxFlow } = useContext(TxModalContext)
   const supportsRecovery = useIsRecoverySupported()
   const [recovery] = useRecovery()
+  const isSwapFeatureEnabled = useHasFeature(FEATURES.NATIVE_SWAPS)
 
   const handleClick = (onClick: () => void) => {
     onClose()
@@ -53,7 +56,11 @@ const FirstTxFlow = ({ open, onClose }: { open: boolean; onClose: () => void }) 
 
   const onSwap = () => {
     trackEvent({ ...OVERVIEW_EVENTS.CHOOSE_TRANSACTION_TYPE, label: 'swap' })
-    router.push({ pathname: AppRoutes.swap, query: { ...router.query } })
+    if (isSwapFeatureEnabled) {
+      router.push({ pathname: AppRoutes.swap, query: { ...router.query } })
+    } else {
+      router.push({ pathname: AppRoutes.apps.index, query: { ...router.query, categories: 'Aggregator' } })
+    }
   }
 
   const onCustomTransaction = () => {


### PR DESCRIPTION

## What it solves

Resolves: https://www.notion.so/safe-global/Create-your-first-transaction-8eb9359fcfd943fcaf1a401500458e43?pvs=4

## How this PR fixes it
- On the first transaction modal on counterfactual safes:
    - Links to native swap feature for supported chains
    - Otherwise keeps current functionality (links to filtered safe apps) 

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
