### PR TITLE
Fix: add skeletons in Account List + stretch Swaps banner

### DIFF
--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -27,6 +27,7 @@ const Dashboard = (): ReactElement => {
   const { safe } = useSafeInfo()
   const { [CREATION_MODAL_QUERY_PARM]: showCreationModal = '' } = router.query
   const showSafeApps = useHasFeature(FEATURES.SAFE_APPS)
+  const isSAPBannerEnabled = useHasFeature(FEATURES.SAP_BANNER)
   const supportsRecovery = useIsRecoverySupported()
   const [recovery] = useRecovery()
   const showRecoveryWidget = supportsRecovery && !recovery
@@ -46,7 +47,7 @@ const Dashboard = (): ReactElement => {
 
         {safe.deployed && (
           <>
-            <Grid item xs={12} xl={6} className={css.hideIfEmpty}>
+            <Grid item xs={12} xl={isSAPBannerEnabled ? 6 : 12} className={css.hideIfEmpty}>
               <SwapWidget />
             </Grid>
 

--- a/src/components/welcome/MyAccounts/AccountItem.tsx
+++ b/src/components/welcome/MyAccounts/AccountItem.tsx
@@ -2,7 +2,7 @@ import { LoopIcon } from '@/features/counterfactual/CounterfactualStatusButton'
 import { selectUndeployedSafe } from '@/features/counterfactual/store/undeployedSafesSlice'
 import type { ChainInfo, SafeOverview } from '@safe-global/safe-gateway-typescript-sdk'
 import { useCallback, useMemo } from 'react'
-import { ListItemButton, Box, Typography, Chip } from '@mui/material'
+import { ListItemButton, Box, Typography, Chip, Skeleton } from '@mui/material'
 import Link from 'next/link'
 import SafeIcon from '@/components/common/SafeIcon'
 import Track from '@/components/common/Track'
@@ -110,7 +110,7 @@ const AccountItem = ({ onLinkClick, safeItem, safeOverview }: AccountItemProps) 
           </Typography>
 
           <Typography variant="body2" fontWeight="bold" textAlign="right" pr={5}>
-            {safeOverview?.fiatTotal && <FiatValue value={safeOverview.fiatTotal} />}
+            {safeOverview ? <FiatValue value={safeOverview.fiatTotal} /> : <Skeleton variant="text" />}
           </Typography>
 
           <ChainIndicator chainId={chainId} responsive />


### PR DESCRIPTION
## What it solves

* Show skeletons while fiat totals are loading in the Account List
* Stretch the Swaps banner to full width if there's no SAP banner

### Account list
<img width="621" alt="Screenshot 2024-06-12 at 09 13 57" src="https://github.com/safe-global/safe-wallet-web/assets/381895/c8c0d163-2ff7-4a48-86f7-67b2237c1921">

### Swaps banner

<img width="1359" alt="Screenshot 2024-06-12 at 09 17 27" src="https://github.com/safe-global/safe-wallet-web/assets/381895/c9202d70-6a0b-43e6-9f4d-b9b113cdce6c">