### PR TITLE
Chore: move checksum upload step

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -34,7 +34,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/workflows/yarn
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       ARCHIVE_NAME: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/workflows/yarn
 
@@ -23,6 +23,27 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           prod: ${{ true }}
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      # Script to upload release files
+      - name: 'Upload release build files for production'
+        env:
+          BUCKET: s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ github.event.release.tag_name }}
+          CHECKSUM_FILE: ${{ env.ARCHIVE_NAME }}-sha256-checksum.txt
+        run: bash ./scripts/github/s3_upload.sh
+
+      # Script to prepare production deployments
+      - run: bash ./scripts/github/prepare_production_deployment.sh
+        env:
+          PROD_DEPLOYMENT_HOOK_TOKEN: ${{ secrets.PROD_DEPLOYMENT_HOOK_TOKEN }}
+          PROD_DEPLOYMENT_HOOK_URL: ${{ secrets.PROD_DEPLOYMENT_HOOK_URL }}
+          VERSION_TAG: ${{ github.event.release.tag_name }}
+
+      # Update the GitHub release with a checksummed archive
       - name: Create archive
         run: tar -czf "$ARCHIVE_NAME".tar.gz out
 
@@ -48,23 +69,3 @@ jobs:
           asset_content_type: text/plain
         env:
           GITHUB_TOKEN: ${{ github.token }}
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      # Script to upload release files
-      - name: 'Upload release build files for production'
-        env:
-          BUCKET: s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ github.event.release.tag_name }}
-          CHECKSUM_FILE: ${{ env.ARCHIVE_NAME }}-sha256-checksum.txt
-        run: bash ./scripts/github/s3_upload.sh
-
-      # Script to prepare production deployments
-      - run: bash ./scripts/github/prepare_production_deployment.sh
-        env:
-          PROD_DEPLOYMENT_HOOK_TOKEN: ${{ secrets.PROD_DEPLOYMENT_HOOK_TOKEN }}
-          PROD_DEPLOYMENT_HOOK_URL: ${{ secrets.PROD_DEPLOYMENT_HOOK_URL }}
-          VERSION_TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/e2e-hp-ondemand.yml
+++ b/.github/workflows/e2e-hp-ondemand.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         containers: [1, 2, 3]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/workflows/cypress
         with:

--- a/.github/workflows/e2e-ondemand.yml
+++ b/.github/workflows/e2e-ondemand.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         containers: [1, 2, 3, 4, 5]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/workflows/cypress
         with:

--- a/.github/workflows/e2e-regression.yml
+++ b/.github/workflows/e2e-regression.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         containers: [1, 2, 3]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/workflows/cypress
         with:

--- a/.github/workflows/e2e-safe-apps.yml
+++ b/.github/workflows/e2e-safe-apps.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         containers: [1, 2]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/workflows/cypress
         with:

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -18,7 +18,7 @@ jobs:
         containers: [1, 2, 3, 4, 5]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/workflows/cypress
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: 'Lint'
+name: Lint
 on: [pull_request]
 
 concurrency:
@@ -9,7 +9,7 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/workflows/yarn
 

--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -18,7 +18,7 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         uses: ./.github/workflows/yarn
@@ -42,7 +42,6 @@ jobs:
         run: bash ./scripts/github/download_bundle_analyser_artifact.sh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
 
       - name: Compare with base branch bundle
         if: success() && github.event.number

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/workflows/yarn
 


### PR DESCRIPTION
## What it solves

`actions/upload-release-asset@v1` is [failing](https://github.com/safe-global/safe-wallet-web/actions/runs/9063027490/job/24898450610) with `Error: Resource not accessible by integration` so I moved it down to let the S3 upload step to run before the entire action fails.

I also updated the checkout action to v4 in all the workflows.