### PR TITLE
Revert "Slim Down Docker Image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM node:18-alpine AS build
-
+FROM node:18-alpine
 RUN apk add --no-cache libc6-compat git python3 py3-pip make g++ libusb-dev eudev-dev linux-headers
 WORKDIR /app
 COPY . .
@@ -18,22 +17,8 @@ ENV NODE_ENV production
 # Uncomment the following line in case you want to disable telemetry during the build.
 ENV NEXT_TELEMETRY_DISABLED 1
 
-RUN yarn build
-
-FROM alpine
-
-RUN apk add busybox-extras tini
-WORKDIR /www
-COPY --from=build /app/out /www
-
-# Next.js automatically adds `.html` extensions to URLs, but static HTTP file
-# servers don't generally do this. You can work around this by creating symbolic
-# links from `my-page.html` to either `my-page/index.html` or `my-page`
-# depending on whether or not a `my-page` directory exists.
-RUN find /www -name '*.html' -exec sh -c 'f="{}"; b="${f%.*}"; [ -d "$b" ] && ln -s "$f" "$b/index.html" || ln -s "$f" "$b"' ';'
-
 EXPOSE 3000
 
 ENV PORT 3000
 
-CMD ["tini", "--", "busybox-extras", "httpd", "-fvv", "-h", "/www", "-p", "0.0.0.0:3000"]
+CMD ["yarn", "static-serve"]


### PR DESCRIPTION
## What it solves

PR #3707 changed the docker file to produce smaller artifacts, however, this started causing [CI errors](https://github.com/safe-global/safe-wallet-web/actions/runs/9083918124/job/24963680879).

## How this PR fixes it

This reverts PR #3707 in the meantime. I will investigate and try to make a follow up PR that fixes the issue.