### PR TITLE
Fix: make safe app id an int

### DIFF
--- a/src/services/safe-apps/manifest.ts
+++ b/src/services/safe-apps/manifest.ts
@@ -99,7 +99,7 @@ const fetchSafeAppFromManifest = async (
   const iconUrl = getAppLogoUrl(normalizedAppUrl, appManifest)
 
   return {
-    id: Math.random(),
+    id: Math.round(Math.random() * Math.pow(10, 18)),
     url: normalizedAppUrl,
     name: appManifest.name,
     description: appManifest.description,


### PR DESCRIPTION
## What it solves

Custom Safe Apps get a random id which might be a problem when validating messages.