### PR TITLE
Fix: filter out undefined address in useSafeOverviews

### DIFF
--- a/src/components/welcome/MyAccounts/__tests__/useSafeOverviews.test.ts
+++ b/src/components/welcome/MyAccounts/__tests__/useSafeOverviews.test.ts
@@ -1,0 +1,47 @@
+import useSafeOverviews from '../useSafeOverviews'
+import * as balances from '@/hooks/loadables/useLoadBalances'
+import * as sdk from '@safe-global/safe-gateway-typescript-sdk'
+import * as useWallet from '@/hooks/wallets/useWallet'
+import * as store from '@/store'
+import type { Eip1193Provider } from 'ethers'
+import { renderHook } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
+
+jest.spyOn(balances, 'useTokenListSetting').mockReturnValue(false)
+jest.spyOn(store, 'useAppSelector').mockReturnValue('USD')
+jest
+  .spyOn(useWallet, 'default')
+  .mockReturnValue({ label: 'MetaMask', chainId: '1', address: '0x1234', provider: null as unknown as Eip1193Provider })
+
+describe('useSafeOverviews', () => {
+  it('should filter out undefined addresses', async () => {
+    const mockResponse = [
+      {
+        address: { value: '0x1234' },
+        chainId: '1',
+        awaitingConfirmation: 1,
+        fiatTotal: '1000',
+        owners: [{ value: '0x1234' }],
+        queued: 10,
+        threshold: 2,
+      },
+    ]
+    const spy = jest.spyOn(sdk, 'getSafeOverviews').mockResolvedValue(mockResponse)
+    const safes = [
+      { address: '0x1234', chainId: '1' },
+      { address: undefined as unknown as string, chainId: '2' },
+      { address: '0x5678', chainId: '3' },
+    ]
+
+    renderHook(() => useSafeOverviews(safes))
+
+    await act(() => Promise.resolve())
+
+    expect(spy).toHaveBeenCalledWith(['1:0x1234', '3:0x5678'], {
+      currency: 'USD',
+      exclude_spam: false,
+      trusted: true,
+      wallet_address: '0x1234',
+    })
+  })
+})

--- a/src/components/welcome/MyAccounts/__tests__/useSafeOverviews.test.ts
+++ b/src/components/welcome/MyAccounts/__tests__/useSafeOverviews.test.ts
@@ -15,21 +15,30 @@ jest
 
 describe('useSafeOverviews', () => {
   it('should filter out undefined addresses', async () => {
-    const mockResponse = [
-      {
-        address: { value: '0x1234' },
-        chainId: '1',
-        awaitingConfirmation: 1,
-        fiatTotal: '1000',
-        owners: [{ value: '0x1234' }],
-        queued: 10,
-        threshold: 2,
-      },
-    ]
-    const spy = jest.spyOn(sdk, 'getSafeOverviews').mockResolvedValue(mockResponse)
+    const spy = jest.spyOn(sdk, 'getSafeOverviews').mockResolvedValue([])
     const safes = [
       { address: '0x1234', chainId: '1' },
       { address: undefined as unknown as string, chainId: '2' },
+      { address: '0x5678', chainId: '3' },
+    ]
+
+    renderHook(() => useSafeOverviews(safes))
+
+    await act(() => Promise.resolve())
+
+    expect(spy).toHaveBeenCalledWith(['1:0x1234', '3:0x5678'], {
+      currency: 'USD',
+      exclude_spam: false,
+      trusted: true,
+      wallet_address: '0x1234',
+    })
+  })
+
+  it('should filter out undefined chain ids', async () => {
+    const spy = jest.spyOn(sdk, 'getSafeOverviews').mockResolvedValue([])
+    const safes = [
+      { address: '0x1234', chainId: '1' },
+      { address: '0x5678', chainId: undefined as unknown as string },
       { address: '0x5678', chainId: '3' },
     ]
 

--- a/src/components/welcome/MyAccounts/useSafeOverviews.ts
+++ b/src/components/welcome/MyAccounts/useSafeOverviews.ts
@@ -16,12 +16,14 @@ type SafeParams = {
 // EIP155 address format
 const makeSafeId = ({ chainId, address }: SafeParams) => `${chainId}:${address}` as `${number}:0x${string}`
 
+const validateSafeParams = ({ chainId, address }: SafeParams) => chainId != null && address != null
+
 function useSafeOverviews(safes: Array<SafeParams>): AsyncResult<SafeOverview[]> {
   const excludeSpam = useTokenListSetting() || false
   const currency = useAppSelector(selectCurrency)
   const wallet = useWallet()
   const walletAddress = wallet?.address
-  const safesIds = useMemo(() => safes.map(makeSafeId), [safes])
+  const safesIds = useMemo(() => safes.filter(validateSafeParams).map(makeSafeId), [safes])
 
   const [data, error, isLoading] = useAsync(async () => {
     return await getSafeOverviews(safesIds, {


### PR DESCRIPTION
## What it solves

I'm not sure what the root cause of undefined addresses is, they seem to be already [filtered by Boolean](https://github.com/safe-global/safe-wallet-web/blob/dev/src/components/welcome/MyAccounts/useAllSafes.ts#L55) before being passed to `useSafeOverviews`. But here's a fix that just filters out bad values before sending a request to CGW.