### PR TITLE
Feat: better fiat and token amount formatting

### DIFF
--- a/src/components/balances/AssetsTable/index.tsx
+++ b/src/components/balances/AssetsTable/index.tsx
@@ -80,6 +80,7 @@ const headCells = [
     id: 'value',
     label: 'Value',
     width: '20%',
+    align: 'right',
   },
   {
     id: 'actions',
@@ -151,8 +152,9 @@ const AssetsTable = ({
               rawValue: rawFiatValue,
               collapsed: item.tokenInfo.address === hidingAsset,
               content: (
-                <>
+                <Typography textAlign="right">
                   <FiatValue value={item.fiatBalance} />
+
                   {rawFiatValue === 0 && (
                     <Tooltip
                       title="Provided values are indicative and we are unable to accommodate pricing requests for individual assets"
@@ -170,7 +172,7 @@ const AssetsTable = ({
                       </span>
                     </Tooltip>
                   )}
-                </>
+                </Typography>
               ),
             },
             actions: {

--- a/src/components/common/EnhancedTable/index.tsx
+++ b/src/components/common/EnhancedTable/index.tsx
@@ -34,6 +34,7 @@ type EnhancedHeadCell = {
   id: string
   label: ReactNode
   width?: string
+  align?: string
   sticky?: boolean
 }
 
@@ -75,7 +76,10 @@ function EnhancedTableHead(props: EnhancedTableHeadProps) {
             align="left"
             padding="normal"
             sortDirection={orderBy === headCell.id ? order : false}
-            sx={headCell.width ? { width: headCell.width } : undefined}
+            sx={{
+              width: headCell.width ? headCell.width : '',
+              textAlign: headCell.align ? headCell.align : '',
+            }}
             className={classNames({ sticky: headCell.sticky })}
           >
             {headCell.label && (

--- a/src/components/common/FiatValue/index.tsx
+++ b/src/components/common/FiatValue/index.tsx
@@ -4,12 +4,12 @@ import { useAppSelector } from '@/store'
 import { selectCurrency } from '@/store/settingsSlice'
 import { formatCurrency } from '@/utils/formatNumber'
 
-const FiatValue = ({ value }: { value: string | number }): ReactElement => {
+const FiatValue = ({ value, maxLength }: { value: string | number; maxLength?: number }): ReactElement => {
   const currency = useAppSelector(selectCurrency)
 
   const fiat = useMemo(() => {
-    return formatCurrency(value, currency)
-  }, [value, currency])
+    return formatCurrency(value, currency, maxLength)
+  }, [value, currency, maxLength])
 
   return <span suppressHydrationWarning>{fiat}</span>
 }

--- a/src/components/common/TokenAmount/index.test.tsx
+++ b/src/components/common/TokenAmount/index.test.tsx
@@ -14,6 +14,6 @@ describe('TokenAmount', () => {
 
   it('should format big amount for zero decimals', async () => {
     const result = render(<TokenAmount value="10000000" decimals={0} />)
-    await expect(result.findByText('10,000,000')).resolves.not.toBeNull()
+    await expect(result.findByText('10M')).resolves.not.toBeNull()
   })
 })

--- a/src/components/dashboard/Assets/index.tsx
+++ b/src/components/dashboard/Assets/index.tsx
@@ -55,7 +55,7 @@ const AssetRow = ({ item, showSwap }: { item: SafeBalanceResponse['items'][numbe
       />
     </Box>
 
-    <Box flex={1} display={['none', 'block']}>
+    <Box flex={1} display={['none', 'block']} textAlign="right" pr={4}>
       <FiatValue value={item.fiatBalance} />
     </Box>
 

--- a/src/components/dashboard/Overview/Overview.tsx
+++ b/src/components/dashboard/Overview/Overview.tsx
@@ -73,7 +73,7 @@ const Overview = (): ReactElement => {
                 </Typography>
                 <Typography component="div" variant="h1" fontSize={44} lineHeight="40px">
                   {safe.deployed ? (
-                    <FiatValue value={balances.fiatTotal} />
+                    <FiatValue value={balances.fiatTotal} maxLength={20} />
                   ) : (
                     <TokenAmount
                       value={balances.items[0].balance}

--- a/src/components/welcome/MyAccounts/AccountItem.tsx
+++ b/src/components/welcome/MyAccounts/AccountItem.tsx
@@ -109,7 +109,7 @@ const AccountItem = ({ onLinkClick, safeItem, safeOverview }: AccountItemProps) 
             )}
           </Typography>
 
-          <Typography variant="body2" fontWeight="bold">
+          <Typography variant="body2" fontWeight="bold" textAlign="right" pr={5}>
             {safeOverview?.fiatTotal && <FiatValue value={safeOverview.fiatTotal} />}
           </Typography>
 

--- a/src/utils/__tests__/formatNumber.test.ts
+++ b/src/utils/__tests__/formatNumber.test.ts
@@ -1,308 +1,61 @@
-import { formatAmount, formatAmountPrecise, formatCurrency } from '@/utils/formatNumber'
+import { formatAmountPrecise, formatAmount, formatCurrency } from '@/utils/formatNumber'
 
 describe('formatNumber', () => {
+  describe('formatAmountPrecise', () => {
+    it('should format a number with a defined precision', () => {
+      expect(formatAmountPrecise(1234.5678, 2)).toBe('1,234.57')
+    })
+  })
+
   describe('formatAmount', () => {
-    it('should remove trailing zeroes', () => {
-      expect(formatAmount('0.10000')).toEqual('0.1')
-      expect(formatAmount('0.100000000000')).toEqual('0.1')
+    it('should format a number below 0.0001', () => {
+      expect(formatAmount(0.000000009)).toBe('< 0.00001')
     })
 
-    it('should use maximum of 5 decimals', () => {
-      expect(formatAmount('0.123456789')).toEqual('0.12346')
+    it('should format a number below 1', () => {
+      expect(formatAmount(0.567811)).toBe('0.56781')
     })
 
-    it('should use five decimals for numbers up until 999.99999', () => {
-      expect(formatAmount('345.123456789')).toEqual('345.12346') // 9 decimals
-      expect(formatAmount('999.99999')).toEqual('999.99999') // 5 decimals
-
-      // rounds above the specified limit
-      expect(formatAmount('999.999992')).toEqual('999.99999') // 6 decimals
-      expect(formatAmount('999.999996')).toEqual('1,000')
+    it('should format a number above 1', () => {
+      expect(formatAmount(285.1257657)).toBe('285.12577')
     })
 
-    it('should use four decimals for numbers between 1,000.0001 until 9,999.9999', () => {
-      // rounds down past the specified precision
-      expect(formatAmount(1_000.00001)).toEqual('1,000')
-
-      expect(formatAmount(1_000.0001234)).toEqual('1,000.0001')
-      expect(formatAmount(1_234.123456789)).toEqual('1,234.1235')
-      expect(formatAmount(9_999.9999)).toEqual('9,999.9999')
-
-      // rounds above the specified limit
-      expect(formatAmount(9_999.99992)).toEqual('9,999.9999')
-      expect(formatAmount(9_999.99996)).toEqual('10,000')
+    it('should abbreviate a number with more than 10 digits', () => {
+      expect(formatAmount(12345678901)).toBe('12.35B')
     })
 
-    it('should use three decimals for numbers between 10,000.001 until 99,999.999', () => {
-      // rounds down past the specified precision
-      expect(formatAmount(10_000.00001)).toEqual('10,000')
-
-      expect(formatAmount(10_000.001)).toEqual('10,000.001')
-      expect(formatAmount(12_345.123456789)).toEqual('12,345.123')
-      expect(formatAmount(99_999.999)).toEqual('99,999.999')
-
-      // rounds above the specified limit
-      expect(formatAmount(99_999.9992)).toEqual('99,999.999')
-      expect(formatAmount(99_999.9996)).toEqual('100,000')
-    })
-
-    it('should use two decimals for numbers between 100,000.01 until 999,999.99', () => {
-      // rounds down past the specified precision
-      expect(formatAmount(100_000.00001)).toEqual('100,000')
-
-      expect(formatAmount(100_000.01)).toEqual('100,000.01')
-      expect(formatAmount(123_456.123456789)).toEqual('123,456.12')
-      expect(formatAmount(999_999.99)).toEqual('999,999.99')
-
-      // rounds above the specified limit
-      expect(formatAmount(999_999.992)).toEqual('999,999.99')
-      expect(formatAmount(999_999.996)).toEqual('1,000,000')
-    })
-
-    it('should use one decimal for numbers between 1,000,000.1 until 9,999,999.9', () => {
-      // rounds down past the specified precision
-      expect(formatAmount(1_000_000.00001)).toEqual('1,000,000')
-
-      expect(formatAmount(1_000_000.1)).toEqual('1,000,000.1')
-      expect(formatAmount(1_234_567.123456789)).toEqual('1,234,567.1')
-      expect(formatAmount(9_999_999.9)).toEqual('9,999,999.9')
-
-      // rounds above the specified limit
-      expect(formatAmount(9_999_999.92)).toEqual('9,999,999.9')
-      expect(formatAmount(9_999_999.96)).toEqual('10,000,000')
-    })
-
-    it('should use no decimals for numbers between 10,000,000 and 99,999,999.5', () => {
-      // rounds down past the specified precision
-      expect(formatAmount(10_000_000.00001)).toEqual('10,000,000')
-
-      expect(formatAmount(10_000_000.1)).toEqual('10,000,000')
-      expect(formatAmount(12_345_678.123456789)).toEqual('12,345,678')
-      expect(formatAmount(99_999_999)).toEqual('99,999,999')
-
-      // rounds above the specified limit
-      expect(formatAmount(99_999_999.2)).toEqual('99,999,999')
-      expect(formatAmount(99_999_999.6)).toEqual('100M')
-    })
-
-    it('should use M symbol for numbers between 100,000,000 and 999,999,500', () => {
-      // rounds down past the specified precision
-      expect(formatAmount(100_000_000.00001)).toEqual('100M')
-      expect(formatAmount(100_000_100)).toEqual('100M')
-
-      expect(formatAmount(100_001_000)).toEqual('100.001M')
-      expect(formatAmount(123_456_789.123456789)).toEqual('123.457M')
-      expect(formatAmount(999_999_000)).toEqual('999.999M')
-
-      // rounds above the specified limit
-      expect(formatAmount(999_999_499)).toEqual('999.999M')
-      expect(formatAmount(999_999_500)).toEqual('1B')
-    })
-
-    it('should use B symbol for numbers between 999,999,500 and 999,999,500,000', () => {
-      // rounds down past the specified precision
-      expect(formatAmount(1_000_000_000.00001)).toEqual('1B')
-      expect(formatAmount(1_000_100_000)).toEqual('1B')
-
-      expect(formatAmount(1_100_000_000)).toEqual('1.1B')
-      expect(formatAmount(1_234_567_898.123456789)).toEqual('1.235B')
-      expect(formatAmount(100_001_000_500)).toEqual('100.001B')
-      expect(formatAmount(999_999_000_000)).toEqual('999.999B')
-
-      // rounds above the specified limit
-      expect(formatAmount(999_999_499_999)).toEqual('999.999B')
-      expect(formatAmount(999_999_500_000)).toEqual('1T')
-    })
-
-    it('should use T notation for numbers between 999,999,500,000 and 999,000,000,000', () => {
-      // rounds down past the specified precision
-      expect(formatAmount(1_000_000_000_000.00001)).toEqual('1T')
-      expect(formatAmount(1_000_100_000_000)).toEqual('1T')
-
-      expect(formatAmount(1_100_000_000_000)).toEqual('1.1T')
-      expect(formatAmount(1_234_567_898_765.123456789)).toEqual('1.235T')
-      expect(formatAmount(100_001_000_000_000)).toEqual('100.001T')
-      expect(formatAmount(999_999_000_000_000)).toEqual('> 999T')
-    })
-
-    it('should use > 999T for numbers above 999,000,000,000,000', () => {
-      expect(formatAmount(999_000_000_000_001)).toEqual('> 999T')
-      expect(formatAmount(999_000_000_000_000.001)).toEqual('> 999T')
-    })
-
-    it('should use < 0.00001 for amounts smaller then 0.00001', () => {
-      expect(formatAmount(0.00001)).toEqual('0.00001')
-      expect(formatAmount(0.000014)).toEqual('0.00001')
-      expect(formatAmount(0.000015)).toEqual('0.00002')
-      expect(formatAmount(0.000001)).toEqual('< 0.00001')
-      expect(formatAmount(0.000009)).toEqual('< 0.00001')
-    })
-
-    it('should use < -0.00001 or < +0.00001 when the Eucledian distance of the amount is smaller than 0.00001', () => {
-      // to keep the '+' sign the amount shall be passed as a string
-      expect(formatAmount('+0.000001')).toEqual('< +0.00001')
-      expect(formatAmount('+0.000009')).toEqual('< +0.00001')
-
-      // negative numbers will keep the sign either way
-      expect(formatAmount(-0.000001)).toEqual('< -0.00001')
-      expect(formatAmount(-0.000009)).toEqual('< -0.00001')
-      expect(formatAmount('-0.000001')).toEqual('< -0.00001')
-      expect(formatAmount('-0.000009')).toEqual('< -0.00001')
+    it('should abbreviate a number with more than a given amount of digits', () => {
+      expect(formatAmount(1234.12, 2, 4)).toBe('1.23K')
     })
   })
 
   describe('formatCurrency', () => {
-    it('returns the correct number of decimals', () => {
-      const amount1 = 0
-
-      expect(formatCurrency(amount1, 'JPY')).toBe('0 JPY')
-      expect(formatCurrency(amount1, 'IQD')).toBe('0 IQD')
-      expect(formatCurrency(amount1, 'USD')).toBe('0.00 USD')
-      expect(formatCurrency(amount1, 'EUR')).toBe('0.00 EUR')
-      expect(formatCurrency(amount1, 'GBP')).toBe('0.00 GBP')
-      expect(formatCurrency(amount1, 'BHD')).toBe('0.000 BHD')
-
-      const amount2 = 1
-
-      expect(formatCurrency(amount2, 'JPY')).toBe('1 JPY')
-      expect(formatCurrency(amount2, 'IQD')).toBe('1 IQD')
-      expect(formatCurrency(amount2, 'USD')).toBe('1.00 USD')
-      expect(formatCurrency(amount2, 'EUR')).toBe('1.00 EUR')
-      expect(formatCurrency(amount2, 'GBP')).toBe('1.00 GBP')
-      expect(formatCurrency(amount2, 'BHD')).toBe('1.000 BHD')
-
-      const amount3 = '1.7777'
-
-      expect(formatCurrency(amount3, 'JPY')).toBe('2 JPY')
-      expect(formatCurrency(amount3, 'IQD')).toBe('2 IQD')
-      expect(formatCurrency(amount3, 'USD')).toBe('1.78 USD')
-      expect(formatCurrency(amount3, 'EUR')).toBe('1.78 EUR')
-      expect(formatCurrency(amount3, 'GBP')).toBe('1.78 GBP')
-      expect(formatCurrency(amount3, 'BHD')).toBe('1.778 BHD')
+    it('should format a 0', () => {
+      expect(formatCurrency(0, 'USD')).toBe('$ 0')
     })
 
-    it('should drop decimals for values above 1k', () => {
-      // It should stop
-      expect(formatCurrency(999.99, 'USD')).toBe('999.99 USD')
-      expect(formatCurrency(1000.1, 'USD')).toBe('1,000 USD')
-      expect(formatCurrency(1000.99, 'USD')).toBe('1,001 USD')
-      expect(formatCurrency(32500.5, 'EUR')).toBe('32,501 EUR')
-      expect(formatCurrency(314285500.1, 'JPY')).toBe('314.286M JPY')
+    it('should format a number below 1', () => {
+      expect(formatCurrency(0.5678, 'USD')).toBe('$ 0.57')
     })
 
-    it('should use M symbol for numbers between 100,000,000 and 999,999,500', () => {
-      const amount1 = 100_000_100
-
-      expect(formatCurrency(amount1, 'JPY')).toBe('100M JPY')
-
-      const amount2 = 123_456_789.123456789
-
-      expect(formatCurrency(amount2, 'JPY')).toBe('123.457M JPY')
-
-      const amount3 = 999_999_500
-
-      expect(formatCurrency(amount3, 'JPY')).toBe('1B JPY')
+    it('should format a number above 1', () => {
+      expect(formatCurrency(285.1257657, 'EUR')).toBe('€ 285')
     })
 
-    it('should use B symbol for numbers between 999,999,500 and 999,999,500,000', () => {
-      const amount1 = 1_000_000_000
-
-      expect(formatCurrency(amount1, 'JPY')).toBe('1B JPY')
-
-      const amount2 = 1_234_567_898.123456789
-
-      expect(formatCurrency(amount2, 'JPY')).toBe('1.235B JPY')
-
-      const amount3 = 999_999_500_000
-
-      expect(formatCurrency(amount3, 'JPY')).toBe('1T JPY')
+    it('should abbreviate billions', () => {
+      expect(formatCurrency(12_345_678_901, 'USD')).toBe('$ 12.35B')
     })
 
-    it('should use T notation for numbers between 999,999,500,000 and 999,000,000,000', () => {
-      const amount1 = 1_000_100_000_000
-
-      expect(formatCurrency(amount1, 'JPY')).toBe('1T JPY')
-
-      const amount2 = 1_234_567_898_765.123456789
-
-      expect(formatCurrency(amount2, 'JPY')).toBe('1.235T JPY')
-
-      const amount3 = 999_999_000_000_000
-
-      expect(formatCurrency(amount3, 'JPY')).toBe('> 999T JPY')
+    it('should abbreviate millions', () => {
+      expect(formatCurrency(9_589_009.543645, 'EUR')).toBe('€ 9.59M')
     })
 
-    it('should use > 999T for numbers above 999,000,000,000,000', () => {
-      const amount1 = 999_000_000_000_001
-
-      expect(formatCurrency(amount1, 'JPY')).toBe('> 999T JPY')
+    it('should abbreviate thousands', () => {
+      expect(formatCurrency(119_589.543645, 'EUR')).toBe('€ 119.59K')
     })
 
-    it('should use < - smallest denomination or < + smallest denomination when amounts are smaller than the smallest denomination', () => {
-      const amount = 0.000001
-
-      expect(formatCurrency(amount, 'JPY')).toBe('< 1 JPY')
-      expect(formatCurrency(amount, 'IQD')).toBe('< 1 IQD')
-      expect(formatCurrency(amount, 'USD')).toBe('< 0.01 USD')
-      expect(formatCurrency(amount, 'EUR')).toBe('< 0.01 EUR')
-      expect(formatCurrency(amount, 'GBP')).toBe('< 0.01 GBP')
-      expect(formatCurrency(amount, 'BHD')).toBe('< 0.001 BHD')
-
-      // Preserves sign if specified
-      const amount2 = '+0.000001'
-
-      expect(formatCurrency(amount2, 'JPY')).toBe('< +1 JPY')
-      expect(formatCurrency(amount2, 'IQD')).toBe('< +1 IQD')
-      expect(formatCurrency(amount2, 'USD')).toBe('< +0.01 USD')
-      expect(formatCurrency(amount2, 'EUR')).toBe('< +0.01 EUR')
-      expect(formatCurrency(amount2, 'GBP')).toBe('< +0.01 GBP')
-      expect(formatCurrency(amount2, 'BHD')).toBe('< +0.001 BHD')
-
-      const amount3 = -0.000009
-
-      expect(formatCurrency(amount3, 'JPY')).toBe('< -1 JPY')
-      expect(formatCurrency(amount3, 'IQD')).toBe('< -1 IQD')
-      expect(formatCurrency(amount3, 'USD')).toBe('< -0.01 USD')
-      expect(formatCurrency(amount3, 'EUR')).toBe('< -0.01 EUR')
-      expect(formatCurrency(amount3, 'GBP')).toBe('< -0.01 GBP')
-      expect(formatCurrency(amount3, 'BHD')).toBe('< -0.001 BHD')
-
-      const amount4 = '-0.000009'
-
-      expect(formatCurrency(amount4, 'JPY')).toBe('< -1 JPY')
-      expect(formatCurrency(amount4, 'IQD')).toBe('< -1 IQD')
-      expect(formatCurrency(amount4, 'USD')).toBe('< -0.01 USD')
-      expect(formatCurrency(amount4, 'EUR')).toBe('< -0.01 EUR')
-      expect(formatCurrency(amount4, 'GBP')).toBe('< -0.01 GBP')
-      expect(formatCurrency(amount4, 'BHD')).toBe('< -0.001 BHD')
-    })
-  })
-
-  describe('formatAmountPrecise', () => {
-    it('should format amounts without the compact notation', () => {
-      const tokenDecimals = 18
-
-      const amount1 = 100_000_000.00001 // 100M
-      expect(formatAmountPrecise(amount1, tokenDecimals)).toEqual('100,000,000.00001')
-
-      const amount2 = 1_000_000_000.00001 // 1B
-      expect(formatAmountPrecise(amount2, tokenDecimals)).toEqual('1,000,000,000.00001')
-
-      const amount3 = 1_234_567_898.123456789 // 1.235B
-      expect(formatAmountPrecise(amount3, tokenDecimals)).toEqual('1,234,567,898.1234567')
-    })
-
-    it('should preserve the max fraction digits', () => {
-      const tokenDecimals = 18
-
-      const amount1 = 0.000001 // < 0.00001
-      expect(formatAmountPrecise(amount1, tokenDecimals)).toEqual('0.000001')
-
-      const amount2 = 0.00000123456789 // 14 decimals
-      expect(formatAmountPrecise(amount2, tokenDecimals)).toEqual('0.00000123456789') // 14 decimals
-
-      const amount3 = 0.00000123456789012345 // 20 decimals
-      expect(formatAmountPrecise(amount3, tokenDecimals)).toEqual('0.000001234567890123') // 18 decimals
+    it('should abbreviate a number with more than a given amount of digits', () => {
+      expect(formatCurrency(1234.12, 'USD', 4)).toBe('$ 1.23K')
     })
   })
 })

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -1,107 +1,26 @@
-import memoize from 'lodash/memoize'
-
-// These follow the guideline of "How to format amounts"
-// https://github.com/5afe/safe/wiki/How-to-format-amounts
-
-const LOWER_LIMIT = 0.00001
-const COMPACT_LIMIT = 99_999_999.5
-const UPPER_LIMIT = 999 * 10 ** 12
-const NO_DECIMALS_LIMIT = 1000
-
-/**
- * Formatter that restricts the upper and lower limit of numbers that can be formatted
- * @param number Number to format
- * @param formatter Function to format number
- * @param minimum Minimum number to format
- */
-const format = (number: string | number, formatter: (float: number) => string, minimum = LOWER_LIMIT) => {
-  const float = Number(number)
-
-  if (float === 0) {
-    return formatter(float)
-  }
-
-  if (Math.abs(float) < minimum) {
-    return `< ${formatter(minimum * Math.sign(float))}`
-  }
-
-  if (float < UPPER_LIMIT) {
-    return formatter(float)
-  }
-
-  return `> ${formatter(UPPER_LIMIT)}`
-}
-
-// Universal amount formatting options
-
-const getNumberFormatNotation = (number: string | number): Intl.NumberFormatOptions['notation'] => {
-  return Number(number) >= COMPACT_LIMIT ? 'compact' : undefined
-}
-
-const getNumberFormatSignDisplay = (number: string | number): Intl.NumberFormatOptions['signDisplay'] => {
-  const shouldDisplaySign = typeof number === 'string' ? number.trim().startsWith('+') : Number(number) < 0
-  return shouldDisplaySign ? 'exceptZero' : undefined
-}
-
-// Amount formatting options
-
-const getAmountFormatterMaxFractionDigits = (
-  number: string | number,
-): Intl.NumberFormatOptions['maximumFractionDigits'] => {
-  const float = Number(number)
-
-  if (float < 1_000) {
-    return 5
-  }
-
-  if (float < 10_000) {
-    return 4
-  }
-
-  if (float < 100_000) {
-    return 3
-  }
-
-  if (float < 1_000_000) {
-    return 2
-  }
-
-  if (float < 10_000_000) {
-    return 1
-  }
-
-  if (float < COMPACT_LIMIT) {
-    return 0
-  }
-
-  // Represents numbers like 767.343M
-  if (float < UPPER_LIMIT) {
-    return 3
-  }
-
-  return 0
-}
-
-const getAmountFormatterOptions = (number: string | number): Intl.NumberFormatOptions => {
-  return {
-    maximumFractionDigits: getAmountFormatterMaxFractionDigits(number),
-    notation: getNumberFormatNotation(number),
-    signDisplay: getNumberFormatSignDisplay(number),
-  }
-}
-
 /**
  * Intl.NumberFormat number formatter that adheres to our style guide
  * @param number Number to format
  */
-export const formatAmount = (number: string | number, precision?: number): string => {
-  const options = getAmountFormatterOptions(number)
-  if (precision !== undefined) {
-    options.maximumFractionDigits = precision
-  }
-  const formatter = new Intl.NumberFormat(undefined, options)
+export const formatAmount = (number: string | number, precision = 5, maxLength = 6): string => {
+  const float = Number(number)
+  if (float === 0) return '0'
+  if (float === Math.round(float)) precision = 0
+  if (Math.abs(float) < 0.00001) return '< 0.00001'
 
-  return format(number, formatter.format)
+  const fullNum = new Intl.NumberFormat(undefined, {
+    style: 'decimal',
+    maximumFractionDigits: precision,
+  }).format(Number(number))
+
+  // +3 for the decimal point and the two decimal places
+  if (fullNum.length <= maxLength + 3) return fullNum
+
+  return new Intl.NumberFormat(undefined, {
+    style: 'decimal',
+    notation: 'compact',
+    maximumFractionDigits: 2,
+  }).format(float)
 }
 
 /**
@@ -110,58 +29,10 @@ export const formatAmount = (number: string | number, precision?: number): strin
  * @param precision Fraction digits to show
  */
 export const formatAmountPrecise = (number: string | number, precision: number): string => {
-  const float = Number(number)
-
-  const formatter = new Intl.NumberFormat(undefined, {
+  return new Intl.NumberFormat(undefined, {
+    style: 'decimal',
     maximumFractionDigits: precision,
-  })
-
-  return formatter.format(float)
-}
-
-// Fiat formatting
-
-const getMinimumCurrencyDenominator = memoize((currency: string): number => {
-  const BASE_VALUE = 1
-
-  const formatter = new Intl.NumberFormat(undefined, {
-    style: 'currency',
-    currency,
-  })
-
-  const fraction = formatter.formatToParts(BASE_VALUE).find(({ type }) => type === 'fraction')
-
-  // Currencies may not have decimals, i.e. JPY
-  return fraction ? Number(`0.${'1'.padStart(fraction.value.length, '0')}`) : 1
-})
-
-const getCurrencyFormatterMaxFractionDigits = (
-  number: string | number,
-  currency: string,
-): Intl.NumberFormatOptions['maximumFractionDigits'] => {
-  const float = Number(number)
-
-  if (float < NO_DECIMALS_LIMIT) {
-    const [, decimals] = getMinimumCurrencyDenominator(currency).toString().split('.')
-    return decimals?.length ?? 0
-  }
-
-  if (float >= COMPACT_LIMIT) {
-    return 3
-  }
-
-  return 0
-}
-
-const getCurrencyFormatterOptions = (number: string | number, currency: string): Intl.NumberFormatOptions => {
-  return {
-    maximumFractionDigits: getCurrencyFormatterMaxFractionDigits(number, currency),
-    notation: getNumberFormatNotation(number),
-    signDisplay: getNumberFormatSignDisplay(number),
-    style: 'currency',
-    currency,
-    currencyDisplay: 'code',
-  }
+  }).format(Number(number))
 }
 
 /**
@@ -169,42 +40,26 @@ const getCurrencyFormatterOptions = (number: string | number, currency: string):
  * @param number Number to format
  * @param currency ISO 4217 currency code
  */
-export const formatCurrency = (number: string | number, currency: string): string => {
-  // Note: we will be able to achieve the following once the `roundingMode` option is supported
-  // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#parameters
+export const formatCurrency = (number: string | number, currency: string, maxLength = 6): string => {
+  let float = Number(number)
 
-  const minimum = getMinimumCurrencyDenominator(currency)
+  let result = new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency,
+    currencyDisplay: 'narrowSymbol',
+    maximumFractionDigits: Math.abs(float) >= 1 || float === 0 ? 0 : 2,
+  }).format(Number(number))
 
-  const currencyFormatter = (float: number): string => {
-    const options = getCurrencyFormatterOptions(number, currency)
-    const formatter = new Intl.NumberFormat(undefined, options)
-
-    const parts = formatter.formatToParts(float) // Returns an array of objects with `type` and `value` properties
-
-    const fraction = parts.find(({ type }) => type === 'fraction')
-
-    const amount = parts
-      .filter(({ type }) => type !== 'currency' && type !== 'literal') // Remove currency code and whitespace
-      .map((part) => {
-        if (float >= 0) {
-          return part
-        }
-
-        if (fraction && part.type === 'fraction') {
-          return { ...part, value: '1'.padStart(fraction.value.length, '0') }
-        }
-
-        if (!fraction && part.type === 'integer') {
-          return { ...part, value: minimum.toString() }
-        }
-
-        return part
-      })
-      .reduce((acc, { value }) => acc + value, '')
-      .trim()
-
-    return `${amount} ${currency.toUpperCase()}`
+  // +1 for the currency symbol
+  if (result.length > maxLength + 1) {
+    result = new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency,
+      currencyDisplay: 'narrowSymbol',
+      notation: 'compact',
+      maximumFractionDigits: 2,
+    }).format(Number(number))
   }
 
-  return format(number, currencyFormatter, minimum)
+  return result.replace(/^(\D+)/, '$1 ')
 }


### PR DESCRIPTION
## What it solves

A revised fiat and token amount formatting rules as outlined [here](https://www.notion.so/safe-global/Revised-number-formatting-cd2f32bcd9174626851c27bb34cb163a).

## How this PR fixes it

This PR simplifies the formatting logic quite a lot, and relies on browser's default formatting plus some tweaks.

Additionally, it right-aligns fiat values in Asset tables.

<img width="1299" alt="Screenshot 2024-06-06 at 14 49 21" src="https://github.com/safe-global/safe-wallet-web/assets/381895/6fc772fb-da55-4d7b-a73a-3194f709bb53">