### PR TITLE
Fix: remove the New chip from Recovery settings

### DIFF
--- a/src/features/recovery/components/RecoverySettings/index.tsx
+++ b/src/features/recovery/components/RecoverySettings/index.tsx
@@ -4,7 +4,6 @@ import { RECOVERY_EVENTS } from '@/services/analytics/events/recovery'
 import { Box, Button, Grid, Paper, SvgIcon, Tooltip, Typography } from '@mui/material'
 import { type ReactElement, useMemo, useState } from 'react'
 
-import { Chip } from '@/components/common/Chip'
 import ExternalLink from '@/components/common/ExternalLink'
 import { DelayModifierRow } from './DelayModifierRow'
 import useRecovery from '@/features/recovery/hooks/useRecovery'
@@ -118,8 +117,6 @@ function RecoverySettings(): ReactElement {
             <Typography variant="h4" fontWeight="bold">
               Account recovery
             </Typography>
-
-            <Chip label="New" />
           </Box>
         </Grid>
 


### PR DESCRIPTION
## What it solves

The Recovery feature is not "new" anymore so this label should be removed.