### PR TITLE
fix: Hide slippage for swap limit orders

### DIFF
--- a/src/features/swap/components/SwapOrderConfirmationView/index.tsx
+++ b/src/features/swap/components/SwapOrderConfirmationView/index.tsx
@@ -7,7 +7,13 @@ import { compareAsc } from 'date-fns'
 import { Alert, Typography } from '@mui/material'
 import { formatAmount } from '@/utils/formatNumber'
 import { formatVisualAmount } from '@/utils/formatters'
-import { getExecutionPrice, getLimitPrice, getSlippageInPercent, getSurplusPrice } from '@/features/swap/helpers/utils'
+import {
+  getExecutionPrice,
+  getLimitPrice,
+  getOrderClass,
+  getSlippageInPercent,
+  getSurplusPrice,
+} from '@/features/swap/helpers/utils'
 import type { CowSwapConfirmationView } from '@safe-global/safe-gateway-typescript-sdk'
 import SwapTokens from '@/features/swap/components/SwapTokens'
 import AlertIcon from '@/public/images/common/alert.svg'
@@ -23,24 +29,13 @@ type SwapOrderProps = {
 export const SwapOrderConfirmationView = ({ order, settlementContract }: SwapOrderProps): ReactElement | null => {
   if (!order) return null
 
-  const {
-    uid,
-    owner,
-    kind,
-    validUntil,
-    status,
-    sellToken,
-    buyToken,
-    sellAmount,
-    buyAmount,
-    explorerUrl,
-    receiver,
-    orderClass,
-  } = order
+  const { uid, owner, kind, validUntil, status, sellToken, buyToken, sellAmount, buyAmount, explorerUrl, receiver } =
+    order
 
   const executionPrice = getExecutionPrice(order)
   const limitPrice = getLimitPrice(order)
   const surplusPrice = getSurplusPrice(order)
+  const orderClass = getOrderClass(order)
   const expires = new Date(validUntil * 1000)
   const now = new Date()
 

--- a/src/features/swap/components/SwapOrderConfirmationView/index.tsx
+++ b/src/features/swap/components/SwapOrderConfirmationView/index.tsx
@@ -23,8 +23,21 @@ type SwapOrderProps = {
 export const SwapOrderConfirmationView = ({ order, settlementContract }: SwapOrderProps): ReactElement | null => {
   if (!order) return null
 
-  const { uid, owner, kind, validUntil, status, sellToken, buyToken, sellAmount, buyAmount, explorerUrl, receiver } =
-    order
+  const {
+    uid,
+    owner,
+    kind,
+    validUntil,
+    status,
+    sellToken,
+    buyToken,
+    sellAmount,
+    buyAmount,
+    explorerUrl,
+    receiver,
+    orderClass,
+  } = order
+
   const executionPrice = getExecutionPrice(order)
   const limitPrice = getLimitPrice(order)
   const surplusPrice = getSurplusPrice(order)
@@ -90,9 +103,13 @@ export const SwapOrderConfirmationView = ({ order, settlementContract }: SwapOrd
           ) : (
             <></>
           ),
-          <DataRow key="Slippage" title="Slippage">
-            {slippage}%
-          </DataRow>,
+          orderClass !== 'limit' ? (
+            <DataRow key="Slippage" title="Slippage">
+              {slippage}%
+            </DataRow>
+          ) : (
+            <></>
+          ),
           <DataRow key="Order ID" title="Order ID">
             <OrderId orderId={uid} href={explorerUrl} />
           </DataRow>,


### PR DESCRIPTION
## What it solves

Resolves [Notion issue](https://www.notion.so/safe-global/Slippage-is-displayed-for-the-Limit-Orders-on-Confirmation-page-during-tx-creation-a2d2a8a3bdb74964950b3611b85ae498)

## How this PR fixes it

- Hides the Slippage if the `orderClass` is `limit`

## How to test it

1. Create a limit order
2. Submit the order in the widget
3. Observe no Slippage in the order details

## Screenshots
<img width="716" alt="Screenshot 2024-05-02 at 15 50 04" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/a47da247-aabf-4c3d-a0a9-e01224a7b0e9">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
