### PR TITLE
feat: relaying for native swaps only [SWAP-100]

### DIFF
--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -41,13 +41,11 @@ export const ExecuteForm = ({
   isCreation,
   isOwner,
   isExecutionLoop,
-  relays,
   txActions,
   txSecurity,
 }: SignOrExecuteProps & {
   isOwner: ReturnType<typeof useIsSafeOwner>
   isExecutionLoop: ReturnType<typeof useIsExecutionLoop>
-  relays: ReturnType<typeof useRelaysBySafe>
   txActions: ReturnType<typeof useTxActions>
   txSecurity: ReturnType<typeof useTxSecurityContext>
   safeTx?: SafeTransaction
@@ -68,7 +66,7 @@ export const ExecuteForm = ({
 
   // SC wallets can relay fully signed transactions
   const [walletCanRelay] = useWalletCanRelay(safeTx)
-
+  const relays = useRelaysBySafe(origin)
   // The transaction can/will be relayed
   const canRelay = walletCanRelay && hasRemainingRelays(relays[0])
   const willRelay = canRelay && executionMethod === ExecutionMethod.RELAY
@@ -214,7 +212,6 @@ const useTxSecurityContext = () => useContext(TxSecurityContext)
 export default madProps(ExecuteForm, {
   isOwner: useIsSafeOwner,
   isExecutionLoop: useIsExecutionLoop,
-  relays: useRelaysBySafe,
   txActions: useTxActions,
   txSecurity: useTxSecurityContext,
 })

--- a/src/hooks/useRemainingRelays.ts
+++ b/src/hooks/useRemainingRelays.ts
@@ -6,14 +6,18 @@ import { getRelayCount } from '@safe-global/safe-gateway-typescript-sdk'
 
 export const MAX_HOUR_RELAYS = 5
 
-export const useRelaysBySafe = () => {
+export const useRelaysBySafe = (txOrigin?: string) => {
   const chain = useCurrentChain()
   const { safe, safeAddress } = useSafeInfo()
 
   return useAsync(() => {
-    if (!safeAddress || !chain || !hasFeature(chain, FEATURES.RELAYING)) return
-
-    return getRelayCount(chain.chainId, safeAddress)
+    if (!safeAddress || !chain) return
+    if (
+      hasFeature(chain, FEATURES.RELAYING) ||
+      (hasFeature(chain, FEATURES.RELAY_NATIVE_SWAPS) && txOrigin && JSON.parse(txOrigin).name === 'Safe Swap')
+    ) {
+      return getRelayCount(chain.chainId, safeAddress)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chain, safeAddress, safe.txHistoryTag])
 }

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -22,6 +22,7 @@ export enum FEATURES {
   SPEED_UP_TX = 'SPEED_UP_TX',
   SAP_BANNER = 'SAP_BANNER',
   NATIVE_SWAPS = 'NATIVE_SWAPS',
+  RELAY_NATIVE_SWAPS = 'RELAY_NATIVE_SWAPS',
 }
 
 export const FeatureRoutes = {


### PR DESCRIPTION
## What it solves

Resolves SWAP-100

## How this PR fixes it
New feature flag to offer relaying for native swaps only.

## How to test it
- On staging gnosis chain swaps are temporily only available for native swaps to test this PR
- Test a tx from the native swaps
- Test a tx from other sources / Safe apps

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
