### PR TITLE
fix: Send orderUid with analytics events

### DIFF
--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -22,7 +22,7 @@ import useDecodeTx from '@/hooks/useDecodeTx'
 import { ErrorBoundary } from '@sentry/react'
 import ApprovalEditor from '../ApprovalEditor'
 import { isDelegateCall } from '@/services/tx/tx-sender/sdk'
-import { getTransactionTrackingType } from '@/services/analytics/tx-tracking'
+import { getTransactionTrackingParams } from '@/services/analytics/tx-tracking'
 import { TX_EVENTS } from '@/services/analytics/events/transactions'
 import { trackEvent } from '@/services/analytics'
 import useChainId from '@/hooks/useChainId'
@@ -46,12 +46,13 @@ export type SignOrExecuteProps = {
 
 const trackTxEvents = async (chainId: string, txId: string, isCreation: boolean, isExecuted: boolean) => {
   const event = isCreation ? TX_EVENTS.CREATE : isExecuted ? TX_EVENTS.EXECUTE : TX_EVENTS.CONFIRM
-  const txType = await getTransactionTrackingType(chainId, txId)
-  trackEvent({ ...event, label: txType })
+  const txParams = await getTransactionTrackingParams(chainId, txId)
+  const { type, ...rest } = txParams
+  trackEvent({ ...event, label: txParams.type, ...rest })
 
   // Immediate execution on creation
   if (isCreation && isExecuted) {
-    trackEvent({ ...TX_EVENTS.EXECUTE, label: txType })
+    trackEvent({ ...TX_EVENTS.EXECUTE, label: txParams.type, ...rest })
   }
 }
 

--- a/src/features/speedup/components/SpeedUpModal.tsx
+++ b/src/features/speedup/components/SpeedUpModal.tsx
@@ -23,7 +23,7 @@ import { PendingTxType, type PendingProcessingTx } from '@/store/pendingTxsSlice
 import useAsync from '@/hooks/useAsync'
 import { MODALS_EVENTS, trackEvent } from '@/services/analytics'
 import { TX_EVENTS } from '@/services/analytics/events/transactions'
-import { getTransactionTrackingType } from '@/services/analytics/tx-tracking'
+import { getTransactionTrackingParams } from '@/services/analytics/tx-tracking'
 import { trackError } from '@/services/exceptions'
 import ErrorCodes from '@/services/exceptions/ErrorCodes'
 
@@ -97,8 +97,8 @@ export const SpeedUpModal = ({
           chainInfo.chainId,
           safeAddress,
         )
-        const txType = await getTransactionTrackingType(chainInfo.chainId, txId)
-        trackEvent({ ...TX_EVENTS.SPEED_UP, label: txType })
+        const trackingParams = await getTransactionTrackingParams(chainInfo.chainId, txId)
+        trackEvent({ ...TX_EVENTS.SPEED_UP, label: trackingParams.type })
       } else {
         await dispatchCustomTxSpeedUp(
           txOptions as Omit<TransactionOptions, 'nonce'> & { nonce: number },

--- a/src/hooks/useTxTracking.ts
+++ b/src/hooks/useTxTracking.ts
@@ -1,6 +1,7 @@
 import { trackEvent, WALLET_EVENTS } from '@/services/analytics'
 import { getTxDetails } from '@/services/transactions'
 import { TxEvent, txSubscribe } from '@/services/tx/txEvents'
+import { isSwapTxInfo } from '@/utils/transaction-guards'
 import { useEffect } from 'react'
 import useChainId from './useChainId'
 
@@ -22,16 +23,20 @@ export const useTxTracking = (): void => {
         const id = txId || txHash
 
         let origin = ''
+        let transaction_id
+
         if (id) {
           try {
             const txDetails = await getTxDetails(chainId, id)
             origin = txDetails.safeAppInfo?.url || ''
+            transaction_id = isSwapTxInfo(txDetails.txInfo) ? txDetails.txInfo.uid : undefined
           } catch {}
         }
 
         trackEvent({
           ...analyticsEvent,
           label: origin,
+          transaction_id,
         })
       }),
     )

--- a/src/services/analytics/__tests__/tx-tracking.test.ts
+++ b/src/services/analytics/__tests__/tx-tracking.test.ts
@@ -6,12 +6,12 @@ import { TX_TYPES } from '../events/transactions'
 
 const getMockTxType = (txDetails: unknown) => {
   jest.spyOn(txDetailsModule, 'getTxDetails').mockImplementation(() => Promise.resolve(txDetails as TransactionDetails))
-  return getTransactionTrackingType('1', '0x123')
+  return getTransactionTrackingType(txDetails as TransactionDetails)
 }
 
 describe('getTransactionTrackingType', () => {
   it('should return transfer_token for native token transfers', async () => {
-    const txType = await getMockTxType({
+    const txType = getMockTxType({
       txInfo: {
         type: TransactionInfoType.TRANSFER,
         transferInfo: {
@@ -24,7 +24,7 @@ describe('getTransactionTrackingType', () => {
   })
 
   it('should return transfer_token for ERC20 token transfers', async () => {
-    const txType = await getMockTxType({
+    const txType = getMockTxType({
       txInfo: {
         type: TransactionInfoType.TRANSFER,
         transferInfo: {
@@ -37,7 +37,7 @@ describe('getTransactionTrackingType', () => {
   })
 
   it('should return transfer_nft for ERC721 token transfers', async () => {
-    const txType = await getMockTxType({
+    const txType = getMockTxType({
       txInfo: {
         type: TransactionInfoType.TRANSFER,
         transferInfo: {
@@ -50,7 +50,7 @@ describe('getTransactionTrackingType', () => {
   })
 
   it('should return owner_add for add owner settings changes', async () => {
-    const txType = await getMockTxType({
+    const txType = getMockTxType({
       txInfo: {
         type: TransactionInfoType.SETTINGS_CHANGE,
         settingsInfo: {
@@ -63,7 +63,7 @@ describe('getTransactionTrackingType', () => {
   })
 
   it('should return owner_remove for remove owner settings changes', async () => {
-    const txType = await getMockTxType({
+    const txType = getMockTxType({
       txInfo: {
         type: TransactionInfoType.SETTINGS_CHANGE,
         settingsInfo: {
@@ -75,8 +75,8 @@ describe('getTransactionTrackingType', () => {
     expect(txType).toEqual(TX_TYPES.owner_remove)
   })
 
-  it('should return owner_swap for swap owner settings changes', async () => {
-    const txType = await getMockTxType({
+  it('should return owner_swap for swap owner settings changes', () => {
+    const txType = getMockTxType({
       txInfo: {
         type: TransactionInfoType.SETTINGS_CHANGE,
         settingsInfo: {
@@ -88,8 +88,8 @@ describe('getTransactionTrackingType', () => {
     expect(txType).toEqual(TX_TYPES.owner_swap)
   })
 
-  it('should return owner_threshold_change for change threshold settings changes', async () => {
-    const txType = await getMockTxType({
+  it('should return owner_threshold_change for change threshold settings changes', () => {
+    const txType = getMockTxType({
       txInfo: {
         type: TransactionInfoType.SETTINGS_CHANGE,
         settingsInfo: {
@@ -101,8 +101,8 @@ describe('getTransactionTrackingType', () => {
     expect(txType).toEqual(TX_TYPES.owner_threshold_change)
   })
 
-  it('should return module_remove for disable module settings changes', async () => {
-    const txType = await getMockTxType({
+  it('should return module_remove for disable module settings changes', () => {
+    const txType = getMockTxType({
       txInfo: {
         type: TransactionInfoType.SETTINGS_CHANGE,
         settingsInfo: {
@@ -114,8 +114,8 @@ describe('getTransactionTrackingType', () => {
     expect(txType).toEqual(TX_TYPES.module_remove)
   })
 
-  it('should return guard_remove for delete guard settings changes', async () => {
-    const txType = await getMockTxType({
+  it('should return guard_remove for delete guard settings changes', () => {
+    const txType = getMockTxType({
       txInfo: {
         type: TransactionInfoType.SETTINGS_CHANGE,
         settingsInfo: {
@@ -127,8 +127,8 @@ describe('getTransactionTrackingType', () => {
     expect(txType).toEqual(TX_TYPES.guard_remove)
   })
 
-  it('should return rejection for rejection transactions', async () => {
-    const txType = await getMockTxType({
+  it('should return rejection for rejection transactions', () => {
+    const txType = getMockTxType({
       txInfo: {
         type: TransactionInfoType.CUSTOM,
         isCancellation: true,
@@ -138,8 +138,8 @@ describe('getTransactionTrackingType', () => {
     expect(txType).toEqual(TX_TYPES.rejection)
   })
 
-  it('should return walletconnect for walletconnect transactions', async () => {
-    const txType = await getMockTxType({
+  it('should return walletconnect for walletconnect transactions', () => {
+    const txType = getMockTxType({
       txInfo: {
         type: TransactionInfoType.CUSTOM,
       },
@@ -151,8 +151,8 @@ describe('getTransactionTrackingType', () => {
     expect(txType).toEqual(TX_TYPES.walletconnect)
   })
 
-  it('should return safeapps for safeapps transactions', async () => {
-    const txType = await getMockTxType({
+  it('should return safeapps for safeapps transactions', () => {
+    const txType = getMockTxType({
       txInfo: {
         type: TransactionInfoType.CUSTOM,
       },
@@ -164,8 +164,8 @@ describe('getTransactionTrackingType', () => {
     expect(txType).toEqual('https://gnosis-safe.io/app')
   })
 
-  it('should return batch for multisend transactions', async () => {
-    const txType = await getMockTxType({
+  it('should return batch for multisend transactions', () => {
+    const txType = getMockTxType({
       txInfo: {
         type: TransactionInfoType.CUSTOM,
         methodName: 'multiSend',
@@ -176,8 +176,8 @@ describe('getTransactionTrackingType', () => {
     expect(txType).toEqual(TX_TYPES.batch)
   })
 
-  it('should return custom for unknown transactions', async () => {
-    const txType = await getMockTxType({
+  it('should return custom for unknown transactions', () => {
+    const txType = getMockTxType({
       txInfo: {
         type: TransactionInfoType.CUSTOM,
       },

--- a/src/services/analytics/tx-tracking.ts
+++ b/src/services/analytics/tx-tracking.ts
@@ -1,4 +1,5 @@
 import { TX_TYPES } from '@/services/analytics/events/transactions'
+import type { GADimensions } from '@/services/analytics/types'
 import { getTxDetails } from '@/services/transactions'
 import { isWalletConnectSafeApp } from '@/utils/gateway'
 import { SettingsInfoType, type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
@@ -12,13 +13,30 @@ import {
   isSwapTxInfo,
 } from '@/utils/transaction-guards'
 
-export const getTransactionTrackingType = async (chainId: string, txId: string): Promise<string> => {
+type TrackingParams = {
+  type: string
+} & Partial<GADimensions>
+
+export const getTransactionTrackingParams = async (chainId: string, txId: string): Promise<TrackingParams> => {
   let details: TransactionDetails
+
   try {
     details = await getTxDetails(chainId, txId)
   } catch {
-    return TX_TYPES.custom
+    return {
+      type: TX_TYPES.custom,
+    }
   }
+
+  const type = getTransactionTrackingType(details)
+
+  return {
+    type,
+    transaction_id: isSwapTxInfo(details.txInfo) ? details.txInfo.uid : undefined,
+  }
+}
+
+export const getTransactionTrackingType = (details: TransactionDetails): string => {
   const { txInfo } = details
 
   if (isTransferTxInfo(txInfo)) {

--- a/src/services/analytics/types.ts
+++ b/src/services/analytics/types.ts
@@ -25,6 +25,11 @@ export type AnalyticsEvent = {
   chainId?: string
 }
 
+// https://support.google.com/analytics/answer/9143382
+export type GADimensions = {
+  transaction_id: string
+}
+
 export type SafeAppSDKEvent = {
   method: string
   ethMethod: string


### PR DESCRIPTION
## What it solves

Resolves [Notion issue](https://www.notion.so/safe-global/Send-order-status-to-GA-740c268ea08f4c929adc3d6c4b3fb041)

## How this PR fixes it

- Sends the `orderUid` as a predefined dimension called `transaction_id` with certain events such as `tx_created`, `tx_confirmed`, `tx_executed`, `on-chain interaction`

## How to test it

1. Create a swap order
2. Press submit in the modal
3. Observe the GTM event containing `transaction_id` with the `orderUid` as the value

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
