### PR TITLE
Analytics: swap analytics

### DIFF
--- a/src/components/balances/AssetsTable/index.tsx
+++ b/src/components/balances/AssetsTable/index.tsx
@@ -133,7 +133,7 @@ const SwapButton = ({ tokenInfo, amount }: { tokenInfo: TokenInfo; amount: strin
   return (
     <CheckWallet allowSpendingLimit={!!spendingLimit}>
       {(isOk) => (
-        <Track {...SWAP_EVENTS.SWAP_ASSETS}>
+        <Track {...SWAP_EVENTS.SWAP_ASSETS} label={tokenInfo.address}>
           <Button
             variant="outlined"
             color="primary"

--- a/src/hooks/safe-apps/useCustomAppCommunicator.tsx
+++ b/src/hooks/safe-apps/useCustomAppCommunicator.tsx
@@ -25,7 +25,7 @@ import { selectOnChainSigning, selectTokenList, TOKEN_LISTS } from '@/store/sett
 import { useAppSelector } from '@/store'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { selectSafeMessages } from '@/store/safeMessagesSlice'
-import { trackSafeAppEvent, SAFE_APPS_EVENTS } from '@/services/analytics'
+import { trackSafeAppEvent, SAFE_APPS_EVENTS, trackEvent } from '@/services/analytics'
 import { safeMsgSubscribe, SafeMsgEvent } from '@/services/safe-messages/safeMsgEvents'
 import { txSubscribe, TxEvent } from '@/services/tx/txEvents'
 import type { ChainInfo as WebCoreChainInfo } from '@safe-global/safe-gateway-typescript-sdk/dist/types/chains'
@@ -72,6 +72,7 @@ export const useCustomAppCommunicator = (
       }
 
       setCurrentRequestId(requestId)
+      trackEvent({ ...SAFE_APPS_EVENTS.OPEN_TRANSACTION_MODAL, label: appData.name })
       setTxFlow(<SafeAppsTxFlow data={data} />, onTxFlowClose)
     },
     onSignMessage: (

--- a/src/services/analytics/events/safeApps.ts
+++ b/src/services/analytics/events/safeApps.ts
@@ -34,6 +34,10 @@ export const SAFE_APPS_EVENTS = {
     ...SAFE_APPS_EVENT_DATA,
     action: 'Add custom Safe App',
   },
+  OPEN_TRANSACTION_MODAL: {
+    ...SAFE_APPS_EVENT_DATA,
+    action: 'Open Transaction modal',
+  },
   PROPOSE_TRANSACTION: {
     ...SAFE_APPS_EVENT_DATA,
     action: 'Propose Transaction',

--- a/src/services/analytics/events/transactions.ts
+++ b/src/services/analytics/events/transactions.ts
@@ -21,6 +21,7 @@ export enum TX_TYPES {
   typed_message = 'typed_message',
   walletconnect = 'walletconnect',
   custom = 'custom',
+  native_swap = 'native_swap',
 
   // Counterfactual
   activate_without_tx = 'activate_without_tx',

--- a/src/services/analytics/tx-tracking.ts
+++ b/src/services/analytics/tx-tracking.ts
@@ -9,6 +9,7 @@ import {
   isTransferTxInfo,
   isCustomTxInfo,
   isCancellationTxInfo,
+  isSwapTxInfo,
 } from '@/utils/transaction-guards'
 
 export const getTransactionTrackingType = async (chainId: string, txId: string): Promise<string> => {
@@ -25,6 +26,10 @@ export const getTransactionTrackingType = async (chainId: string, txId: string):
       return TX_TYPES.transfer_nft
     }
     return TX_TYPES.transfer_token
+  }
+
+  if (isSwapTxInfo(txInfo)) {
+    return TX_TYPES.native_swap
   }
 
   if (isSettingsChangeTxInfo(txInfo)) {


### PR DESCRIPTION
## How this PR fixes it
- Adds event for opening safe apps modals with app name as label
- Adds token address as label to event for the Swap button in the assets table
- adds native_swap as tx type for swap transactions

## How to test it
- Create a Swap through our modal and observe the new /adjusted events

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
