### PR TITLE
feat: Execute transaction through role 

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "react-papaparse": "^4.0.2",
     "react-redux": "^8.0.5",
     "semver": "^7.5.2",
-    "zodiac-roles-deployments": "^2.1.1"
+    "zodiac-roles-deployments": "^2.2.2"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     "react-hook-form": "7.41.1",
     "react-papaparse": "^4.0.2",
     "react-redux": "^8.0.5",
-    "semver": "^7.5.2"
+    "semver": "^7.5.2",
+    "zodiac-roles-deployments": "^2.1.1"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.3.1",

--- a/src/components/tx/SignOrExecuteForm/PermissionsCheck.tsx
+++ b/src/components/tx/SignOrExecuteForm/PermissionsCheck.tsx
@@ -1,21 +1,31 @@
 import { useContext, useState } from 'react'
+import { type ChainId, chains, fetchRolesMod } from 'zodiac-roles-deployments'
+
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { Box, Button, CardActions, CircularProgress, Divider, Typography } from '@mui/material'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
-
 import CheckWallet from '@/components/common/CheckWallet'
-import WalletRejectionError from './WalletRejectionError'
 import TxCard from '@/components/tx-flow/common/TxCard'
-import ErrorMessage from '../ErrorMessage'
 import { getTransactionTrackingType } from '@/services/analytics/tx-tracking'
 import { TX_EVENTS } from '@/services/analytics/events/transactions'
 import { trackEvent } from '@/services/analytics'
 import useChainId from '@/hooks/useChainId'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import useWallet from '@/hooks/wallets/useWallet'
+import useAsync from '@/hooks/useAsync'
+import WalletRejectionError from './WalletRejectionError'
+import ErrorMessage from '../ErrorMessage'
 
 const PermissionsCheck: React.FC<{}> = ({}) => {
   const chainId = useChainId()
   const { safeTx, safeTxError } = useContext(SafeTxContext)
   const [isRejectedByUser, setIsRejectedByUser] = useState<boolean>(false)
+
+  const rolesMods = useRolesMods()
+
+  //   if (rolesMods.length === 0) {
+  //     return null
+  //   }
 
   const isPending = false
   const isDisabled = isPending
@@ -72,3 +82,35 @@ const PermissionsCheck: React.FC<{}> = ({}) => {
 }
 
 export default PermissionsCheck
+
+const ROLES_V2_SUPPORTED_CHAINS = Object.keys(chains)
+
+/**
+ * Returns all Zodiac Roles Modifiers v2 instances that are enabled and correctly configured on this Safe
+ */
+const useRolesMods = () => {
+  const { safe } = useSafeInfo()
+  const wallet = useWallet()
+
+  const [data] = useAsync(async () => {
+    if (!wallet) return []
+    if (!ROLES_V2_SUPPORTED_CHAINS.includes(safe.chainId)) return []
+
+    const safeModules = safe.modules || []
+    const rolesMods = await Promise.all(
+      safeModules.map((address) =>
+        fetchRolesMod({ address: address.value, chainId: parseInt(safe.chainId) as ChainId }),
+      ),
+    )
+
+    return rolesMods.filter(
+      (mod): mod is Exclude<typeof mod, null> =>
+        mod !== null &&
+        mod.target === safe.address.value.toLowerCase() &&
+        mod.avatar === safe.address.value.toLowerCase() &&
+        mod.roles.length > 0,
+    )
+  }, [safe, wallet])
+
+  return data || []
+}

--- a/src/components/tx/SignOrExecuteForm/PermissionsCheck.tsx
+++ b/src/components/tx/SignOrExecuteForm/PermissionsCheck.tsx
@@ -1,5 +1,14 @@
-import { useContext, useState } from 'react'
-import { type ChainId, chains, fetchRolesMod } from 'zodiac-roles-deployments'
+import { useContext, useMemo, useState } from 'react'
+import {
+  type ChainId,
+  chains,
+  fetchRolesMod,
+  Clearance,
+  type RoleSummary,
+  ExecutionOptions,
+  Status,
+} from 'zodiac-roles-deployments'
+import { type MetaTransactionData } from '@safe-global/safe-core-sdk-types'
 
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { Box, Button, CardActions, CircularProgress, Divider, Typography } from '@mui/material'
@@ -11,21 +20,17 @@ import { TX_EVENTS } from '@/services/analytics/events/transactions'
 import { trackEvent } from '@/services/analytics'
 import useChainId from '@/hooks/useChainId'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import useWallet from '@/hooks/wallets/useWallet'
 import useAsync from '@/hooks/useAsync'
 import WalletRejectionError from './WalletRejectionError'
 import ErrorMessage from '../ErrorMessage'
+import useWallet from '@/hooks/wallets/useWallet'
 
 const PermissionsCheck: React.FC<{}> = ({}) => {
   const chainId = useChainId()
   const { safeTx, safeTxError } = useContext(SafeTxContext)
   const [isRejectedByUser, setIsRejectedByUser] = useState<boolean>(false)
 
-  const rolesMods = useRolesMods()
-
-  //   if (rolesMods.length === 0) {
-  //     return null
-  //   }
+  const roles = useRoles(safeTx?.data)
 
   const isPending = false
   const isDisabled = isPending
@@ -90,16 +95,14 @@ const ROLES_V2_SUPPORTED_CHAINS = Object.keys(chains)
  */
 const useRolesMods = () => {
   const { safe } = useSafeInfo()
-  const wallet = useWallet()
 
   const [data] = useAsync(async () => {
-    if (!wallet) return []
     if (!ROLES_V2_SUPPORTED_CHAINS.includes(safe.chainId)) return []
 
     const safeModules = safe.modules || []
     const rolesMods = await Promise.all(
       safeModules.map((address) =>
-        fetchRolesMod({ address: address.value, chainId: parseInt(safe.chainId) as ChainId }),
+        fetchRolesMod({ address: address.value as `0x${string}`, chainId: parseInt(safe.chainId) as ChainId }),
       ),
     )
 
@@ -110,7 +113,86 @@ const useRolesMods = () => {
         mod.avatar === safe.address.value.toLowerCase() &&
         mod.roles.length > 0,
     )
-  }, [safe, wallet])
+  }, [safe])
 
-  return data || []
+  return data
+}
+
+/**
+ * Returns a list of roles mod address + role key assigned to the connected wallet.
+ * For each role, checks if the role allows the given meta transaction and returns the status.
+ */
+const useRoles = (metaTx?: MetaTransactionData) => {
+  const rolesMods = useRolesMods()
+  const wallet = useWallet()
+  const walletAddress = wallet?.address.toLowerCase() as undefined | `0x${string}`
+
+  // find all roles assigned to the connected wallet, statically check if they allow the given meta transaction
+  const potentialRoles = useMemo(() => {
+    const result: {
+      modAddress: `0x${string}`
+      roleKey: `0x${string}`
+      status: Status | null
+    }[] = []
+
+    if (walletAddress && rolesMods) {
+      for (const rolesMod of rolesMods) {
+        for (const role of rolesMod.roles) {
+          if (role.members.includes(walletAddress)) {
+            potentialRoles.push({
+              modAddress: rolesMod.address,
+              roleKey: role.key,
+              status: metaTx ? checkTransaction(role, metaTx) : null,
+            })
+          }
+        }
+      }
+    }
+
+    return result
+  }, [rolesMods, walletAddress, metaTx])
+
+  // TODO if the static check is inconclusive (status: null), evaluate the condition through a test call
+
+  return potentialRoles
+}
+
+/**
+ * Returns the status of the permissions check, `null` if it depends on the condition evaluation.
+ */
+const checkTransaction = (role: RoleSummary, metaTx: MetaTransactionData): Status | null => {
+  const target = role.targets.find((t) => t.address === metaTx.to.toLowerCase())
+  if (!target) return Status.TargetAddressNotAllowed
+
+  if (target.clearance === Clearance.Target) {
+    // all calls to the target are allowed
+    return checkExecutionOptions(target.executionOptions, metaTx)
+  }
+
+  if (target.clearance === Clearance.Function) {
+    // check if the function is allowed
+    const selector = metaTx.data.slice(0, 10) as `0x${string}`
+    const func = target.functions.find((f) => f.selector === selector)
+    if (func) {
+      const execOptionsStatus = checkExecutionOptions(func.executionOptions, metaTx)
+      if (execOptionsStatus !== Status.Ok) return execOptionsStatus
+      return func.wildcarded ? Status.Ok : null // wildcarded means there's no condition set
+    }
+  }
+
+  return Status.FunctionNotAllowed
+}
+
+const checkExecutionOptions = (execOptions: ExecutionOptions, metaTx: MetaTransactionData): Status => {
+  const isSend = BigInt(metaTx.value || '0') === BigInt(0)
+  const isDelegateCall = metaTx.operation === 1
+
+  if (isSend && execOptions !== ExecutionOptions.Send && execOptions !== ExecutionOptions.Both) {
+    return Status.SendNotAllowed
+  }
+  if (isDelegateCall && execOptions !== ExecutionOptions.DelegateCall && execOptions !== ExecutionOptions.Both) {
+    return Status.DelegateCallNotAllowed
+  }
+
+  return Status.Ok
 }

--- a/src/components/tx/SignOrExecuteForm/PermissionsCheck.tsx
+++ b/src/components/tx/SignOrExecuteForm/PermissionsCheck.tsx
@@ -1,0 +1,74 @@
+import { useContext, useState } from 'react'
+import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
+import { Box, Button, CardActions, CircularProgress, Divider, Typography } from '@mui/material'
+import commonCss from '@/components/tx-flow/common/styles.module.css'
+
+import CheckWallet from '@/components/common/CheckWallet'
+import WalletRejectionError from './WalletRejectionError'
+import TxCard from '@/components/tx-flow/common/TxCard'
+import ErrorMessage from '../ErrorMessage'
+import { getTransactionTrackingType } from '@/services/analytics/tx-tracking'
+import { TX_EVENTS } from '@/services/analytics/events/transactions'
+import { trackEvent } from '@/services/analytics'
+import useChainId from '@/hooks/useChainId'
+
+const PermissionsCheck: React.FC<{}> = ({}) => {
+  const chainId = useChainId()
+  const { safeTx, safeTxError } = useContext(SafeTxContext)
+  const [isRejectedByUser, setIsRejectedByUser] = useState<boolean>(false)
+
+  const isPending = false
+  const isDisabled = isPending
+
+  const handleExecute = async () => {
+    setIsRejectedByUser(false)
+
+    const txId = 'TODO'
+
+    // Track tx event
+    const txType = await getTransactionTrackingType(chainId, txId)
+    trackEvent({ ...TX_EVENTS.EXECUTE_THROUGH_ROLE, label: txType })
+  }
+
+  return (
+    <TxCard>
+      <Typography variant="h5">Execute through role</Typography>
+
+      <Typography>As a member of the Swapper role you can execute this transaction immediately.</Typography>
+
+      {safeTxError && (
+        <ErrorMessage error={safeTxError}>
+          This transaction will most likely fail. To save gas costs, avoid confirming the transaction.
+        </ErrorMessage>
+      )}
+
+      {isRejectedByUser && (
+        <Box mt={1}>
+          <WalletRejectionError />
+        </Box>
+      )}
+
+      <div>
+        <Divider className={commonCss.nestedDivider} sx={{ pt: 3 }} />
+
+        <CardActions>
+          <CheckWallet allowNonOwner>
+            {(isOk) => (
+              <Button
+                data-testid="execute-through-role-btn"
+                variant="contained"
+                onClick={handleExecute}
+                disabled={!isOk || isDisabled}
+                sx={{ minWidth: '209px' }}
+              >
+                {isPending ? <CircularProgress size={20} /> : 'Execute through role'}
+              </Button>
+            )}
+          </CheckWallet>
+        </CardActions>
+      </div>
+    </TxCard>
+  )
+}
+
+export default PermissionsCheck

--- a/src/components/tx/SignOrExecuteForm/PermissionsCheck.tsx
+++ b/src/components/tx/SignOrExecuteForm/PermissionsCheck.tsx
@@ -8,20 +8,23 @@ import {
   ExecutionOptions,
   Status,
 } from 'zodiac-roles-deployments'
-import { OperationType, type Transaction, type MetaTransactionData } from '@safe-global/safe-core-sdk-types'
+import {
+  OperationType,
+  type Transaction,
+  type MetaTransactionData,
+  type SafeTransaction,
+} from '@safe-global/safe-core-sdk-types'
 import { decodeBytes32String, type JsonRpcProvider } from 'ethers'
 import { KnownContracts, getModuleInstance } from '@gnosis.pm/zodiac'
 import { Box, Button, CardActions, Chip, CircularProgress, Divider, Typography } from '@mui/material'
 import { backOff } from 'exponential-backoff'
 
-import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
 import CheckWallet from '@/components/common/CheckWallet'
 import TxCard from '@/components/tx-flow/common/TxCard'
 import { getTransactionTrackingType } from '@/services/analytics/tx-tracking'
 import { TX_EVENTS } from '@/services/analytics/events/transactions'
 import { trackEvent } from '@/services/analytics'
-import useChainId from '@/hooks/useChainId'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import useAsync from '@/hooks/useAsync'
 import WalletRejectionError from './WalletRejectionError'
@@ -51,14 +54,18 @@ const Role = ({ children }: { children: string }) => {
   return <Chip label={humanReadableRoleKey} />
 }
 
-const PermissionsCheck: React.FC<{ onSubmit?: SubmitCallback }> = ({ onSubmit }) => {
-  const chainId = useChainId()
+const PermissionsCheck: React.FC<{ onSubmit?: SubmitCallback; safeTx: SafeTransaction; safeTxError?: Error }> = ({
+  onSubmit,
+  safeTx,
+  safeTxError,
+}) => {
   const currentChain = useCurrentChain()
   const onboard = useOnboard()
   const wallet = useWallet()
   const { safe } = useSafeInfo()
 
-  const { safeTx, safeTxError } = useContext(SafeTxContext)
+  const chainId = currentChain?.chainId || '1'
+
   const [isPending, setIsPending] = useState<boolean>(false)
   const [isRejectedByUser, setIsRejectedByUser] = useState<boolean>(false)
   const [submitError, setSubmitError] = useState<Error | undefined>()

--- a/src/components/tx/SignOrExecuteForm/PermissionsCheck.tsx
+++ b/src/components/tx/SignOrExecuteForm/PermissionsCheck.tsx
@@ -155,7 +155,7 @@ const PermissionsCheck: React.FC<{ onSubmit?: SubmitCallback; safeTx: SafeTransa
 
       {allowingRole && (
         <>
-          <Typography>
+          <Typography component="div">
             As a member of the <Role>{allowingRole.roleKey}</Role> role you can execute this transaction immediately.
           </Typography>
           <AdvancedParams
@@ -170,7 +170,7 @@ const PermissionsCheck: React.FC<{ onSubmit?: SubmitCallback; safeTx: SafeTransa
 
       {!allowingRole && (
         <>
-          <Typography>
+          <Typography component="div">
             You are a member of the <Role>{mostLikelyRole.roleKey}</Role> role but it does not allow this transaction.
           </Typography>
 

--- a/src/components/tx/SignOrExecuteForm/PermissionsCheck.tsx
+++ b/src/components/tx/SignOrExecuteForm/PermissionsCheck.tsx
@@ -59,7 +59,7 @@ const PermissionsCheck: React.FC<{ onSubmit?: SubmitCallback }> = ({ onSubmit })
   const { safe } = useSafeInfo()
 
   const { safeTx, safeTxError } = useContext(SafeTxContext)
-  const [isPending, setIsPending] = useState<boolean>(true)
+  const [isPending, setIsPending] = useState<boolean>(false)
   const [isRejectedByUser, setIsRejectedByUser] = useState<boolean>(false)
   const [submitError, setSubmitError] = useState<Error | undefined>()
 
@@ -126,13 +126,15 @@ const PermissionsCheck: React.FC<{ onSubmit?: SubmitCallback }> = ({ onSubmit })
       txHash,
     })
 
-    onSubmit?.(moduleTxId, true)
+    const txId = `module_${safe.address.value}_${moduleTxId}`
+
+    onSubmit?.(txId, true)
 
     // Track tx event
-    const txType = await getTransactionTrackingType(chainId, moduleTxId)
+    const txType = await getTransactionTrackingType(chainId, txId)
     trackEvent({ ...TX_EVENTS.EXECUTE_THROUGH_ROLE, label: txType })
 
-    setTxFlow(<SuccessScreenFlow txId={moduleTxId} />, undefined, false)
+    setTxFlow(<SuccessScreenFlow txId={txId} />, undefined, false)
   }
 
   // Only render the card if the connected wallet is a member of any role
@@ -445,7 +447,7 @@ const useGasLimit = (
   return { gasLimit, gasLimitError, gasLimitLoading }
 }
 
-export const pollModuleTransactionId = async (props: {
+const pollModuleTransactionId = async (props: {
   transactionService: string
   safeAddress: string
   txHash: string

--- a/src/components/tx/SignOrExecuteForm/__tests__/PermissionsCheck.test.tsx
+++ b/src/components/tx/SignOrExecuteForm/__tests__/PermissionsCheck.test.tsx
@@ -1,0 +1,176 @@
+import { createMockSafeTransaction } from '@/tests/transactions'
+import { OperationType } from '@safe-global/safe-core-sdk-types'
+import { type ReactElement } from 'react'
+import * as zodiacRoles from 'zodiac-roles-deployments'
+
+import { type ConnectedWallet } from '@/hooks/wallets/useOnboard'
+import * as useSafeInfoHook from '@/hooks/useSafeInfo'
+import * as wallet from '@/hooks/wallets/useWallet'
+import * as onboardHooks from '@/hooks/wallets/useOnboard'
+import * as txSender from '@/services/tx/tx-sender/dispatch'
+import { mockWeb3Provider, render } from '@/tests/test-utils'
+import { fireEvent, waitFor } from '@testing-library/react'
+import { extendedSafeInfoBuilder } from '@/tests/builders/safe'
+import { type OnboardAPI } from '@web3-onboard/core'
+import { AbiCoder, encodeBytes32String } from 'ethers'
+import PermissionsCheck from '../PermissionsCheck'
+
+// We assume that CheckWallet always returns true
+jest.mock('@/components/common/CheckWallet', () => ({
+  __esModule: true,
+  default({ children }: { children: (ok: boolean) => ReactElement }) {
+    return children(true)
+  },
+}))
+
+// mock useCurrentChain & useHasFeature
+jest.mock('@/hooks/useChains', () => ({
+  useCurrentChain: jest.fn(() => ({
+    shortName: 'eth',
+    chainId: '1',
+    chainName: 'Ethereum',
+    features: [],
+  })),
+  useHasFeature: jest.fn(() => true), // used to check for EIP1559 support
+}))
+
+describe('PermissionsCheck', () => {
+  let executeSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    // Safe info
+    jest.spyOn(useSafeInfoHook, 'default').mockImplementation(() => ({
+      safe: SAFE_INFO,
+      safeAddress: SAFE_INFO.address.value,
+      safeError: undefined,
+      safeLoading: false,
+      safeLoaded: true,
+    }))
+
+    // Onboard
+    jest.spyOn(onboardHooks, 'default').mockReturnValue({
+      setChain: jest.fn(),
+      state: {
+        get: () => ({
+          wallets: [
+            {
+              label: 'MetaMask',
+              accounts: [{ address: MEMBER_ADDRESS }],
+              connected: true,
+              chains: [{ id: '1' }],
+            },
+          ],
+        }),
+      },
+    } as unknown as OnboardAPI)
+
+    // Wallet
+    jest.spyOn(wallet, 'default').mockReturnValue({
+      chainId: '1',
+      label: 'MetaMask',
+      address: MEMBER_ADDRESS,
+    } as unknown as ConnectedWallet)
+
+    // Roles mod fetching
+
+    // Mock the Roles mod fetching function to return the test roles mod
+
+    jest.spyOn(zodiacRoles, 'fetchRolesMod').mockReturnValue(Promise.resolve(TEST_ROLES_MOD as any))
+
+    // Mock signing and dispatching the module transaction
+    executeSpy = jest
+      .spyOn(txSender, 'dispatchModuleTxExecution')
+      .mockReturnValue(Promise.resolve('0xabababababababababababababababababababababababababababababababab')) // tx hash
+
+    // Mock return value of useWeb3ReadOnly
+    // It's only used for eth_estimateGas requests
+    mockWeb3Provider([])
+  })
+
+  it('execute the tx when the submit button is clicked', async () => {
+    const safeTx = createMockSafeTransaction({
+      to: WETH_ADDRESS,
+      data: '0xd0e30db0', // deposit()
+      value: AbiCoder.defaultAbiCoder().encode(['uint256'], [123]),
+      operation: OperationType.Call,
+    })
+
+    const { findByText } = render(<PermissionsCheck safeTx={safeTx} />)
+
+    fireEvent.click(await findByText('Execute through role', { selector: 'button' }))
+
+    await waitFor(() => {
+      expect(executeSpy).toHaveBeenCalledWith(
+        // call to the Roles mod's execTransactionWithRole function
+        expect.objectContaining({
+          to: TEST_ROLES_MOD.address,
+          data: '0xc6fe8747000000000000000000000000fff9976782d46cc05630d1f6ebab18b2324d6b14000000000000000000000000000000000000000000000000000000000000007b00000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000006574685f7772617070696e67000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000004d0e30db000000000000000000000000000000000000000000000000000000000',
+          value: '0',
+        }),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      )
+    })
+  })
+})
+
+const ROLES_MOD_ADDRESS = '0x1234567890000000000000000000000000000000'
+const MEMBER_ADDRESS = '0x1111111110000000000000000000000000000000'
+const ROLE_KEY = encodeBytes32String('eth_wrapping')
+
+const SAFE_INFO = extendedSafeInfoBuilder().build()
+SAFE_INFO.modules = [{ value: ROLES_MOD_ADDRESS }]
+SAFE_INFO.chainId = '1'
+
+const lowercaseSafeAddress = SAFE_INFO.address.value.toLowerCase()
+
+const WETH_ADDRESS = '0xfff9976782d46cc05630d1f6ebab18b2324d6b14'
+
+const { Clearance, ExecutionOptions } = zodiacRoles
+
+const TEST_ROLES_MOD = {
+  address: ROLES_MOD_ADDRESS,
+  owner: lowercaseSafeAddress,
+  avatar: lowercaseSafeAddress,
+  target: lowercaseSafeAddress,
+  roles: [
+    {
+      key: ROLE_KEY,
+      members: [MEMBER_ADDRESS],
+      targets: [
+        {
+          address: '0xc36442b4a4522e871399cd717abdd847ab11fe88',
+          clearance: Clearance.Function,
+          executionOptions: ExecutionOptions.None,
+          functions: [
+            {
+              selector: '0x49404b7c',
+              wildcarded: false,
+              executionOptions: ExecutionOptions.None,
+            },
+          ],
+        },
+        {
+          address: WETH_ADDRESS, // WETH
+          clearance: Clearance.Function,
+          executionOptions: ExecutionOptions.None,
+          functions: [
+            {
+              selector: '0x2e1a7d4d', // withdraw(uint256)
+              wildcarded: true,
+              executionOptions: ExecutionOptions.None,
+            },
+            {
+              selector: '0xd0e30db0', // deposit()
+              wildcarded: true,
+              executionOptions: ExecutionOptions.Send,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -120,7 +120,7 @@ export const SignOrExecuteForm = ({
         </TxCard>
       )}
 
-      {!isCounterfactualSafe && <PermissionsCheck />}
+      {!isCounterfactualSafe && isCreation && <PermissionsCheck />}
 
       <TxCard>
         <ConfirmationTitle

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -120,7 +120,7 @@ export const SignOrExecuteForm = ({
         </TxCard>
       )}
 
-      {!isCounterfactualSafe && isCreation && <PermissionsCheck />}
+      {!isCounterfactualSafe && isCreation && <PermissionsCheck onSubmit={onSubmit} />}
 
       <TxCard>
         <ConfirmationTitle

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -26,6 +26,7 @@ import { getTransactionTrackingType } from '@/services/analytics/tx-tracking'
 import { TX_EVENTS } from '@/services/analytics/events/transactions'
 import { trackEvent } from '@/services/analytics'
 import useChainId from '@/hooks/useChainId'
+import PermissionsCheck from './PermissionsCheck'
 
 export type SubmitCallback = (txId: string, isExecuted?: boolean) => void
 
@@ -118,6 +119,8 @@ export const SignOrExecuteForm = ({
           <TxChecks />
         </TxCard>
       )}
+
+      {!isCounterfactualSafe && <PermissionsCheck />}
 
       <TxCard>
         <ConfirmationTitle

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -120,7 +120,9 @@ export const SignOrExecuteForm = ({
         </TxCard>
       )}
 
-      {!isCounterfactualSafe && isCreation && <PermissionsCheck onSubmit={onSubmit} />}
+      {!isCounterfactualSafe && safeTx && isCreation && (
+        <PermissionsCheck onSubmit={onSubmit} safeTx={safeTx} safeTxError={safeTxError} />
+      )}
 
       <TxCard>
         <ConfirmationTitle

--- a/src/services/analytics/events/transactions.ts
+++ b/src/services/analytics/events/transactions.ts
@@ -52,4 +52,9 @@ export const TX_EVENTS = {
     action: 'Speed up transaction',
     category: TX_CATEGORY,
   },
+  EXECUTE_THROUGH_ROLE: {
+    event: EventType.TX_EXECUTED_THROUGH_ROLE,
+    action: 'Execute transaction through role',
+    category: TX_CATEGORY,
+  },
 }

--- a/src/services/analytics/types.ts
+++ b/src/services/analytics/types.ts
@@ -13,6 +13,7 @@ export enum EventType {
   TX_CREATED = 'tx_created',
   TX_CONFIRMED = 'tx_confirmed',
   TX_EXECUTED = 'tx_executed',
+  TX_EXECUTED_THROUGH_ROLE = 'tx_executed_through_role',
 }
 
 export type EventLabel = string | number | boolean | null

--- a/src/services/exceptions/ErrorCodes.ts
+++ b/src/services/exceptions/ErrorCodes.ts
@@ -66,6 +66,7 @@ enum ErrorCodes {
   _812 = '812: Failed to recover',
   _813 = '813: Failed to cancel recovery',
   _814 = '814: Failed to speed up transaction',
+  _815 = '815: Error executing a transaction through a role',
 
   _900 = '900: Error loading Safe App',
   _901 = '901: Error processing Safe Apps SDK request',

--- a/src/services/tx/tx-sender/dispatch.ts
+++ b/src/services/tx/tx-sender/dispatch.ts
@@ -1,5 +1,10 @@
 import { relayTransaction, type SafeInfo, type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
-import type { SafeTransaction, TransactionOptions, TransactionResult } from '@safe-global/safe-core-sdk-types'
+import type {
+  SafeTransaction,
+  Transaction,
+  TransactionOptions,
+  TransactionResult,
+} from '@safe-global/safe-core-sdk-types'
 import { didRevert } from '@/utils/ethers-utils'
 import type { MultiSendCallOnlyEthersContract } from '@safe-global/protocol-kit'
 import { type SpendingLimitTxParams } from '@/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx'
@@ -324,6 +329,56 @@ export const dispatchBatchExecution = async (
   }
 
   return result!.hash
+}
+
+/**
+ * Execute a module transaction
+ */
+export const dispatchModuleTxExecution = async (
+  tx: Transaction,
+  onboard: OnboardAPI,
+  chainId: SafeInfo['chainId'],
+  safeAddress: string,
+): Promise<string> => {
+  const id = JSON.stringify(tx)
+
+  let result: TransactionResponse | undefined
+  try {
+    const wallet = await assertWalletChain(onboard, chainId)
+    const provider = createWeb3(wallet.provider)
+    const signer = await provider.getSigner()
+
+    txDispatch(TxEvent.EXECUTING, { groupKey: id })
+    result = await signer.sendTransaction(tx)
+  } catch (error) {
+    txDispatch(TxEvent.FAILED, { groupKey: id, error: asError(error) })
+    throw error
+  }
+
+  txDispatch(TxEvent.PROCESSING_MODULE, {
+    groupKey: id,
+    txHash: result.hash,
+  })
+
+  result
+    ?.wait()
+    .then((receipt) => {
+      if (receipt === null) {
+        txDispatch(TxEvent.FAILED, { groupKey: id, error: new Error('No transaction receipt found') })
+      } else if (didRevert(receipt)) {
+        txDispatch(TxEvent.REVERTED, {
+          groupKey: id,
+          error: new Error('Transaction reverted by EVM'),
+        })
+      } else {
+        txDispatch(TxEvent.PROCESSED, { groupKey: id, safeAddress, txHash: result?.hash })
+      }
+    })
+    .catch((error) => {
+      txDispatch(TxEvent.FAILED, { groupKey: id, error: asError(error) })
+    })
+
+  return result?.hash
 }
 
 export const dispatchSpendingLimitTxExecution = async (

--- a/yarn.lock
+++ b/yarn.lock
@@ -20902,7 +20902,7 @@ yocto-queue@^1.0.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
-zodiac-roles-deployments@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/zodiac-roles-deployments/-/zodiac-roles-deployments-2.1.1.tgz#099e3b4ece9461c0388a2370d255b00d682a96bc"
-  integrity sha512-og0TQUdjHnSWNZImovWLcZs53Q4bagTWvleMXh1Cu1u5Fer4QeOcdRlmz7vqif/QVSbOzPBLkJUMGJaxueRZNQ==
+zodiac-roles-deployments@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/zodiac-roles-deployments/-/zodiac-roles-deployments-2.2.2.tgz#feb7e7544398e1572d2f7fa6ff2be033f2c736ce"
+  integrity sha512-6nG6/AuJh9SIrXR1NieRzSfn1+J6k9p2mb3qns3cRYhx3+i4wWIRh1JcE+jueHSYo+H7yKG/jfwRXMVN1L938A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -20901,3 +20901,8 @@ yocto-queue@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
+
+zodiac-roles-deployments@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/zodiac-roles-deployments/-/zodiac-roles-deployments-2.1.1.tgz#099e3b4ece9461c0388a2370d255b00d682a96bc"
+  integrity sha512-og0TQUdjHnSWNZImovWLcZs53Q4bagTWvleMXh1Cu1u5Fer4QeOcdRlmz7vqif/QVSbOzPBLkJUMGJaxueRZNQ==


### PR DESCRIPTION
## What it solves

With [SEP-14](https://forum.safe.global/t/sep-14-obra-role-based-access-control-pilot-browser-extension-gnosis-guild/4676) the community voted to implement role-based access control in Safe{Wallet} based on the Zodiac Roles Modifier.

## How this PR fixes it

This PR allows role members to use Safe{Wallet} to execute transaction from the Safe using their role. For this purpose, a new section has been added to the transaction sign/execute form, which only shows up if the connected wallet is a member of any role enabled on the Safe.

## How to test it

- Deploy a Roles Modifier through the Zodiac Safe app
- Set up some permissions for a testing role, e.g. using [permissions-starter-kit](https://github.com/gnosisguild/permissions-starter-kit), apply and assign the role to an EOA using the mod's `assignRoles` function

Alternatively, send me your EOA address so I can assign a role in my [Sepolia test setup](https://app.safe.global/apps/open?safe=sep:0xB9289969bd138b802cfD48466e0cCc8aCD528Ba1) to it.

## Screenshots

A new card appears in the transaction sign/execute form only if the Safe has a Roles mod enabled and the connected wallet account is a role member.

##### Connected with role member wallet, permission checks pass:
<img width="758" alt="image" src="https://github.com/safe-global/safe-wallet-web/assets/524089/67d73c06-5ac9-49df-b95c-65df510d4b16">


##### Connected with role member wallet, permission checks fail:
<img width="758" alt="image" src="https://github.com/safe-global/safe-wallet-web/assets/524089/7f2dc24d-d0b5-4c6b-9b0c-c95be981cd81">

(Status can be any value from the Roles mods' [Status enum](https://github.com/gnosisguild/zodiac-modifier-roles/blob/00b68f361e9bfbbd2cd3d527c084f39e6fd85606/packages/evm/contracts/PermissionChecker.sol#L727))

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
