### PR TITLE
fix: Disable execute button for expired swaps

### DIFF
--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -1,4 +1,5 @@
 import { POLLING_INTERVAL } from '@/config/constants'
+import useIsExpiredSwap from '@/features/swap/hooks/useIsExpiredSwap'
 import useIntervalCounter from '@/hooks/useIntervalCounter'
 import React, { type ReactElement } from 'react'
 import type { TransactionDetails, TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
@@ -12,7 +13,6 @@ import useChainId from '@/hooks/useChainId'
 import useAsync from '@/hooks/useAsync'
 import {
   isAwaitingExecution,
-  isExpiredSwap,
   isModuleExecutionInfo,
   isMultiSendTxInfo,
   isMultisigDetailedExecutionInfo,
@@ -67,7 +67,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
     safeTxHash = txDetails.detailedExecutionInfo.safeTxHash
   }
 
-  const expiredSwap = isExpiredSwap(txSummary.txInfo)
+  const expiredSwap = useIsExpiredSwap(txSummary.txInfo)
 
   return (
     <>

--- a/src/hooks/__tests__/useInterval.test.ts
+++ b/src/hooks/__tests__/useInterval.test.ts
@@ -6,22 +6,31 @@ describe('useInterval', () => {
     jest.useFakeTimers()
   })
 
+  it('should run the callback function once immediately', () => {
+    let mockValue = 0
+    const mockCallback = jest.fn(() => mockValue++)
+
+    renderHook(() => useInterval(mockCallback, 100))
+
+    expect(mockValue).toEqual(1)
+  })
+
   it('should run the callback function with every interval', async () => {
     let mockValue = 0
     const mockCallback = jest.fn(() => mockValue++)
 
     renderHook(() => useInterval(mockCallback, 100))
 
-    expect(mockValue).toEqual(0)
-
-    act(() => {
-      jest.advanceTimersByTime(100)
-    })
     expect(mockValue).toEqual(1)
 
     act(() => {
       jest.advanceTimersByTime(100)
     })
     expect(mockValue).toEqual(2)
+
+    act(() => {
+      jest.advanceTimersByTime(100)
+    })
+    expect(mockValue).toEqual(3)
   })
 })

--- a/src/hooks/useInterval.ts
+++ b/src/hooks/useInterval.ts
@@ -15,6 +15,9 @@ const useInterval = (callback: () => void, time: number) => {
   useEffect(() => {
     const interval = setInterval(() => callbackRef.current?.(), time)
 
+    // Call the function once initially
+    callbackRef.current?.()
+
     return () => clearInterval(interval)
   }, [time])
 }


### PR DESCRIPTION
## What it solves

Follow-up on [Notion issue](https://www.notion.so/safe-global/Disable-Confirm-for-expired-orders-a9a31d79065e4b63976a40a4cadc8d3c)

The swap buttons were only disabled after the first interval passed (10s) but they should be disabled immediately.

## How this PR fixes it

- Runs the callback function passed to `useInterval` on mount instead of waiting for the first interval

## How to test it

1. Create and queue a swap
2. Let it expire
3. Navigate to a different page and navigate back to the queue
4. Observe the Execute button becomes disabled immediately

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
