### PR TITLE
fix: Disable batching for native swaps

### DIFF
--- a/src/components/tx-flow/flows/SafeAppsTx/ReviewSafeAppsTx.tsx
+++ b/src/components/tx-flow/flows/SafeAppsTx/ReviewSafeAppsTx.tsx
@@ -1,3 +1,4 @@
+import { SWAP_TITLE } from '@/features/swap'
 import { useContext, useEffect, useMemo } from 'react'
 import type { ReactElement } from 'react'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
@@ -64,7 +65,7 @@ const ReviewSafeAppsTx = ({
   const error = !isTxValid(txs)
 
   return (
-    <SignOrExecuteForm onSubmit={handleSubmit} origin={origin} showToBlock>
+    <SignOrExecuteForm onSubmit={handleSubmit} origin={origin} showToBlock isBatchable={app?.name !== SWAP_TITLE}>
       {error ? (
         <ErrorMessage error={safeTxError}>
           This Safe App initiated a transaction which cannot be processed. Please get in touch with the developer of


### PR DESCRIPTION
## What it solves

Resolves [Notion issue](https://www.notion.so/safe-global/Remove-the-option-of-Add-to-batch-ff5ce2a525c1406d90b5db92445ab0e3) [SWT-72]

## How this PR fixes it

- Disables the Add to Batch button if the transaction comes from the native swap widget

## How to test it

1. Create a swap order
2. Try to sign it
3. Observe the Add to Batch button is disabled

## Screenshots
<img width="749" alt="Screenshot 2024-05-10 at 12 17 48" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/7e45cea7-067f-4b24-829a-bd7ed9385177">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
