### PR TITLE
Fix: explicitly pass a locale to NumberFormat

### DIFF
--- a/src/components/common/FiatValue/index.tsx
+++ b/src/components/common/FiatValue/index.tsx
@@ -1,8 +1,10 @@
-import type { ReactElement } from 'react'
+import type { CSSProperties, ReactElement } from 'react'
 import { useMemo } from 'react'
 import { useAppSelector } from '@/store'
 import { selectCurrency } from '@/store/settingsSlice'
 import { formatCurrency } from '@/utils/formatNumber'
+
+const style = { whiteSpace: 'nowrap' } as CSSProperties
 
 const FiatValue = ({ value, maxLength }: { value: string | number; maxLength?: number }): ReactElement => {
   const currency = useAppSelector(selectCurrency)
@@ -11,7 +13,11 @@ const FiatValue = ({ value, maxLength }: { value: string | number; maxLength?: n
     return formatCurrency(value, currency, maxLength)
   }, [value, currency, maxLength])
 
-  return <span suppressHydrationWarning>{fiat}</span>
+  return (
+    <span suppressHydrationWarning style={style}>
+      {fiat}
+    </span>
+  )
 }
 
 export default FiatValue

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -1,3 +1,5 @@
+const locale = typeof navigator !== 'undefined' ? navigator.language : undefined
+
 /**
  * Intl.NumberFormat number formatter that adheres to our style guide
  * @param number Number to format
@@ -8,7 +10,7 @@ export const formatAmount = (number: string | number, precision = 5, maxLength =
   if (float === Math.round(float)) precision = 0
   if (Math.abs(float) < 0.00001) return '< 0.00001'
 
-  const fullNum = new Intl.NumberFormat(undefined, {
+  const fullNum = new Intl.NumberFormat(locale, {
     style: 'decimal',
     maximumFractionDigits: precision,
   }).format(Number(number))
@@ -16,7 +18,7 @@ export const formatAmount = (number: string | number, precision = 5, maxLength =
   // +3 for the decimal point and the two decimal places
   if (fullNum.length <= maxLength + 3) return fullNum
 
-  return new Intl.NumberFormat(undefined, {
+  return new Intl.NumberFormat(locale, {
     style: 'decimal',
     notation: 'compact',
     maximumFractionDigits: 2,
@@ -29,7 +31,7 @@ export const formatAmount = (number: string | number, precision = 5, maxLength =
  * @param precision Fraction digits to show
  */
 export const formatAmountPrecise = (number: string | number, precision: number): string => {
-  return new Intl.NumberFormat(undefined, {
+  return new Intl.NumberFormat(locale, {
     style: 'decimal',
     maximumFractionDigits: precision,
   }).format(Number(number))
@@ -43,7 +45,7 @@ export const formatAmountPrecise = (number: string | number, precision: number):
 export const formatCurrency = (number: string | number, currency: string, maxLength = 6): string => {
   let float = Number(number)
 
-  let result = new Intl.NumberFormat(undefined, {
+  let result = new Intl.NumberFormat(locale, {
     style: 'currency',
     currency,
     currencyDisplay: 'narrowSymbol',
@@ -52,7 +54,7 @@ export const formatCurrency = (number: string | number, currency: string, maxLen
 
   // +1 for the currency symbol
   if (result.length > maxLength + 1) {
-    result = new Intl.NumberFormat(undefined, {
+    result = new Intl.NumberFormat(locale, {
       style: 'currency',
       currency,
       currencyDisplay: 'narrowSymbol',


### PR DESCRIPTION
## What it solves

Firefox doesn't play nicely with `undefined` as a locale parameter.
