### PR TITLE
Fix: do not show pending status if swap order is expired

### DIFF
--- a/src/components/transactions/TxSummary/index.tsx
+++ b/src/components/transactions/TxSummary/index.tsx
@@ -78,19 +78,19 @@ const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
         </Box>
       )}
 
-      {(!isQueue || isPending) && (
-        <Box gridArea="status" justifyContent="flex-end" display="flex" className={css.status}>
-          <TxStatusLabel tx={tx} />
-        </Box>
-      )}
-
-      {isQueue && expiredSwap && (
+      {isQueue && expiredSwap ? (
         <Box gridArea="status" justifyContent="flex-end" display="flex" className={css.status}>
           <StatusLabel status="expired" />
         </Box>
+      ) : !isQueue || isPending ? (
+        <Box gridArea="status" justifyContent="flex-end" display="flex" className={css.status}>
+          <TxStatusLabel tx={tx} />
+        </Box>
+      ) : (
+        ''
       )}
 
-      {isQueue && (
+      {isQueue && !expiredSwap && (
         <Box gridArea="actions">
           <QueueActions tx={tx} />
         </Box>

--- a/src/components/transactions/TxSummary/styles.module.css
+++ b/src/components/transactions/TxSummary/styles.module.css
@@ -1,7 +1,7 @@
 .gridContainer {
   --grid-nonce: minmax(50px, 0.25fr);
   --grid-type: minmax(150px, 3fr);
-  --grid-info: minmax(250px, 3fr);
+  --grid-info: minmax(150px, 3fr);
   --grid-date: minmax(200px, 3fr);
   --grid-confirmations: minmax(150px, 1fr);
 

--- a/src/components/transactions/TxSummary/styles.module.css
+++ b/src/components/transactions/TxSummary/styles.module.css
@@ -1,7 +1,7 @@
 .gridContainer {
   --grid-nonce: minmax(50px, 0.25fr);
   --grid-type: minmax(150px, 3fr);
-  --grid-info: minmax(150px, 3fr);
+  --grid-info: minmax(250px, 3fr);
   --grid-date: minmax(200px, 3fr);
   --grid-confirmations: minmax(150px, 1fr);
 
@@ -13,11 +13,10 @@
   gap: var(--space-2);
   align-items: center;
   white-space: nowrap;
-  grid-template-columns: var(--grid-nonce) var(--grid-type) var(--grid-info) var(--grid-date) var(--grid-confirmations)
-  var(--grid-actions)
-  var(
-      --grid-status
-    );
+  grid-template-columns:
+    var(--grid-nonce) var(--grid-type) var(--grid-info) var(--grid-date) var(--grid-confirmations)
+    var(--grid-actions)
+    var(--grid-status);
   grid-template-areas: 'nonce type info date confirmations  status actions';
 }
 


### PR DESCRIPTION
## What it solves

Resolves:https://www.notion.so/safe-global/Loader-icon-on-top-of-the-expired-tag-4ddba4d2f2564ab0b1481b92ca6451a7?pvs=4

## How this PR fixes it
- If a pending swap transaction takes longer than the allotted time to execute
    - show the transaction as expired only. 
    - Do not give the option to speed up the transaction.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
