### PR TITLE
fix: Disable execute button for pending transactions

### DIFF
--- a/src/components/transactions/ExecuteTxButton/index.tsx
+++ b/src/components/transactions/ExecuteTxButton/index.tsx
@@ -1,3 +1,4 @@
+import useIsPending from '@/hooks/useIsPending'
 import type { SyntheticEvent } from 'react'
 import { type ReactElement, useContext } from 'react'
 import { type TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
@@ -23,11 +24,12 @@ const ExecuteTxButton = ({
   const { setTxFlow } = useContext(TxModalContext)
   const { safe } = useSafeInfo()
   const txNonce = isMultisigExecutionInfo(txSummary.executionInfo) ? txSummary.executionInfo.nonce : undefined
+  const isPending = useIsPending(txSummary.id)
   const { setSelectedTxId } = useContext(ReplaceTxHoverContext)
   const safeSDK = useSafeSDK()
 
   const isNext = txNonce !== undefined && txNonce === safe.nonce
-  const isDisabled = !isNext || !safeSDK
+  const isDisabled = !isNext || !safeSDK || isPending
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()


### PR DESCRIPTION
## What it solves

Resolves #3644 

## How this PR fixes it

Disables the execute button if transaction is pending

## How to test it

1. Create and queue a transaction
2. Execute the transaction
3. The transaction should be pending
4. Open the transaction details
5. Observe the Execute button is disabled

## Screenshots
<img width="1272" alt="Screenshot 2024-05-02 at 16 05 42" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/4338ab00-ff89-4a37-a267-c93895965fc5">



## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
