### PR TITLE
Fix: move rhino.fi to warned bridges

### DIFF
--- a/src/features/walletconnect/constants.ts
+++ b/src/features/walletconnect/constants.ts
@@ -46,7 +46,6 @@ export const BlockedBridges = [
   'zksync-era.l2scan.co',
   'www.portalbridge.com',
   'wallet.polygon.technology',
-  'app.rhino.fi',
 
   // Unsupported chain bridges
   'bridge.zora.energy',
@@ -67,6 +66,7 @@ export const WarnedBridges = [
   'core.app',
   'across.to', // doesn't send their URL in the session proposal
   'app.allbridge.io',
+  'app.rhino.fi',
   'bridge.arbitrum.io',
   'bridge.base.org',
   'bridge.linea.build',


### PR DESCRIPTION
## What it solves

Resolves #3738

## How this PR fixes it

It will now only show a bridge warning for rhino.fi.