### PR TITLE
Fix: restore lowercase "native transfer"

### DIFF
--- a/cypress/fixtures/txhistory_data_data.json
+++ b/cypress/fixtures/txhistory_data_data.json
@@ -72,7 +72,7 @@
       "transactionHash": "0xa5dd...b064",
       "safeTxHash": "0x4dd0...b2b8",
       "nativeTransfer": {
-        "title": "Native transfer",
+        "title": "native transfer",
         "description": "Interact with (and send < 0.00001 ETH to)"
       }
     },

--- a/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.test.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.test.tsx
@@ -28,7 +28,7 @@ describe('SingleTxDecoded', () => {
       />,
     )
 
-    expect(result.queryByText('Native transfer')).not.toBeNull()
+    expect(result.queryByText('native transfer')).not.toBeNull()
   })
 
   it('should show unknown contract interactions', () => {
@@ -52,7 +52,7 @@ describe('SingleTxDecoded', () => {
       />,
     )
 
-    expect(result.queryByText('Contract interaction')).not.toBeNull()
+    expect(result.queryByText('contract interaction')).not.toBeNull()
   })
 
   it('should show decoded data ', () => {

--- a/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
@@ -36,7 +36,7 @@ export const SingleTxDecoded = ({
 }: SingleTxDecodedProps) => {
   const chain = useCurrentChain()
   const isNativeTransfer = tx.value !== '0' && (!tx.data || isEmptyHexData(tx.data))
-  const method = tx.dataDecoded?.method || (isNativeTransfer ? 'Native transfer' : 'Contract interaction')
+  const method = tx.dataDecoded?.method || (isNativeTransfer ? 'native transfer' : 'contract interaction')
   const { decimals, symbol } = chain?.nativeCurrency || {}
   const amount = tx.value ? formatVisualAmount(tx.value, decimals) : 0
 


### PR DESCRIPTION
## What it solves

Lowercase "native transfer" was capitalized in #3760 but it's not consistent with other tx types in decoded multisends.

## How this PR fixes it

Restores it to how it was.