### PR TITLE
Feat: calculate surplus for partially filled orders

### DIFF
--- a/src/features/swap/components/SwapOrder/index.tsx
+++ b/src/features/swap/components/SwapOrder/index.tsx
@@ -19,6 +19,7 @@ import {
   getExecutionPrice,
   getLimitPrice,
   getOrderClass,
+  getPartiallyFilledSurplus,
   getSurplusPrice,
   isOrderPartiallyFilled,
 } from '@/features/swap/helpers/utils'
@@ -34,17 +35,16 @@ export const SellOrder = ({ order }: { order: SwapOrderType }) => {
   const { safeAddress } = useSafeInfo()
   const { uid, kind, validUntil, status, sellToken, buyToken, sellAmount, buyAmount, explorerUrl, receiver } = order
 
+  const isPartiallyFilled = isOrderPartiallyFilled(order)
   const executionPrice = getExecutionPrice(order)
   const limitPrice = getLimitPrice(order)
-  const surplusPrice = getSurplusPrice(order)
+  const surplusPrice = isPartiallyFilled ? getPartiallyFilledSurplus(order) : getSurplusPrice(order)
   const expires = new Date(validUntil * 1000)
   const now = new Date()
   const orderClass = getOrderClass(order)
 
   const orderKindLabel = capitalize(kind)
   const isSellOrder = kind === 'sell'
-
-  const isPartiallyFilled = isOrderPartiallyFilled(order)
 
   return (
     <DataTable
@@ -77,7 +77,7 @@ export const SellOrder = ({ order }: { order: SwapOrderType }) => {
             1 {buyToken.symbol} = {formatAmount(limitPrice)} {sellToken.symbol}
           </DataRow>
         ),
-        status === 'fulfilled' ? (
+        status === 'fulfilled' || isPartiallyFilled ? (
           <DataRow key="Surplus" title="Surplus">
             {formatAmount(surplusPrice)} {isSellOrder ? buyToken.symbol : sellToken.symbol}
           </DataRow>

--- a/src/features/swap/helpers/__tests__/utils.test.ts
+++ b/src/features/swap/helpers/__tests__/utils.test.ts
@@ -2,6 +2,7 @@ import {
   getExecutionPrice,
   getFilledPercentage,
   getLimitPrice,
+  getPartiallyFilledSurplus,
   getSurplusPrice,
   isOrderPartiallyFilled,
 } from '../utils'
@@ -250,6 +251,67 @@ describe('Swap helpers', () => {
       })
 
       expect(result1).toBe(false)
+    })
+  })
+  describe('getPartiallyFilledSurplusPrice', () => {
+    it('returns 0 for partially filled sell order with no surplus', () => {
+      const mockOrder = {
+        sellAmount: '100000000000000000000', // 100 tokens
+        executedSellAmount: '50000000000000000000', // 50 tokens
+        executedBuyAmount: '50000000000000000000', // 50 tokens
+        buyAmount: '100000000000000000000', // 100 tokens
+        kind: 'sell',
+        buyToken: { decimals: 18 },
+        sellToken: { decimals: 18 },
+      } as unknown as SwapOrder
+
+      const result = getPartiallyFilledSurplus(mockOrder)
+
+      expect(result).toEqual(0)
+    })
+    it('returns 0 for partially filled buy order with no surplus', () => {
+      const mockOrder = {
+        sellAmount: '100000000000000000000', // 100 tokens
+        executedSellAmount: '50000000000000000000', // 50 tokens
+        executedBuyAmount: '50000000000000000000', // 50 tokens
+        buyAmount: '100000000000000000000', // 100 tokens
+        kind: 'buy',
+        buyToken: { decimals: 18 },
+        sellToken: { decimals: 18 },
+      } as unknown as SwapOrder
+
+      const result = getPartiallyFilledSurplus(mockOrder)
+
+      expect(result).toEqual(0)
+    })
+    it('returns surplus for partially filled sell orders', () => {
+      const mockOrder = {
+        sellAmount: '100000000000000000000', // 100 tokens
+        executedSellAmount: '50000000000000000000', // 50 tokens
+        executedBuyAmount: '55000000000000000000', // 55 tokens
+        buyAmount: '100000000000000000000', // 100 tokens
+        kind: 'sell',
+        buyToken: { decimals: 18 },
+        sellToken: { decimals: 18 },
+      } as unknown as SwapOrder
+
+      const result = getPartiallyFilledSurplus(mockOrder)
+      expect(result).toEqual(5)
+    })
+    it('returns surplus for partially filled buy orders', () => {
+      const mockOrder = {
+        sellAmount: '100000000000000000000', // 100 tokens
+        executedSellAmount: '45000000000000000000', // 50 tokens
+        executedBuyAmount: '50000000000000000000', // 55 tokens
+        buyAmount: '100000000000000000000', // 100 tokens
+        kind: 'buy',
+        buyToken: { decimals: 18 },
+        sellToken: { decimals: 18 },
+      } as unknown as SwapOrder
+
+      const result = getPartiallyFilledSurplus(mockOrder)
+
+      expect(result).toEqual(5)
     })
   })
 })

--- a/src/features/swap/helpers/utils.ts
+++ b/src/features/swap/helpers/utils.ts
@@ -37,16 +37,13 @@ export const getExecutionPrice = (
 }
 
 export const getLimitPrice = (
-  order: Pick<SwapOrder, 'sellAmount' | 'buyAmount' | 'buyAmount' | 'buyToken' | 'sellToken'>,
+  order: Pick<SwapOrder, 'sellAmount' | 'buyAmount' | 'buyToken' | 'sellToken'>,
 ): number => {
   const { sellAmount, buyAmount, buyToken, sellToken } = order
 
   const ratio = calculateRatio(
     { amount: sellAmount, decimals: sellToken.decimals },
-    {
-      amount: buyAmount,
-      decimals: buyToken.decimals,
-    },
+    { amount: buyAmount, decimals: buyToken.decimals },
   )
 
   return ratio
@@ -70,6 +67,49 @@ export const getSurplusPrice = (
   } else {
     return 0
   }
+}
+
+export const getPartiallyFilledSurplus = (order: SwapOrder): number => {
+  if (order.kind === OrderKind.BUY) {
+    return _getPartiallyFilledBuySurplus(order)
+  } else if (order.kind === OrderKind.SELL) {
+    return _getPartiallyFilledSellSurplus(order)
+  } else {
+    return 0
+  }
+}
+
+const _getPartiallyFilledBuySurplus = (
+  order: Pick<
+    SwapOrder,
+    'executedBuyAmount' | 'buyAmount' | 'buyToken' | 'executedSellAmount' | 'sellAmount' | 'sellToken' | 'kind'
+  >,
+): number => {
+  const { executedSellAmount, sellAmount, sellToken, executedBuyAmount, buyAmount, buyToken } = order
+
+  const limitPrice = calculateRatio(
+    { amount: sellAmount, decimals: sellToken.decimals },
+    { amount: buyAmount, decimals: buyToken.decimals },
+  )
+  const maximumSellAmount = asDecimal(BigInt(executedBuyAmount), buyToken.decimals) * limitPrice
+  return maximumSellAmount - asDecimal(BigInt(executedSellAmount), sellToken.decimals)
+}
+
+const _getPartiallyFilledSellSurplus = (
+  order: Pick<
+    SwapOrder,
+    'executedBuyAmount' | 'buyAmount' | 'buyToken' | 'executedSellAmount' | 'sellAmount' | 'sellToken' | 'kind'
+  >,
+): number => {
+  const { executedSellAmount, sellAmount, sellToken, executedBuyAmount, buyAmount, buyToken } = order
+
+  const limitPrice = calculateRatio(
+    { amount: buyAmount, decimals: buyToken.decimals },
+    { amount: sellAmount, decimals: sellToken.decimals },
+  )
+
+  const minimumBuyAmount = asDecimal(BigInt(executedSellAmount), sellToken.decimals) * limitPrice
+  return asDecimal(BigInt(executedBuyAmount), buyToken.decimals) - minimumBuyAmount
 }
 
 export const getFilledPercentage = (

--- a/src/features/swap/helpers/utils.ts
+++ b/src/features/swap/helpers/utils.ts
@@ -71,15 +71,15 @@ export const getSurplusPrice = (
 
 export const getPartiallyFilledSurplus = (order: SwapOrder): number => {
   if (order.kind === OrderKind.BUY) {
-    return _getPartiallyFilledBuySurplus(order)
+    return getPartiallyFilledBuySurplus(order)
   } else if (order.kind === OrderKind.SELL) {
-    return _getPartiallyFilledSellSurplus(order)
+    return getPartiallyFilledSellSurplus(order)
   } else {
     return 0
   }
 }
 
-const _getPartiallyFilledBuySurplus = (
+const getPartiallyFilledBuySurplus = (
   order: Pick<
     SwapOrder,
     'executedBuyAmount' | 'buyAmount' | 'buyToken' | 'executedSellAmount' | 'sellAmount' | 'sellToken' | 'kind'
@@ -95,7 +95,7 @@ const _getPartiallyFilledBuySurplus = (
   return maximumSellAmount - asDecimal(BigInt(executedSellAmount), sellToken.decimals)
 }
 
-const _getPartiallyFilledSellSurplus = (
+const getPartiallyFilledSellSurplus = (
   order: Pick<
     SwapOrder,
     'executedBuyAmount' | 'buyAmount' | 'buyToken' | 'executedSellAmount' | 'sellAmount' | 'sellToken' | 'kind'


### PR DESCRIPTION
## What it solves

Resolves: https://www.notion.so/safe-global/Better-Surplus-calculation-2e3bf20feeed46938c6efa6728c5ea94?pvs=4

## How this PR fixes it
- Calculate surplus for partially filled orders instead of only for fully fulfilled orders, like CoW Swap are doing.

## How to test it
- Create a partially fillable limit order.
- When the order is partially filled, check that the surplus price is displayed. Check that it is the same as the order on cowswap.
- You can set the sell amount to more than your current balance to make sure that it will be partially filled

## Screenshots
<img width="796" alt="image" src="https://github.com/safe-global/safe-wallet-web/assets/17801424/a96a44b4-a6cf-448e-8ee8-e251fe4ec776">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
