### PR TITLE
feat: add link to tx for order notifications [SWAP-61]

### DIFF
--- a/src/components/tx-flow/flows/SuccessScreen/index.tsx
+++ b/src/components/tx-flow/flows/SuccessScreen/index.tsx
@@ -6,7 +6,6 @@ import css from './styles.module.css'
 import { useAppSelector } from '@/store'
 import { PendingStatus, selectPendingTxById } from '@/store/pendingTxsSlice'
 import { useCallback, useContext, useEffect, useState } from 'react'
-import { getTxLink } from '@/hooks/useTxNotifications'
 import { useCurrentChain } from '@/hooks/useChains'
 import { TxEvent, txSubscribe } from '@/services/tx/txEvents'
 import useSafeInfo from '@/hooks/useSafeInfo'
@@ -18,6 +17,7 @@ import { DefaultStatus } from '@/components/tx-flow/flows/SuccessScreen/statuses
 import useDecodeTx from '@/hooks/useDecodeTx'
 import { isSwapConfirmationViewOrder } from '@/utils/transaction-guards'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import { getTxLink } from '@/utils/tx-link'
 
 const SuccessScreen = ({ txId, safeTx }: { txId: string; safeTx?: SafeTransaction }) => {
   const [localTxHash, setLocalTxHash] = useState<string>()

--- a/src/hooks/useTxNotifications.ts
+++ b/src/hooks/useTxNotifications.ts
@@ -1,14 +1,12 @@
 import { useEffect, useMemo, useRef } from 'react'
 import { formatError } from '@/utils/formatters'
-import type { LinkProps } from 'next/link'
 import { selectNotifications, showNotification } from '@/store/notificationsSlice'
 import { useAppDispatch, useAppSelector } from '@/store'
 import { TxEvent, txSubscribe } from '@/services/tx/txEvents'
-import { AppRoutes } from '@/config/routes'
 import { useCurrentChain } from './useChains'
 import useTxQueue from './useTxQueue'
 import { isSignableBy, isTransactionListItem } from '@/utils/transaction-guards'
-import { type ChainInfo, TransactionStatus } from '@safe-global/safe-gateway-typescript-sdk'
+import { TransactionStatus } from '@safe-global/safe-gateway-typescript-sdk'
 import { selectPendingTxs } from '@/store/pendingTxsSlice'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import useWallet from './wallets/useWallet'
@@ -16,6 +14,7 @@ import useSafeAddress from './useSafeAddress'
 import { getExplorerLink } from '@/utils/gateway'
 import { getTxDetails } from '@/services/transactions'
 import { isWalletRejection } from '@/utils/wallets'
+import { getTxLink } from '@/utils/tx-link'
 
 const TxNotifications = {
   [TxEvent.SIGN_FAILED]: 'Failed to sign. Please try again.',
@@ -42,20 +41,6 @@ enum Variant {
 }
 
 const successEvents = [TxEvent.PROPOSED, TxEvent.SIGNATURE_PROPOSED, TxEvent.ONCHAIN_SIGNATURE_SUCCESS, TxEvent.SUCCESS]
-
-export const getTxLink = (
-  txId: string,
-  chain: ChainInfo,
-  safeAddress: string,
-): { href: LinkProps['href']; title: string } => {
-  return {
-    href: {
-      pathname: AppRoutes.transactions.tx,
-      query: { id: txId, safe: `${chain?.shortName}:${safeAddress}` },
-    },
-    title: 'View transaction',
-  }
-}
 
 const useTxNotifications = (): void => {
   const dispatch = useAppDispatch()

--- a/src/store/swapOrderSlice.ts
+++ b/src/store/swapOrderSlice.ts
@@ -6,6 +6,8 @@ import { isSwapTxInfo, isTransactionListItem } from '@/utils/transaction-guards'
 import { txHistorySlice } from '@/store/txHistorySlice'
 import { showNotification } from '@/store/notificationsSlice'
 import { selectSafeInfo } from '@/store/safeInfoSlice'
+import { selectChainById } from '@/store/chainsSlice'
+import { getTxLink } from '@/utils/tx-link'
 
 type AllStatuses = OrderStatuses | 'created'
 type Order = {
@@ -80,11 +82,18 @@ export const swapOrderStatusListener = (listenerMiddleware: typeof listenerMiddl
       if (oldStatus === newStatus || newStatus === undefined) {
         return
       }
+      const safeInfo = selectSafeInfo(listenerApi.getState())
+
+      let link = null
+      if (swapOrder.txId && safeInfo.data?.chainId && safeInfo.data?.address) {
+        const chainInfo = selectChainById(listenerApi.getState(), safeInfo.data?.chainId)
+        if (chainInfo !== undefined) {
+          link = getTxLink(swapOrder.txId, chainInfo, safeInfo.data?.address.value)
+        }
+      }
 
       switch (newStatus) {
         case 'created':
-          const safeInfo = selectSafeInfo(listenerApi.getState())
-
           dispatch(
             showNotification({
               title: 'Order created',
@@ -94,6 +103,7 @@ export const swapOrderStatusListener = (listenerMiddleware: typeof listenerMiddl
                   : 'Waiting for confirmation from signers of your Safe',
               groupKey,
               variant: 'info',
+              link: link ? link : undefined,
             }),
           )
 
@@ -105,6 +115,7 @@ export const swapOrderStatusListener = (listenerMiddleware: typeof listenerMiddl
               message: 'Waiting for confirmation from signers of your Safe',
               groupKey,
               variant: 'info',
+              link: link ? link : undefined,
             }),
           )
           break
@@ -115,6 +126,7 @@ export const swapOrderStatusListener = (listenerMiddleware: typeof listenerMiddl
               message: 'Waiting for order execution by the CoW Protocol',
               groupKey,
               variant: 'info',
+              link: link ? link : undefined,
             }),
           )
           break
@@ -129,6 +141,7 @@ export const swapOrderStatusListener = (listenerMiddleware: typeof listenerMiddl
               message: 'Your order has been successful',
               groupKey,
               variant: 'success',
+              link: link ? link : undefined,
             }),
           )
           break
@@ -143,6 +156,7 @@ export const swapOrderStatusListener = (listenerMiddleware: typeof listenerMiddl
               message: 'Your order has reached the expiry time and has become invalid',
               groupKey,
               variant: 'warning',
+              link: link ? link : undefined,
             }),
           )
           break
@@ -157,6 +171,7 @@ export const swapOrderStatusListener = (listenerMiddleware: typeof listenerMiddl
               message: 'Your order has been cancelled',
               groupKey,
               variant: 'warning',
+              link: link ? link : undefined,
             }),
           )
           break

--- a/src/store/swapOrderSlice.ts
+++ b/src/store/swapOrderSlice.ts
@@ -84,7 +84,7 @@ export const swapOrderStatusListener = (listenerMiddleware: typeof listenerMiddl
       }
       const safeInfo = selectSafeInfo(listenerApi.getState())
 
-      let link = null
+      let link = undefined
       if (swapOrder.txId && safeInfo.data?.chainId && safeInfo.data?.address) {
         const chainInfo = selectChainById(listenerApi.getState(), safeInfo.data?.chainId)
         if (chainInfo !== undefined) {
@@ -103,7 +103,7 @@ export const swapOrderStatusListener = (listenerMiddleware: typeof listenerMiddl
                   : 'Waiting for confirmation from signers of your Safe',
               groupKey,
               variant: 'info',
-              link: link ? link : undefined,
+              link,
             }),
           )
 
@@ -115,7 +115,7 @@ export const swapOrderStatusListener = (listenerMiddleware: typeof listenerMiddl
               message: 'Waiting for confirmation from signers of your Safe',
               groupKey,
               variant: 'info',
-              link: link ? link : undefined,
+              link,
             }),
           )
           break
@@ -126,7 +126,7 @@ export const swapOrderStatusListener = (listenerMiddleware: typeof listenerMiddl
               message: 'Waiting for order execution by the CoW Protocol',
               groupKey,
               variant: 'info',
-              link: link ? link : undefined,
+              link,
             }),
           )
           break
@@ -141,7 +141,7 @@ export const swapOrderStatusListener = (listenerMiddleware: typeof listenerMiddl
               message: 'Your order has been successful',
               groupKey,
               variant: 'success',
-              link: link ? link : undefined,
+              link,
             }),
           )
           break
@@ -156,7 +156,7 @@ export const swapOrderStatusListener = (listenerMiddleware: typeof listenerMiddl
               message: 'Your order has reached the expiry time and has become invalid',
               groupKey,
               variant: 'warning',
-              link: link ? link : undefined,
+              link,
             }),
           )
           break
@@ -171,7 +171,7 @@ export const swapOrderStatusListener = (listenerMiddleware: typeof listenerMiddl
               message: 'Your order has been cancelled',
               groupKey,
               variant: 'warning',
-              link: link ? link : undefined,
+              link,
             }),
           )
           break

--- a/src/utils/tx-link.ts
+++ b/src/utils/tx-link.ts
@@ -1,0 +1,17 @@
+import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import type { LinkProps } from 'next/link'
+import { AppRoutes } from '@/config/routes'
+
+export const getTxLink = (
+  txId: string,
+  chain: ChainInfo,
+  safeAddress: string,
+): { href: LinkProps['href']; title: string } => {
+  return {
+    href: {
+      pathname: AppRoutes.transactions.tx,
+      query: { id: txId, safe: `${chain?.shortName}:${safeAddress}` },
+    },
+    title: 'View transaction',
+  }
+}


### PR DESCRIPTION
## What it solves
We don’t always have the txId in the order information, but when we do we add a link to the notification.
It’s highly likely that order created events won’t ever have a txId as this event is created before submitting the tx to the blockchain.

I had to extract getTxLink to a separate file as having it in useTxNotifications was causing a circular dependency error in our tests.

Resolves #

## How this PR fixes it
This PR cannot guarantee that the push notification displayed will have a "view transaction" link. It all depends in what order the updates to the order will come through (whether they will be triggered through the widget or through the transaction service). If the user leaves the widget page after submitting a tx, then updates will most probably come from the tx service and there will be "view transaction" link in the notification.

## How to test it
Submit an order and watch the push notifications. The "order executed" one should have a link to "view transaction".

## Screenshots
![grafik](https://github.com/safe-global/safe-wallet-web/assets/693770/df006e96-66cd-4078-9180-53d359c6b73d)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
