### PR TITLE
fix: always show tx value

### DIFF
--- a/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
@@ -1,19 +1,25 @@
 import { isEmptyHexData } from '@/utils/hex'
-import { type InternalTransaction, Operation, type TransactionData } from '@safe-global/safe-gateway-typescript-sdk'
+import {
+  type InternalTransaction,
+  Operation,
+  type TransactionData,
+  TokenType,
+} from '@safe-global/safe-gateway-typescript-sdk'
 import type { AccordionProps } from '@mui/material/Accordion/Accordion'
 import { useCurrentChain } from '@/hooks/useChains'
 import { formatVisualAmount } from '@/utils/formatters'
 import { MethodDetails } from '@/components/transactions/TxDetails/TxData/DecodedData/MethodDetails'
 import { HexEncodedData } from '@/components/transactions/HexEncodedData'
 import { isDeleteAllowance, isSetAllowance } from '@/utils/transaction-guards'
-import { Accordion, AccordionDetails, AccordionSummary, Typography } from '@mui/material'
+import { Accordion, AccordionDetails, AccordionSummary, Stack, Typography } from '@mui/material'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import css from './styles.module.css'
 import accordionCss from '@/styles/accordion.module.css'
 import CodeIcon from '@mui/icons-material/Code'
 import { DelegateCallWarning } from '@/components/transactions/Warning'
-import { InfoDetails } from '@/components/transactions/InfoDetails'
-import NamedAddressInfo from '@/components/common/NamedAddressInfo'
+import SendAmountBlock from '@/components/tx-flow/flows/TokenTransfer/SendAmountBlock'
+import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
+import SendToBlock from '@/components/tx/SendToBlock'
 
 type SingleTxDecodedProps = {
   tx: InternalTransaction
@@ -51,8 +57,6 @@ export const SingleTxDecoded = ({
   const addressInfo = txData.addressInfoIndex?.[tx.to]
   const name = addressInfo?.name
   const avatarUrl = addressInfo?.logoUri
-
-  const title = `Interact with${Number(amount) !== 0 ? ` (and send ${amount} ${symbol} to)` : ''}:`
   const isDelegateCall = tx.operation === Operation.DELEGATE && showDelegateCallWarning
   const isSpendingLimitMethod = isSetAllowance(tx.dataDecoded?.method) || isDeleteAllowance(tx.dataDecoded?.method)
 
@@ -73,16 +77,21 @@ export const SingleTxDecoded = ({
         {/* We always warn of nested delegate calls */}
         {isDelegateCall && <DelegateCallWarning showWarning={!txData.trustedDelegateCallTarget} />}
         {!isSpendingLimitMethod && (
-          <InfoDetails title={title}>
-            <NamedAddressInfo
-              address={tx.to}
-              name={name}
-              customAvatar={avatarUrl}
-              shortAddress={false}
-              showCopyButton
-              hasExplorer
-            />
-          </InfoDetails>
+          <Stack spacing={1}>
+            {amount !== '0' && (
+              <SendAmountBlock
+                amount={amount}
+                tokenInfo={{
+                  type: TokenType.NATIVE_TOKEN,
+                  address: ZERO_ADDRESS,
+                  decimals: chain?.nativeCurrency.decimals ?? 18,
+                  symbol: chain?.nativeCurrency.symbol ?? 'ETH',
+                  logoUri: chain?.nativeCurrency.logoUri,
+                }}
+              />
+            )}
+            <SendToBlock address={tx.to} title="Interact with:" avatarSize={26} />
+          </Stack>
         )}
         {details}
       </AccordionDetails>

--- a/src/components/transactions/TxDetails/TxData/DecodedData/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/index.tsx
@@ -1,10 +1,15 @@
 import type { ReactElement } from 'react'
-import type { TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
-import { isCustomTxInfo } from '@/utils/transaction-guards'
-import { InfoDetails } from '@/components/transactions/InfoDetails'
+import { TokenType, type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
+
 import { HexEncodedData } from '@/components/transactions/HexEncodedData'
 import { MethodDetails } from '@/components/transactions/TxDetails/TxData/DecodedData/MethodDetails'
-import NamedAddressInfo from '@/components/common/NamedAddressInfo'
+import { useCurrentChain } from '@/hooks/useChains'
+import { formatVisualAmount } from '@/utils/formatters'
+import SendAmountBlock from '@/components/tx-flow/flows/TokenTransfer/SendAmountBlock'
+import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
+import SendToBlock from '@/components/tx/SendToBlock'
+import { Stack } from '@mui/material'
+import { isCustomTxInfo } from '@/utils/transaction-guards'
 
 interface Props {
   txData: TransactionDetails['txData']
@@ -12,6 +17,7 @@ interface Props {
 }
 
 export const DecodedData = ({ txData, txInfo }: Props): ReactElement | null => {
+  const chainInfo = useCurrentChain()
   // nothing to render
   if (!txData) {
     return null
@@ -25,22 +31,31 @@ export const DecodedData = ({ txData, txInfo }: Props): ReactElement | null => {
     decodedData = <HexEncodedData title="Data (hex encoded)" hexData={txData.hexData} />
   }
 
+  const amount = txData.value ? formatVisualAmount(txData.value, chainInfo?.nativeCurrency.decimals) : '0'
   // we render the decoded data
   return (
-    <>
-      <InfoDetails title="Interact with:">
-        <NamedAddressInfo
-          address={txData.to.value}
-          name={isCustomTxInfo(txInfo) ? txInfo.to.name : undefined}
-          customAvatar={isCustomTxInfo(txInfo) ? txInfo.to.logoUri : undefined}
-          shortAddress={false}
-          showCopyButton
-          hasExplorer
+    <Stack spacing={1}>
+      {amount !== '0' && (
+        <SendAmountBlock
+          amount={amount}
+          tokenInfo={{
+            type: TokenType.NATIVE_TOKEN,
+            address: ZERO_ADDRESS,
+            decimals: chainInfo?.nativeCurrency.decimals ?? 18,
+            symbol: chainInfo?.nativeCurrency.symbol ?? 'ETH',
+            logoUri: chainInfo?.nativeCurrency.logoUri,
+          }}
         />
-      </InfoDetails>
+      )}
+      <SendToBlock
+        address={txData.to.value}
+        title="Interact with"
+        name={isCustomTxInfo(txInfo) ? txInfo.to.name : undefined}
+        avatarSize={26}
+      />
 
       {decodedData}
-    </>
+    </Stack>
   )
 }
 

--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -1,4 +1,3 @@
-import { getInteractionTitle } from '@/components/safe-apps/utils'
 import SendToBlock from '@/components/tx/SendToBlock'
 import SwapOrderConfirmationView from '@/features/swap/components/SwapOrderConfirmationView'
 import { useCurrentChain } from '@/hooks/useChains'
@@ -10,13 +9,19 @@ import {
   AccordionSummary,
   Box,
   Skeleton,
+  Stack,
   SvgIcon,
   Tooltip,
   Typography,
 } from '@mui/material'
 import { OperationType, type SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import type { DecodedDataResponse } from '@safe-global/safe-gateway-typescript-sdk'
-import { getTransactionDetails, type TransactionDetails, Operation } from '@safe-global/safe-gateway-typescript-sdk'
+import {
+  getTransactionDetails,
+  type TransactionDetails,
+  Operation,
+  TokenType,
+} from '@safe-global/safe-gateway-typescript-sdk'
 import useChainId from '@/hooks/useChainId'
 import useAsync from '@/hooks/useAsync'
 import { MethodDetails } from '@/components/transactions/TxDetails/TxData/DecodedData/MethodDetails'
@@ -29,6 +34,9 @@ import ExternalLink from '@/components/common/ExternalLink'
 import { HelpCenterArticle } from '@/config/constants'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import accordionCss from '@/styles/accordion.module.css'
+import { formatVisualAmount } from '@/utils/formatters'
+import SendAmountBlock from '@/components/tx-flow/flows/TokenTransfer/SendAmountBlock'
+import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 
 type DecodedTxProps = {
   tx?: SafeTransaction
@@ -68,16 +76,28 @@ const DecodedTx = ({
 
   if (!decodedData) return null
 
+  const amount = tx?.data.value ? formatVisualAmount(tx.data.value, chain?.nativeCurrency.decimals) : '0'
+
   return (
-    <div>
-      {!isSwapOrder && tx && showToBlock && (
-        <SendToBlock address={tx.data.to} title={getInteractionTitle(tx.data.value || '', chain)} />
+    <Stack spacing={2}>
+      {!isSwapOrder && tx && showToBlock && amount !== '0' && (
+        <SendAmountBlock
+          amount={amount}
+          tokenInfo={{
+            type: TokenType.NATIVE_TOKEN,
+            address: ZERO_ADDRESS,
+            decimals: chain?.nativeCurrency.decimals ?? 18,
+            symbol: chain?.nativeCurrency.symbol ?? 'ETH',
+            logoUri: chain?.nativeCurrency.logoUri,
+          }}
+        />
       )}
+      {!isSwapOrder && tx && showToBlock && <SendToBlock address={tx.data.to} title="Interact with" />}
 
       {isSwapOrder && tx && <SwapOrderConfirmationView order={decodedData} settlementContract={tx.data.to} />}
 
       {isMultisend && showMultisend && (
-        <Box my={2}>
+        <Box>
           <Multisend
             txData={{
               dataDecoded: decodedData,
@@ -92,7 +112,7 @@ const DecodedTx = ({
         </Box>
       )}
 
-      <Box mt={2}>
+      <Box>
         <Accordion elevation={0} onChange={onChangeExpand} sx={!tx ? { pointerEvents: 'none' } : undefined}>
           <AccordionSummary
             data-testid="decoded-tx-summary"
@@ -159,7 +179,7 @@ const DecodedTx = ({
           </AccordionDetails>
         </Accordion>
       </Box>
-    </div>
+    </Stack>
   )
 }
 

--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -92,7 +92,9 @@ const DecodedTx = ({
           }}
         />
       )}
-      {!isSwapOrder && tx && showToBlock && <SendToBlock address={tx.data.to} title="Interact with" />}
+      {!isSwapOrder && tx && showToBlock && (
+        <SendToBlock address={tx.data.to} title="Interact with" name={addressInfoIndex?.[tx.data.to]?.name} />
+      )}
 
       {isSwapOrder && tx && <SwapOrderConfirmationView order={decodedData} settlementContract={tx.data.to} />}
 

--- a/src/components/tx/FieldsGrid/index.tsx
+++ b/src/components/tx/FieldsGrid/index.tsx
@@ -4,7 +4,7 @@ import { Grid, Typography } from '@mui/material'
 const FieldsGrid = ({ title, children }: { title: string; children: ReactNode }) => {
   return (
     <Grid container alignItems="center" gap={1}>
-      <Grid item xs={1} xl={2} minWidth={90}>
+      <Grid item xs={2} xl={2} minWidth={90}>
         <Typography variant="body2" color="text.secondary" noWrap>
           {title}
         </Typography>

--- a/src/components/tx/SendToBlock/index.tsx
+++ b/src/components/tx/SendToBlock/index.tsx
@@ -2,11 +2,28 @@ import { Typography } from '@mui/material'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import FieldsGrid from '../FieldsGrid'
 
-const SendToBlock = ({ address, title = 'To' }: { address: string; title?: string }) => {
+const SendToBlock = ({
+  address,
+  title = 'To',
+  avatarSize,
+  name,
+}: {
+  address: string
+  name?: string
+  title?: string
+  avatarSize?: number
+}) => {
   return (
     <FieldsGrid title={title}>
       <Typography variant="body2" component="div">
-        <EthHashInfo address={address} shortAddress={false} hasExplorer showCopyButton />
+        <EthHashInfo
+          address={address}
+          name={name}
+          shortAddress={false}
+          hasExplorer
+          showCopyButton
+          avatarSize={avatarSize}
+        />
       </Typography>
     </FieldsGrid>
   )


### PR DESCRIPTION
## What it solves
On some resolutions the value of a transaction is cut off and not visible in the transaction review screen.

## How this PR fixes it
Show value of transaction separately to the to address.

## How to test it
Create a tx with value > 0 via. e.g. transaction builder.

## Screenshots
<img width="582" alt="Screenshot 2024-06-03 at 17 02 17" src="https://github.com/safe-global/safe-wallet-web/assets/2670790/e21d179d-3cab-43dd-be35-85be0cf71555">

<img width="1239" alt="Screenshot 2024-06-06 at 14 11 35" src="https://github.com/safe-global/safe-wallet-web/assets/2670790/ca894235-fc42-4fae-89b7-47938fc6bed9">
<img width="1239" alt="Screenshot 2024-06-06 at 14 11 22" src="https://github.com/safe-global/safe-wallet-web/assets/2670790/cdb467ad-80a4-4322-8967-678003838b3e">


## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
