### PR TITLE
Analytics: differentiate bulk executions from batches

### DIFF
--- a/src/components/tx-flow/flows/ExecuteBatch/ReviewBatch.tsx
+++ b/src/components/tx-flow/flows/ExecuteBatch/ReviewBatch.tsx
@@ -141,7 +141,7 @@ export const ReviewBatch = ({ params }: { params: ExecuteBatchFlowProps }) => {
       return
     }
 
-    trackEvent({ ...TX_EVENTS.EXECUTE, label: TX_TYPES.batch })
+    trackEvent({ ...TX_EVENTS.EXECUTE, label: TX_TYPES.bulk_execute })
   }
 
   const submitDisabled = loading || !isSubmittable || !gasPrice

--- a/src/services/analytics/events/transactions.ts
+++ b/src/services/analytics/events/transactions.ts
@@ -22,6 +22,7 @@ export enum TX_TYPES {
   walletconnect = 'walletconnect',
   custom = 'custom',
   native_swap = 'native_swap',
+  bulk_execute = 'bulk_execute',
 
   // Counterfactual
   activate_without_tx = 'activate_without_tx',


### PR DESCRIPTION
## What it solves

Add a new tx type for bulk executions to differentiate them from batches.