### PR TITLE
Fix: cow swap disclaimer communication

### DIFF
--- a/src/features/swap/index.tsx
+++ b/src/features/swap/index.tsx
@@ -194,7 +194,7 @@ const SwapWidget = ({ sell }: Params) => {
     if (iframeElement) {
       iframeRef.current = iframeElement as HTMLIFrameElement
     }
-  }, [params])
+  }, [params, isConsentAccepted])
 
   useCustomAppCommunicator(iframeRef, appData, chain)
 

--- a/src/features/swap/index.tsx
+++ b/src/features/swap/index.tsx
@@ -57,7 +57,7 @@ const SwapWidget = ({ sell }: Params) => {
   const swapParams = useAppSelector(selectSwapParams)
   const { tradeType } = swapParams
 
-  const { safeAddress } = useSafeInfo()
+  const { safeAddress, safeLoading } = useSafeInfo()
   const wallet = useWallet()
   const { isConsentAccepted, onAccept } = useSwapConsent()
 
@@ -194,7 +194,7 @@ const SwapWidget = ({ sell }: Params) => {
     if (iframeElement) {
       iframeRef.current = iframeElement as HTMLIFrameElement
     }
-  }, [params, isConsentAccepted])
+  }, [params, isConsentAccepted, safeLoading])
 
   useCustomAppCommunicator(iframeRef, appData, chain)
 


### PR DESCRIPTION
## What it solves
- the app communicator was not correctly initialized when the disclaimer is displayed

Resolves #

## How this PR fixes it
- Adds the consent flag to the dependencies of the useEffect that sets the iframeRef.

## How to test it
- Delete the disclaimer consent from local storage
- Open the CoW widget
- Witness that the connection succeeds

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
