### PR TITLE
fix: (WC) do not return Safe as available on all optional Namespaces

### DIFF
--- a/src/features/walletconnect/services/WalletConnectWallet.ts
+++ b/src/features/walletconnect/services/WalletConnectWallet.ts
@@ -82,8 +82,7 @@ class WalletConnectWallet {
   }
 
   private getNamespaces(proposal: Web3WalletTypes.SessionProposal, currentChainId: string, safeAddress: string) {
-    // Most dApps require mainnet, but we aren't always on mainnet
-    // As workaround, we pretend include all required with the Safe chainId
+    // As workaround, we pretend to support all the required chains plus the current Safe's chain
     const requiredChains = proposal.params.requiredNamespaces[EIP155]?.chains || []
 
     const supportedChainIds = [currentChainId].concat(requiredChains.map(stripEip155Prefix))

--- a/src/features/walletconnect/services/WalletConnectWallet.ts
+++ b/src/features/walletconnect/services/WalletConnectWallet.ts
@@ -83,14 +83,10 @@ class WalletConnectWallet {
 
   private getNamespaces(proposal: Web3WalletTypes.SessionProposal, currentChainId: string, safeAddress: string) {
     // Most dApps require mainnet, but we aren't always on mainnet
-    // As workaround, we pretend include all required and optional chains with the Safe chainId
+    // As workaround, we pretend include all required with the Safe chainId
     const requiredChains = proposal.params.requiredNamespaces[EIP155]?.chains || []
-    const optionalChains = proposal.params.optionalNamespaces[EIP155]?.chains || []
 
-    const supportedChainIds = [currentChainId].concat(
-      requiredChains.map(stripEip155Prefix),
-      optionalChains.map(stripEip155Prefix),
-    )
+    const supportedChainIds = [currentChainId].concat(requiredChains.map(stripEip155Prefix))
 
     const eip155ChainIds = supportedChainIds.map(getEip155ChainId)
     const eip155Accounts = eip155ChainIds.map((eip155ChainId) => `${eip155ChainId}:${safeAddress}`)

--- a/src/features/walletconnect/services/__tests__/WalletConnectWallet.test.ts
+++ b/src/features/walletconnect/services/__tests__/WalletConnectWallet.test.ts
@@ -155,21 +155,13 @@ describe('WalletConnectWallet', () => {
 
       await wallet.approveSession(
         proposal,
-        '69420', // Not in proposal, therefore not supported
+        '43114', // Not in proposal, therefore not supported
         toBeHex('0x123', 20),
       )
 
       const namespaces = {
         eip155: {
-          chains: [
-            'eip155:1',
-            'eip155:43114',
-            'eip155:42161',
-            'eip155:8453',
-            'eip155:100',
-            'eip155:137',
-            'eip155:1101',
-          ],
+          chains: ['eip155:1', 'eip155:43114'],
           methods: [
             'eth_sendTransaction',
             'personal_sign',
@@ -180,15 +172,7 @@ describe('WalletConnectWallet', () => {
             'wallet_switchEthereumChain',
           ],
           events: ['chainChanged', 'accountsChanged'],
-          accounts: [
-            `eip155:1:${toBeHex('0x123', 20)}`,
-            `eip155:43114:${toBeHex('0x123', 20)}`,
-            `eip155:42161:${toBeHex('0x123', 20)}`,
-            `eip155:8453:${toBeHex('0x123', 20)}`,
-            `eip155:100:${toBeHex('0x123', 20)}`,
-            `eip155:137:${toBeHex('0x123', 20)}`,
-            `eip155:1101:${toBeHex('0x123', 20)}`,
-          ],
+          accounts: [`eip155:1:${toBeHex('0x123', 20)}`, `eip155:43114:${toBeHex('0x123', 20)}`],
         },
       }
 
@@ -226,23 +210,16 @@ describe('WalletConnectWallet', () => {
 
       await wallet.approveSession(
         proposal,
-        '69420', // Not in proposal, therefore not supported
+        '43114', // Not in proposal, therefore not supported
         toBeHex('0x123', 20),
       )
 
       const namespaces = {
         eip155: {
-          chains: ['eip155:43114', 'eip155:42161', 'eip155:8453', 'eip155:100', 'eip155:137', 'eip155:1101'],
+          chains: ['eip155:43114'],
           methods: ['eth_accounts', 'personal_sign', 'eth_sendTransaction'],
           events: ['chainChanged', 'accountsChanged'],
-          accounts: [
-            `eip155:43114:${toBeHex('0x123', 20)}`,
-            `eip155:42161:${toBeHex('0x123', 20)}`,
-            `eip155:8453:${toBeHex('0x123', 20)}`,
-            `eip155:100:${toBeHex('0x123', 20)}`,
-            `eip155:137:${toBeHex('0x123', 20)}`,
-            `eip155:1101:${toBeHex('0x123', 20)}`,
-          ],
+          accounts: [`eip155:43114:${toBeHex('0x123', 20)}`],
         },
       }
 


### PR DESCRIPTION
## What it solves
Sometimes the chainChanged event is ignored if the connected dapp did not acknowledge the new session yet.
Then the dapp is stuck with a wrong chain on which the Safe is not deployed.

## How this PR fixes it
- Only uses our workaround if the Safe is not present in the requiredNamespace

## How to test it
- Connect to uniswap with a polygon Safe
- observe that the Safe is correctly recognized on Polygon

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
