### PR TITLE
Fix: redirect routes w/o ?safe

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/components/settings/SecurityLogin/index.tsx
+++ b/src/components/settings/SecurityLogin/index.tsx
@@ -2,15 +2,17 @@ import { Box } from '@mui/material'
 import dynamic from 'next/dynamic'
 import { useIsRecoverySupported } from '@/features/recovery/hooks/useIsRecoverySupported'
 import SecuritySettings from '../SecuritySettings'
+import { useRouter } from 'next/router'
 
 const RecoverySettings = dynamic(() => import('@/features/recovery/components/RecoverySettings'))
 
 const SecurityLogin = () => {
   const isRecoverySupported = useIsRecoverySupported()
+  const router = useRouter()
 
   return (
     <Box display="flex" flexDirection="column" gap={2}>
-      {isRecoverySupported && <RecoverySettings />}
+      {isRecoverySupported && router.query.safe ? <RecoverySettings /> : null}
 
       <SecuritySettings />
     </Box>

--- a/src/hooks/useAdjustUrl.ts
+++ b/src/hooks/useAdjustUrl.ts
@@ -6,6 +6,8 @@ const SAFE_ROUTES = [
   AppRoutes.balances.index,
   AppRoutes.balances.nfts,
   AppRoutes.home,
+  AppRoutes.settings.modules,
+  AppRoutes.settings.setup,
   AppRoutes.swap,
   AppRoutes.transactions.index,
   AppRoutes.transactions.history,

--- a/src/hooks/useAdjustUrl.ts
+++ b/src/hooks/useAdjustUrl.ts
@@ -1,16 +1,37 @@
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
+import { AppRoutes } from '@/config/routes'
+
+const SAFE_ROUTES = [
+  AppRoutes.balances.index,
+  AppRoutes.balances.nfts,
+  AppRoutes.home,
+  AppRoutes.swap,
+  AppRoutes.transactions.index,
+  AppRoutes.transactions.history,
+  AppRoutes.transactions.messages,
+  AppRoutes.transactions.queue,
+  AppRoutes.transactions.tx,
+]
 
 // Replace %3A with : in the ?safe= parameter
+// Redirect to index if a required safe parameter is missing
 const useAdjustUrl = () => {
-  const { asPath } = useRouter()
+  const router = useRouter()
 
   useEffect(() => {
+    const { asPath, isReady, query, pathname } = router
+
     const newPath = asPath.replace(/([?&]safe=.+?)%3A(?=0x)/g, '$1:')
     if (newPath !== asPath) {
       history.replaceState(history.state, '', newPath)
+      return
     }
-  }, [asPath])
+
+    if (isReady && !query.safe && SAFE_ROUTES.includes(pathname)) {
+      router.replace({ pathname: AppRoutes.index })
+    }
+  }, [router])
 }
 
 export default useAdjustUrl

--- a/src/pages/apps/open.tsx
+++ b/src/pages/apps/open.tsx
@@ -55,6 +55,15 @@ const SafeApps: NextPage = () => {
   // appUrl is required to be present
   if (!isSafeAppsEnabled || !appUrl || !router.isReady) return null
 
+  // No `safe` query param, redirect to the share route
+  if (router.isReady && !router.query.safe) {
+    router.push({
+      pathname: AppRoutes.share.safeApp,
+      query: { appUrl },
+    })
+    return null
+  }
+
   if (isModalVisible) {
     return (
       <SafeAppsInfoModal


### PR DESCRIPTION
## What it solves

Resolves #3843

## How this PR fixes it

* I've added a static list of routes that require a `safe` query param
* I've added this logic to an existing `useAdjustUrl` hook that has somewhat related functionality
* For `/apps/open` without `?safe`, there's a special redirect to the Safe App share route
