### PR TITLE
fix: Check expiry status of swaps at a given interval

### DIFF
--- a/src/components/transactions/ExecuteTxButton/index.tsx
+++ b/src/components/transactions/ExecuteTxButton/index.tsx
@@ -1,10 +1,11 @@
+import useIsExpiredSwap from '@/features/swap/hooks/useIsExpiredSwap'
 import type { SyntheticEvent } from 'react'
 import { type ReactElement, useContext } from 'react'
 import { type TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import { Button, Tooltip } from '@mui/material'
 
 import useSafeInfo from '@/hooks/useSafeInfo'
-import { isExpiredSwap, isMultisigExecutionInfo } from '@/utils/transaction-guards'
+import { isMultisigExecutionInfo } from '@/utils/transaction-guards'
 import Track from '@/components/common/Track'
 import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
 import { ReplaceTxHoverContext } from '../GroupedTxListItems/ReplaceTxHoverProvider'
@@ -26,7 +27,7 @@ const ExecuteTxButton = ({
   const { setSelectedTxId } = useContext(ReplaceTxHoverContext)
   const safeSDK = useSafeSDK()
 
-  const expiredSwap = isExpiredSwap(txSummary.txInfo)
+  const expiredSwap = useIsExpiredSwap(txSummary.txInfo)
 
   const isNext = txNonce !== undefined && txNonce === safe.nonce
   const isDisabled = !isNext || !safeSDK || expiredSwap

--- a/src/components/transactions/SignTxButton/index.tsx
+++ b/src/components/transactions/SignTxButton/index.tsx
@@ -1,3 +1,4 @@
+import useIsExpiredSwap from '@/features/swap/hooks/useIsExpiredSwap'
 import type { SyntheticEvent } from 'react'
 import { useContext, type ReactElement } from 'react'
 import { type TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
@@ -23,7 +24,8 @@ const SignTxButton = ({
   const wallet = useWallet()
   const isSignable = isSignableBy(txSummary, wallet?.address || '')
   const safeSDK = useSafeSDK()
-  const isDisabled = !isSignable || !safeSDK
+  const expiredSwap = useIsExpiredSwap(txSummary.txInfo)
+  const isDisabled = !isSignable || !safeSDK || expiredSwap
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()

--- a/src/components/transactions/TxSummary/index.tsx
+++ b/src/components/transactions/TxSummary/index.tsx
@@ -1,4 +1,5 @@
 import StatusLabel from '@/features/swap/components/StatusLabel'
+import useIsExpiredSwap from '@/features/swap/hooks/useIsExpiredSwap'
 import { Box } from '@mui/material'
 import type { ReactElement } from 'react'
 import { type Transaction } from '@safe-global/safe-gateway-typescript-sdk'
@@ -6,7 +7,7 @@ import { type Transaction } from '@safe-global/safe-gateway-typescript-sdk'
 import css from './styles.module.css'
 import DateTime from '@/components/common/DateTime'
 import TxInfo from '@/components/transactions/TxInfo'
-import { isExpiredSwap, isMultisigExecutionInfo, isTxQueued } from '@/utils/transaction-guards'
+import { isMultisigExecutionInfo, isTxQueued } from '@/utils/transaction-guards'
 import TxType from '@/components/transactions/TxType'
 import classNames from 'classnames'
 import { isTrustedTx } from '@/utils/transactions'
@@ -32,7 +33,7 @@ const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
   const isTrusted = !hasDefaultTokenlist || isTrustedTx(tx)
   const isPending = useIsPending(tx.id)
   const executionInfo = isMultisigExecutionInfo(tx.executionInfo) ? tx.executionInfo : undefined
-  const expiredSwap = isExpiredSwap(tx.txInfo)
+  const expiredSwap = useIsExpiredSwap(tx.txInfo)
 
   return (
     <Box

--- a/src/features/swap/hooks/useIsExpiredSwap.ts
+++ b/src/features/swap/hooks/useIsExpiredSwap.ts
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+import type { TransactionInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import useInterval from '@/hooks/useInterval'
+import { isSwapTxInfo } from '@/utils/transaction-guards'
+
+const INTERVAL_IN_MS = 10_000
+
+/**
+ * Checks the expiry time of a swap every 10s
+ * and returns true if the swap expired
+ * @param txInfo
+ */
+const useIsExpiredSwap = (txInfo: TransactionInfo) => {
+  const [isExpired, setIsExpired] = useState<boolean>(false)
+
+  const isExpiredSwap = () => {
+    if (!isSwapTxInfo(txInfo)) return
+
+    setIsExpired(Date.now() > txInfo.validUntil * 1000)
+  }
+
+  useInterval(isExpiredSwap, INTERVAL_IN_MS)
+
+  return isExpired
+}
+
+export default useIsExpiredSwap

--- a/src/hooks/__tests__/useInterval.test.ts
+++ b/src/hooks/__tests__/useInterval.test.ts
@@ -1,0 +1,27 @@
+import { act, renderHook } from '@testing-library/react'
+import useInterval from '../useInterval'
+
+describe('useInterval', () => {
+  beforeAll(() => {
+    jest.useFakeTimers()
+  })
+
+  it('should run the callback function with every interval', async () => {
+    let mockValue = 0
+    const mockCallback = jest.fn(() => mockValue++)
+
+    renderHook(() => useInterval(mockCallback, 100))
+
+    expect(mockValue).toEqual(0)
+
+    act(() => {
+      jest.advanceTimersByTime(100)
+    })
+    expect(mockValue).toEqual(1)
+
+    act(() => {
+      jest.advanceTimersByTime(100)
+    })
+    expect(mockValue).toEqual(2)
+  })
+})

--- a/src/hooks/useInterval.ts
+++ b/src/hooks/useInterval.ts
@@ -1,0 +1,22 @@
+import { useRef, useEffect } from 'react'
+
+/**
+ * Run a callback function every {time} milliseconds
+ * @param callback
+ * @param time in milliseconds
+ */
+const useInterval = (callback: () => void, time: number) => {
+  const callbackRef = useRef<() => void>()
+
+  useEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
+
+  useEffect(() => {
+    const interval = setInterval(() => callbackRef.current?.(), time)
+
+    return () => clearInterval(interval)
+  }, [time])
+}
+
+export default useInterval


### PR DESCRIPTION
## What it solves

Resolves [Notion issue](https://www.notion.so/safe-global/Disable-Confirm-for-expired-orders-a9a31d79065e4b63976a40a4cadc8d3c)

## How this PR fixes it

Checks the expiry date of a swap order every 10s and disables the Confirm/Execute button if it expired

- Adds a new hook `useInterval`
- Adds a new hook `useIsExpiredSwap`

## How to test it

This should be tested in a 1/n and n/m safe
1. Create a limit swap with an expiry of 5 minutes and an unfillable order
2. Queue the transaction but don't execute it
3. Observe that after 5 minutes the status automatically changes to expired and the button becomes disabled

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
