### PR TITLE
Fix: delay chainChanged event in test wallet

### DIFF
--- a/src/services/private-key-module/index.ts
+++ b/src/services/private-key-module/index.ts
@@ -43,7 +43,6 @@ const PrivateKeyModule = (chainId: ChainInfo['chainId'], rpcUri: ChainInfo['rpcU
 
         let provider: JsonRpcProvider
         let wallet: Wallet
-        let lastChainId = ''
         const chainChangedListeners = new Set<(chainId: string) => void>()
 
         const updateProvider = () => {
@@ -51,8 +50,10 @@ const PrivateKeyModule = (chainId: ChainInfo['chainId'], rpcUri: ChainInfo['rpcU
           provider?.destroy()
           provider = new JsonRpcProvider(currentRpcUri, Number(currentChainId), { staticNetwork: true })
           wallet = new Wallet(privateKey, provider)
-          lastChainId = currentChainId
-          chainChangedListeners.forEach((listener) => listener(numberToHex(Number(currentChainId))))
+
+          setTimeout(() => {
+            chainChangedListeners.forEach((listener) => listener(numberToHex(Number(currentChainId))))
+          }, 100)
         }
 
         updateProvider()
@@ -71,9 +72,6 @@ const PrivateKeyModule = (chainId: ChainInfo['chainId'], rpcUri: ChainInfo['rpcU
               },
 
               request: async (request: { method: string; params: any[] }) => {
-                if (currentChainId !== lastChainId) {
-                  updateProvider()
-                }
                 return provider.send(request.method, request.params)
               },
 

--- a/src/tests/e2e-wallet.ts
+++ b/src/tests/e2e-wallet.ts
@@ -21,15 +21,16 @@ const E2EWalletMoule = (chainId: ChainInfo['chainId'], rpcUri: ChainInfo['rpcUri
       getInterface: async () => {
         let provider: JsonRpcProvider
         let wallet: HDNodeWallet
-        let lastChainId = ''
         const chainChangedListeners = new Set<(chainId: string) => void>()
 
         const updateProvider = () => {
           provider?.destroy()
           provider = new JsonRpcProvider(currentRpcUri, Number(currentChainId), { staticNetwork: true })
           wallet = Wallet.fromPhrase(CYPRESS_MNEMONIC, provider)
-          lastChainId = currentChainId
-          chainChangedListeners.forEach((listener) => listener(numberToHex(Number(currentChainId))))
+
+          setTimeout(() => {
+            chainChangedListeners.forEach((listener) => listener(numberToHex(Number(currentChainId))))
+          }, 100)
         }
 
         updateProvider()
@@ -48,13 +49,8 @@ const E2EWalletMoule = (chainId: ChainInfo['chainId'], rpcUri: ChainInfo['rpcUri
               },
 
               request: async (request: { method: string; params: any[] }) => {
-                if (currentChainId !== lastChainId) {
-                  updateProvider()
-                }
                 return provider.send(request.method, request.params)
               },
-
-              disconnect: () => {},
             },
             {
               eth_chainId: async () => currentChainId,


### PR DESCRIPTION
## What it solves

Onboard cannot subscribe to the chainChanged event if it's emitted synchronously right after connecting.
Giving it a small delay allows onboard to subscribe to this event and fetch an ENS name and account balance of the connected address.