### PR TITLE
fix: remove swap from counterfactual safes [SWAP-66]

### DIFF
--- a/src/components/balances/AssetsTable/index.tsx
+++ b/src/components/balances/AssetsTable/index.tsx
@@ -27,6 +27,7 @@ import { TxModalContext } from '@/components/tx-flow'
 import { TokenTransferFlow } from '@/components/tx-flow/flows'
 import AddFundsCTA from '@/components/common/AddFunds'
 import SwapButton from '@/features/swap/components/SwapButton'
+import useIsCounterfactualSafe from '@/features/counterfactual/hooks/useIsCounterfactualSafe'
 
 const skeletonCells: EnhancedTableProps['rows'][0]['cells'] = {
   asset: {
@@ -133,7 +134,8 @@ const AssetsTable = ({
   const hiddenAssets = useHiddenTokens()
   const { balances, loading } = useBalances()
   const { setTxFlow } = useContext(TxModalContext)
-  const isSwapFeatureEnabled = useHasFeature(FEATURES.NATIVE_SWAPS)
+  const isCounterfactualSafe = useIsCounterfactualSafe()
+  const isSwapFeatureEnabled = useHasFeature(FEATURES.NATIVE_SWAPS) && !isCounterfactualSafe
 
   const { isAssetSelected, toggleAsset, hidingAsset, hideAsset, cancel, deselectAll, saveChanges } = useHideAssets(() =>
     setShowHiddenAssets(false),

--- a/src/components/sidebar/SidebarNavigation/index.tsx
+++ b/src/components/sidebar/SidebarNavigation/index.tsx
@@ -16,6 +16,7 @@ import { AppRoutes } from '@/config/routes'
 import { useQueuedTxsLength } from '@/hooks/useTxQueue'
 import { useCurrentChain } from '@/hooks/useChains'
 import { FeatureRoutes, hasFeature } from '@/utils/chains'
+import useIsCounterfactualSafe from '@/features/counterfactual/hooks/useIsCounterfactualSafe'
 
 const getSubdirectory = (pathname: string): string => {
   return pathname.split('/')[1]
@@ -34,10 +35,17 @@ const Navigation = (): ReactElement => {
   const { safe } = useSafeInfo()
   const currentSubdirectory = getSubdirectory(router.pathname)
   const queueSize = useQueuedTxsLength()
-
+  const isCounterFactualSafe = useIsCounterfactualSafe()
   const enabledNavItems = useMemo(() => {
-    return navItems.filter((item) => isRouteEnabled(item.href, chain))
-  }, [chain])
+    return navItems.filter((item) => {
+      const enabled = isRouteEnabled(item.href, chain)
+
+      if (item.href === AppRoutes.swap && isCounterFactualSafe) {
+        return false
+      }
+      return enabled
+    })
+  }, [chain, isCounterFactualSafe])
 
   const getBadge = (item: NavItem) => {
     // Indicate whether the current Safe needs an upgrade

--- a/src/features/counterfactual/FirstTxFlow.tsx
+++ b/src/features/counterfactual/FirstTxFlow.tsx
@@ -20,6 +20,7 @@ import SafeLogo from '@/public/images/logo-no-text.svg'
 import HandymanOutlinedIcon from '@mui/icons-material/HandymanOutlined'
 import { useHasFeature } from '@/hooks/useChains'
 import { FEATURES } from '@/utils/chains'
+import useIsCounterfactualSafe from '@/features/counterfactual/hooks/useIsCounterfactualSafe'
 
 const FirstTxFlow = ({ open, onClose }: { open: boolean; onClose: () => void }) => {
   const txBuilder = useTxBuilderApp()
@@ -27,7 +28,8 @@ const FirstTxFlow = ({ open, onClose }: { open: boolean; onClose: () => void }) 
   const { setTxFlow } = useContext(TxModalContext)
   const supportsRecovery = useIsRecoverySupported()
   const [recovery] = useRecovery()
-  const isSwapFeatureEnabled = useHasFeature(FEATURES.NATIVE_SWAPS)
+  const isCounterfactualSafe = useIsCounterfactualSafe()
+  const isSwapFeatureEnabled = useHasFeature(FEATURES.NATIVE_SWAPS) && !isCounterfactualSafe
 
   const handleClick = (onClick: () => void) => {
     onClose()


### PR DESCRIPTION


Resolves #

Due to a bug, the swap widget is not picking up the creation of a counterfactual safe. 

## How this PR fixes it
Until this is resolved, we’ll disable the swap feature for counterfactual safes

## How to test it
Create a counterfactual safe. The swap button should be missing from the dashboard, assets and navigation. For the first transaction modal there is a swap button, but it should lead to the safe apps page and not the native integration.

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
