### PR TITLE
Fix: memoize Safe List data

### DIFF
--- a/src/components/welcome/MyAccounts/useSafeOverviews.ts
+++ b/src/components/welcome/MyAccounts/useSafeOverviews.ts
@@ -1,26 +1,44 @@
+import { useMemo } from 'react'
 import { useTokenListSetting } from '@/hooks/loadables/useLoadBalances'
 import useAsync from '@/hooks/useAsync'
 import useWallet from '@/hooks/wallets/useWallet'
 import { useAppSelector } from '@/store'
 import { selectCurrency } from '@/store/settingsSlice'
-import { getSafeOverviews } from '@safe-global/safe-gateway-typescript-sdk'
+import { type SafeOverview, getSafeOverviews } from '@safe-global/safe-gateway-typescript-sdk'
 
-function useSafeOverviews(safes: Array<{ address: string; chainId: string }>) {
+const _cache: Record<string, SafeOverview[]> = {}
+
+type SafeParams = {
+  address: string
+  chainId: string
+}
+
+// EIP155 address format
+const makeSafeId = ({ chainId, address }: SafeParams) => `${chainId}:${address}` as `${number}:0x${string}`
+
+function useSafeOverviews(safes: Array<SafeParams>) {
   const excludeSpam = useTokenListSetting() || false
   const currency = useAppSelector(selectCurrency)
   const wallet = useWallet()
   const walletAddress = wallet?.address
+  const safesStrings = useMemo(() => safes.map(makeSafeId), [safes])
 
-  return useAsync(async () => {
-    const safesStrings = safes.map((safe) => `${safe.chainId}:${safe.address}` as `${number}:0x${string}`)
-
+  const [data, error, isLoading] = useAsync(async () => {
     return await getSafeOverviews(safesStrings, {
       trusted: true,
       exclude_spam: excludeSpam,
       currency,
       wallet_address: walletAddress,
     })
-  }, [safes, excludeSpam, currency, walletAddress])
+  }, [safesStrings, excludeSpam, currency, walletAddress])
+
+  const cacheKey = safesStrings.join()
+  const result = data ?? _cache[cacheKey]
+
+  // Cache until the next page load
+  _cache[cacheKey] = result
+
+  return useMemo(() => [result, error, isLoading], [result, error, isLoading])
 }
 
 export default useSafeOverviews

--- a/src/components/welcome/MyAccounts/useSafeOverviews.ts
+++ b/src/components/welcome/MyAccounts/useSafeOverviews.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { useTokenListSetting } from '@/hooks/loadables/useLoadBalances'
-import useAsync from '@/hooks/useAsync'
+import useAsync, { type AsyncResult } from '@/hooks/useAsync'
 import useWallet from '@/hooks/wallets/useWallet'
 import { useAppSelector } from '@/store'
 import { selectCurrency } from '@/store/settingsSlice'
@@ -16,23 +16,23 @@ type SafeParams = {
 // EIP155 address format
 const makeSafeId = ({ chainId, address }: SafeParams) => `${chainId}:${address}` as `${number}:0x${string}`
 
-function useSafeOverviews(safes: Array<SafeParams>) {
+function useSafeOverviews(safes: Array<SafeParams>): AsyncResult<SafeOverview[]> {
   const excludeSpam = useTokenListSetting() || false
   const currency = useAppSelector(selectCurrency)
   const wallet = useWallet()
   const walletAddress = wallet?.address
-  const safesStrings = useMemo(() => safes.map(makeSafeId), [safes])
+  const safesIds = useMemo(() => safes.map(makeSafeId), [safes])
 
   const [data, error, isLoading] = useAsync(async () => {
-    return await getSafeOverviews(safesStrings, {
+    return await getSafeOverviews(safesIds, {
       trusted: true,
       exclude_spam: excludeSpam,
       currency,
       wallet_address: walletAddress,
     })
-  }, [safesStrings, excludeSpam, currency, walletAddress])
+  }, [safesIds, excludeSpam, currency, walletAddress])
 
-  const cacheKey = safesStrings.join()
+  const cacheKey = safesIds.join()
   const result = data ?? _cache[cacheKey]
 
   // Cache until the next page load


### PR DESCRIPTION
## What it solves

Balances and pending actions in the Safe List are now cached until the new data arrives or the page is reloaded, so that there's less jumping every time you open the sidebar.

## How to test

* Connect a wallet with many Safes
* Open the Sidebar
* Disconnect or switch to another wallet
* The list should be updated accordingly
* Close the sidebar and open it again
* Balances and pending actions should be visible immediately
