### PR TITLE
feat: add new label to swaps button [SWAP-86]

### DIFF
--- a/src/components/sidebar/SidebarNavigation/config.tsx
+++ b/src/components/sidebar/SidebarNavigation/config.tsx
@@ -9,11 +9,13 @@ import AppsIcon from '@/public/images/apps/apps-icon.svg'
 import SettingsIcon from '@/public/images/sidebar/settings.svg'
 import SwapIcon from '@/public/images/common/swap.svg'
 import { SvgIcon } from '@mui/material'
+import Chip from '@mui/material/Chip'
 
 export type NavItem = {
   label: string
   icon?: ReactElement
   href: string
+  tag?: ReactElement
 }
 
 export const navItems: NavItem[] = [
@@ -31,6 +33,7 @@ export const navItems: NavItem[] = [
     label: 'Swap',
     icon: <SvgIcon component={SwapIcon} inheritViewBox />,
     href: AppRoutes.swap,
+    tag: <Chip label="New" color="success" sx={{ ml: 1 }} />,
   },
   {
     label: 'Transactions',

--- a/src/components/sidebar/SidebarNavigation/index.tsx
+++ b/src/components/sidebar/SidebarNavigation/index.tsx
@@ -31,16 +31,6 @@ const isRouteEnabled = (route: string, chain?: ChainInfo) => {
   return !featureRoute || hasFeature(chain, featureRoute)
 }
 
-const NavItemTag = ({ item }: { item: NavItem }) => {
-  const queueSize = useQueuedTxsLength()
-
-  if (item.href === AppRoutes.transactions.history) {
-    return <SidebarListItemCounter count={queueSize} />
-  }
-
-  return item.tag
-}
-
 const Navigation = (): ReactElement => {
   const chain = useCurrentChain()
   const router = useRouter()
@@ -85,6 +75,12 @@ const Navigation = (): ReactElement => {
       {enabledNavItems.map((item) => {
         const isSelected = currentSubdirectory === getSubdirectory(item.href)
 
+        let ItemTag = item.tag ? item.tag : null
+
+        if (item.href === AppRoutes.transactions.history) {
+          ItemTag = queueSize ? <SidebarListItemCounter count={queueSize} /> : null
+        }
+
         return (
           <ListItem
             key={item.href}
@@ -101,7 +97,7 @@ const Navigation = (): ReactElement => {
               <SidebarListItemText data-testid="sidebar-list-item" bold>
                 {item.label}
 
-                <NavItemTag item={item} />
+                {ItemTag}
               </SidebarListItemText>
             </SidebarListItemButton>
           </ListItem>

--- a/src/components/sidebar/SidebarNavigation/index.tsx
+++ b/src/components/sidebar/SidebarNavigation/index.tsx
@@ -19,7 +19,6 @@ import { FeatureRoutes, hasFeature } from '@/utils/chains'
 import { trackEvent } from '@/services/analytics'
 import { SWAP_EVENTS, SWAP_LABELS } from '@/services/analytics/events/swaps'
 import useIsCounterfactualSafe from '@/features/counterfactual/hooks/useIsCounterfactualSafe'
-import Chip from '@mui/material/Chip'
 
 const getSubdirectory = (pathname: string): string => {
   return pathname.split('/')[1]
@@ -32,17 +31,14 @@ const isRouteEnabled = (route: string, chain?: ChainInfo) => {
   return !featureRoute || hasFeature(chain, featureRoute)
 }
 
-const NavItemLabel = ({ item }: { item: NavItem }) => {
+const NavItemTag = ({ item }: { item: NavItem }) => {
   const queueSize = useQueuedTxsLength()
 
   if (item.href === AppRoutes.transactions.history) {
     return <SidebarListItemCounter count={queueSize} />
   }
 
-  if (item.href === AppRoutes.swap) {
-    return <Chip label="New" color="success" sx={{ ml: 1 }} />
-  }
-  return null
+  return item.tag
 }
 
 const Navigation = (): ReactElement => {
@@ -105,7 +101,7 @@ const Navigation = (): ReactElement => {
               <SidebarListItemText data-testid="sidebar-list-item" bold>
                 {item.label}
 
-                <NavItemLabel item={item} />
+                <NavItemTag item={item} />
               </SidebarListItemText>
             </SidebarListItemButton>
           </ListItem>

--- a/src/components/sidebar/SidebarNavigation/index.tsx
+++ b/src/components/sidebar/SidebarNavigation/index.tsx
@@ -19,6 +19,7 @@ import { FeatureRoutes, hasFeature } from '@/utils/chains'
 import { trackEvent } from '@/services/analytics'
 import { SWAP_EVENTS, SWAP_LABELS } from '@/services/analytics/events/swaps'
 import useIsCounterfactualSafe from '@/features/counterfactual/hooks/useIsCounterfactualSafe'
+import Chip from '@mui/material/Chip'
 
 const getSubdirectory = (pathname: string): string => {
   return pathname.split('/')[1]
@@ -29,6 +30,19 @@ const isRouteEnabled = (route: string, chain?: ChainInfo) => {
 
   const featureRoute = FeatureRoutes[route]
   return !featureRoute || hasFeature(chain, featureRoute)
+}
+
+const NavItemLabel = ({ item }: { item: NavItem }) => {
+  const queueSize = useQueuedTxsLength()
+
+  if (item.href === AppRoutes.transactions.history) {
+    return <SidebarListItemCounter count={queueSize} />
+  }
+
+  if (item.href === AppRoutes.swap) {
+    return <Chip label="New" color="success" sx={{ ml: 1 }} />
+  }
+  return null
 }
 
 const Navigation = (): ReactElement => {
@@ -53,13 +67,6 @@ const Navigation = (): ReactElement => {
     // Indicate whether the current Safe needs an upgrade
     if (item.href === AppRoutes.settings.setup) {
       return safe.implementationVersionState === ImplementationVersionState.OUTDATED
-    }
-  }
-
-  const getCounter = (item: NavItem) => {
-    // Indicate qeueued txs
-    if (item.href === AppRoutes.transactions.history) {
-      return queueSize
     }
   }
 
@@ -98,7 +105,7 @@ const Navigation = (): ReactElement => {
               <SidebarListItemText data-testid="sidebar-list-item" bold>
                 {item.label}
 
-                <SidebarListItemCounter count={getCounter(item)} />
+                <NavItemLabel item={item} />
               </SidebarListItemText>
             </SidebarListItemButton>
           </ListItem>

--- a/src/components/theme/darkPalette.ts
+++ b/src/components/theme/darkPalette.ts
@@ -12,7 +12,7 @@ const darkPalette = {
   secondary: {
     dark: '#636669',
     main: '#FFFFFF',
-    light: '#12FF80',
+    light: '#B0FFC9',
     background: '#1B2A22',
   },
   border: {

--- a/src/components/theme/safeTheme.ts
+++ b/src/components/theme/safeTheme.ts
@@ -17,6 +17,7 @@ declare module '@mui/material/styles' {
     backdrop: Palette['primary']
     static: Palette['primary']
   }
+
   export interface PaletteOptions {
     border: PaletteOptions['primary']
     logo: PaletteOptions['primary']
@@ -33,6 +34,7 @@ declare module '@mui/material/styles' {
   export interface PaletteColor {
     background?: string
   }
+
   export interface SimplePaletteColorOptions {
     background?: string
   }
@@ -52,6 +54,7 @@ declare module '@mui/material/Button' {
   export interface ButtonPropsColorOverrides {
     background: true
   }
+
   export interface ButtonPropsVariantOverrides {
     danger: true
   }
@@ -277,6 +280,13 @@ const createSafeTheme = (mode: PaletteMode): Theme => {
           root: {
             textTransform: 'none',
           },
+        },
+      },
+      MuiChip: {
+        styleOverrides: {
+          colorSuccess: ({ theme }) => ({
+            backgroundColor: theme.palette.secondary.light,
+          }),
         },
       },
       MuiAlert: {

--- a/src/components/theme/safeTheme.ts
+++ b/src/components/theme/safeTheme.ts
@@ -286,6 +286,7 @@ const createSafeTheme = (mode: PaletteMode): Theme => {
         styleOverrides: {
           colorSuccess: ({ theme }) => ({
             backgroundColor: theme.palette.secondary.light,
+            height: '24px',
           }),
         },
       },


### PR DESCRIPTION
## What it solves
Displays a "new" label next to the swap navitem

## How to test it
Open a safe and in the menu on the right Swap should have a "new" badge/label.

## Screenshots
<img width="918" alt="grafik" src="https://github.com/safe-global/safe-wallet-web/assets/693770/e3778b1c-69d3-464d-83e4-cbc8af8b9aa6">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
