### PR TITLE
fix: fetch single message if safe message is not in the messagesSlice

### DIFF
--- a/src/components/tx-flow/flows/SignMessage/SignMessage.test.tsx
+++ b/src/components/tx-flow/flows/SignMessage/SignMessage.test.tsx
@@ -8,7 +8,6 @@ import * as useIsWrongChainHook from '@/hooks/useIsWrongChain'
 import * as useIsSafeOwnerHook from '@/hooks/useIsSafeOwner'
 import * as useWalletHook from '@/hooks/wallets/useWallet'
 import * as useSafeInfoHook from '@/hooks/useSafeInfo'
-import * as useAsyncHook from '@/hooks/useAsync'
 import * as useChainsHook from '@/hooks/useChains'
 import * as sender from '@/services/safe-messages/safeMsgSender'
 import * as onboard from '@/hooks/wallets/useOnboard'
@@ -220,8 +219,7 @@ describe('SignMessage', () => {
   it('proposes a message if not already proposed', async () => {
     jest.spyOn(useIsSafeOwnerHook, 'default').mockImplementation(() => true)
     jest.spyOn(onboard, 'default').mockReturnValue(mockOnboard)
-
-    jest.spyOn(useAsyncHook, 'default').mockReturnValue([undefined, new Error('SafeMessage not found'), false])
+    ;(getSafeMessage as jest.Mock).mockRejectedValue(new Error('SafeMessage not found'))
 
     const { getByText, baseElement } = render(
       <SignMessage
@@ -520,8 +518,7 @@ describe('SignMessage', () => {
     mockUseSafeMessages.mockReturnValue(msgs)
 
     jest.spyOn(useIsSafeOwnerHook, 'default').mockImplementation(() => true)
-
-    jest.spyOn(useAsyncHook, 'default').mockReturnValue([undefined, new Error('SafeMessage not found'), false])
+    ;(getSafeMessage as jest.Mock).mockRejectedValue(new Error('SafeMessage not found'))
 
     const proposalSpy = jest
       .spyOn(sender, 'dispatchSafeMsgProposal')
@@ -553,6 +550,119 @@ describe('SignMessage', () => {
   it('displays an error if the message could not be confirmed', async () => {
     jest.spyOn(onboard, 'default').mockReturnValue(mockOnboard)
     jest.spyOn(useIsSafeOwnerHook, 'default').mockImplementation(() => true)
+    jest.spyOn(useWalletHook, 'default').mockImplementation(
+      () =>
+        ({
+          address: zeroPadValue('0x03', 20),
+        } as ConnectedWallet),
+    )
+
+    const messageText = 'Hello world!'
+    const messageHash = generateSafeMessageHash(
+      {
+        version: '1.3.0',
+        address: {
+          value: zeroPadValue('0x01', 20),
+        },
+        chainId: '5',
+      } as SafeInfo,
+      messageText,
+    )
+    const msg = {
+      type: SafeMessageListItemType.MESSAGE,
+      messageHash,
+      confirmations: [
+        {
+          owner: {
+            value: zeroPadValue('0x02', 20),
+          },
+        },
+      ],
+      confirmationsRequired: 2,
+      confirmationsSubmitted: 1,
+    } as unknown as SafeMessage
+    ;(getSafeMessage as jest.Mock).mockResolvedValue(msg)
+
+    const msgs: {
+      page?: SafeMessageListPage
+      error?: string
+      loading: boolean
+    } = {
+      page: {
+        results: [msg],
+      },
+      error: undefined,
+      loading: false,
+    }
+
+    mockUseSafeMessages.mockReturnValue(msgs)
+
+    const { getByText } = render(
+      <SignMessage logoUri="www.fake.com/test.png" name="Test App" message={messageText} requestId="123" />,
+    )
+
+    await act(async () => {
+      Promise.resolve()
+    })
+
+    const confirmationSpy = jest
+      .spyOn(sender, 'dispatchSafeMsgConfirmation')
+      .mockImplementation(() => Promise.reject(new Error('Error confirming')))
+
+    const button = getByText('Sign')
+
+    expect(button).toBeEnabled()
+
+    await act(() => {
+      fireEvent.click(button)
+    })
+
+    await waitFor(() => {
+      expect(confirmationSpy).toHaveBeenCalled()
+      expect(getByText('Error confirming the message. Please try again.')).toBeInTheDocument()
+    })
+  })
+
+  it('shows all signatures and success message if message has already been signed', async () => {
+    jest.spyOn(onboard, 'default').mockReturnValue(mockOnboard)
+    jest.spyOn(useIsSafeOwnerHook, 'default').mockImplementation(() => true)
+    jest.spyOn(useWalletHook, 'default').mockImplementation(
+      () =>
+        ({
+          address: zeroPadValue('0x03', 20),
+        } as ConnectedWallet),
+    )
+
+    const messageText = 'Hello world!'
+    const messageHash = generateSafeMessageHash(
+      {
+        version: '1.3.0',
+        address: {
+          value: zeroPadValue('0x01', 20),
+        },
+        chainId: '5',
+      } as SafeInfo,
+      messageText,
+    )
+    const msg = {
+      type: SafeMessageListItemType.MESSAGE,
+      messageHash,
+      confirmations: [
+        {
+          owner: {
+            value: zeroPadValue('0x02', 20),
+          },
+        },
+        {
+          owner: {
+            value: zeroPadValue('0x03', 20),
+          },
+        },
+      ],
+      confirmationsRequired: 2,
+      confirmationsSubmitted: 2,
+      preparedSignature: '0x678',
+    } as unknown as SafeMessage
 
     const msgs: {
       page?: SafeMessageListPage
@@ -567,39 +677,14 @@ describe('SignMessage', () => {
     }
 
     mockUseSafeMessages.mockReturnValue(msgs)
-
-    jest
-      .spyOn(useAsyncHook, 'default')
-      .mockReturnValue([
-        { confirmations: [] as SafeMessage['confirmations'] } as SafeMessage,
-        new Error('SafeMessage not found'),
-        false,
-      ])
-
-    const confirmationSpy = jest
-      .spyOn(sender, 'dispatchSafeMsgProposal')
-      .mockImplementation(() => Promise.reject(new Error('Test error')))
+    ;(getSafeMessage as jest.Mock).mockResolvedValue(msg)
 
     const { getByText } = render(
-      <SignMessage
-        logoUri="www.fake.com/test.png"
-        name="Test App"
-        message="Hello world!"
-        requestId="123"
-        safeAppId={25}
-      />,
+      <SignMessage logoUri="www.fake.com/test.png" name="Test App" message={messageText} requestId="123" />,
     )
 
-    const button = getByText('Sign')
-
-    await act(() => {
-      fireEvent.click(button)
-    })
-
-    expect(confirmationSpy).toHaveBeenCalled()
-
     await waitFor(() => {
-      expect(getByText('Error confirming the message. Please try again.')).toBeInTheDocument()
+      expect(getByText('Message successfully signed')).toBeInTheDocument()
     })
   })
 })

--- a/src/components/tx-flow/flows/SignMessage/index.tsx
+++ b/src/components/tx-flow/flows/SignMessage/index.tsx
@@ -5,6 +5,7 @@ import { selectSwapParams } from '@/features/swap/store/swapParamsSlice'
 import { useAppSelector } from '@/store'
 import { Box, Typography } from '@mui/material'
 import SafeAppIconCard from '@/components/safe-apps/SafeAppIconCard'
+import { ErrorBoundary } from '@sentry/react'
 
 const APP_LOGO_FALLBACK_IMAGE = '/images/apps/apps-icon.svg'
 const APP_NAME_FALLBACK = 'Sign message'
@@ -36,7 +37,9 @@ const SignMessageFlow = ({ ...props }: ProposeProps | ConfirmProps) => {
       hideNonce
       isMessage
     >
-      <SignMessage {...props} />
+      <ErrorBoundary fallback={<div>Error signing message</div>}>
+        <SignMessage {...props} />
+      </ErrorBoundary>
     </TxLayout>
   )
 }

--- a/src/hooks/messages/useSafeMessage.ts
+++ b/src/hooks/messages/useSafeMessage.ts
@@ -1,10 +1,17 @@
 import { isSafeMessageListItem } from '@/utils/safe-message-guards'
-import type { SafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
+import { type SafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
 import { useState, useEffect } from 'react'
 import useSafeMessages from './useSafeMessages'
+import useAsync from '../useAsync'
+import useSafeInfo from '../useSafeInfo'
+import { fetchSafeMessage } from './useSyncSafeMessageSigner'
 
 const useSafeMessage = (safeMessageHash: string) => {
   const [safeMessage, setSafeMessage] = useState<SafeMessage | undefined>()
+
+  safeMessage?.type
+
+  const { safe } = useSafeInfo()
 
   const messages = useSafeMessages()
 
@@ -12,9 +19,14 @@ const useSafeMessage = (safeMessageHash: string) => {
     ?.filter(isSafeMessageListItem)
     .find((msg) => msg.messageHash === safeMessageHash)
 
+  const [updatedMessage] = useAsync(async () => {
+    return fetchSafeMessage(safeMessageHash, safe.chainId)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [safeMessageHash, safe.chainId, safe.messagesTag])
+
   useEffect(() => {
-    setSafeMessage(ongoingMessage)
-  }, [ongoingMessage])
+    setSafeMessage(updatedMessage ?? ongoingMessage)
+  }, [ongoingMessage, updatedMessage])
 
   return [safeMessage, setSafeMessage] as const
 }

--- a/src/hooks/messages/useSyncSafeMessageSigner.ts
+++ b/src/hooks/messages/useSyncSafeMessageSigner.ts
@@ -14,7 +14,7 @@ import useOnboard from '../wallets/useOnboard'
 
 const HIDE_DELAY = 3000
 
-const fetchSafeMessage = async (safeMessageHash: string, chainId: string) => {
+export const fetchSafeMessage = async (safeMessageHash: string, chainId: string) => {
   let message: SafeMessage | undefined
   try {
     // fetchedMessage does not have a type because it is explicitly a message


### PR DESCRIPTION
## What it solves

Resolves #3718 

## How this PR fixes it
- Looks in the messageSlice and additionally fetches the message from the single message endpoint

## How to test it
- Sign 21+ messages in a Safe
- Then request the first message again

## Screenshots

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
