### PR TITLE
Fix: same addresses showing same balance

### DIFF
--- a/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
+++ b/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
@@ -26,7 +26,9 @@ const SafeListPage = ({ safes, onLinkClick }: SafeListPageProps) => {
   const [overviews] = useSafeOverviews(safes)
 
   const findOverview = (item: SafeItem) => {
-    return overviews?.find((overview) => sameAddress(overview.address.value, item.address))
+    return overviews?.find(
+      (overview) => item.chainId === overview.chainId && sameAddress(overview.address.value, item.address),
+    )
   }
 
   return (


### PR DESCRIPTION
## What it solves

Resolves #3794

## How this PR fixes it

`chainId` wasn't taken into account when looking up Safes in the balances list.