### PR TITLE
Chore: update release action

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -51,21 +51,17 @@ jobs:
 
       # Update the GitHub release with a checksummed archive
       - name: Upload archive
-        uses: actions/upload-release-asset@v1
+      - uses: Shopify/upload-to-release@v1
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ env.ARCHIVE_NAME }}.tar.gz
-          asset_name: ${{ env.ARCHIVE_NAME }}.tar.gz
-          asset_content_type: application/gzip
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+          path: ${{ env.ARCHIVE_NAME }}.tar.gz
+          name: ${{ env.ARCHIVE_NAME }}.tar.gz
+          content-type: application/gzip
+          repo-token: ${{ github.token }}
 
       - name: Upload checksum
         uses: actions/upload-release-asset@v1
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ env.ARCHIVE_NAME }}-sha256-checksum.txt
-          asset_name: ${{ env.ARCHIVE_NAME }}-sha256-checksum.txt
-          asset_content_type: text/plain
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+          path: ${{ env.ARCHIVE_NAME }}-sha256-checksum.txt
+          name: ${{ env.ARCHIVE_NAME }}-sha256-checksum.txt
+          content-type: text/plain
+          repo-token: ${{ github.token }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -59,7 +59,7 @@ jobs:
           repo-token: ${{ github.token }}
 
       - name: Upload checksum
-        uses: actions/upload-release-asset@v1
+        uses: Shopify/upload-to-release@v2.0.0
         with:
           path: ${{ env.ARCHIVE_NAME }}-sha256-checksum.txt
           name: ${{ env.ARCHIVE_NAME }}-sha256-checksum.txt

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -51,7 +51,7 @@ jobs:
 
       # Update the GitHub release with a checksummed archive
       - name: Upload archive
-      - uses: Shopify/upload-to-release@v1
+      - uses: Shopify/upload-to-release@v2.0.0
         with:
           path: ${{ env.ARCHIVE_NAME }}.tar.gz
           name: ${{ env.ARCHIVE_NAME }}.tar.gz


### PR DESCRIPTION
## What it solves


The action `actions/upload-release-asset@v1` stopped working and it's not maintained, so I replaced it with `Shopify/upload-to-release@v1`. See https://github.com/marketplace/actions/upload-to-release-action