### PR TITLE
Chore: prod build on staging (main)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: ./.github/workflows/build
         with:
           secrets: ${{ toJSON(secrets) }}
-          prod: ${{ github.base_ref == 'main' }} # PRs to main are Release Candidates and must be tested with prod settings
+          if: startsWith(github.ref, 'refs/heads/main')
 
       - uses: ./.github/workflows/build-storybook
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -10,9 +10,12 @@ jobs:
       id-token: write
 
     runs-on: ubuntu-latest
+
     name: Deploy release
+
     env:
       ARCHIVE_NAME: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -36,14 +39,15 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       # Script to upload release files
-      - name: 'Upload release build files for production'
+      - name: Upload release build files for production
         env:
           BUCKET: s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ github.event.release.tag_name }}
           CHECKSUM_FILE: ${{ env.ARCHIVE_NAME }}-sha256-checksum.txt
         run: bash ./scripts/github/s3_upload.sh
 
       # Script to prepare production deployments
-      - run: bash ./scripts/github/prepare_production_deployment.sh
+      - name: Prepare deployment
+        run: bash ./scripts/github/prepare_production_deployment.sh
         env:
           PROD_DEPLOYMENT_HOOK_TOKEN: ${{ secrets.PROD_DEPLOYMENT_HOOK_TOKEN }}
           PROD_DEPLOYMENT_HOOK_URL: ${{ secrets.PROD_DEPLOYMENT_HOOK_URL }}
@@ -51,7 +55,7 @@ jobs:
 
       # Update the GitHub release with a checksummed archive
       - name: Upload archive
-      - uses: Shopify/upload-to-release@v2.0.0
+        uses: Shopify/upload-to-release@v2.0.0
         with:
           path: ${{ env.ARCHIVE_NAME }}.tar.gz
           name: ${{ env.ARCHIVE_NAME }}.tar.gz


### PR DESCRIPTION
## What it solves

Having prod settings on the release branch is not convenient to QA, so we'll use the `main` branch, i.e. the staging deployment, for this.