### PR TITLE
fix: counterfactual safe tracking

### DIFF
--- a/src/components/welcome/MyAccounts/useTrackedSafesCount.ts
+++ b/src/components/welcome/MyAccounts/useTrackedSafesCount.ts
@@ -22,11 +22,11 @@ const useTrackSafesCount = (
   }, [wallet?.address])
 
   useEffect(() => {
-    if (!isOwnedSafesTracked && ownedSafes && ownedSafes.length > 0 && isLoginPage) {
+    if (wallet && !isOwnedSafesTracked && ownedSafes && ownedSafes.length > 0 && isLoginPage) {
       trackEvent({ ...OVERVIEW_EVENTS.TOTAL_SAFES_OWNED, label: ownedSafes.length })
       isOwnedSafesTracked = true
     }
-  }, [isLoginPage, ownedSafes])
+  }, [isLoginPage, ownedSafes, wallet])
 
   useEffect(() => {
     if (watchlistSafes && isLoginPage && watchlistSafes.length > 0 && !isWatchlistTracked) {


### PR DESCRIPTION
## What it solves

Resolves https://www.notion.so/safe-global/1f1df3f06ead4378ab1c9c3de24951b1?v=6ad2667b868d4c0f8cf18e129f762583&p=cf2a606d10e94de49050d87973a54621&pm=s

## How this PR fixes it
- Does not track owned Safes if no wallet is connected

## How to test it
- Add a counterfactual Safe
- observe that nothing is logged without owner connected
- Observe that with owner connected the counts are correct


## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
