### PR TITLE
fix: do not pass negative app id

### DIFF
--- a/src/features/walletconnect/__tests__/WalletConnectContext.test.tsx
+++ b/src/features/walletconnect/__tests__/WalletConnectContext.test.tsx
@@ -410,7 +410,6 @@ describe('WalletConnectProvider', () => {
         1,
         { method: 'fake', params: [] },
         {
-          id: -1,
           name: 'name',
           description: 'description',
           url: 'https://apps-portal.safe.global/wallet-connect',

--- a/src/features/walletconnect/components/WalletConnectProvider/index.tsx
+++ b/src/features/walletconnect/components/WalletConnectProvider/index.tsx
@@ -88,7 +88,6 @@ export const WalletConnectProvider = ({ children }: { children: ReactNode }) => 
 
         // Get response from Safe Wallet Provider
         return safeWalletProvider.request(event.id, event.params.request, {
-          id: -1,
           url: session.peer.metadata.url,
           name: getPeerName(session.peer) || 'WalletConnect',
           description: session.peer.metadata.description,

--- a/src/services/safe-wallet-provider/index.ts
+++ b/src/services/safe-wallet-provider/index.ts
@@ -15,7 +15,7 @@ type SafeSettings = {
 type GetCapabilitiesResult = Record<`0x${string}`, Record<string, any>>
 
 export type AppInfo = {
-  id: number
+  id?: number
   name: string
   description: string
   url: string


### PR DESCRIPTION
## What it solves

Resolves https://www.notion.so/safe-global/Signing-message-shows-a-too_small-error-8d4a815756e142e194e56fb57638b211

## How this PR fixes it
- Does not pass -1 as appId but undefined instead

## How to test it
- Sign a message
- Sign a tx

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
