### PR TITLE
fix: Add network to Rabby if unknown

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/components/common/BuyCryptoButton/index.tsx
+++ b/src/components/common/BuyCryptoButton/index.tsx
@@ -21,7 +21,7 @@ const useOnrampAppUrl = (): string | undefined => {
 
 const useBuyCryptoHref = (): LinkProps['href'] | undefined => {
   const query = useSearchParams()
-  const safe = query.get('safe')
+  const safe = query?.get('safe')
   const appUrl = useOnrampAppUrl()
 
   return useMemo(() => {

--- a/src/components/common/SafeTokenWidget/index.tsx
+++ b/src/components/common/SafeTokenWidget/index.tsx
@@ -54,7 +54,7 @@ const SafeTokenWidget = () => {
 
   const url = {
     pathname: AppRoutes.apps.open,
-    query: { safe: query.get('safe'), appUrl: GOVERNANCE_APP_URL },
+    query: { safe: query?.get('safe'), appUrl: GOVERNANCE_APP_URL },
   }
 
   const canRedeemSep5 = canRedeemSep5Airdrop(allocationData)

--- a/src/components/tx-flow/index.tsx
+++ b/src/components/tx-flow/index.tsx
@@ -32,7 +32,7 @@ export const TxModalProvider = ({ children }: { children: ReactNode }): ReactEle
   const safeId = useChainId() + useSafeAddress()
   const prevSafeId = useRef<string>(safeId ?? '')
   const pathname = usePathname()
-  const prevPathname = useRef<string>(pathname)
+  const prevPathname = useRef<string | null>(pathname)
 
   const handleModalClose = useCallback(() => {
     if (shouldWarn.current && !confirmClose()) {

--- a/src/hooks/useIsSidebarRoute.ts
+++ b/src/hooks/useIsSidebarRoute.ts
@@ -25,7 +25,7 @@ const TOGGLE_SIDEBAR_ROUTES = [AppRoutes.apps.open]
  */
 export function useIsSidebarRoute(pathname?: string): [boolean, boolean] {
   const clientPathname = usePathname()
-  const route = pathname || clientPathname
+  const route = pathname || clientPathname || ''
   const noSidebar = NO_SIDEBAR_ROUTES.includes(route)
   const toggledSidebar = TOGGLE_SIDEBAR_ROUTES.includes(route)
   const router = useRouter()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -16,11 +20,31 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@/public/*": ["./public/*"]
+      "@/*": [
+        "./src/*"
+      ],
+      "@/public/*": [
+        "./public/*"
+      ]
     },
-    "plugins": [{ "name": "typescript-plugin-css-modules" }]
+    "plugins": [
+      {
+        "name": "typescript-plugin-css-modules"
+      },
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "src/definitions.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", "src/types/contracts"]
+  "include": [
+    "next-env.d.ts",
+    "src/definitions.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "src/types/contracts"
+  ]
 }


### PR DESCRIPTION
## What it solves

Part of #3745

## How this PR fixes it

In Rabby, the error when trying to switch to a network that is not yet added is nested and doesn't pass our condition. It now checks for a nested `code` in the error that is thrown.

## How to test it

1. Remove Sepolia network from Rabby
2. Connect to a Sepolia Safe
3. Create / Execute a transaction or sign a message
4. Observe there is no error and instead Rabby pops up to add Sepolia as a new network

## Screenshots

<img width="903" alt="Screenshot 2024-05-30 at 13 52 15" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/f7ccab1f-7e42-41f0-a7c5-0b735b030597">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
