### PR TITLE
fix: Hide signed transaction from untrusted pending queue

### DIFF
--- a/src/components/transactions/TxList/index.tsx
+++ b/src/components/transactions/TxList/index.tsx
@@ -1,10 +1,13 @@
+import GroupedTxListItems from '@/components/transactions/GroupedTxListItems'
+import { useHasPendingTxs } from '@/hooks/usePendingTxs'
+import { isLabelListItem } from '@/utils/transaction-guards'
+import { groupConflictingTxs } from '@/utils/tx-list'
+import { Box } from '@mui/material'
+import type { LabelValue, TransactionListPage } from '@safe-global/safe-gateway-typescript-sdk'
+import { TransactionListItemType } from '@safe-global/safe-gateway-typescript-sdk'
 import type { ReactElement, ReactNode } from 'react'
 import { useMemo } from 'react'
-import { Box } from '@mui/material'
-import type { TransactionListPage } from '@safe-global/safe-gateway-typescript-sdk'
 import TxListItem from '../TxListItem'
-import GroupedTxListItems from '@/components/transactions/GroupedTxListItems'
-import { groupConflictingTxs } from '@/utils/tx-list'
 import css from './styles.module.css'
 
 type TxListProps = {
@@ -15,8 +18,24 @@ export const TxListGrid = ({ children }: { children: ReactNode }): ReactElement 
   return <Box className={css.container}>{children}</Box>
 }
 
+const adjustPendingLabel = (items: TransactionListPage['results']) => {
+  const result = [...items]
+
+  if (isLabelListItem(result[0])) {
+    result[0] = {
+      label: 'Pending' as LabelValue,
+      type: TransactionListItemType.LABEL,
+    }
+  }
+
+  return result
+}
+
 const TxList = ({ items }: TxListProps): ReactElement => {
-  const groupedItems = useMemo(() => groupConflictingTxs(items), [items])
+  const hasPending = useHasPendingTxs()
+
+  const pendingItems = useMemo(() => (hasPending ? adjustPendingLabel(items) : items), [items, hasPending])
+  const groupedItems = useMemo(() => groupConflictingTxs(pendingItems), [pendingItems])
 
   const transactions = groupedItems.map((item, index) => {
     if (Array.isArray(item)) {

--- a/src/components/transactions/TxList/index.tsx
+++ b/src/components/transactions/TxList/index.tsx
@@ -1,10 +1,7 @@
 import GroupedTxListItems from '@/components/transactions/GroupedTxListItems'
-import { useHasPendingTxs } from '@/hooks/usePendingTxs'
-import { isLabelListItem } from '@/utils/transaction-guards'
 import { groupConflictingTxs } from '@/utils/tx-list'
 import { Box } from '@mui/material'
-import type { LabelValue, TransactionListPage } from '@safe-global/safe-gateway-typescript-sdk'
-import { TransactionListItemType } from '@safe-global/safe-gateway-typescript-sdk'
+import type { TransactionListPage } from '@safe-global/safe-gateway-typescript-sdk'
 import type { ReactElement, ReactNode } from 'react'
 import { useMemo } from 'react'
 import TxListItem from '../TxListItem'
@@ -18,24 +15,8 @@ export const TxListGrid = ({ children }: { children: ReactNode }): ReactElement 
   return <Box className={css.container}>{children}</Box>
 }
 
-const adjustPendingLabel = (items: TransactionListPage['results']) => {
-  const result = [...items]
-
-  if (isLabelListItem(result[0])) {
-    result[0] = {
-      label: 'Pending' as LabelValue,
-      type: TransactionListItemType.LABEL,
-    }
-  }
-
-  return result
-}
-
 const TxList = ({ items }: TxListProps): ReactElement => {
-  const hasPending = useHasPendingTxs()
-
-  const pendingItems = useMemo(() => (hasPending ? adjustPendingLabel(items) : items), [items, hasPending])
-  const groupedItems = useMemo(() => groupConflictingTxs(pendingItems), [pendingItems])
+  const groupedItems = useMemo(() => groupConflictingTxs(items), [items])
 
   const transactions = groupedItems.map((item, index) => {
     if (Array.isArray(item)) {

--- a/src/hooks/__tests__/usePendingTxs.test.ts
+++ b/src/hooks/__tests__/usePendingTxs.test.ts
@@ -6,38 +6,130 @@ import {
   type Transaction,
   getTransactionQueue,
   TransactionListItemType,
+  DetailedExecutionInfoType,
+  LabelValue,
+  type TransactionListPage,
+  type ExecutionInfo,
+  type TransactionSummary,
+  ConflictType,
 } from '@safe-global/safe-gateway-typescript-sdk'
 import * as useSafeInfoHook from '@/hooks/useSafeInfo'
-import { useHasPendingTxs, usePendingTxsQueue } from '../usePendingTxs'
+import { filterUntrustedQueue, useHasPendingTxs, usePendingTxsQueue } from '../usePendingTxs'
+
+const mockQueue = <TransactionListPage>{
+  next: undefined,
+  previous: undefined,
+  results: [
+    {
+      type: TransactionListItemType.LABEL,
+      label: LabelValue.Next,
+    },
+    {
+      type: 'TRANSACTION',
+      transaction: {
+        id: 'multisig_123',
+        executionInfo: {
+          confirmationsSubmitted: 0,
+          type: DetailedExecutionInfoType.MULTISIG,
+        },
+      },
+    },
+    {
+      type: 'TRANSACTION',
+      transaction: {
+        id: 'multisig_456',
+      },
+    },
+  ],
+}
+
+const mockQueueWithConflictHeaders = <TransactionListPage>{
+  next: undefined,
+  previous: undefined,
+  results: [
+    {
+      type: TransactionListItemType.LABEL,
+      label: LabelValue.Next,
+    },
+    {
+      type: TransactionListItemType.CONFLICT_HEADER,
+      nonce: 2,
+    },
+    {
+      type: 'TRANSACTION',
+      transaction: {
+        id: 'multisig_123',
+        executionInfo: {
+          confirmationsSubmitted: 0,
+          type: DetailedExecutionInfoType.MULTISIG,
+        },
+      },
+    },
+    {
+      type: 'TRANSACTION',
+      transaction: {
+        id: 'multisig_456',
+      },
+    },
+  ],
+}
 
 // Mock getTransactionQueue
 jest.mock('@safe-global/safe-gateway-typescript-sdk', () => ({
   ...jest.requireActual('@safe-global/safe-gateway-typescript-sdk'),
-  getTransactionQueue: jest.fn(() =>
-    Promise.resolve({
-      next: null,
-      previous: null,
-      results: [
-        {
-          type: 'LABEL',
-          label: 'Next',
-        },
-        {
-          type: 'TRANSACTION',
-          transaction: {
-            id: 'multisig_123',
-          },
-        },
-        {
-          type: 'TRANSACTION',
-          transaction: {
-            id: 'multisig_456',
-          },
-        },
-      ],
-    }),
-  ),
+  getTransactionQueue: jest.fn(() => Promise.resolve(mockQueue)),
 }))
+
+describe('filterUntrustedQueue', () => {
+  it('should remove transactions that are not pending', () => {
+    const mockPendingIds = ['multisig_123']
+
+    const result = filterUntrustedQueue(mockQueue, mockPendingIds)
+
+    expect(result?.results.length).toEqual(2)
+  })
+
+  it('should rename the first label to Pending', () => {
+    const mockPendingIds = ['multisig_123']
+
+    const result = filterUntrustedQueue(mockQueue, mockPendingIds)
+
+    expect(result?.results[0]).toEqual({ type: 'LABEL', label: 'Pending' })
+  })
+
+  it('should remove all conflict headers', () => {
+    const mockPendingIds = ['multisig_123']
+
+    const result = filterUntrustedQueue(mockQueueWithConflictHeaders, mockPendingIds)
+
+    expect(result?.results[0]).toEqual({ type: 'LABEL', label: 'Pending' })
+    expect(result?.results.length).toEqual(2)
+    expect(result?.results[1].type).not.toEqual(TransactionListItemType.CONFLICT_HEADER)
+  })
+
+  it('should remove all transactions that are signed', () => {
+    const mockPendingIds = ['multisig_123', 'multisig_789']
+    const mockQueueWithSignedTxs = { ...mockQueue }
+
+    mockQueueWithSignedTxs.results.push({
+      type: TransactionListItemType.TRANSACTION,
+      transaction: {
+        id: 'multisig_789',
+        executionInfo: {
+          confirmationsSubmitted: 1,
+          confirmationsRequired: 1,
+          type: DetailedExecutionInfoType.MULTISIG,
+        } as ExecutionInfo,
+      } as unknown as TransactionSummary,
+      conflictType: ConflictType.NONE,
+    })
+
+    const result = filterUntrustedQueue(mockQueueWithSignedTxs, mockPendingIds)
+
+    expect(result?.results.length).toEqual(2)
+    expect(result?.results[2]).not.toEqual(mockQueueWithSignedTxs.results[2])
+  })
+})
 
 describe('usePendingTxsQueue', () => {
   beforeEach(() => {
@@ -59,7 +151,7 @@ describe('usePendingTxsQueue', () => {
     }))
   })
 
-  it('should return the pending txs queue', async () => {
+  it('should return the pending txs queue for unsigned transactions', async () => {
     const { result } = renderHook(() => usePendingTxsQueue(), {
       initialReduxState: {
         pendingTxs: {
@@ -106,35 +198,29 @@ describe('usePendingTxsQueue', () => {
     expect(result?.current.page).toBeUndefined()
   })
 
-  it('should remove conflicting header if only one of the conflicting txs is pending', async () => {
-    ;(getTransactionQueue as jest.Mock).mockImplementation(() =>
-      Promise.resolve({
-        next: null,
-        previous: null,
-        results: [
-          {
-            type: 'LABEL',
-            label: 'Next',
-          },
-          {
-            type: TransactionListItemType.CONFLICT_HEADER,
-            nonce: 2,
-          },
-          {
-            type: 'TRANSACTION',
-            transaction: {
-              id: 'multisig_123',
-            },
-          },
-          {
-            type: 'TRANSACTION',
-            transaction: {
-              id: 'multisig_456',
-            },
-          },
-        ],
-      }),
-    )
+  it('should return undefined if none of the pending txs are unsigned', async () => {
+    const { result } = renderHook(() => usePendingTxsQueue(), {
+      initialReduxState: {
+        pendingTxs: {
+          multisig_456: {
+            chainId: '5',
+            safeAddress: '0x0000000000000000000000000000000000000001',
+            txHash: 'tx567',
+          } as PendingTx,
+        },
+      },
+    })
+
+    expect(result?.current.loading).toBe(true)
+
+    await act(() => Promise.resolve(true))
+
+    expect(result?.current.loading).toBe(false)
+    expect(result?.current.page).toBeUndefined()
+  })
+
+  it('should remove all conflict headers', async () => {
+    ;(getTransactionQueue as jest.Mock).mockImplementation(() => Promise.resolve(mockQueueWithConflictHeaders))
 
     const { result } = renderHook(() => usePendingTxsQueue(), {
       initialReduxState: {

--- a/src/hooks/usePendingTxs.ts
+++ b/src/hooks/usePendingTxs.ts
@@ -8,7 +8,12 @@ import {
 import { useAppSelector } from '@/store'
 import { selectPendingTxIdsBySafe } from '@/store/pendingTxsSlice'
 import useAsync from './useAsync'
-import { isConflictHeaderListItem, isLabelListItem, isTransactionListItem } from '@/utils/transaction-guards'
+import {
+  isConflictHeaderListItem,
+  isLabelListItem,
+  isMultisigExecutionInfo,
+  isTransactionListItem,
+} from '@/utils/transaction-guards'
 import useSafeInfo from './useSafeInfo'
 
 const usePendingTxIds = (): Array<TransactionSummary['id']> => {
@@ -62,20 +67,24 @@ export const usePendingTxsQueue = (): {
     // Adjust the first label ("Next" -> "Pending")
     if (results[0] && isLabelListItem(results[0])) {
       results[0].label = 'Pending' as LabelValue
-
-      if (results.filter((item) => isTransactionListItem(item)).length === 0) {
-        results.splice(0, 1)
-      }
     }
 
-    if (results[1] && isConflictHeaderListItem(results[1])) {
-      // Check if we both conflicting txs are still pending
-      if (results.filter((item) => isTransactionListItem(item)).length <= 1) {
-        results.splice(1, 1)
-      }
-    }
+    // Filter out signed transactions
+    const filteredResults = results
+      // Only one transaction per nonce can be pending at the same time so no need for conflict headers
+      .filter((item) => !isConflictHeaderListItem(item))
+      .filter((item) => {
+        return (
+          !isTransactionListItem(item) ||
+          (isTransactionListItem(item) &&
+            isMultisigExecutionInfo(item.transaction.executionInfo) &&
+            item.transaction.executionInfo.confirmationsSubmitted === 0)
+        )
+      })
 
-    return results.length ? { results } : undefined
+    const transactions = filteredResults.filter((item) => isTransactionListItem(item))
+
+    return transactions.length ? { results: filteredResults } : undefined
   }, [untrustedQueue, pendingIds])
 
   return useMemo(

--- a/src/hooks/usePendingTxs.ts
+++ b/src/hooks/usePendingTxs.ts
@@ -36,6 +36,38 @@ export const useShowUnsignedQueue = (): boolean => {
   return safe.threshold === 1 && hasPending
 }
 
+export const filterUntrustedQueue = (
+  untrustedQueue: TransactionListPage,
+  pendingIds: Array<TransactionSummary['id']>,
+) => {
+  // Only keep labels and pending transactions
+  const results = untrustedQueue.results.filter(
+    (item) => !isTransactionListItem(item) || pendingIds.includes(item.transaction.id),
+  )
+
+  // Adjust the first label ("Next" -> "Pending")
+  if (results[0] && isLabelListItem(results[0])) {
+    results[0].label = 'Pending' as LabelValue
+  }
+
+  // Filter out signed transactions
+  const filteredResults = results
+    // Only one transaction per nonce can be pending at the same time so no need for conflict headers
+    .filter((item) => !isConflictHeaderListItem(item))
+    .filter((item) => {
+      return (
+        !isTransactionListItem(item) ||
+        (isTransactionListItem(item) &&
+          isMultisigExecutionInfo(item.transaction.executionInfo) &&
+          item.transaction.executionInfo.confirmationsSubmitted === 0)
+      )
+    })
+
+  const transactions = filteredResults.filter((item) => isTransactionListItem(item))
+
+  return transactions.length ? { results: filteredResults } : undefined
+}
+
 export const usePendingTxsQueue = (): {
   page?: TransactionListPage
   error?: string
@@ -58,33 +90,7 @@ export const usePendingTxsQueue = (): {
   const pendingTxPage = useMemo(() => {
     if (!untrustedQueue || !pendingIds.length) return
 
-    // Find the pending txs in the "untrusted" queue by id
-    // Keep labels too
-    const results = untrustedQueue.results.filter(
-      (item) => !isTransactionListItem(item) || pendingIds.includes(item.transaction.id),
-    )
-
-    // Adjust the first label ("Next" -> "Pending")
-    if (results[0] && isLabelListItem(results[0])) {
-      results[0].label = 'Pending' as LabelValue
-    }
-
-    // Filter out signed transactions
-    const filteredResults = results
-      // Only one transaction per nonce can be pending at the same time so no need for conflict headers
-      .filter((item) => !isConflictHeaderListItem(item))
-      .filter((item) => {
-        return (
-          !isTransactionListItem(item) ||
-          (isTransactionListItem(item) &&
-            isMultisigExecutionInfo(item.transaction.executionInfo) &&
-            item.transaction.executionInfo.confirmationsSubmitted === 0)
-        )
-      })
-
-    const transactions = filteredResults.filter((item) => isTransactionListItem(item))
-
-    return transactions.length ? { results: filteredResults } : undefined
+    return filterUntrustedQueue(untrustedQueue, pendingIds)
   }, [untrustedQueue, pendingIds])
 
   return useMemo(


### PR DESCRIPTION
## What it solves

Resolves #3215

## How this PR fixes it

- Only shows unsigned transactions in the untrusted pending queue
- Changes the first label of the queue to always show "Pending" when a transaction is pending

## ToDos

- [x] Write tests for `usePendingTxsQueue`

## How to test it

A few variations in 1/n and n/m safes should be tests
1. Queue 2 transactions and execute the first one
2. Queue 2 transactions and bulk execute
3. Queue 1 transaction, create another one and immediately execute that one to replace the first

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
