### PR TITLE
Fix: move the execute button on recovery transactions to the correct column [SWAP-75]

### DIFF
--- a/src/components/transactions/TxSummary/index.tsx
+++ b/src/components/transactions/TxSummary/index.tsx
@@ -91,7 +91,7 @@ const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
       )}
 
       {isQueue && !expiredSwap && (
-        <Box gridArea="actions" className={css.actions}>
+        <Box gridArea="actions">
           <QueueActions tx={tx} />
         </Box>
       )}

--- a/src/features/recovery/components/ExecuteRecoveryButton/index.tsx
+++ b/src/features/recovery/components/ExecuteRecoveryButton/index.tsx
@@ -74,6 +74,7 @@ export function ExecuteRecoveryButton({
                 onClick={onClick}
                 variant="contained"
                 disabled={isDisabled}
+                sx={{ minWidth: '106.5px', py: compact ? 0.8 : undefined }}
                 size={compact ? 'small' : 'stretched'}
               >
                 Execute

--- a/src/features/recovery/components/RecoverySummary/index.tsx
+++ b/src/features/recovery/components/RecoverySummary/index.tsx
@@ -30,7 +30,7 @@ export function RecoverySummary({ item }: { item: RecoveryQueueItem }): ReactEle
         <DateTime value={Number(item.timestamp)} />
       </Box>
 
-      <Box gridArea="status">
+      <Box gridArea="actions" mr={2} display="flex" justifyContent="center">
         {!isExecutable || isPending ? (
           <RecoveryStatus recovery={item} />
         ) : (

--- a/src/features/recovery/components/RecoverySummary/index.tsx
+++ b/src/features/recovery/components/RecoverySummary/index.tsx
@@ -30,13 +30,15 @@ export function RecoverySummary({ item }: { item: RecoveryQueueItem }): ReactEle
         <DateTime value={Number(item.timestamp)} />
       </Box>
 
-      <Box gridArea="actions" mr={2} display="flex" justifyContent="center">
-        {!isExecutable || isPending ? (
+      {!isExecutable || isPending ? (
+        <Box gridArea="status">
           <RecoveryStatus recovery={item} />
-        ) : (
-          !isMalicious && wallet && <ExecuteRecoveryButton recovery={item} compact />
-        )}
-      </Box>
+        </Box>
+      ) : (
+        <Box gridArea="actions" mr={2} display="flex" justifyContent="center">
+          {!isMalicious && wallet && <ExecuteRecoveryButton recovery={item} compact />}
+        </Box>
+      )}
     </Box>
   )
 }


### PR DESCRIPTION
## What it solves

Resolves: https://www.notion.so/safe-global/Reposition-execute-button-for-the-recovery-transaction-ba6c3968a2c44d2f93f9f9e848bda873

## How this PR fixes it
- puts the recovery transactions execute button in the 'actions' column.
- uses the same styles as the normal recovery button to make sure they are aligned.
- removes unused css class (unrelated)

## Screenshots
<img width="1249" alt="image" src="https://github.com/safe-global/safe-wallet-web/assets/17801424/e91e53a7-1008-49a6-82d1-36058fb1b16a">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
