### PR TITLE
fix: malicious recovery detection

### DIFF
--- a/src/features/recovery/services/__tests__/recovery-state.test.ts
+++ b/src/features/recovery/services/__tests__/recovery-state.test.ts
@@ -142,7 +142,7 @@ describe('recovery-state', () => {
           const safeAbi = getSafeSingletonDeployment({ network: chainId, version })!.abi
           const safeInterface = new Interface(safeAbi)
 
-          const multiSendDeployment = getMultiSendCallOnlyDeployment({ network: chainId })!
+          const multiSendDeployment = getMultiSendCallOnlyDeployment({ network: chainId, version })!
           const multiSendInterface = new Interface(multiSendDeployment.abi)
 
           const multiSendData = encodeMultiSendData([
@@ -177,7 +177,11 @@ describe('recovery-state', () => {
           const safeAbi = getSafeSingletonDeployment({ network: chainId, version })!.abi
           const safeInterface = new Interface(safeAbi)
 
-          const multiSendDeployment = getMultiSendCallOnlyDeployment({ network: chainId })!
+          const multiSendDeployment = getMultiSendCallOnlyDeployment({
+            network: chainId,
+            // The safe-core-sdk uses the 1.3.0 MultisendCallOnly for Pre multisend call only Safes
+            version: '1.3.0',
+          })!
           const multiSendInterface = new Interface(multiSendDeployment.abi)
 
           const multiSendData = encodeMultiSendData([

--- a/src/features/recovery/services/recovery-state.ts
+++ b/src/features/recovery/services/recovery-state.ts
@@ -9,6 +9,7 @@ import { trimTrailingSlash } from '@/utils/url'
 import { sameAddress } from '@/utils/addresses'
 import { isMultiSendCalldata } from '@/utils/transaction-calldata'
 import { decodeMultiSendTxs } from '@/utils/transactions'
+import { LATEST_SAFE_VERSION } from '@/config/constants'
 
 export const MAX_RECOVERER_PAGE_SIZE = 100
 
@@ -52,7 +53,15 @@ export function _isMaliciousRecovery({
     return !sameAddress(transaction.to, safeAddress)
   }
 
-  const multiSendDeployment = getMultiSendCallOnlyDeployment({ network: chainId })
+  const multiSendDeployment =
+    getMultiSendCallOnlyDeployment({
+      network: chainId,
+      version: version ?? LATEST_SAFE_VERSION,
+    }) ??
+    getMultiSendCallOnlyDeployment({
+      network: chainId,
+      version: LATEST_SAFE_VERSION,
+    })
 
   if (!multiSendDeployment) {
     return true


### PR DESCRIPTION
## What it solves

Resolves https://www.notion.so/safe-global/Recovery-tx-is-being-considered-a-malicious-tx-724664e7de4e4a8da4d88b5606af047c?pvs=4

## How this PR fixes it
- Uses correct multiSend deployment when trying to detect if recovery is malicious

## How to test it
- Queue a recovery through the interface

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
