### PR TITLE
Feat: Add click event for dashboard swap button

### DIFF
--- a/src/components/dashboard/Overview/Overview.tsx
+++ b/src/components/dashboard/Overview/Overview.tsx
@@ -20,6 +20,7 @@ import { useRouter } from 'next/router'
 import { type ReactElement, useContext } from 'react'
 import { WidgetBody, WidgetContainer } from '../styled'
 import { useTheme } from '@mui/material/styles'
+import { SWAP_EVENTS, SWAP_LABELS } from '@/services/analytics/events/swaps'
 
 const SkeletonOverview = (
   <>
@@ -127,17 +128,19 @@ const Overview = (): ReactElement => {
 
                   {isSwapFeatureEnabled && (
                     <Grid item xs={buttonWidth} sm="auto">
-                      <Link href={{ pathname: AppRoutes.swap, query: router.query }} passHref type="button">
-                        <Button
-                          size={isSmallScreen ? 'medium' : 'small'}
-                          variant="outlined"
-                          color="primary"
-                          startIcon={<SwapIcon />}
-                          fullWidth
-                        >
-                          Swap
-                        </Button>
-                      </Link>
+                      <Track {...SWAP_EVENTS.SWAP_ASSETS} label={SWAP_LABELS.dashboard}>
+                        <Link href={{ pathname: AppRoutes.swap, query: router.query }} passHref type="button">
+                          <Button
+                            size={isSmallScreen ? 'medium' : 'small'}
+                            variant="outlined"
+                            color="primary"
+                            startIcon={<SwapIcon />}
+                            fullWidth
+                          >
+                            Swap
+                          </Button>
+                        </Link>
+                      </Track>
                     </Grid>
                   )}
                 </Grid>

--- a/src/services/analytics/events/swaps.ts
+++ b/src/services/analytics/events/swaps.ts
@@ -10,3 +10,7 @@ export const SWAP_EVENTS = {
     category: SWAP_CATEGORY,
   },
 }
+
+export const SWAP_LABELS = {
+  dashboard: 'dashboard',
+}


### PR DESCRIPTION
## What it solves
- adds an extra click event for entering the native swaps feature from the dashbaord.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
