### PR TITLE
fix: Safe stats tracking for owned Safes

### DIFF
--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -28,7 +28,7 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
 
   const ownedSafes = useMemo(() => safes?.filter(({ isWatchlist }) => !isWatchlist), [safes])
   const watchlistSafes = useMemo(() => safes?.filter(({ isWatchlist }) => isWatchlist), [safes])
-  useTrackSafesCount(ownedSafes, watchlistSafes)
+  useTrackSafesCount(ownedSafes, watchlistSafes, wallet)
 
   const isLoginPage = router.pathname === AppRoutes.welcome.accounts
   const trackingLabel = isLoginPage ? OVERVIEW_LABELS.login_page : OVERVIEW_LABELS.sidebar

--- a/src/components/welcome/MyAccounts/useAllOwnedSafes.ts
+++ b/src/components/welcome/MyAccounts/useAllOwnedSafes.ts
@@ -7,17 +7,32 @@ import { useEffect } from 'react'
 
 const CACHE_KEY = 'ownedSafesCache_'
 
+type OwnedSafesPerAddress = {
+  address: string | undefined
+  ownedSafes: AllOwnedSafes
+}
+
 const useAllOwnedSafes = (address: string): AsyncResult<AllOwnedSafes> => {
   const [cache, setCache] = useLocalStorage<AllOwnedSafes>(CACHE_KEY + address)
 
-  const [data, error, isLoading] = useAsync<AllOwnedSafes>(async () => {
-    if (!address) return {}
-    return getAllOwnedSafes(address)
+  const [data, error, isLoading] = useAsync<OwnedSafesPerAddress>(async () => {
+    if (!address)
+      return {
+        ownedSafes: {},
+        address: undefined,
+      }
+    const ownedSafes = await getAllOwnedSafes(address)
+    return {
+      ownedSafes,
+      address,
+    }
   }, [address])
 
   useEffect(() => {
-    if (data != undefined) setCache(data)
-  }, [data, setCache])
+    if (data?.ownedSafes != undefined && data.address === address) {
+      setCache(data.ownedSafes)
+    }
+  }, [address, cache, data, setCache])
 
   return [cache, error, isLoading]
 }

--- a/src/components/welcome/MyAccounts/useAllSafes.ts
+++ b/src/components/welcome/MyAccounts/useAllSafes.ts
@@ -7,8 +7,6 @@ import useAllOwnedSafes from './useAllOwnedSafes'
 import useChains from '@/hooks/useChains'
 import useWallet from '@/hooks/wallets/useWallet'
 import { selectUndeployedSafes } from '@/store/slices'
-import { sameAddress } from '@/utils/addresses'
-
 export type SafeItem = {
   chainId: string
   address: string
@@ -53,10 +51,8 @@ const useAllSafes = (): SafeItems | undefined => {
       const uniqueAddresses = uniq(addedOnChain.concat(ownedOnChain)).filter(Boolean)
 
       return uniqueAddresses.map((address) => {
-        const owners = allAdded?.[chainId]?.[address]?.owners
-        const isOwner = owners?.some(({ value }) => sameAddress(walletAddress, value))
         const isUndeployed = undeployedOnChain.includes(address)
-        const isOwned = (ownedOnChain || []).includes(address) || isOwner
+        const isOwned = (ownedOnChain || []).includes(address)
         return {
           address,
           chainId,
@@ -64,7 +60,7 @@ const useAllSafes = (): SafeItems | undefined => {
         }
       })
     })
-  }, [allAdded, allOwned, configs, undeployedSafes, walletAddress])
+  }, [allAdded, allOwned, configs, undeployedSafes])
 }
 
 export default useAllSafes

--- a/src/components/welcome/MyAccounts/useTrackedSafesCount.ts
+++ b/src/components/welcome/MyAccounts/useTrackedSafesCount.ts
@@ -3,20 +3,37 @@ import { OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import type { SafeItems } from './useAllSafes'
+import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
 
-let isTracked = false
+let isOwnedSafesTracked = false
+let isWatchlistTracked = false
 
-const useTrackSafesCount = (ownedSafes: SafeItems | undefined, watchlistSafes: SafeItems | undefined) => {
+const useTrackSafesCount = (
+  ownedSafes: SafeItems | undefined,
+  watchlistSafes: SafeItems | undefined,
+  wallet: ConnectedWallet | null,
+) => {
   const router = useRouter()
   const isLoginPage = router.pathname === AppRoutes.welcome.accounts
 
+  // Reset tracking for new wallet
   useEffect(() => {
-    if (watchlistSafes && ownedSafes && isLoginPage && !isTracked) {
+    isOwnedSafesTracked = false
+  }, [wallet?.address])
+
+  useEffect(() => {
+    if (!isOwnedSafesTracked && ownedSafes && ownedSafes.length > 0 && isLoginPage) {
       trackEvent({ ...OVERVIEW_EVENTS.TOTAL_SAFES_OWNED, label: ownedSafes.length })
-      trackEvent({ ...OVERVIEW_EVENTS.TOTAL_SAFES_WATCHLIST, label: watchlistSafes.length })
-      isTracked = true
+      isOwnedSafesTracked = true
     }
-  }, [isLoginPage, ownedSafes, watchlistSafes])
+  }, [isLoginPage, ownedSafes])
+
+  useEffect(() => {
+    if (watchlistSafes && isLoginPage && watchlistSafes.length > 0 && !isWatchlistTracked) {
+      trackEvent({ ...OVERVIEW_EVENTS.TOTAL_SAFES_WATCHLIST, label: watchlistSafes.length })
+      isWatchlistTracked = true
+    }
+  }, [isLoginPage, watchlistSafes])
 }
 
 export default useTrackSafesCount

--- a/src/services/analytics/events/overview.ts
+++ b/src/services/analytics/events/overview.ts
@@ -38,10 +38,12 @@ export const OVERVIEW_EVENTS = {
   TOTAL_SAFES_OWNED: {
     action: 'Total Safes owned',
     category: OVERVIEW_CATEGORY,
+    event: EventType.META,
   },
   TOTAL_SAFES_WATCHLIST: {
     action: 'Total Safes watchlist',
     category: OVERVIEW_CATEGORY,
+    event: EventType.META,
   },
   SIDEBAR: {
     action: 'Sidebar',


### PR DESCRIPTION
## What it solves

Resolves #3702 

## How this PR fixes it
- Track owned Safes whenever the connected wallet address changes
- Do not track 0 owned Safes or 0 watchlist Safes as these usually relate to loading states and are not really interesting
- Fixes a bug that caused the cached owned Safes to get overwritten with wrong values


## How to test it
- Load the /welcome/accounts page and check analytics
- Switch the connected wallet whilst being on this page and observe the correct owned Safes to be tracked

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
