### PR TITLE
Fix: adjust approval editor with swaps

### DIFF
--- a/src/components/tx/ApprovalEditor/ApprovalEditorForm.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalEditorForm.tsx
@@ -46,7 +46,6 @@ export const ApprovalEditorForm = ({
         {Object.entries(groupedApprovals).map(([spender, approvals], spenderIdx) => (
           <Box key={spender}>
             <Stack gap={2}>
-              <SpenderField address={spender} />
               {approvals.map((tx) => (
                 <ListItem
                   key={tx.tokenAddress + tx.spender}
@@ -57,6 +56,8 @@ export const ApprovalEditorForm = ({
                   <EditableApprovalItem approval={tx} name={`approvals.${fieldIndex++}`} onSave={onSave} />
                 </ListItem>
               ))}
+              <SpenderField address={spender} />
+
               {spenderIdx !== Object.keys(groupedApprovals).length - 1 && <Divider />}
             </Stack>
           </Box>

--- a/src/components/tx/ApprovalEditor/EditableApprovalItem.tsx
+++ b/src/components/tx/ApprovalEditor/EditableApprovalItem.tsx
@@ -32,7 +32,6 @@ const EditableApprovalItem = ({
   const handleSave = () => {
     onSave()
     setReadOnly(true)
-    MODALS_EVENTS.EDIT_APPROVALS
   }
 
   const handleEditMode = () => {

--- a/src/components/tx/ApprovalEditor/EditableApprovalItem.tsx
+++ b/src/components/tx/ApprovalEditor/EditableApprovalItem.tsx
@@ -32,6 +32,7 @@ const EditableApprovalItem = ({
   const handleSave = () => {
     onSave()
     setReadOnly(true)
+    MODALS_EVENTS.EDIT_APPROVALS
   }
 
   const handleEditMode = () => {
@@ -41,12 +42,20 @@ const EditableApprovalItem = ({
   }
 
   return (
-    <Stack direction="row" alignItems="center" gap={2} className={css.approvalField}>
+    <Stack
+      direction="row"
+      alignItems="center"
+      gap={2}
+      className={css.approvalField}
+      onClick={readOnly ? handleEditMode : undefined}
+    >
       <Box display="flex" flexDirection="row" alignItems="center" gap="4px">
         <TokenIcon size={32} logoUri={approval.tokenInfo?.logoUri} tokenSymbol={approval.tokenInfo?.symbol} />
       </Box>
+
       <ApprovalValueField name={name} tx={approval} readOnly={readOnly} />
-      <Track {...MODALS_EVENTS.EDIT_APPROVALS}>
+
+      <Track {...MODALS_EVENTS.EDIT_APPROVALS} label={readOnly ? 'edit' : 'save'}>
         {readOnly ? (
           <IconButton color="border" onClick={handleEditMode} title="Edit">
             <SvgIcon fontSize="small" component={EditOutlined} inheritViewBox />

--- a/src/components/tx/ApprovalEditor/index.tsx
+++ b/src/components/tx/ApprovalEditor/index.tsx
@@ -54,7 +54,7 @@ export const ApprovalEditor = ({
   const isReadOnly = (safeTransaction && safeTransaction.signatures.size > 0) || safeMessage !== undefined
 
   return (
-    <Box display="flex" flexDirection="column" gap={2} mb={3} className={css.container}>
+    <Box display="flex" flexDirection="column" gap={2} className={css.container}>
       <Title />
       {error ? (
         <Alert severity="error">Error while decoding approval transactions.</Alert>

--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -1,5 +1,4 @@
 import SendToBlock from '@/components/tx/SendToBlock'
-import SwapOrderConfirmationView from '@/features/swap/components/SwapOrderConfirmationView'
 import { useCurrentChain } from '@/hooks/useChains'
 import { isSwapConfirmationViewOrder } from '@/utils/transaction-guards'
 import { type SyntheticEvent, type ReactElement, memo } from 'react'
@@ -46,7 +45,6 @@ type DecodedTxProps = {
   decodedDataError?: Error
   decodedDataLoading?: boolean
   showToBlock?: boolean
-  children?: ReactElement
 }
 
 const DecodedTx = ({
@@ -57,7 +55,6 @@ const DecodedTx = ({
   decodedDataError,
   decodedDataLoading = false,
   showToBlock = false,
-  children,
 }: DecodedTxProps): ReactElement | null => {
   const chainId = useChainId()
   const chain = useCurrentChain()
@@ -76,31 +73,29 @@ const DecodedTx = ({
     trackEvent({ ...MODALS_EVENTS.TX_DETAILS, label: expanded ? 'Open' : 'Close' })
   }
 
-  if (!decodedData) return children ?? null
+  if (!decodedData) return null
 
   const amount = tx?.data.value ? formatVisualAmount(tx.data.value, chain?.nativeCurrency.decimals) : '0'
 
   return (
     <Stack spacing={2}>
-      {!isSwapOrder && tx && showToBlock && amount !== '0' && (
-        <SendAmountBlock
-          amount={amount}
-          tokenInfo={{
-            type: TokenType.NATIVE_TOKEN,
-            address: ZERO_ADDRESS,
-            decimals: chain?.nativeCurrency.decimals ?? 18,
-            symbol: chain?.nativeCurrency.symbol ?? 'ETH',
-            logoUri: chain?.nativeCurrency.logoUri,
-          }}
-        />
-      )}
       {!isSwapOrder && tx && showToBlock && (
-        <SendToBlock address={tx.data.to} title="Interact with" name={addressInfoIndex?.[tx.data.to]?.name} />
+        <>
+          {amount !== '0' && (
+            <SendAmountBlock
+              amount={amount}
+              tokenInfo={{
+                type: TokenType.NATIVE_TOKEN,
+                address: ZERO_ADDRESS,
+                decimals: chain?.nativeCurrency.decimals ?? 18,
+                symbol: chain?.nativeCurrency.symbol ?? 'ETH',
+                logoUri: chain?.nativeCurrency.logoUri,
+              }}
+            />
+          )}
+          <SendToBlock address={tx.data.to} title="Interact with" name={addressInfoIndex?.[tx.data.to]?.name} />
+        </>
       )}
-
-      {isSwapOrder && tx && <SwapOrderConfirmationView order={decodedData} settlementContract={tx.data.to} />}
-
-      {children}
 
       {isMultisend && showMultisend && (
         <Box>

--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -46,6 +46,7 @@ type DecodedTxProps = {
   decodedDataError?: Error
   decodedDataLoading?: boolean
   showToBlock?: boolean
+  children?: ReactElement
 }
 
 const DecodedTx = ({
@@ -56,6 +57,7 @@ const DecodedTx = ({
   decodedDataError,
   decodedDataLoading = false,
   showToBlock = false,
+  children,
 }: DecodedTxProps): ReactElement | null => {
   const chainId = useChainId()
   const chain = useCurrentChain()
@@ -74,7 +76,7 @@ const DecodedTx = ({
     trackEvent({ ...MODALS_EVENTS.TX_DETAILS, label: expanded ? 'Open' : 'Close' })
   }
 
-  if (!decodedData) return null
+  if (!decodedData) return children ?? null
 
   const amount = tx?.data.value ? formatVisualAmount(tx.data.value, chain?.nativeCurrency.decimals) : '0'
 
@@ -97,6 +99,8 @@ const DecodedTx = ({
       )}
 
       {isSwapOrder && tx && <SwapOrderConfirmationView order={decodedData} settlementContract={tx.data.to} />}
+
+      {children}
 
       {isMultisend && showMultisend && (
         <Box>

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -27,6 +27,8 @@ import { TX_EVENTS } from '@/services/analytics/events/transactions'
 import { trackEvent } from '@/services/analytics'
 import useChainId from '@/hooks/useChainId'
 import PermissionsCheck from './PermissionsCheck'
+import { isSwapConfirmationViewOrder } from '@/utils/transaction-guards'
+import SwapOrderConfirmationView from '@/features/swap/components/SwapOrderConfirmationView'
 
 export type SubmitCallback = (txId: string, isExecuted?: boolean) => void
 
@@ -74,6 +76,7 @@ export const SignOrExecuteForm = ({
   const isCorrectNonce = useValidateNonce(safeTx)
   const [decodedData, decodedDataError, decodedDataLoading] = useDecodeTx(safeTx)
   const isBatchable = props.isBatchable !== false && safeTx && !isDelegateCall(safeTx)
+  const isSwapOrder = isSwapConfirmationViewOrder(decodedData)
 
   const { safe } = useSafeInfo()
   const isCounterfactualSafe = !safe.deployed
@@ -97,6 +100,16 @@ export const SignOrExecuteForm = ({
       <TxCard>
         {props.children}
 
+        {isSwapOrder && (
+          <ErrorBoundary fallback={<></>}>
+            <SwapOrderConfirmationView order={decodedData} settlementContract={safeTx?.data.to ?? ''} />
+          </ErrorBoundary>
+        )}
+
+        <ErrorBoundary fallback={<div>Error parsing data</div>}>
+          <ApprovalEditor safeTransaction={safeTx} />
+        </ErrorBoundary>
+
         <DecodedTx
           tx={safeTx}
           txId={props.txId}
@@ -105,11 +118,7 @@ export const SignOrExecuteForm = ({
           decodedDataLoading={decodedDataLoading}
           showMultisend={!props.isBatch}
           showToBlock={props.showToBlock}
-        >
-          <ErrorBoundary fallback={<div>Error parsing data</div>}>
-            <ApprovalEditor safeTransaction={safeTx} />
-          </ErrorBoundary>
-        </DecodedTx>
+        />
 
         {!isCounterfactualSafe && <RedefineBalanceChanges />}
       </TxCard>

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -97,10 +97,6 @@ export const SignOrExecuteForm = ({
       <TxCard>
         {props.children}
 
-        <ErrorBoundary fallback={<div>Error parsing data</div>}>
-          <ApprovalEditor safeTransaction={safeTx} />
-        </ErrorBoundary>
-
         <DecodedTx
           tx={safeTx}
           txId={props.txId}
@@ -109,7 +105,11 @@ export const SignOrExecuteForm = ({
           decodedDataLoading={decodedDataLoading}
           showMultisend={!props.isBatch}
           showToBlock={props.showToBlock}
-        />
+        >
+          <ErrorBoundary fallback={<div>Error parsing data</div>}>
+            <ApprovalEditor safeTransaction={safeTx} />
+          </ErrorBoundary>
+        </DecodedTx>
 
         {!isCounterfactualSafe && <RedefineBalanceChanges />}
       </TxCard>

--- a/src/features/swap/components/SwapOrderConfirmationView/index.tsx
+++ b/src/features/swap/components/SwapOrderConfirmationView/index.tsx
@@ -1,6 +1,6 @@
 import OrderId from '@/features/swap/components/OrderId'
 import { formatDateTime, formatTimeInWords } from '@/utils/date'
-import type { ReactElement } from 'react'
+import { Fragment, type ReactElement } from 'react'
 import { DataRow } from '@/components/common/Table/DataRow'
 import { DataTable } from '@/components/common/Table/DataTable'
 import { compareAsc } from 'date-fns'
@@ -20,9 +20,7 @@ type SwapOrderProps = {
   settlementContract: string
 }
 
-export const SwapOrderConfirmationView = ({ order, settlementContract }: SwapOrderProps): ReactElement | null => {
-  if (!order) return null
-
+export const SwapOrderConfirmationView = ({ order, settlementContract }: SwapOrderProps): ReactElement => {
   const { uid, owner, kind, validUntil, sellToken, buyToken, sellAmount, buyAmount, explorerUrl, receiver } = order
 
   const limitPrice = getLimitPrice(order)
@@ -78,7 +76,7 @@ export const SwapOrderConfirmationView = ({ order, settlementContract }: SwapOrd
               {slippage}%
             </DataRow>
           ) : (
-            <></>
+            <Fragment key="none" />
           ),
           <DataRow key="Order ID" title="Order ID">
             <OrderId orderId={uid} href={explorerUrl} />

--- a/src/features/swap/components/SwapOrderConfirmationView/index.tsx
+++ b/src/features/swap/components/SwapOrderConfirmationView/index.tsx
@@ -36,7 +36,7 @@ export const SwapOrderConfirmationView = ({ order, settlementContract }: SwapOrd
   return (
     <div className={css.tableWrapper}>
       <DataTable
-        header="Order Details"
+        header="Order details"
         rows={[
           <div key="amount">
             <SwapTokens

--- a/src/hooks/useDecodeTx.ts
+++ b/src/hooks/useDecodeTx.ts
@@ -23,13 +23,17 @@ const useDecodeTx = (
 
   const [data, error, loading] = useAsync<
     DecodedDataResponse | BaselineConfirmationView | CowSwapConfirmationView | undefined
-  >(() => {
-    if (!encodedData || isEmptyData) {
-      const nativeTransfer = isEmptyData && !isRejection ? getNativeTransferData(tx?.data) : undefined
-      return Promise.resolve(nativeTransfer)
-    }
-    return getConfirmationView(chainId, safeAddress, encodedData, tx.data.to)
-  }, [chainId, encodedData, isEmptyData, tx?.data, isRejection, safeAddress])
+  >(
+    () => {
+      if (!encodedData || isEmptyData) {
+        const nativeTransfer = isEmptyData && !isRejection ? getNativeTransferData(tx?.data) : undefined
+        return Promise.resolve(nativeTransfer)
+      }
+      return getConfirmationView(chainId, safeAddress, encodedData, tx.data.to)
+    },
+    [chainId, encodedData, isEmptyData, tx?.data, isRejection, safeAddress],
+    false,
+  )
 
   return [data, error, loading]
 }


### PR DESCRIPTION
## What it solves
A few UI adjustments for the Approval Editor in swap transactions.

* The approval editor is now shown below Swap details
* The entire Unlimited amount block is clickable (becomes editable)
* The tracking event on click is now differentiated by label: `edit` or `save`.

### Before
<img width="690" alt="Screenshot 2024-06-20 at 15 06 12" src="https://github.com/safe-global/safe-wallet-web/assets/381895/5cc28c4b-cec2-48ce-bbe7-56c14cbc0fa2">

### After
![Screenshot 2024-06-20 at 15 02 16](https://github.com/safe-global/safe-wallet-web/assets/381895/5c39399e-ef0a-47f6-acd2-54a6bca02eec)

## Links
Internal discussion: https://5afe.slack.com/archives/C06GBBW39QU/p1718885834196179
