### PR TITLE
fix: display swap button in top assets only on hover

### DIFF
--- a/src/components/dashboard/PendingTxs/styles.module.css
+++ b/src/components/dashboard/PendingTxs/styles.module.css
@@ -11,9 +11,17 @@
   min-height: 50px;
 }
 
+.container button {
+  opacity: 0;
+}
+
 .container:hover {
   background-color: var(--color-background-light);
   border-color: var(--color-secondary-light);
+}
+
+.container:hover button {
+  opacity: 1;
 }
 
 .list {

--- a/src/components/dashboard/PendingTxs/styles.module.css
+++ b/src/components/dashboard/PendingTxs/styles.module.css
@@ -13,6 +13,7 @@
 
 .container button {
   opacity: 0;
+  transition: opacity .1s ease-in;
 }
 
 .container:hover {


### PR DESCRIPTION
## What it solves
Display the swap button only on hover in the "top asset" block. 
@TanyaEfremova @kirkkonen looks a bit weird or like a bug, because we have this space on the right now without the button.

## Screenshots
<img width="932" alt="grafik" src="https://github.com/safe-global/safe-wallet-web/assets/693770/d4aa4187-5071-4ba0-a03f-295086b7428d">
<img width="958" alt="grafik" src="https://github.com/safe-global/safe-wallet-web/assets/693770/e21d4c3e-74c7-4fc0-bc19-763b3a16ff73">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
