### PR TITLE
Fix: Error initializing the Safe Core SDK -> Error connecting to the blockchain

### DIFF
--- a/src/hooks/coreSDK/useInitSafeCoreSDK.ts
+++ b/src/hooks/coreSDK/useInitSafeCoreSDK.ts
@@ -43,7 +43,7 @@ export const useInitSafeCoreSDK = () => {
         const e = asError(_e)
         dispatch(
           showNotification({
-            message: 'Please try connecting your wallet again.',
+            message: 'Error connecting to the blockchain. Please try reloading the page.',
             groupKey: 'core-sdk-init-error',
             variant: 'error',
             detailedMessage: e.message,

--- a/src/services/exceptions/ErrorCodes.ts
+++ b/src/services/exceptions/ErrorCodes.ts
@@ -11,7 +11,7 @@ enum ErrorCodes {
   _101 = '101: Failed to resolve the address',
   _103 = '103: Error creating a SafeTransaction',
   _104 = '104: Invalid chain short name in the URL',
-  _105 = '105: Error initializing the Safe Core SDK',
+  _105 = '105: Error connecting to the blockchain',
   _106 = '106: Failed to get connected wallet',
 
   _302 = '302: Error connecting to the wallet',


### PR DESCRIPTION
## What it solves

Resolves #3587

Judging by the Sentry logs, this error is happening when an RCP responds with an error.

There's nothing we can do about this from the frontend, but the error message should be clearer.