### PR TITLE
Analytics: remove 0x from signer address

### DIFF
--- a/src/services/analytics/gtm.ts
+++ b/src/services/analytics/gtm.ts
@@ -58,7 +58,7 @@ export const gtmSetDeviceType = (type: DeviceType): void => {
 }
 
 export const gtmSetSafeAddress = (safeAddress: string): void => {
-  commonEventParams.safeAddress = safeAddress.slice(2)
+  commonEventParams.safeAddress = safeAddress.slice(2) // Remove 0x prefix
 }
 
 export const gtmInit = (): void => {

--- a/src/services/analytics/useGtm.ts
+++ b/src/services/analytics/useGtm.ts
@@ -96,7 +96,7 @@ const useGtm = () => {
 
   useEffect(() => {
     if (wallet?.address) {
-      gtmSetUserProperty(AnalyticsUserProperties.WALLET_ADDRESS, wallet.address)
+      gtmSetUserProperty(AnalyticsUserProperties.WALLET_ADDRESS, wallet.address.slice(2)) // Remove 0x prefix
       spindlAttribute(wallet.address)
     }
   }, [wallet?.address])


### PR DESCRIPTION
## What it solves

Like we do with Safe addresses, signer addresses must be trimmed so that GA/BigQuery doesn't try to convert them to integers.