### PR TITLE
fix: feeTooltip text was wrong

### DIFF
--- a/src/features/swap/index.tsx
+++ b/src/features/swap/index.tsx
@@ -192,7 +192,7 @@ const SwapWidget = ({ sell }: Params) => {
       content: {
         feeLabel: 'No fee for one month',
         feeTooltipMarkdown:
-          'The transaction fee incurred here will contribute to a license fee that supports the Safe Ecosystem Foundation (SEF). SEF does not operate this service.',
+          'Any future transaction fee incurred by Cow Protocol here will contribute to a license fee that supports the Safe Community. Neither Safe Ecosystem Foundation nor Core Contributors GmbH operate the CoW Swap Widget and/or Cow Swap.',
       },
     })
   }, [sell, palette, darkMode, tradeType, chainId])


### PR DESCRIPTION
## What it solves
The title says it all.


## How to test it
Create a swap and observe the fees section.
<img width="642" alt="grafik" src="https://github.com/safe-global/safe-wallet-web/assets/693770/89c69919-be55-4042-a8c0-542bf5f94520">


## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
