### PR TITLE
fix: typo in feeTooltipMarkdown [SWAP-93]

### DIFF
--- a/src/features/swap/index.tsx
+++ b/src/features/swap/index.tsx
@@ -200,7 +200,7 @@ const SwapWidget = ({ sell }: Params) => {
       content: {
         feeLabel: 'No fee for one month',
         feeTooltipMarkdown:
-          'Any future transaction fee incurred by Cow Protocol here will contribute to a license fee that supports the Safe Community. Neither Safe Ecosystem Foundation nor Core Contributors GmbH operate the CoW Swap Widget and/or Cow Swap.',
+          'Any future transaction fee incurred by CoW Protocol here will contribute to a license fee that supports the Safe Community. Neither Safe Ecosystem Foundation nor Core Contributors GmbH operate the CoW Swap Widget and/or CoW Swap.',
       },
     })
   }, [sell, palette, darkMode, chainId])


### PR DESCRIPTION
## What it solves
CoW was not written properly in the fee tooltip:
https://prnt.sc/LHMI8U0QvfQa

## How to test it
Look at the fee tooltip.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
