### PR TITLE
Fix: Show loading state in WC input between pairing and receiving proposal

### DIFF
--- a/src/features/walletconnect/components/WalletConnectUi/index.tsx
+++ b/src/features/walletconnect/components/WalletConnectUi/index.tsx
@@ -5,7 +5,7 @@ import useWalletConnectSessions from '@/features/walletconnect/hooks/useWalletCo
 import { WalletConnectContext } from '@/features/walletconnect/WalletConnectContext'
 import useWcUri from '../../hooks/useWcUri'
 import WcHeaderWidget from '../WcHeaderWidget'
-import WcSessionManager from '../WcSessionMananger'
+import WcSessionManager from '../WcSessionManager'
 import { WalletConnectProvider } from '../WalletConnectProvider'
 
 const WalletConnectWidget = () => {

--- a/src/features/walletconnect/components/WcInput/index.tsx
+++ b/src/features/walletconnect/components/WcInput/index.tsx
@@ -48,6 +48,7 @@ const WcInput = ({ uri }: { uri: string }) => {
         await walletConnect.connect(val)
       } catch (e) {
         setError(asError(e))
+        setIsLoading(undefined)
       }
     },
     [setIsLoading, walletConnect],

--- a/src/features/walletconnect/components/WcInput/index.tsx
+++ b/src/features/walletconnect/components/WcInput/index.tsx
@@ -53,11 +53,13 @@ const WcInput = ({ uri }: { uri: string }) => {
         setIsLoading(undefined)
       }
       setTimeout(() => {
-        setIsLoading(undefined)
-        setError(new Error('Connection timed out'))
+        if (isLoading && isLoading !== WCLoadingState.APPROVE) {
+          setIsLoading(undefined)
+          setError(new Error('Connection timed out'))
+        }
       }, PROPOSAL_TIMEOUT)
     },
-    [setError, setIsLoading, walletConnect],
+    [isLoading, setError, setIsLoading, walletConnect],
   )
 
   // Insert a pre-filled uri

--- a/src/features/walletconnect/components/WcInput/index.tsx
+++ b/src/features/walletconnect/components/WcInput/index.tsx
@@ -10,6 +10,8 @@ import { getClipboard, isClipboardSupported } from '@/utils/clipboard'
 import { Button, CircularProgress, InputAdornment, TextField } from '@mui/material'
 import { useCallback, useContext, useEffect, useState } from 'react'
 
+const PROPOSAL_TIMEOUT = 30_000
+
 const useTrackErrors = (error?: Error) => {
   const debouncedErrorMessage = useDebounce(error?.message, 1000)
 
@@ -22,10 +24,10 @@ const useTrackErrors = (error?: Error) => {
 }
 
 const WcInput = ({ uri }: { uri: string }) => {
-  const { walletConnect, isLoading, setIsLoading } = useContext(WalletConnectContext)
+  const { walletConnect, isLoading, setIsLoading, setError } = useContext(WalletConnectContext)
   const [value, setValue] = useState('')
-  const [error, setError] = useState<Error>()
-  useTrackErrors(error)
+  const [inputError, setInputError] = useState<Error>()
+  useTrackErrors(inputError)
 
   const onInput = useCallback(
     async (val: string) => {
@@ -34,11 +36,11 @@ const WcInput = ({ uri }: { uri: string }) => {
       setValue(val)
 
       if (val && !isPairingUri(val)) {
-        setError(new Error('Invalid pairing code'))
+        setInputError(new Error('Invalid pairing code'))
         return
       }
 
-      setError(undefined)
+      setInputError(undefined)
 
       if (!val) return
 
@@ -47,11 +49,15 @@ const WcInput = ({ uri }: { uri: string }) => {
       try {
         await walletConnect.connect(val)
       } catch (e) {
-        setError(asError(e))
+        setInputError(asError(e))
         setIsLoading(undefined)
       }
+      setTimeout(() => {
+        setIsLoading(undefined)
+        setError(new Error('Connection timed out'))
+      }, PROPOSAL_TIMEOUT)
     },
-    [setIsLoading, walletConnect],
+    [setError, setIsLoading, walletConnect],
   )
 
   // Insert a pre-filled uri
@@ -76,8 +82,8 @@ const WcInput = ({ uri }: { uri: string }) => {
       autoComplete="off"
       autoFocus
       disabled={!!isLoading}
-      error={!!error}
-      label={error ? error.message : 'Pairing code'}
+      error={!!inputError}
+      label={inputError ? inputError.message : 'Pairing code'}
       placeholder="wc:"
       spellCheck={false}
       InputProps={{

--- a/src/features/walletconnect/components/WcInput/index.tsx
+++ b/src/features/walletconnect/components/WcInput/index.tsx
@@ -49,8 +49,6 @@ const WcInput = ({ uri }: { uri: string }) => {
       } catch (e) {
         setError(asError(e))
       }
-
-      setIsLoading(undefined)
     },
     [setIsLoading, walletConnect],
   )

--- a/src/features/walletconnect/components/WcSessionManager/index.tsx
+++ b/src/features/walletconnect/components/WcSessionManager/index.tsx
@@ -43,18 +43,19 @@ const WcSessionManager = ({ sessions, uri }: WcSessionManagerProps) => {
       setIsLoading(WCLoadingState.APPROVE)
 
       try {
-        await walletConnect.approveSession(sessionProposal, chainId, safeAddress)
+        throw 'Failed connection'
+        // await walletConnect.approveSession(sessionProposal, chainId, safeAddress)
 
-        // Auto approve future sessions for non-malicious dApps
-        if (
-          sessionProposal.verifyContext.verified.validation !== 'INVALID' &&
-          !sessionProposal.verifyContext.verified.isScam
-        ) {
-          setAutoApprove((prev) => ({
-            ...prev,
-            [chainId]: { ...prev?.[chainId], [sessionProposal.verifyContext.verified.origin]: true },
-          }))
-        }
+        // // Auto approve future sessions for non-malicious dApps
+        // if (
+        //   sessionProposal.verifyContext.verified.validation !== 'INVALID' &&
+        //   !sessionProposal.verifyContext.verified.isScam
+        // ) {
+        //   setAutoApprove((prev) => ({
+        //     ...prev,
+        //     [chainId]: { ...prev?.[chainId], [sessionProposal.verifyContext.verified.origin]: true },
+        //   }))
+        // }
 
         setOpen(false)
       } catch (e) {

--- a/src/features/walletconnect/components/WcSessionManager/index.tsx
+++ b/src/features/walletconnect/components/WcSessionManager/index.tsx
@@ -43,19 +43,18 @@ const WcSessionManager = ({ sessions, uri }: WcSessionManagerProps) => {
       setIsLoading(WCLoadingState.APPROVE)
 
       try {
-        throw 'Failed connection'
-        // await walletConnect.approveSession(sessionProposal, chainId, safeAddress)
+        await walletConnect.approveSession(sessionProposal, chainId, safeAddress)
 
-        // // Auto approve future sessions for non-malicious dApps
-        // if (
-        //   sessionProposal.verifyContext.verified.validation !== 'INVALID' &&
-        //   !sessionProposal.verifyContext.verified.isScam
-        // ) {
-        //   setAutoApprove((prev) => ({
-        //     ...prev,
-        //     [chainId]: { ...prev?.[chainId], [sessionProposal.verifyContext.verified.origin]: true },
-        //   }))
-        // }
+        // Auto approve future sessions for non-malicious dApps
+        if (
+          sessionProposal.verifyContext.verified.validation !== 'INVALID' &&
+          !sessionProposal.verifyContext.verified.isScam
+        ) {
+          setAutoApprove((prev) => ({
+            ...prev,
+            [chainId]: { ...prev?.[chainId], [sessionProposal.verifyContext.verified.origin]: true },
+          }))
+        }
 
         setOpen(false)
       } catch (e) {

--- a/src/features/walletconnect/components/WcSessionMananger/index.tsx
+++ b/src/features/walletconnect/components/WcSessionMananger/index.tsx
@@ -87,8 +87,9 @@ const WcSessionManager = ({ sessions, uri }: WcSessionManagerProps) => {
       }
 
       setProposal(proposalData)
+      setIsLoading(undefined)
     })
-  }, [walletConnect, setError, autoApprove, onApprove, chainId])
+  }, [autoApprove, chainId, onApprove, setError, setIsLoading, walletConnect])
 
   // Track errors
   useEffect(() => {


### PR DESCRIPTION
## What it solves

Resolves #3598
Resolves #3731

## How this PR fixes it
After successfully pairing with wallet connect, and before receiving a proposal, keep the paste button in its loading state.
Only remove the loading state after the proposal is received and handled.

## How to test it
note: This bug only appears when Walletconnect is slow to send the proposal from their side.
- connect a safe to any dapp using walletconnect.
- after pasting the pairing code, the loading state should appear.
- the loading state should persist until the WC modal closes.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
