### PR TITLE
fix: Hide Expired status in tx history

### DIFF
--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -137,7 +137,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
             </Box>
           )}
 
-          {expiredSwap && (
+          {isQueue && expiredSwap && (
             <Typography color="text.secondary" mt={2}>
               This order has expired. Reject this transaction and try again.
             </Typography>

--- a/src/components/transactions/TxSummary/index.tsx
+++ b/src/components/transactions/TxSummary/index.tsx
@@ -84,7 +84,7 @@ const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
         </Box>
       )}
 
-      {expiredSwap && (
+      {isQueue && expiredSwap && (
         <Box gridArea="status" justifyContent="flex-end" display="flex" className={css.status}>
           <StatusLabel status="expired" />
         </Box>

--- a/src/features/swap/hooks/useIsExpiredSwap.ts
+++ b/src/features/swap/hooks/useIsExpiredSwap.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import type { TransactionInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import useInterval from '@/hooks/useInterval'
-import { isExpiredSwap as isSwapInfoExpired, isSwapTxInfo } from '@/utils/transaction-guards'
+import { isSwapTxInfo } from '@/utils/transaction-guards'
 
 const INTERVAL_IN_MS = 10_000
 
@@ -16,7 +16,7 @@ const useIsExpiredSwap = (txInfo: TransactionInfo) => {
   const isExpiredSwap = () => {
     if (!isSwapTxInfo(txInfo)) return
 
-    setIsExpired(Date.now() > txInfo.validUntil * 1000 && isSwapInfoExpired(txInfo))
+    setIsExpired(Date.now() > txInfo.validUntil * 1000)
   }
 
   useInterval(isExpiredSwap, INTERVAL_IN_MS)

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -110,10 +110,6 @@ export const isSwapConfirmationViewOrder = (
   return false
 }
 
-export const isExpiredSwap = (value: TransactionInfo) => {
-  return isSwapTxInfo(value) && value.status === 'expired'
-}
-
 export const isCancelledSwap = (value: TransactionInfo) => {
   return isSwapTxInfo(value) && value.status === 'cancelled'
 }


### PR DESCRIPTION
## What it solves

Resolves [Notion issue](https://www.notion.so/safe-global/Issue-Expired-status-is-displayed-for-the-orders-with-filled-status-in-the-history-3b1c5384735c405d8ba91a7fd47772b8)

## How this PR fixes it

- Checks `isQueue` before rendering the status label and expiry message
- Removes the previously added `isExpiredSwapInfo` check

## How to test it

1. Create and queue a limit swap order
2. Wait for it to expire
3. The buttons should become disabled in the queue and the message should be visible
4. Execute a swap order that can be fulfilled
5. Wait for the execution time to pass
6. Observe the status label saying Success in the tx history and no message visible
7. Execute a limit order that can't be fulfilled
8. Observe the status label saying Success in the tx history and no message visible

## Screenshots

Queue expired:
<img width="1264" alt="Screenshot 2024-05-06 at 11 54 50" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/7c59f5bf-df3d-4d86-a826-e7d8cc57339c">

History expired:
<img width="1254" alt="Screenshot 2024-05-06 at 11 55 02" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/f111767e-0542-42dc-94ee-884dd411424f">

History filled:
<img width="1256" alt="Screenshot 2024-05-06 at 11 55 20" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/ae88c9e7-a99f-4372-a511-6e6b293b821e">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
