### PR TITLE
fix: Use native swap icon for native swap transactions in the queue

### DIFF
--- a/src/hooks/useTransactionType.ts
+++ b/src/hooks/useTransactionType.ts
@@ -66,7 +66,7 @@ export const getTransactionType = (tx: TransactionSummary, addressBook: AddressB
       const orderClass = getOrderClass(tx.txInfo)
 
       return {
-        icon: '/images/transactions/cow-logo.png',
+        icon: '/images/common/swap.svg',
         text: orderClass === 'limit' ? 'Limit order' : 'Swap order',
       }
     }


### PR DESCRIPTION
## What it solves

Resolves:  https://www.notion.so/safe-global/Issue-Add-new-icon-for-the-txs-from-the-Native-swap-diff-from-Cowswap-history-and-queued-lists-aab4b65e0f7e495f934f0b76bd2c317a?pvs=4

## How this PR fixes it
- Use the new icon for native swaps but keep the cow icon for swaps done via the cowswap safe app.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
