### PR TITLE
Fix: Account for when fullAppData is undefined on swap orders 

### DIFF
--- a/src/features/swap/helpers/utils.ts
+++ b/src/features/swap/helpers/utils.ts
@@ -105,12 +105,14 @@ export const getFilledAmount = (
 
 export const getSlippageInPercent = (order: Pick<SwapOrder, 'fullAppData'>): string => {
   const fullAppData = order.fullAppData as AnyAppDataDocVersion
-  const slippageBips = (fullAppData.metadata.quote as latest.Quote).slippageBips || 0
+  const slippageBips = (fullAppData?.metadata?.quote as latest.Quote)?.slippageBips || 0
 
   return (Number(slippageBips) / 100).toFixed(2)
 }
 
 export const getOrderClass = (order: Pick<SwapOrder, 'fullAppData'>): latest.OrderClass1 => {
   const fullAppData = order.fullAppData as AnyAppDataDocVersion
-  return (fullAppData.metadata.orderClass as latest.OrderClass).orderClass
+  const orderClass = (fullAppData?.metadata?.orderClass as latest.OrderClass)?.orderClass
+
+  return orderClass || 'market'
 }


### PR DESCRIPTION
## What it solves

Resolves: https://www.notion.so/safe-global/Look-at-our-appData-usage-714b0f9b7639465ab39b5d13d2d102b0

According to the cowswap team, fullAppData can not be assumed to always be defined, so we must include default values for when it isn't.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
