### PR TITLE
fix: re-enable swaps for counterfactual safes [SW-23]

### DIFF
--- a/src/components/balances/AssetsTable/index.tsx
+++ b/src/components/balances/AssetsTable/index.tsx
@@ -18,7 +18,6 @@ import useBalances from '@/hooks/useBalances'
 import { useHideAssets, useVisibleAssets } from './useHideAssets'
 import AddFundsCTA from '@/components/common/AddFunds'
 import SwapButton from '@/features/swap/components/SwapButton'
-import useIsCounterfactualSafe from '@/features/counterfactual/hooks/useIsCounterfactualSafe'
 import { SWAP_LABELS } from '@/services/analytics/events/swaps'
 import SendButton from './SendButton'
 import useIsSwapFeatureEnabled from '@/features/swap/hooks/useIsSwapFeatureEnabled'
@@ -97,8 +96,7 @@ const AssetsTable = ({
   setShowHiddenAssets: (hidden: boolean) => void
 }): ReactElement => {
   const { balances, loading } = useBalances()
-  const isCounterfactualSafe = useIsCounterfactualSafe()
-  const isSwapFeatureEnabled = useIsSwapFeatureEnabled() && !isCounterfactualSafe
+  const isSwapFeatureEnabled = useIsSwapFeatureEnabled()
 
   const { isAssetSelected, toggleAsset, hidingAsset, hideAsset, cancel, deselectAll, saveChanges } = useHideAssets(() =>
     setShowHiddenAssets(false),

--- a/src/components/sidebar/SidebarNavigation/index.tsx
+++ b/src/components/sidebar/SidebarNavigation/index.tsx
@@ -18,7 +18,6 @@ import { useCurrentChain } from '@/hooks/useChains'
 import { isRouteEnabled } from '@/utils/chains'
 import { trackEvent } from '@/services/analytics'
 import { SWAP_EVENTS, SWAP_LABELS } from '@/services/analytics/events/swaps'
-import useIsCounterfactualSafe from '@/features/counterfactual/hooks/useIsCounterfactualSafe'
 import { GeoblockingContext } from '@/components/common/GeoblockingProvider'
 
 const getSubdirectory = (pathname: string): string => {
@@ -31,18 +30,17 @@ const Navigation = (): ReactElement => {
   const { safe } = useSafeInfo()
   const currentSubdirectory = getSubdirectory(router.pathname)
   const queueSize = useQueuedTxsLength()
-  const isCounterFactualSafe = useIsCounterfactualSafe()
   const isBlockedCountry = useContext(GeoblockingContext)
   const enabledNavItems = useMemo(() => {
     return navItems.filter((item) => {
       const enabled = isRouteEnabled(item.href, chain)
 
-      if (item.href === AppRoutes.swap && (isCounterFactualSafe || isBlockedCountry)) {
+      if (item.href === AppRoutes.swap && isBlockedCountry) {
         return false
       }
       return enabled
     })
-  }, [chain, isBlockedCountry, isCounterFactualSafe])
+  }, [chain, isBlockedCountry])
 
   const getBadge = (item: NavItem) => {
     // Indicate whether the current Safe needs an upgrade

--- a/src/features/counterfactual/CounterfactualForm.tsx
+++ b/src/features/counterfactual/CounterfactualForm.tsx
@@ -3,6 +3,7 @@ import useDeployGasLimit from '@/features/counterfactual/hooks/useDeployGasLimit
 import { deploySafeAndExecuteTx } from '@/features/counterfactual/utils'
 import useChainId from '@/hooks/useChainId'
 import { getTotalFeeFormatted } from '@/hooks/useGasPrice'
+import useSafeInfo from '@/hooks/useSafeInfo'
 import useWalletCanPay from '@/hooks/useWalletCanPay'
 import useOnboard from '@/hooks/wallets/useOnboard'
 import useWallet from '@/hooks/wallets/useWallet'
@@ -50,6 +51,7 @@ export const CounterfactualForm = ({
   const onboard = useOnboard()
   const chain = useCurrentChain()
   const chainId = useChainId()
+  const { safeAddress } = useSafeInfo()
 
   // Form state
   const [isSubmittable, setIsSubmittable] = useState<boolean>(true)
@@ -83,7 +85,7 @@ export const CounterfactualForm = ({
       trackEvent({ ...OVERVIEW_EVENTS.PROCEED_WITH_TX, label: TX_TYPES.activate_with_tx })
 
       onboard && (await assertWalletChain(onboard, chainId))
-      await deploySafeAndExecuteTx(txOptions, wallet, safeTx, wallet?.provider)
+      await deploySafeAndExecuteTx(txOptions, wallet, safeAddress, safeTx, wallet?.provider)
 
       trackEvent({ ...TX_EVENTS.CREATE, label: TX_TYPES.activate_with_tx })
       trackEvent({ ...TX_EVENTS.EXECUTE, label: TX_TYPES.activate_with_tx })

--- a/src/features/counterfactual/FirstTxFlow.tsx
+++ b/src/features/counterfactual/FirstTxFlow.tsx
@@ -18,7 +18,6 @@ import RecoveryPlus from '@/public/images/common/recovery-plus.svg'
 import SwapIcon from '@/public/images/common/swap.svg'
 import SafeLogo from '@/public/images/logo-no-text.svg'
 import HandymanOutlinedIcon from '@mui/icons-material/HandymanOutlined'
-import useIsCounterfactualSafe from '@/features/counterfactual/hooks/useIsCounterfactualSafe'
 import useIsSwapFeatureEnabled from '../swap/hooks/useIsSwapFeatureEnabled'
 
 const FirstTxFlow = ({ open, onClose }: { open: boolean; onClose: () => void }) => {
@@ -27,8 +26,7 @@ const FirstTxFlow = ({ open, onClose }: { open: boolean; onClose: () => void }) 
   const { setTxFlow } = useContext(TxModalContext)
   const supportsRecovery = useIsRecoverySupported()
   const [recovery] = useRecovery()
-  const isCounterfactualSafe = useIsCounterfactualSafe()
-  const isSwapFeatureEnabled = useIsSwapFeatureEnabled() && !isCounterfactualSafe
+  const isSwapFeatureEnabled = useIsSwapFeatureEnabled()
 
   const handleClick = (onClick: () => void) => {
     onClose()

--- a/src/features/counterfactual/hooks/usePendingSafeStatuses.ts
+++ b/src/features/counterfactual/hooks/usePendingSafeStatuses.ts
@@ -16,7 +16,7 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import { isSmartContract, useWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { CREATE_SAFE_EVENTS, trackEvent } from '@/services/analytics'
 import { useAppDispatch, useAppSelector } from '@/store'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 
 export const safeCreationPendingStatuses: Partial<Record<SafeCreationEvent, PendingSafeStatus | null>> = {
   [SafeCreationEvent.PROCESSING]: PendingSafeStatus.PROCESSING,
@@ -76,9 +76,8 @@ const usePendingSafeMonitor = (): void => {
 }
 
 const usePendingSafeStatus = (): void => {
-  const [safeAddress, setSafeAddress] = useState<string>('')
   const dispatch = useAppDispatch()
-  const { safe } = useSafeInfo()
+  const { safe, safeAddress } = useSafeInfo()
   const chainId = useChainId()
   const provider = useWeb3ReadOnly()
 
@@ -107,8 +106,6 @@ const usePendingSafeStatus = (): void => {
   useEffect(() => {
     const unsubFns = Object.entries(safeCreationPendingStatuses).map(([event, status]) =>
       safeCreationSubscribe(event as SafeCreationEvent, async (detail) => {
-        setSafeAddress(detail.safeAddress)
-
         if (event === SafeCreationEvent.SUCCESS) {
           // TODO: Possible to add a label with_tx, without_tx?
           trackEvent(CREATE_SAFE_EVENTS.ACTIVATED_SAFE)

--- a/src/features/counterfactual/utils.ts
+++ b/src/features/counterfactual/utils.ts
@@ -49,6 +49,7 @@ export const dispatchTxExecutionAndDeploySafe = async (
   safeTx: SafeTransaction,
   txOptions: TransactionOptions,
   provider: Eip1193Provider,
+  safeAddress: string,
 ) => {
   const sdkUnchecked = await getUncheckedSafeSDK(provider)
   const eventParams = { groupKey: CF_TX_GROUP_KEY }
@@ -68,12 +69,11 @@ export const dispatchTxExecutionAndDeploySafe = async (
     // @ts-ignore TODO: Check why TransactionResponse type doesn't work
     result = await signer.sendTransaction({ ...deploymentTx, gasLimit: gas })
   } catch (error) {
-    safeCreationDispatch(SafeCreationEvent.FAILED, { ...eventParams, error: asError(error), safeAddress: '' })
+    safeCreationDispatch(SafeCreationEvent.FAILED, { ...eventParams, error: asError(error), safeAddress })
     throw error
   }
 
-  // TODO: Probably need to pass the actual safe address
-  safeCreationDispatch(SafeCreationEvent.PROCESSING, { ...eventParams, txHash: result!.hash, safeAddress: '' })
+  safeCreationDispatch(SafeCreationEvent.PROCESSING, { ...eventParams, txHash: result!.hash, safeAddress })
 
   return result!.hash
 }
@@ -81,6 +81,7 @@ export const dispatchTxExecutionAndDeploySafe = async (
 export const deploySafeAndExecuteTx = async (
   txOptions: TransactionOptions,
   wallet: ConnectedWallet | null,
+  safeAddress: string,
   safeTx?: SafeTransaction,
   provider?: Eip1193Provider,
 ) => {
@@ -88,7 +89,7 @@ export const deploySafeAndExecuteTx = async (
   assertWallet(wallet)
   assertProvider(provider)
 
-  return dispatchTxExecutionAndDeploySafe(safeTx, txOptions, provider)
+  return dispatchTxExecutionAndDeploySafe(safeTx, txOptions, provider, safeAddress)
 }
 
 export const { getStore: getNativeBalance, setStore: setNativeBalance } = new ExternalStore<bigint>(0n)


### PR DESCRIPTION
## What it solves
Cow was not being able to work with counterfactual safes - it was showing the widget as not connected. 

Resolves #
Now the widget is connected to the safe and one can submit an order.

## How this PR fixes it

## How to test it
1. Create counterfactual safe
2. Fund it with money
3. Try to make a swap

1. Create a safe and deploy it right away
2. Create counterfactual safe and activate it without a transaction

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
