### PR TITLE
Feat: resolve Safe address ENS in sidebar

### DIFF
--- a/src/components/sidebar/SidebarHeader/index.tsx
+++ b/src/components/sidebar/SidebarHeader/index.tsx
@@ -31,6 +31,7 @@ import EnvHintButton from '@/components/settings/EnvironmentVariables/EnvHintBut
 import useSafeAddress from '@/hooks/useSafeAddress'
 import ExplorerButton from '@/components/common/ExplorerButton'
 import CopyTooltip from '@/components/common/CopyTooltip'
+import { useAddressResolver } from '@/hooks/useAddressResolver'
 
 const SafeHeader = (): ReactElement => {
   const currency = useAppSelector(selectCurrency)
@@ -40,6 +41,7 @@ const SafeHeader = (): ReactElement => {
   const { threshold, owners } = safe
   const chain = useCurrentChain()
   const settings = useAppSelector(selectSettings)
+  const { ens } = useAddressResolver(safeAddress)
 
   const fiatTotal = useMemo(
     () => (balances.fiatTotal ? formatCurrency(balances.fiatTotal, currency) : ''),
@@ -64,7 +66,7 @@ const SafeHeader = (): ReactElement => {
 
           <div className={css.address}>
             {safeAddress ? (
-              <EthHashInfo address={safeAddress} shortAddress showAvatar={false} />
+              <EthHashInfo address={safeAddress} shortAddress showAvatar={false} name={ens} />
             ) : (
               <Typography variant="body2">
                 <Skeleton variant="text" width={86} />


### PR DESCRIPTION
## What it solves

If a Safe doesn't have a name in the Address Book, do a reverse ENS lookup in the Sidebar.

## How to test it

Can be tested with the Safe from the PR preview link.

## Screenshots

<img width="250" alt="Screenshot 2024-05-08 at 09 48 27" src="https://github.com/safe-global/safe-wallet-web/assets/381895/51e216e5-3bea-4633-aaa7-f39322330d98">
