### PR TITLE
Slim Down Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:18-alpine
+FROM node:18-alpine AS build
+
 RUN apk add --no-cache libc6-compat git python3 py3-pip make g++ libusb-dev eudev-dev linux-headers
 WORKDIR /app
 COPY . .
@@ -17,8 +18,22 @@ ENV NODE_ENV production
 # Uncomment the following line in case you want to disable telemetry during the build.
 ENV NEXT_TELEMETRY_DISABLED 1
 
+RUN yarn build
+
+FROM alpine
+
+RUN apk add busybox-extras tini
+WORKDIR /www
+COPY --from=build /app/out /www
+
+# Next.js automatically adds `.html` extensions to URLs, but static HTTP file
+# servers don't generally do this. You can work around this by creating symbolic
+# links from `my-page.html` to either `my-page/index.html` or `my-page`
+# depending on whether or not a `my-page` directory exists.
+RUN find /www -name '*.html' -exec sh -c 'f="{}"; b="${f%.*}"; [ -d "$b" ] && ln -s "$f" "$b/index.html" || ln -s "$f" "$b"' ';'
+
 EXPOSE 3000
 
 ENV PORT 3000
 
-CMD ["yarn", "static-serve"]
+CMD ["tini", "--", "busybox-extras", "httpd", "-fvv", "-h", "/www", "-p", "0.0.0.0:3000"]


### PR DESCRIPTION
## What it solves

When playing around with the Safe web interface I noticed that the Docker image that it produces is **over 6GB in size**! This is very large for a docker image that just hosts static files.

## How this PR fixes it

This PR slims down the docker image significantly by using a multistage build where the first stage builds the static website, and the actual image just hosts the static webside (here using BusyBox `httpd` which is nice and lightweight).

This gets the image down to around 72MB, around 1% of the original image size _(sizes computed from Docker images built on amd64 Linux)_.

Note that there is one weird detail is that static HTTP servers typically don't have support for automatically adding `.html` endings to URL paths. It was worked around here with symlinks. See comment in the Dockerfile for more details.

## How to test it

Build the docker image and run the container locally:

```sh
docker build . -t safe-wallet-web
docker run --rm -p 3000:3000 safe-wallet-web
```

This should give you a local interface at <http://localhost:3000>.

## "Screenshots"

```
$ docker images
REPOSITORY                            TAG          IMAGE ID      CREATED            SIZE
localhost/safe-web                    small        2bb37df44d9f  14 minutes ago     71.9 MB
localhost/safe-web                    big          ae2940e99e19  3 hours ago        6.52 GB
```

## Checklist

* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
    * Analytics are not affected
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
    * Not applicable
