### PR TITLE
Refactor: Consistently use latest MultiSendCallOnly address 

### DIFF
--- a/src/components/tx-flow/flows/ExecuteBatch/ReviewBatch.tsx
+++ b/src/components/tx-flow/flows/ExecuteBatch/ReviewBatch.tsx
@@ -70,9 +70,9 @@ export const ReviewBatch = ({ params }: { params: ExecuteBatchFlowProps }) => {
   }, [params.txs, chain?.chainId])
 
   const [multiSendContract] = useAsync(async () => {
-    if (!chain?.chainId || !safe.version) return
-    return await getReadOnlyMultiSendCallOnlyContract(chain.chainId, safe.version)
-  }, [chain?.chainId, safe.version])
+    if (!chain?.chainId) return
+    return await getReadOnlyMultiSendCallOnlyContract(chain.chainId)
+  }, [chain?.chainId])
 
   const [multisendContractAddress = ''] = useAsync(async () => {
     if (!multiSendContract) return ''

--- a/src/components/tx/security/tenderly/__tests__/utils.test.ts
+++ b/src/components/tx/security/tenderly/__tests__/utils.test.ts
@@ -19,8 +19,8 @@ const SIGNATURE_LENGTH = 65 * 2
 const getPreValidatedSignature = (addr: string): string => generatePreValidatedSignature(addr).data
 
 describe('simulation utils', () => {
-  const safeContractInterface = new Interface(getSafeSingletonDeployment({ version: '1.3.0' })?.abi || [])
-  const multiSendContractInterface = new Interface(getMultiSendCallOnlyDeployment({ version: '1.3.0' })?.abi || [])
+  const safeContractInterface = new Interface(getSafeSingletonDeployment()?.abi || [])
+  const multiSendContractInterface = new Interface(getMultiSendCallOnlyDeployment()?.abi || [])
   const mockSafeAddress = zeroPadValue('0x0123', 20)
   const mockMultisendAddress = zeroPadValue('0x1234', 20)
 

--- a/src/components/tx/security/tenderly/utils.ts
+++ b/src/components/tx/security/tenderly/utils.ts
@@ -121,7 +121,7 @@ export const _getMultiSendCallOnlyPayload = async (
   params: MultiSendTransactionSimulationParams,
 ): Promise<Pick<TenderlySimulatePayload, 'to' | 'input'>> => {
   const data = encodeMultiSendData(params.transactions)
-  const readOnlyMultiSendContract = await getReadOnlyMultiSendCallOnlyContract(params.safe.chainId, params.safe.version)
+  const readOnlyMultiSendContract = await getReadOnlyMultiSendCallOnlyContract(params.safe.chainId)
 
   return {
     to: await readOnlyMultiSendContract.getAddress(),

--- a/src/features/recovery/services/__tests__/recovery-state.test.ts
+++ b/src/features/recovery/services/__tests__/recovery-state.test.ts
@@ -72,9 +72,7 @@ describe('recovery-state', () => {
           const safeAbi = getSafeSingletonDeployment({ network: chainId, version })!.abi
           const safeInterface = new Interface(safeAbi)
 
-          const multiSendAbi =
-            getMultiSendCallOnlyDeployment({ network: chainId, version }) ??
-            getMultiSendCallOnlyDeployment({ network: chainId, version: '1.3.0' })
+          const multiSendAbi = getMultiSendCallOnlyDeployment({ network: chainId })
           const multiSendInterface = new Interface(multiSendAbi!.abi)
 
           const multiSendData = encodeMultiSendData([
@@ -109,9 +107,7 @@ describe('recovery-state', () => {
           const safeAbi = getSafeSingletonDeployment({ network: chainId, version })!.abi
           const safeInterface = new Interface(safeAbi)
 
-          const multiSendDeployment =
-            getMultiSendCallOnlyDeployment({ network: chainId, version }) ??
-            getMultiSendCallOnlyDeployment({ network: chainId, version: '1.3.0' })
+          const multiSendDeployment = getMultiSendCallOnlyDeployment({ network: chainId })
           const multiSendInterface = new Interface(multiSendDeployment!.abi)
 
           const multiSendData = encodeMultiSendData([
@@ -146,7 +142,7 @@ describe('recovery-state', () => {
           const safeAbi = getSafeSingletonDeployment({ network: chainId, version })!.abi
           const safeInterface = new Interface(safeAbi)
 
-          const multiSendDeployment = getMultiSendCallOnlyDeployment({ network: chainId, version })!
+          const multiSendDeployment = getMultiSendCallOnlyDeployment({ network: chainId })!
           const multiSendInterface = new Interface(multiSendDeployment.abi)
 
           const multiSendData = encodeMultiSendData([
@@ -181,7 +177,7 @@ describe('recovery-state', () => {
           const safeAbi = getSafeSingletonDeployment({ network: chainId, version })!.abi
           const safeInterface = new Interface(safeAbi)
 
-          const multiSendDeployment = getMultiSendCallOnlyDeployment({ network: chainId, version: '1.3.0' })!
+          const multiSendDeployment = getMultiSendCallOnlyDeployment({ network: chainId })!
           const multiSendInterface = new Interface(multiSendDeployment.abi)
 
           const multiSendData = encodeMultiSendData([

--- a/src/features/recovery/services/__tests__/transaction-list.test.ts
+++ b/src/features/recovery/services/__tests__/transaction-list.test.ts
@@ -124,7 +124,6 @@ describe('getRecoveredSafeInfo', () => {
 
     const multiSendDeployment = getMultiSendCallOnlyDeployment({
       network: safe.chainId,
-      version: safe.version ?? undefined,
     })
     const multiSendAddress = multiSendDeployment!.networkAddresses[safe.chainId]
     const multiSendInterface = new Interface(multiSendDeployment!.abi)

--- a/src/features/recovery/services/recovery-state.ts
+++ b/src/features/recovery/services/recovery-state.ts
@@ -44,8 +44,6 @@ export function _isMaliciousRecovery({
   safeAddress: string
   transaction: Pick<AddedEvent['args'], 'to' | 'data'>
 }) {
-  const BASE_MULTI_SEND_CALL_ONLY_VERSION = '1.3.0'
-
   const isMultiSend = isMultiSendCalldata(transaction.data)
   const transactions = isMultiSend ? decodeMultiSendTxs(transaction.data) : [transaction]
 
@@ -54,9 +52,7 @@ export function _isMaliciousRecovery({
     return !sameAddress(transaction.to, safeAddress)
   }
 
-  const multiSendDeployment =
-    getMultiSendCallOnlyDeployment({ network: chainId, version: version ?? undefined }) ??
-    getMultiSendCallOnlyDeployment({ network: chainId, version: BASE_MULTI_SEND_CALL_ONLY_VERSION })
+  const multiSendDeployment = getMultiSendCallOnlyDeployment({ network: chainId })
 
   if (!multiSendDeployment) {
     return true

--- a/src/services/contracts/__tests__/deployments.test.ts
+++ b/src/services/contracts/__tests__/deployments.test.ts
@@ -232,45 +232,6 @@ describe('deployments', () => {
     })
   })
 
-  describe('getMultiSendCallOnlyContractDeployment', () => {
-    it('should return the versioned deployment for supported version/chain', () => {
-      const expected = safeDeployments.getMultiSendCallOnlyDeployment({
-        version: '1.3.0', // First available version
-        network: '1',
-      })
-
-      expect(expected).toBeDefined()
-      const deployment = deployments.getMultiSendCallOnlyContractDeployment('1', '1.3.0')
-      expect(deployment).toStrictEqual(expected)
-    })
-
-    it('should return undefined for supported version/unsupported chain', () => {
-      const deployment = deployments.getMultiSendCallOnlyContractDeployment('69420', '1.3.0')
-      expect(deployment).toBe(undefined)
-    })
-
-    it('should return undefined for unsupported version/chain', () => {
-      const deployment = deployments.getMultiSendCallOnlyContractDeployment('69420', '1.2.3')
-      expect(deployment).toBe(undefined)
-    })
-
-    it('should return the latest deployment for no version/supported chain', () => {
-      const expected = safeDeployments.getMultiSendCallOnlyDeployment({
-        version: LATEST_SAFE_VERSION,
-        network: '1',
-      })
-
-      expect(expected).toBeDefined()
-      const deployment = deployments.getMultiSendCallOnlyContractDeployment('1', null)
-      expect(deployment).toStrictEqual(expected)
-    })
-
-    it('should return undefined for no version/unsupported chain', () => {
-      const deployment = deployments.getMultiSendCallOnlyContractDeployment('69420', null)
-      expect(deployment).toBe(undefined)
-    })
-  })
-
   describe('getFallbackHandlerContractDeployment', () => {
     it('should return the versioned deployment for supported version/chain', () => {
       const expected = safeDeployments.getFallbackHandlerDeployment({

--- a/src/services/contracts/__tests__/safeContracts.test.ts
+++ b/src/services/contracts/__tests__/safeContracts.test.ts
@@ -1,5 +1,5 @@
 import { ImplementationVersionState } from '@safe-global/safe-gateway-typescript-sdk'
-import { _getValidatedGetContractProps, isValidMasterCopy, _getMinimumMultiSendCallOnlyVersion } from '../safeContracts'
+import { _getValidatedGetContractProps, isValidMasterCopy } from '../safeContracts'
 
 describe('safeContracts', () => {
   describe('isValidMasterCopy', () => {
@@ -47,20 +47,6 @@ describe('safeContracts', () => {
       expect(() => _getValidatedGetContractProps('0.0.1')).toThrow('0.0.1 is not a valid Safe Account version')
 
       expect(() => _getValidatedGetContractProps('')).toThrow(' is not a valid Safe Account version')
-    })
-  })
-
-  describe('_getMinimumMultiSendCallOnlyVersion', () => {
-    it('should return the initial version if the Safe version is null', () => {
-      expect(_getMinimumMultiSendCallOnlyVersion(null)).toBe('1.3.0')
-    })
-
-    it('should return the initial version if the Safe version is lower than the initial version', () => {
-      expect(_getMinimumMultiSendCallOnlyVersion('1.0.0')).toBe('1.3.0')
-    })
-
-    it('should return the Safe version if the Safe version is higher than the initial version', () => {
-      expect(_getMinimumMultiSendCallOnlyVersion('1.4.1')).toBe('1.4.1')
     })
   })
 })

--- a/src/services/contracts/deployments.ts
+++ b/src/services/contracts/deployments.ts
@@ -2,7 +2,6 @@ import semverSatisfies from 'semver/functions/satisfies'
 import {
   getSafeSingletonDeployment,
   getSafeL2SingletonDeployment,
-  getMultiSendCallOnlyDeployment,
   getFallbackHandlerDeployment,
   getProxyFactoryDeployment,
   getSignMessageLibDeployment,
@@ -62,10 +61,6 @@ export const getSafeContractDeployment = (
   const getDeployment = _isL2(chain, safeVersion) ? getSafeL2SingletonDeployment : getSafeSingletonDeployment
 
   return _tryDeploymentVersions(getDeployment, chain.chainId, safeVersion)
-}
-
-export const getMultiSendCallOnlyContractDeployment = (chainId: string, safeVersion: SafeInfo['version']) => {
-  return _tryDeploymentVersions(getMultiSendCallOnlyDeployment, chainId, safeVersion)
 }
 
 export const getFallbackHandlerContractDeployment = (chainId: string, safeVersion: SafeInfo['version']) => {

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -1,6 +1,5 @@
 import {
   getFallbackHandlerContractDeployment,
-  getMultiSendCallOnlyContractDeployment,
   getProxyFactoryContractDeployment,
   getSafeContractDeployment,
   getSignMessageLibContractDeployment,
@@ -12,9 +11,9 @@ import type { GetContractProps, SafeVersion } from '@safe-global/safe-core-sdk-t
 import { assertValidSafeVersion, createEthersAdapter, createReadOnlyEthersAdapter } from '@/hooks/coreSDK/safeCoreSDK'
 import type { BrowserProvider } from 'ethers'
 import type { EthersAdapter, SafeContractEthers, SignMessageLibEthersContract } from '@safe-global/protocol-kit'
-import semver from 'semver'
 
 import type CompatibilityFallbackHandlerEthersContract from '@safe-global/protocol-kit/dist/src/adapters/ethers/contracts/CompatibilityFallbackHandler/CompatibilityFallbackHandlerEthersContract'
+import { getMultiSendCallOnlyDeployment } from '@safe-global/safe-deployments'
 
 // `UNKNOWN` is returned if the mastercopy does not match supported ones
 // @see https://github.com/safe-global/safe-client-gateway/blob/main/src/routes/safes/handlers/safes.rs#L28-L31
@@ -70,36 +69,22 @@ export const getReadOnlyGnosisSafeContract = async (chain: ChainInfo, safeVersio
 
 // MultiSend
 
-export const _getMinimumMultiSendCallOnlyVersion = (safeVersion: SafeInfo['version']) => {
-  const INITIAL_CALL_ONLY_VERSION = '1.3.0'
-
-  if (!safeVersion) {
-    return INITIAL_CALL_ONLY_VERSION
-  }
-
-  return semver.gte(safeVersion, INITIAL_CALL_ONLY_VERSION) ? safeVersion : INITIAL_CALL_ONLY_VERSION
-}
-
 export const getMultiSendCallOnlyContract = async (
   chainId: string,
   safeVersion: SafeInfo['version'],
   provider: BrowserProvider,
 ) => {
   const ethAdapter = await createEthersAdapter(provider)
-  const multiSendVersion = _getMinimumMultiSendCallOnlyVersion(safeVersion)
-
   return ethAdapter.getMultiSendCallOnlyContract({
-    singletonDeployment: getMultiSendCallOnlyContractDeployment(chainId, multiSendVersion),
+    singletonDeployment: getMultiSendCallOnlyDeployment({ network: chainId }),
     ..._getValidatedGetContractProps(safeVersion),
   })
 }
 
 export const getReadOnlyMultiSendCallOnlyContract = async (chainId: string, safeVersion: SafeInfo['version']) => {
   const ethAdapter = createReadOnlyEthersAdapter()
-  const multiSendVersion = _getMinimumMultiSendCallOnlyVersion(safeVersion)
-
   return ethAdapter.getMultiSendCallOnlyContract({
-    singletonDeployment: getMultiSendCallOnlyContractDeployment(chainId, multiSendVersion),
+    singletonDeployment: getMultiSendCallOnlyDeployment({ network: chainId }),
     ..._getValidatedGetContractProps(safeVersion),
   })
 }

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -71,9 +71,11 @@ export const getReadOnlyGnosisSafeContract = async (chain: ChainInfo, safeVersio
 
 export const getReadOnlyMultiSendCallOnlyContract = async (chainId: string) => {
   const ethAdapter = createReadOnlyEthersAdapter()
+  const singletonDeployment = getMultiSendCallOnlyDeployment({ network: chainId })
+  if (!singletonDeployment) throw new Error('No deployment found for MultiSendCallOnly')
   return ethAdapter.getMultiSendCallOnlyContract({
     singletonDeployment: getMultiSendCallOnlyDeployment({ network: chainId }),
-    safeVersion: '1.4.1', // we generally use the latest multisend version (there is no dependency on the Safe version)
+    safeVersion: singletonDeployment.version as SafeVersion,
   })
 }
 

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -69,11 +69,11 @@ export const getReadOnlyGnosisSafeContract = async (chain: ChainInfo, safeVersio
 
 // MultiSend
 
-export const getReadOnlyMultiSendCallOnlyContract = async (chainId: string, safeVersion: SafeInfo['version']) => {
+export const getReadOnlyMultiSendCallOnlyContract = async (chainId: string) => {
   const ethAdapter = createReadOnlyEthersAdapter()
   return ethAdapter.getMultiSendCallOnlyContract({
     singletonDeployment: getMultiSendCallOnlyDeployment({ network: chainId }),
-    ..._getValidatedGetContractProps(safeVersion),
+    safeVersion: '1.4.1', // we generally use the latest multisend version (there is no dependency on the Safe version)
   })
 }
 

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -69,18 +69,6 @@ export const getReadOnlyGnosisSafeContract = async (chain: ChainInfo, safeVersio
 
 // MultiSend
 
-export const getMultiSendCallOnlyContract = async (
-  chainId: string,
-  safeVersion: SafeInfo['version'],
-  provider: BrowserProvider,
-) => {
-  const ethAdapter = await createEthersAdapter(provider)
-  return ethAdapter.getMultiSendCallOnlyContract({
-    singletonDeployment: getMultiSendCallOnlyDeployment({ network: chainId }),
-    ..._getValidatedGetContractProps(safeVersion),
-  })
-}
-
 export const getReadOnlyMultiSendCallOnlyContract = async (chainId: string, safeVersion: SafeInfo['version']) => {
   const ethAdapter = createReadOnlyEthersAdapter()
   return ethAdapter.getMultiSendCallOnlyContract({

--- a/src/services/security/modules/DelegateCallModule/index.test.ts
+++ b/src/services/security/modules/DelegateCallModule/index.test.ts
@@ -34,7 +34,6 @@ describe('DelegateCallModule', () => {
 
     const multiSend = getMultiSendCallOnlyDeployment({
       network: CHAIN_ID,
-      version: SAFE_VERSION,
     })!.defaultAddress
 
     const recipient1 = toBeHex('0x2', 20)

--- a/src/services/security/modules/DelegateCallModule/index.ts
+++ b/src/services/security/modules/DelegateCallModule/index.ts
@@ -1,10 +1,10 @@
 import { OperationType } from '@safe-global/safe-core-sdk-types'
-import { getMultiSendCallOnlyContractDeployment } from '@/services/contracts/deployments'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 
 import { SecuritySeverity } from '../types'
 import type { SecurityModule, SecurityResponse } from '../types'
+import { getMultiSendCallOnlyDeployment } from '@safe-global/safe-deployments'
 
 type DelegateCallModuleRequest = {
   chainId: string
@@ -28,7 +28,7 @@ export class DelegateCallModule implements SecurityModule<DelegateCallModuleRequ
     }
 
     // We need not check for nested delegate calls as we only use MultiSendCallOnly in the UI
-    const multiSendDeployment = getMultiSendCallOnlyContractDeployment(chainId, safeVersion)
+    const multiSendDeployment = getMultiSendCallOnlyDeployment({ network: chainId })
 
     return multiSendDeployment?.networkAddresses[chainId] !== safeTransaction.data.to
   }


### PR DESCRIPTION
Refactoring to generally use the latest version of the MultiSendCallOnly available for the given network. This simplification enables removing some logic for determining the MultiSendCallOnly version from the codebase.

There is no dependency between the Safe version and the multisend version, meaning any Safe can use any multisend version. Assuming that the latest MultiSendCallOnly contract version is most optimized, it doesn't make sense to use legacy versions with older Safes.

A consistent multisend address also makes the configuration of the Roles Modifier more straightforward. (Users of the Roles mod need to explicitly enable all allowed multisend addresses.)

## How to test

Make some multisend transactions on different versions of Safe (1.3.0, 1.1.1, 1.4.1)



