### PR TITLE
Fix: text overlaps and hidden execute button in the transaction summary

### DIFF
--- a/src/components/transactions/TxInfo/index.tsx
+++ b/src/components/transactions/TxInfo/index.tsx
@@ -95,8 +95,7 @@ const SwapTx = ({ info }: { info: SwapOrder }): ReactElement => {
   return (
     <Box display="flex">
       <Typography display="flex" alignItems="center" fontWeight="bold">
-        Swap{' '}
-        <Box style={{ paddingLeft: 5, paddingRight: 5, display: 'inline-block' }}>
+        <Box style={{ paddingRight: 5, display: 'inline-block' }}>
           <TokenIcon logoUri={info.sellToken.logoUri || undefined} tokenSymbol={info.sellToken.symbol} />
         </Box>
         <Typography sx={{ maxWidth: '60px' }} noWrap>

--- a/src/components/transactions/TxInfo/index.tsx
+++ b/src/components/transactions/TxInfo/index.tsx
@@ -99,11 +99,16 @@ const SwapTx = ({ info }: { info: SwapOrder }): ReactElement => {
         <Box style={{ paddingLeft: 5, paddingRight: 5, display: 'inline-block' }}>
           <TokenIcon logoUri={info.sellToken.logoUri || undefined} tokenSymbol={info.sellToken.symbol} />
         </Box>
-        {info.sellToken.symbol} to
+        <Typography sx={{ maxWidth: '60px' }} noWrap>
+          {info.sellToken.symbol}&nbsp;
+        </Typography>
+        to
         <Box style={{ paddingLeft: 5, paddingRight: 5, display: 'inline-block' }}>
           <TokenIcon logoUri={info.buyToken.logoUri || undefined} tokenSymbol={info.buyToken.symbol} />
         </Box>{' '}
-        {info.buyToken.symbol}
+        <Typography sx={{ maxWidth: '60px' }} noWrap>
+          {info.buyToken.symbol}
+        </Typography>
       </Typography>
     </Box>
   )

--- a/src/components/transactions/TxSummary/styles.module.css
+++ b/src/components/transactions/TxSummary/styles.module.css
@@ -1,7 +1,7 @@
 .gridContainer {
   --grid-nonce: minmax(50px, 0.25fr);
   --grid-type: minmax(150px, 3fr);
-  --grid-info: minmax(150px, 3fr);
+  --grid-info: minmax(250px, 3fr);
   --grid-date: minmax(200px, 3fr);
   --grid-confirmations: minmax(150px, 1fr);
 
@@ -13,11 +13,10 @@
   gap: var(--space-2);
   align-items: center;
   white-space: nowrap;
-  grid-template-columns: var(--grid-nonce) var(--grid-type) var(--grid-info) var(--grid-date) var(--grid-confirmations)
-  var(--grid-actions)
-  var(
-      --grid-status
-    );
+  grid-template-columns:
+    var(--grid-nonce) var(--grid-type) var(--grid-info) var(--grid-date) var(--grid-confirmations)
+    var(--grid-actions)
+    var(--grid-status);
   grid-template-areas: 'nonce type info date confirmations  status actions';
 }
 
@@ -47,7 +46,7 @@
   color: var(--color-text-secondary);
 }
 
-@media (max-width: 1200px) {
+@media (max-width: 1460px) {
   .gridContainer {
     gap: var(--space-1);
     display: flex;

--- a/src/components/transactions/TxSummary/styles.module.css
+++ b/src/components/transactions/TxSummary/styles.module.css
@@ -1,9 +1,9 @@
 .gridContainer {
   --grid-nonce: minmax(50px, 0.25fr);
   --grid-type: minmax(150px, 3fr);
-  --grid-info: minmax(250px, 3fr);
+  --grid-info: minmax(150px, 3fr);
   --grid-date: minmax(200px, 3fr);
-  --grid-confirmations: minmax(150px, 1fr);
+  --grid-confirmations: minmax(130px, 1fr);
 
   --grid-actions: minmax(120px, 1fr);
   --grid-status: minmax(120px, 1fr);


### PR DESCRIPTION
## What it solves
- execute tx button is hidden for some widths [1]
- the tx info overlaps with the tx date for some widths in swap transactions [2]

Resolves #3664 
Resolves: https://www.notion.so/safe-global/07996126a3c041db90e36e01eb4ce46c?v=03b2eaffc9af4b48b1bf57e50546ac3d&p=12098c01ba6743b7a3669e6262c9800c&pm=s (thread)

## How this PR fixes it
- Increases the breakpoint for splitting the summary over two lines, so the execute button does not become hidden
- Increases the width of the tx info section to accomodate the longer swap transaction info
- Add a max with with `nowrap` for longer token names  in the tx summary

## How to test it
- View a swap transaction in the queue.
- see that the execute/speed up button is visible for all screen widths
- see that there is no overlap between the tx info and the date, including when the token names are very long.

## Screenshots
[1]

![image](https://github.com/safe-global/safe-wallet-web/assets/17801424/bdff1dc7-786b-4bd5-8715-0edfc6424dec)
[2]
![image](https://github.com/safe-global/safe-wallet-web/assets/17801424/af4f8eeb-d76c-45a6-9433-eff233fc963e)


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
