### PR TITLE
Fix: Set initial sell token when entering swaps through assets page

### DIFF
--- a/src/features/swap/index.tsx
+++ b/src/features/swap/index.tsx
@@ -25,6 +25,7 @@ import LegalDisclaimerContent from '@/components/common/LegalDisclaimerContent'
 import { isBlockedAddress } from '@/services/ofac'
 import { selectSwapParams, setSwapParams, type SwapState } from './store/swapParamsSlice'
 import { setSwapOrder } from '@/store/swapOrderSlice'
+import useChainId from '@/hooks/useChainId'
 
 const BASE_URL = typeof window !== 'undefined' && window.location.origin ? window.location.origin : ''
 
@@ -44,6 +45,7 @@ export const getSwapTitle = (tradeType: SwapState['tradeType']) => {
 const SwapWidget = ({ sell }: Params) => {
   const { palette } = useTheme()
   const darkMode = useDarkMode()
+  const chainId = useChainId()
   const dispatch = useAppDispatch()
   const isSwapFeatureEnabled = useHasFeature(FEATURES.NATIVE_SWAPS)
   const swapParams = useAppSelector(selectSwapParams)
@@ -150,6 +152,7 @@ const SwapWidget = ({ sell }: Params) => {
       appCode: 'Safe Wallet Swaps', // Name of your app (max 50 characters)
       width: '100%', // Width in pixels (or 100% to use all available space)
       height: '860px',
+      chainId,
       standaloneMode: false,
       disableToastMessages: true,
       disablePostedOrderConfirmationModal: true,

--- a/src/features/swap/index.tsx
+++ b/src/features/swap/index.tsx
@@ -189,7 +189,7 @@ const SwapWidget = ({ sell }: Params) => {
         alert: palette.warning.main,
       },
     })
-  }, [sell, palette, darkMode, tradeType])
+  }, [sell, palette, darkMode, tradeType, chainId])
 
   const chain = useCurrentChain()
 


### PR DESCRIPTION
## What it solves
Resolves: https://www.notion.so/safe-global/WETH-is-selected-in-the-widget-when-pressing-Swap-for-ETH-on-the-assets-page-1e9981aed97340979538bfd2c43b51c2?pvs=4 [SWT-73]

When clicking the swap option on an asset, that asset was not set as the sell token in the widget. It was always initialised with WETH.

## How this PR fixes it
- Include the chainId in the swap widget params. It seems to be necessary to be able to set the sell token.

## How to test it
- click on the swap button on an asset in the assets page
- the swap widget should open with the chosen asset as the sell token, with the amount set to the token balance.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
