### PR TITLE
fix: Optimize RPC requests when predicting safe address

### DIFF
--- a/src/components/new-safe/create/logic/index.ts
+++ b/src/components/new-safe/create/logic/index.ts
@@ -19,7 +19,7 @@ import { AppRoutes } from '@/config/routes'
 import { SAFE_APPS_EVENTS, trackEvent } from '@/services/analytics'
 import type { AppDispatch, AppThunk } from '@/store'
 import { showNotification } from '@/store/notificationsSlice'
-import { SafeFactory } from '@safe-global/protocol-kit'
+import { predictSafeAddress, SafeFactory } from '@safe-global/protocol-kit'
 import type Safe from '@safe-global/protocol-kit'
 import type { DeploySafeProps } from '@safe-global/protocol-kit'
 import { createEthersAdapter, isValidSafeVersion } from '@/hooks/coreSDK/safeCoreSDK'
@@ -86,9 +86,18 @@ export const createNewSafe = async (
 export const computeNewSafeAddress = async (
   ethersProvider: BrowserProvider,
   props: DeploySafeProps,
+  chainId: string,
 ): Promise<string> => {
-  const safeFactory = await getSafeFactory(ethersProvider)
-  return safeFactory.predictSafeAddress(props.safeAccountConfig, props.saltNonce)
+  const ethAdapter = await createEthersAdapter(ethersProvider)
+
+  return predictSafeAddress({
+    ethAdapter,
+    chainId: BigInt(chainId),
+    safeAccountConfig: props.safeAccountConfig,
+    safeDeploymentConfig: {
+      saltNonce: props.saltNonce,
+    },
+  })
 }
 
 /**

--- a/src/components/new-safe/create/logic/utils.test.ts
+++ b/src/components/new-safe/create/logic/utils.test.ts
@@ -30,8 +30,13 @@ describe('getAvailableSaltNonce', () => {
   it('should return initial nonce if no contract is deployed to the computed address', async () => {
     jest.spyOn(web3Utils, 'isSmartContract').mockReturnValue(Promise.resolve(false))
     const initialNonce = faker.string.numeric()
+    const mockChainId = faker.string.numeric()
 
-    const result = await getAvailableSaltNonce(mockProvider, { ...mockDeployProps, saltNonce: initialNonce })
+    const result = await getAvailableSaltNonce(
+      mockProvider,
+      { ...mockDeployProps, saltNonce: initialNonce },
+      mockChainId,
+    )
 
     expect(result).toEqual(initialNonce)
   })
@@ -39,8 +44,13 @@ describe('getAvailableSaltNonce', () => {
   it('should return an increased nonce if a contract is deployed to the computed address', async () => {
     jest.spyOn(web3Utils, 'isSmartContract').mockReturnValueOnce(Promise.resolve(true))
     const initialNonce = faker.string.numeric()
+    const mockChainId = faker.string.numeric()
 
-    const result = await getAvailableSaltNonce(mockProvider, { ...mockDeployProps, saltNonce: initialNonce })
+    const result = await getAvailableSaltNonce(
+      mockProvider,
+      { ...mockDeployProps, saltNonce: initialNonce },
+      mockChainId,
+    )
 
     jest.spyOn(web3Utils, 'isSmartContract').mockReturnValueOnce(Promise.resolve(false))
 

--- a/src/components/new-safe/create/logic/utils.ts
+++ b/src/components/new-safe/create/logic/utils.ts
@@ -3,13 +3,17 @@ import { isSmartContract } from '@/hooks/wallets/web3'
 import type { DeploySafeProps } from '@safe-global/protocol-kit'
 import type { BrowserProvider } from 'ethers'
 
-export const getAvailableSaltNonce = async (provider: BrowserProvider, props: DeploySafeProps): Promise<string> => {
-  const safeAddress = await computeNewSafeAddress(provider, props)
+export const getAvailableSaltNonce = async (
+  provider: BrowserProvider,
+  props: DeploySafeProps,
+  chainId: string,
+): Promise<string> => {
+  const safeAddress = await computeNewSafeAddress(provider, props, chainId)
   const isContractDeployed = await isSmartContract(provider, safeAddress)
 
   // Safe is already deployed so we try the next saltNonce
   if (isContractDeployed) {
-    return getAvailableSaltNonce(provider, { ...props, saltNonce: (Number(props.saltNonce) + 1).toString() })
+    return getAvailableSaltNonce(provider, { ...props, saltNonce: (Number(props.saltNonce) + 1).toString() }, chainId)
   }
 
   // We know that there will be a saltNonce but the type has it as optional

--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -175,8 +175,8 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
         },
       }
 
-      const saltNonce = await getAvailableSaltNonce(provider, { ...props, saltNonce: '0' })
-      const safeAddress = await computeNewSafeAddress(provider, { ...props, saltNonce })
+      const saltNonce = await getAvailableSaltNonce(provider, { ...props, saltNonce: '0' }, chain.chainId)
+      const safeAddress = await computeNewSafeAddress(provider, { ...props, saltNonce }, chain.chainId)
 
       if (isCounterfactual && payMethod === PayMethod.PayLater) {
         gtmSetSafeAddress(safeAddress)


### PR DESCRIPTION
## What it solves

Noticed this when debugging failing e2e tests the other day. This change reduces the number of RPC requests when calling `getAvailableSaltNonce` from 3 to 1.

## How this PR fixes it

- Calling `SafeFactory.create` always checks if the factory contract(s) are deployed on the current network
- Doesn't create a new instance of `SafeFactory` every time we want to predict the safe address
- Instead it now calls the utils function that hte protocol-kit provides directly

## How to test it

1. Creating a Safe should still work
2. Creating a counterfactual safe should still work
3. The predicted safe address should still be correct and what the user ends up with eventually once its deployed on chain

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
