### PR TITLE
Fix: text overflow for Safe names

### DIFF
--- a/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
@@ -84,8 +84,10 @@ const SrcEthHashInfo = ({
 
       <Box overflow="hidden" className={onlyName ? css.inline : undefined}>
         {name && (
-          <Box textOverflow="ellipsis" overflow="hidden" title={name} display="flex" alignItems="center" gap={0.5}>
-            {name}
+          <Box title={name} display="flex" alignItems="center" gap={0.5}>
+            <Box overflow="hidden" textOverflow="ellipsis">
+              {name}
+            </Box>
 
             {isAddressBookName && (
               <Tooltip title="From your address book" placement="top">


### PR DESCRIPTION
Fix long names cutting off and hiding the address book icon, see https://www.notion.so/safe-global/name-on-address-book-icon-looks-cut-with-long-names-7b7a4f02ad844573981906e5afe33619

<img width="243" alt="Screenshot 2024-06-12 at 11 05 45" src="https://github.com/safe-global/safe-wallet-web/assets/381895/f2be6208-988a-41bb-af5e-192d41dbaab0">
