### PR TITLE
Fix: remove empty span in balance changes

### DIFF
--- a/src/components/tx/security/redefine/RedefineBalanceChange.tsx
+++ b/src/components/tx/security/redefine/RedefineBalanceChange.tsx
@@ -39,10 +39,9 @@ const FungibleBalanceChange = ({
         {formatVisualAmount(change.amount.value, change.decimals)}
       </Typography>
       <TokenIcon size={16} logoUri={logoUri} tokenSymbol={change.symbol} />
-      <Typography variant="body2" fontWeight={700} display="inline" ml={0.5}>
+      <Typography variant="body2" fontWeight={700} display="inline" ml={0.5} mr="auto">
         {change.symbol}
       </Typography>
-      <span style={{ margin: 'auto' }} />
       <Chip className={css.categoryChip} label={change.type} />
     </>
   )


### PR DESCRIPTION
## What it solves

Resolves https://github.com/5afe/safe-support/issues/461

## How this PR fixes it

I haven't been able to reproduce the ▯▯▯▯▯▯▯▯ bug but my best guess is that this empty span is the culprit.

![Screenshot 2024-06-14 at 09 15 54](https://github.com/safe-global/safe-wallet-web/assets/381895/bc427146-e182-49f0-9fe3-cf06a5960bb4)
