### PR TITLE
Fix: queue changes to mobile layout on desktop resolutions

### DIFF
--- a/src/components/transactions/TxSummary/index.tsx
+++ b/src/components/transactions/TxSummary/index.tsx
@@ -91,7 +91,7 @@ const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
       )}
 
       {isQueue && !expiredSwap && (
-        <Box gridArea="actions">
+        <Box gridArea="actions" className={css.actions}>
           <QueueActions tx={tx} />
         </Box>
       )}

--- a/src/components/transactions/TxSummary/styles.module.css
+++ b/src/components/transactions/TxSummary/styles.module.css
@@ -26,11 +26,13 @@
 
 .gridContainer.history {
   grid-template-columns: var(--grid-nonce) var(--grid-type) var(--grid-info) var(--grid-date) var(--grid-status);
-  grid-template-areas: 'nonce type info date status';
+  grid-template-areas: 'nonce type info date status ';
 }
 
 .gridContainer.grouped {
-  grid-template-columns: var(--grid-type) var(--grid-info) var(--grid-date) var(--grid-confirmations) var(--grid-status);
+  grid-template-columns: var(--grid-type) var(--grid-info) var(--grid-date) var(--grid-confirmations) var(
+      --grid-actions
+    ) var(--grid-status);
   grid-template-areas: 'type info date confirmations status actions';
 }
 

--- a/src/components/transactions/TxSummary/styles.module.css
+++ b/src/components/transactions/TxSummary/styles.module.css
@@ -26,13 +26,13 @@
 
 .gridContainer.history {
   grid-template-columns: var(--grid-nonce) var(--grid-type) var(--grid-info) var(--grid-date) var(--grid-status);
-  grid-template-areas: 'nonce type info date status ';
+  grid-template-areas: 'nonce type info date status';
 }
 
 .gridContainer.grouped {
-  grid-template-columns: var(--grid-type) var(--grid-info) var(--grid-date) var(--grid-confirmations) var(
-      --grid-actions
-    ) var(--grid-status);
+  grid-template-columns:
+    var(--grid-type) var(--grid-info) var(--grid-date) var(--grid-confirmations) var(--grid-actions)
+    var(--grid-status);
   grid-template-areas: 'type info date confirmations status actions';
 }
 

--- a/src/components/transactions/TxSummary/styles.module.css
+++ b/src/components/transactions/TxSummary/styles.module.css
@@ -5,8 +5,8 @@
   --grid-date: minmax(200px, 3fr);
   --grid-confirmations: minmax(120px, 1fr);
 
-  --grid-actions: minmax(120px, 1fr);
-  --grid-status: minmax(100px, 1fr);
+  --grid-status: minmax(120px, 1fr);
+  --grid-actions: minmax(100px, 1fr);
 
   width: 100%;
   display: grid;
@@ -15,8 +15,7 @@
   white-space: nowrap;
   grid-template-columns:
     var(--grid-nonce) var(--grid-type) var(--grid-info) var(--grid-date) var(--grid-confirmations)
-    var(--grid-actions)
-    var(--grid-status);
+    var(--grid-status) var(--grid-actions);
   grid-template-areas: 'nonce type info date confirmations  status actions';
 }
 
@@ -30,9 +29,9 @@
 }
 
 .gridContainer.grouped {
-  grid-template-columns:
-    var(--grid-type) var(--grid-info) var(--grid-date) var(--grid-confirmations) var(--grid-actions)
-    var(--grid-status);
+  grid-template-columns: var(--grid-type) var(--grid-info) var(--grid-date) var(--grid-confirmations) var(--grid-status) var(
+      --grid-actions
+    );
   grid-template-areas: 'type info date confirmations status actions';
 }
 

--- a/src/components/transactions/TxSummary/styles.module.css
+++ b/src/components/transactions/TxSummary/styles.module.css
@@ -1,12 +1,12 @@
 .gridContainer {
-  --grid-nonce: minmax(50px, 0.25fr);
+  --grid-nonce: minmax(45px, 0.25fr);
   --grid-type: minmax(150px, 3fr);
-  --grid-info: minmax(150px, 3fr);
+  --grid-info: minmax(190px, 3fr);
   --grid-date: minmax(200px, 3fr);
-  --grid-confirmations: minmax(130px, 1fr);
+  --grid-confirmations: minmax(120px, 1fr);
 
   --grid-actions: minmax(120px, 1fr);
-  --grid-status: minmax(120px, 1fr);
+  --grid-status: minmax(100px, 1fr);
 
   width: 100%;
   display: grid;
@@ -46,7 +46,7 @@
   color: var(--color-text-secondary);
 }
 
-@media (max-width: 1460px) {
+@media (max-width: 1350px) {
   .gridContainer {
     gap: var(--space-1);
     display: flex;


### PR DESCRIPTION
## What it solves
- Queue switches to mobile/tablet view on too large screens
- grouped transactions are not aligned

resolves: https://www.notion.so/safe-global/Issue-dancing-view-for-the-Queued-because-of-expired-state-f81f11c9114d4e8e9975708b3fe899db [SWT-69]

## Screenshots
<img width="926" alt="image" src="https://github.com/safe-global/safe-wallet-web/assets/17801424/96003c0e-657f-4919-ad9c-f7455761a565">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
