### PR TITLE
Feat: TWAP order decoding in tx history/queue [SW-1]

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@safe-global/protocol-kit": "^3.1.1",
     "@safe-global/safe-apps-sdk": "^9.1.0",
     "@safe-global/safe-deployments": "^1.36.0",
-    "@safe-global/safe-gateway-typescript-sdk": "3.21.2",
+    "@safe-global/safe-gateway-typescript-sdk": "^3.21.5",
     "@safe-global/safe-modules-deployments": "^1.2.0",
     "@sentry/react": "^7.91.0",
     "@spindl-xyz/attribution-lite": "^1.4.0",

--- a/src/components/common/Table/EmptyRow.tsx
+++ b/src/components/common/Table/EmptyRow.tsx
@@ -1,0 +1,6 @@
+import type { ReactElement } from 'react'
+import css from './styles.module.css'
+
+export const EmptyRow = (): ReactElement | null => {
+  return <div className={css.gridEmptyRow}></div>
+}

--- a/src/components/common/Table/styles.module.css
+++ b/src/components/common/Table/styles.module.css
@@ -7,14 +7,14 @@
 }
 
 .gridEmptyRow {
-    display: grid;
-    grid-template-columns: 35% auto;
-    gap: var(--space-1);
-    justify-content: flex-start;
-    max-width: 900px;
-    margin-top: var(--space-1);
-    margin-bottom: var(--space-1);
-    border-top: 1px solid var(--color-border-light);
+  display: grid;
+  grid-template-columns: 35% auto;
+  gap: var(--space-1);
+  justify-content: flex-start;
+  max-width: 900px;
+  margin-top: var(--space-1);
+  margin-bottom: var(--space-1);
+  border-top: 1px solid var(--color-border-light);
 }
 .title {
   color: var(--color-primary-light);

--- a/src/components/common/Table/styles.module.css
+++ b/src/components/common/Table/styles.module.css
@@ -6,6 +6,16 @@
   max-width: 900px;
 }
 
+.gridEmptyRow {
+    display: grid;
+    grid-template-columns: 35% auto;
+    gap: var(--space-1);
+    justify-content: flex-start;
+    max-width: 900px;
+    margin-top: var(--space-1);
+    margin-bottom: var(--space-1);
+    border-top: 1px solid var(--color-border-light);
+}
 .title {
   color: var(--color-primary-light);
   font-weight: 400;

--- a/src/components/transactions/TxDetails/TxData/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/index.tsx
@@ -8,7 +8,7 @@ import {
   isSettingsChangeTxInfo,
   isSpendingLimitMethod,
   isSupportedSpendingLimitAddress,
-  isSwapTxInfo,
+  isSwapOrderTxInfo,
   isTransferTxInfo,
 } from '@/utils/transaction-guards'
 import { SpendingLimits } from '@/components/transactions/TxDetails/TxData/SpendingLimits'
@@ -46,7 +46,7 @@ const TxData = ({ txDetails, trusted }: { txDetails: TransactionDetails; trusted
     return <SpendingLimits txData={txDetails.txData} txInfo={txInfo} type={method} />
   }
 
-  if (isSwapTxInfo(txInfo)) {
+  if (isSwapOrderTxInfo(txInfo)) {
     return <InteractWith txData={txDetails.txData} />
   }
 

--- a/src/components/transactions/TxDetails/TxData/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/index.tsx
@@ -1,5 +1,4 @@
 import SettingsChangeTxInfo from '@/components/transactions/TxDetails/TxData/SettingsChange'
-import SwapTxInfo from '@/features/swap/components/SwapTxInfo'
 import type { SpendingLimitMethods } from '@/utils/transaction-guards'
 import {
   isCancellationTxInfo,
@@ -20,6 +19,7 @@ import DecodedData from '@/components/transactions/TxDetails/TxData/DecodedData'
 import TransferTxInfo from '@/components/transactions/TxDetails/TxData/Transfer'
 import useChainId from '@/hooks/useChainId'
 import { MultiSendTxInfo } from '@/components/transactions/TxDetails/TxData/MultiSendTxInfo'
+import InteractWith from '@/features/swap/components/SwapTxInfo/interactWith'
 
 const TxData = ({ txDetails, trusted }: { txDetails: TransactionDetails; trusted: boolean }): ReactElement => {
   const chainId = useChainId()
@@ -47,7 +47,7 @@ const TxData = ({ txDetails, trusted }: { txDetails: TransactionDetails; trusted
   }
 
   if (isSwapTxInfo(txInfo)) {
-    return <SwapTxInfo txData={txDetails.txData} />
+    return <InteractWith txData={txDetails.txData} />
   }
 
   return <DecodedData txData={txDetails.txData} txInfo={txInfo} />

--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -13,12 +13,12 @@ import useChainId from '@/hooks/useChainId'
 import useAsync from '@/hooks/useAsync'
 import {
   isAwaitingExecution,
-  isCoWOrderTxInfo,
+  isOrderTxInfo,
   isModuleExecutionInfo,
   isMultiSendTxInfo,
   isMultisigDetailedExecutionInfo,
   isMultisigExecutionInfo,
-  isOpenSwap,
+  isOpenSwapOrder,
   isTxQueued,
 } from '@/utils/transaction-guards'
 import { InfoDetails } from '@/components/transactions/InfoDetails'
@@ -73,7 +73,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
     <>
       {/* /Details */}
       <div className={`${css.details} ${isUnsigned ? css.noSigners : ''}`}>
-        {isCoWOrderTxInfo(txDetails.txInfo) && (
+        {isOrderTxInfo(txDetails.txInfo) && (
           <div className={css.swapOrder}>
             <ErrorBoundary fallback={<div>Error parsing data</div>}>
               <SwapOrder txData={txDetails.txData} txInfo={txDetails.txInfo} />
@@ -116,7 +116,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
           <Summary txDetails={txDetails} />
         </div>
 
-        {(isMultiSendTxInfo(txDetails.txInfo) || isCoWOrderTxInfo(txDetails.txInfo)) && (
+        {(isMultiSendTxInfo(txDetails.txInfo) || isOrderTxInfo(txDetails.txInfo)) && (
           <div className={css.multiSend}>
             <ErrorBoundary fallback={<div>Error parsing data</div>}>
               <Multisend txData={txDetails.txData} />
@@ -159,7 +159,7 @@ const TxDetails = ({
   const { safe } = useSafeInfo()
 
   const [pollCount] = useIntervalCounter(POLLING_INTERVAL)
-  const swapPollCount = isOpenSwap(txSummary.txInfo) ? pollCount : 0
+  const swapPollCount = isOpenSwapOrder(txSummary.txInfo) ? pollCount : 0
 
   const [txDetailsData, error, loading] = useAsync<TransactionDetails>(
     async () => {

--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -12,13 +12,13 @@ import TxData from '@/components/transactions/TxDetails/TxData'
 import useChainId from '@/hooks/useChainId'
 import useAsync from '@/hooks/useAsync'
 import {
-  isAwaitingExecution,
+  isAwaitingExecution, isCoWOrderTxInfo,
   isModuleExecutionInfo,
   isMultiSendTxInfo,
   isMultisigDetailedExecutionInfo,
   isMultisigExecutionInfo,
   isOpenSwap,
-  isSwapTxInfo,
+  isSwapTxInfo, isTwapTxInfo,
   isTxQueued,
 } from '@/utils/transaction-guards'
 import { InfoDetails } from '@/components/transactions/InfoDetails'
@@ -73,7 +73,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
     <>
       {/* /Details */}
       <div className={`${css.details} ${isUnsigned ? css.noSigners : ''}`}>
-        {isSwapTxInfo(txDetails.txInfo) && (
+        {isCoWOrderTxInfo(txDetails.txInfo) && (
           <div className={css.swapOrder}>
             <ErrorBoundary fallback={<div>Error parsing data</div>}>
               <SwapOrder txData={txDetails.txData} txInfo={txDetails.txInfo} />
@@ -116,7 +116,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
           <Summary txDetails={txDetails} />
         </div>
 
-        {(isMultiSendTxInfo(txDetails.txInfo) || isSwapTxInfo(txDetails.txInfo)) && (
+        {(isMultiSendTxInfo(txDetails.txInfo) || isCoWOrderTxInfo(txDetails.txInfo)) && (
           <div className={css.multiSend}>
             <ErrorBoundary fallback={<div>Error parsing data</div>}>
               <Multisend txData={txDetails.txData} />

--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -12,13 +12,13 @@ import TxData from '@/components/transactions/TxDetails/TxData'
 import useChainId from '@/hooks/useChainId'
 import useAsync from '@/hooks/useAsync'
 import {
-  isAwaitingExecution, isCoWOrderTxInfo,
+  isAwaitingExecution,
+  isCoWOrderTxInfo,
   isModuleExecutionInfo,
   isMultiSendTxInfo,
   isMultisigDetailedExecutionInfo,
   isMultisigExecutionInfo,
   isOpenSwap,
-  isSwapTxInfo, isTwapTxInfo,
   isTxQueued,
 } from '@/utils/transaction-guards'
 import { InfoDetails } from '@/components/transactions/InfoDetails'

--- a/src/components/transactions/TxInfo/index.tsx
+++ b/src/components/transactions/TxInfo/index.tsx
@@ -103,7 +103,7 @@ const SwapTx = ({ info }: { info: Order }): ReactElement => {
         <TokenIcon logoUri={sellToken.logoUri || undefined} tokenSymbol={sellToken.symbol} />
       </Box>
       <Typography component="span" fontWeight="bold">
-        {formatVisualAmount(sellAmount, sellToken.decimals)} {sellToken.symbol} {" "}
+        {formatVisualAmount(sellAmount, sellToken.decimals)} {sellToken.symbol}{' '}
       </Typography>
     </>
   )

--- a/src/components/transactions/TxInfo/index.tsx
+++ b/src/components/transactions/TxInfo/index.tsx
@@ -10,7 +10,7 @@ import type {
 import { SettingsInfoType } from '@safe-global/safe-gateway-typescript-sdk'
 import TokenAmount from '@/components/common/TokenAmount'
 import {
-  isCoWOrderTxInfo,
+  isOrderTxInfo,
   isCreationTxInfo,
   isCustomTxInfo,
   isERC20Transfer,
@@ -121,7 +121,7 @@ const TxInfo = ({ info, ...rest }: { info: TransactionInfo; omitSign?: boolean; 
     return <CreationTx info={info} />
   }
 
-  if (isCoWOrderTxInfo(info)) {
+  if (isOrderTxInfo(info)) {
     return <SwapTx info={info} />
   }
 

--- a/src/components/transactions/TxInfo/index.tsx
+++ b/src/components/transactions/TxInfo/index.tsx
@@ -1,12 +1,11 @@
 import { type ReactElement } from 'react'
 import type {
-  Transfer,
-  Custom,
   Creation,
-  TransactionInfo,
+  Custom,
   MultiSend,
   SettingsChange,
-  Order,
+  TransactionInfo,
+  Transfer,
 } from '@safe-global/safe-gateway-typescript-sdk'
 import { SettingsInfoType } from '@safe-global/safe-gateway-typescript-sdk'
 import TokenAmount from '@/components/common/TokenAmount'
@@ -21,11 +20,9 @@ import {
   isSettingsChangeTxInfo,
   isTransferTxInfo,
 } from '@/utils/transaction-guards'
-import { ellipsis, formatVisualAmount, shortenAddress } from '@/utils/formatters'
+import { ellipsis, shortenAddress } from '@/utils/formatters'
 import { useCurrentChain } from '@/hooks/useChains'
-import TokenIcon from '@/components/common/TokenIcon'
-import { Box, Typography } from '@mui/material'
-import { capitalize } from '@/hooks/useMnemonicName'
+import { SwapTx } from '@/features/swap/components/SwapTxInfo/SwapTx'
 
 export const TransferTx = ({
   info,
@@ -92,49 +89,6 @@ const MultiSendTx = ({ info }: { info: MultiSend }): ReactElement => {
   )
 }
 
-const SwapTx = ({ info }: { info: Order }): ReactElement => {
-  const { kind, sellToken, sellAmount, buyToken } = info
-  const orderKindLabel = capitalize(kind)
-  const isSellOrder = kind === 'sell'
-
-  let from = (
-    <>
-      <Box style={{ paddingRight: 5, display: 'inline-block' }}>
-        <TokenIcon logoUri={sellToken.logoUri || undefined} tokenSymbol={sellToken.symbol} />
-      </Box>
-      <Typography component="span" fontWeight="bold">
-        {formatVisualAmount(sellAmount, sellToken.decimals)} {sellToken.symbol}{' '}
-      </Typography>
-    </>
-  )
-
-  let to = (
-    <>
-      <Box style={{ paddingLeft: 5, paddingRight: 5, display: 'inline-block' }}>
-        <TokenIcon logoUri={buyToken.logoUri || undefined} tokenSymbol={buyToken.symbol} />
-      </Box>{' '}
-      <Typography component="span" fontWeight="bold">
-        {buyToken.symbol}
-      </Typography>
-    </>
-  )
-  if (!isSellOrder) {
-    // switch them around for buy order
-    ;[from, to] = [to, from]
-  }
-
-  return (
-    <Box display="flex">
-      <Typography component="div" display="flex" alignItems="center" fontWeight="bold">
-        {from}
-        <Typography component="span" ml={0.5}>
-          to
-        </Typography>
-        {to}
-      </Typography>
-    </Box>
-  )
-}
 const SettingsChangeTx = ({ info }: { info: SettingsChange }): ReactElement => {
   if (
     info.settingsInfo?.type === SettingsInfoType.ENABLE_MODULE ||

--- a/src/components/transactions/TxInfo/index.tsx
+++ b/src/components/transactions/TxInfo/index.tsx
@@ -94,7 +94,7 @@ const MultiSendTx = ({ info }: { info: MultiSend }): ReactElement => {
 const SwapTx = ({ info }: { info: SwapOrder }): ReactElement => {
   return (
     <Box display="flex">
-      <Typography display="flex" alignItems="center" fontWeight="bold">
+      <Typography component="div" display="flex" alignItems="center" fontWeight="bold">
         <Box style={{ paddingRight: 5, display: 'inline-block' }}>
           <TokenIcon logoUri={info.sellToken.logoUri || undefined} tokenSymbol={info.sellToken.symbol} />
         </Box>

--- a/src/components/transactions/TxStatusLabel/index.tsx
+++ b/src/components/transactions/TxStatusLabel/index.tsx
@@ -1,11 +1,11 @@
-import { isCancelledSwap } from '@/utils/transaction-guards'
+import { isCancelledSwapOrder } from '@/utils/transaction-guards'
 import { CircularProgress, type Palette, Typography } from '@mui/material'
 import { TransactionStatus, type TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import useIsPending from '@/hooks/useIsPending'
 import useTransactionStatus from '@/hooks/useTransactionStatus'
 
 const getStatusColor = (tx: TransactionSummary, palette: Palette) => {
-  if (isCancelledSwap(tx.txInfo)) {
+  if (isCancelledSwapOrder(tx.txInfo)) {
     return palette.error.main
   }
 

--- a/src/components/tx-flow/flows/ConfirmTx/index.tsx
+++ b/src/components/tx-flow/flows/ConfirmTx/index.tsx
@@ -1,4 +1,4 @@
-import { isSwapTxInfo } from '@/utils/transaction-guards'
+import { isSwapOrderTxInfo } from '@/utils/transaction-guards'
 import type { TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import TxLayout from '@/components/tx-flow/common/TxLayout'
 import ConfirmProposedTx from './ConfirmProposedTx'
@@ -8,7 +8,7 @@ import SwapIcon from '@/public/images/common/swap.svg'
 
 const ConfirmTxFlow = ({ txSummary }: { txSummary: TransactionSummary }) => {
   const { text } = useTransactionType(txSummary)
-  const isSwapOrder = isSwapTxInfo(txSummary.txInfo)
+  const isSwapOrder = isSwapOrderTxInfo(txSummary.txInfo)
 
   return (
     <TxLayout

--- a/src/features/swap/components/SwapOrder/index.tsx
+++ b/src/features/swap/components/SwapOrder/index.tsx
@@ -6,9 +6,9 @@ import { capitalize } from '@/hooks/useMnemonicName'
 import { formatDateTime, formatTimeInWords } from '@/utils/date'
 import Stack from '@mui/material/Stack'
 import type { ReactElement } from 'react'
+import type { TwapOrder as SwapTwapOrder } from '@safe-global/safe-gateway-typescript-sdk'
 import {
   type SwapOrder as SwapOrderType,
-  TwapOrder as SwapTwapOrder,
   type Order,
   type TransactionData,
   TransactionInfoType,

--- a/src/features/swap/components/SwapOrder/index.tsx
+++ b/src/features/swap/components/SwapOrder/index.tsx
@@ -30,7 +30,7 @@ import {
 } from '@/features/swap/helpers/utils'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import { isSwapTxInfo, isTwapTxInfo } from '@/utils/transaction-guards'
+import { isSwapOrderTxInfo, isTwapOrderTxInfo } from '@/utils/transaction-guards'
 import { EmptyRow } from '@/components/common/Table/EmptyRow'
 
 type SwapOrderProps = {
@@ -275,11 +275,11 @@ export const TwapOrder = ({ order }: { order: SwapTwapOrder }) => {
 export const SwapOrder = ({ txData, txInfo }: SwapOrderProps): ReactElement | null => {
   if (!txData || !txInfo) return null
 
-  if (isTwapTxInfo(txInfo)) {
+  if (isTwapOrderTxInfo(txInfo)) {
     return <TwapOrder order={txInfo} />
   }
 
-  if (isSwapTxInfo(txInfo)) {
+  if (isSwapOrderTxInfo(txInfo)) {
     return <SellOrder order={txInfo} />
   }
   return null

--- a/src/features/swap/components/SwapOrder/index.tsx
+++ b/src/features/swap/components/SwapOrder/index.tsx
@@ -6,7 +6,13 @@ import { capitalize } from '@/hooks/useMnemonicName'
 import { formatDateTime, formatTimeInWords } from '@/utils/date'
 import Stack from '@mui/material/Stack'
 import type { ReactElement } from 'react'
-import { type SwapOrder as SwapOrderType, type TransactionData } from '@safe-global/safe-gateway-typescript-sdk'
+import {
+  type SwapOrder as SwapOrderType,
+  TwapOrder as SwapTwapOrder,
+  type Order,
+  type TransactionData,
+  TransactionInfoType,
+} from '@safe-global/safe-gateway-typescript-sdk'
 import { DataRow } from '@/components/common/Table/DataRow'
 import { DataTable } from '@/components/common/Table/DataTable'
 import { HexEncodedData } from '@/components/transactions/HexEncodedData'
@@ -25,103 +31,243 @@ import {
 } from '@/features/swap/helpers/utils'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import useSafeInfo from '@/hooks/useSafeInfo'
+import { isTwapTxInfo } from '@/utils/transaction-guards'
+import { EmptyRow } from '@/components/common/Table/EmptyRow'
 
 type SwapOrderProps = {
   txData?: TransactionData
-  txInfo?: SwapOrderType
+  txInfo?: Order
+}
+
+const AmountRow = ({ order }: { order: Order }) => {
+  const { sellToken, buyToken, sellAmount, buyAmount, kind } = order
+  const orderKindLabel = capitalize(kind)
+  const isSellOrder = kind === 'sell'
+  return (
+    <DataRow key="Amount" title="Amount">
+      <Stack flexDirection={isSellOrder ? 'column' : 'column-reverse'}>
+        <div>
+          <span className={css.value}>
+            {isSellOrder ? 'Sell' : 'For at most'}{' '}
+            {sellToken.logoUri && <TokenIcon logoUri={sellToken.logoUri} size={24} />}{' '}
+            <Typography component="span" fontWeight="bold">
+              {formatVisualAmount(sellAmount, sellToken.decimals)} {sellToken.symbol}
+            </Typography>
+          </span>
+        </div>
+        <div>
+          <span className={css.value}>
+            {isSellOrder ? 'for at least' : 'Buy'}{' '}
+            {buyToken.logoUri && <TokenIcon logoUri={buyToken.logoUri} size={24} />}
+            <Typography component="span" fontWeight="bold">
+              {formatVisualAmount(buyAmount, buyToken.decimals)} {buyToken.symbol}
+            </Typography>
+          </span>
+        </div>
+      </Stack>
+    </DataRow>
+  )
+}
+
+const PriceRow = ({ order }: { order: Order }) => {
+  const { status, sellToken, buyToken } = order
+  const executionPrice = getExecutionPrice(order)
+  const limitPrice = getLimitPrice(order)
+
+  if (status === 'fulfilled') {
+    return (
+      <DataRow key="Execution price" title="Execution price">
+        1 {buyToken.symbol} = {formatAmount(executionPrice)} {sellToken.symbol}
+      </DataRow>
+    )
+  }
+
+  return (
+    <DataRow key="Limit price" title="Limit price">
+      1 {buyToken.symbol} = {formatAmount(limitPrice)} {sellToken.symbol}
+    </DataRow>
+  )
+}
+
+const ExpiryRow = ({ order }: { order: Order }) => {
+  const { validUntil, status } = order
+  const now = new Date()
+  const expires = new Date(validUntil * 1000)
+  if (status! == 'fulfilled') {
+    if (compareAsc(now, expires) !== 1) {
+      return (
+        <DataRow key="Expiry" title="Expiry">
+          <Typography>
+            <Typography fontWeight={700} component="span">
+              {formatTimeInWords(validUntil * 1000)}
+            </Typography>{' '}
+            ({formatDateTime(validUntil * 1000)})
+          </Typography>
+        </DataRow>
+      )
+    } else {
+      return (
+        <DataRow key="Expiry" title="Expiry">
+          {formatDateTime(validUntil * 1000)}
+        </DataRow>
+      )
+    }
+  }
+
+  return <></>
+}
+
+const SurplusRow = ({ order }: { order: Order }) => {
+  const { status, kind } = order
+  const isPartiallyFilled = isOrderPartiallyFilled(order)
+  const surplusPrice = isPartiallyFilled ? getPartiallyFilledSurplus(order) : getSurplusPrice(order)
+  const { sellToken, buyToken } = order
+  const isSellOrder = kind === 'sell'
+  if (status === 'fulfilled' || isPartiallyFilled) {
+    return (
+      <DataRow key="Surplus" title="Surplus">
+        {formatAmount(surplusPrice)} {isSellOrder ? buyToken.symbol : sellToken.symbol}
+      </DataRow>
+    )
+  }
+
+  return <></>
+}
+
+const FilledRow = ({ order }: { order: Order }) => {
+  const orderClass = getOrderClass(order)
+  if (['limit', 'twap'].includes(orderClass)) {
+    return (
+      <DataRow title="Filled" key="Filled">
+        <SwapProgress order={order} />
+      </DataRow>
+    )
+  }
+
+  return <></>
+}
+
+const OrderUidRow = ({ order }: { order: Order }) => {
+  if (order.type === TransactionInfoType.SWAP_ORDER) {
+    const { uid, explorerUrl } = order
+    return (
+      <DataRow key="Order ID" title="Order ID">
+        <OrderId orderId={uid} href={explorerUrl} />
+      </DataRow>
+    )
+  }
+  return <></>
+}
+
+const StatusRow = ({ order }: { order: Order }) => {
+  const { status } = order
+  const isPartiallyFilled = isOrderPartiallyFilled(order)
+  return (
+    <DataRow key="Status" title="Status">
+      <StatusLabel status={isPartiallyFilled ? 'partiallyFilled' : status} />
+    </DataRow>
+  )
+}
+
+const RecipientRow = ({ order }: { order: Order }) => {
+  const { safeAddress } = useSafeInfo()
+  const { receiver } = order
+
+  if (receiver && receiver !== safeAddress) {
+    return (
+      <DataRow key="Recipient" title="Recipient">
+        <EthHashInfo address={receiver} showAvatar={false} />
+      </DataRow>
+    )
+  }
+
+  return <></>
 }
 
 export const SellOrder = ({ order }: { order: SwapOrderType }) => {
-  const { safeAddress } = useSafeInfo()
-  const { uid, kind, validUntil, status, sellToken, buyToken, sellAmount, buyAmount, explorerUrl, receiver } = order
-
-  const isPartiallyFilled = isOrderPartiallyFilled(order)
-  const executionPrice = getExecutionPrice(order)
-  const limitPrice = getLimitPrice(order)
-  const surplusPrice = isPartiallyFilled ? getPartiallyFilledSurplus(order) : getSurplusPrice(order)
-  const expires = new Date(validUntil * 1000)
-  const now = new Date()
-  const orderClass = getOrderClass(order)
-
+  const { kind } = order
   const orderKindLabel = capitalize(kind)
-  const isSellOrder = kind === 'sell'
 
   return (
     <DataTable
       header={`${orderKindLabel} order`}
       rows={[
-        <DataRow key="Amount" title="Amount">
-          <Stack flexDirection={isSellOrder ? 'column' : 'column-reverse'}>
-            <div>
-              <span className={css.value}>
-                {isSellOrder ? 'Sell' : 'For at most'}{' '}
-                {sellToken.logoUri && <TokenIcon logoUri={sellToken.logoUri} size={24} />}{' '}
-                {formatVisualAmount(sellAmount, sellToken.decimals)} {sellToken.symbol}
-              </span>
-            </div>
-            <div>
-              <span className={css.value}>
-                {isSellOrder ? 'for at least' : 'Buy'}{' '}
-                {buyToken.logoUri && <TokenIcon logoUri={buyToken.logoUri} size={24} />}
-                {formatVisualAmount(buyAmount, buyToken.decimals)} {buyToken.symbol}
-              </span>
-            </div>
-          </Stack>
+        <AmountRow order={order} key="amount-row" />,
+        <PriceRow order={order} key="price-row" />,
+        <SurplusRow order={order} key="surplus-row" />,
+        <ExpiryRow order={order} key="expiry-row" />,
+        <FilledRow order={order} key="filled-row" />,
+        <OrderUidRow order={order} key="order-uid-row" />,
+        <StatusRow order={order} key="status-row" />,
+        <RecipientRow order={order} key="recipient-row" />,
+      ]}
+    />
+  )
+}
+
+export const TwapOrder = ({ order }: { order: SwapTwapOrder }) => {
+  const {
+    kind,
+    validUntil,
+    status,
+    sellToken,
+    buyToken,
+    numberOfParts,
+    partSellAmount,
+    minPartLimit,
+    timeBetweenParts,
+  } = order
+
+  const isPartiallyFilled = isOrderPartiallyFilled(order)
+  const expires = new Date(validUntil * 1000)
+  const now = new Date()
+
+  const orderKindLabel = capitalize(kind)
+
+  return (
+    <DataTable
+      header={`${orderKindLabel} order`}
+      rows={[
+        <AmountRow order={order} key="amount-row" />,
+        <PriceRow order={order} key="price-row" />,
+        <SurplusRow order={order} key="surplus-row" />,
+        <RecipientRow order={order} key="recipient-row" />,
+        <EmptyRow key="spacer-0" />,
+        <DataRow title="No of parts" key="n_of_parts">
+          {numberOfParts}
         </DataRow>,
-        status === 'fulfilled' ? (
-          <DataRow key="Execution price" title="Execution price">
-            1 {buyToken.symbol} = {formatAmount(executionPrice)} {sellToken.symbol}
-          </DataRow>
-        ) : (
-          <DataRow key="Limit price" title="Limit price">
-            1 {buyToken.symbol} = {formatAmount(limitPrice)} {sellToken.symbol}
-          </DataRow>
-        ),
-        status === 'fulfilled' || isPartiallyFilled ? (
-          <DataRow key="Surplus" title="Surplus">
-            {formatAmount(surplusPrice)} {isSellOrder ? buyToken.symbol : sellToken.symbol}
-          </DataRow>
-        ) : (
-          <></>
-        ),
-        status !== 'fulfilled' ? (
-          compareAsc(now, expires) !== 1 ? (
-            <DataRow key="Expiry" title="Expiry">
-              <Typography>
-                <Typography fontWeight={700} component="span">
-                  {formatTimeInWords(validUntil * 1000)}
-                </Typography>{' '}
-                ({formatDateTime(validUntil * 1000)})
-              </Typography>
-            </DataRow>
-          ) : (
-            <DataRow key="Expiry" title="Expiry">
-              {formatDateTime(validUntil * 1000)}
-            </DataRow>
-          )
-        ) : (
-          <></>
-        ),
-        orderClass === 'limit' ? (
-          <DataRow title="Filled" key="Filled">
-            <SwapProgress order={order} />
-          </DataRow>
-        ) : (
-          <></>
-        ),
-        <DataRow key="Order ID" title="Order ID">
-          <OrderId orderId={uid} href={explorerUrl} />
+        <DataRow title="Sell amount" key="sell_amount_part">
+          <Typography component="span" fontWeight="bold">
+            {formatVisualAmount(partSellAmount, sellToken.decimals)} {sellToken.symbol}
+          </Typography>
         </DataRow>,
+        <DataRow title="Buy amount" key="buy_amount_part">
+          <Typography component="span" fontWeight="bold">
+            {formatVisualAmount(minPartLimit, buyToken.decimals)} {buyToken.symbol}
+          </Typography>
+        </DataRow>,
+        <FilledRow order={order} key="filled-row" />,
+        <DataRow title="Part duration" key="part_duration">
+          {+timeBetweenParts / 60} minutes
+        </DataRow>,
+        <EmptyRow key="spacer-1" />,
+        status !== 'fulfilled' && compareAsc(now, expires) !== 1 ? (
+          <DataRow key="Expiry" title="Expiry">
+            <Typography>
+              <Typography fontWeight={700} component="span">
+                {formatTimeInWords(validUntil * 1000)}
+              </Typography>{' '}
+              ({formatDateTime(validUntil * 1000)})
+            </Typography>
+          </DataRow>
+        ) : (
+          <DataRow key="Expired" title="Expired">
+            {formatDateTime(validUntil * 1000)}
+          </DataRow>
+        ),
         <DataRow key="Status" title="Status">
           <StatusLabel status={isPartiallyFilled ? 'partiallyFilled' : status} />
         </DataRow>,
-        receiver && receiver !== safeAddress ? (
-          <DataRow key="Recipient" title="Recipient">
-            <EthHashInfo address={receiver} showAvatar={false} />
-          </DataRow>
-        ) : (
-          <></>
-        ),
       ]}
     />
   )
@@ -129,6 +275,11 @@ export const SellOrder = ({ order }: { order: SwapOrderType }) => {
 
 export const SwapOrder = ({ txData, txInfo }: SwapOrderProps): ReactElement | null => {
   if (!txData || !txInfo) return null
+
+  // TODO: figure out why the gateway returns txData.hexData for twaps, but not for swaps
+  if (isTwapTxInfo(txInfo)) {
+    return <TwapOrder order={txInfo} />
+  }
 
   // ? when can a multiSend call take no parameters?
   if (!txData.dataDecoded?.parameters) {

--- a/src/features/swap/components/SwapOrder/index.tsx
+++ b/src/features/swap/components/SwapOrder/index.tsx
@@ -114,7 +114,7 @@ const ExpiryRow = ({ order }: { order: Order }) => {
     }
   }
 
-  return <></>
+  return null
 }
 
 const SurplusRow = ({ order }: { order: Order }) => {
@@ -131,7 +131,7 @@ const SurplusRow = ({ order }: { order: Order }) => {
     )
   }
 
-  return <></>
+  return null
 }
 
 const FilledRow = ({ order }: { order: Order }) => {
@@ -144,7 +144,7 @@ const FilledRow = ({ order }: { order: Order }) => {
     )
   }
 
-  return <></>
+  return null
 }
 
 const OrderUidRow = ({ order }: { order: Order }) => {
@@ -156,7 +156,7 @@ const OrderUidRow = ({ order }: { order: Order }) => {
       </DataRow>
     )
   }
-  return <></>
+  return null
 }
 
 const StatusRow = ({ order }: { order: Order }) => {
@@ -181,7 +181,7 @@ const RecipientRow = ({ order }: { order: Order }) => {
     )
   }
 
-  return <></>
+  return null
 }
 
 export const SellOrder = ({ order }: { order: SwapOrderType }) => {

--- a/src/features/swap/components/SwapOrder/index.tsx
+++ b/src/features/swap/components/SwapOrder/index.tsx
@@ -15,7 +15,6 @@ import {
 } from '@safe-global/safe-gateway-typescript-sdk'
 import { DataRow } from '@/components/common/Table/DataRow'
 import { DataTable } from '@/components/common/Table/DataTable'
-import { HexEncodedData } from '@/components/transactions/HexEncodedData'
 import { compareAsc } from 'date-fns'
 import css from './styles.module.css'
 import { Typography } from '@mui/material'
@@ -31,7 +30,7 @@ import {
 } from '@/features/swap/helpers/utils'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import { isTwapTxInfo } from '@/utils/transaction-guards'
+import { isSwapTxInfo, isTwapTxInfo } from '@/utils/transaction-guards'
 import { EmptyRow } from '@/components/common/Table/EmptyRow'
 
 type SwapOrderProps = {
@@ -276,20 +275,14 @@ export const TwapOrder = ({ order }: { order: SwapTwapOrder }) => {
 export const SwapOrder = ({ txData, txInfo }: SwapOrderProps): ReactElement | null => {
   if (!txData || !txInfo) return null
 
-  // TODO: figure out why the gateway returns txData.hexData for twaps, but not for swaps
   if (isTwapTxInfo(txInfo)) {
     return <TwapOrder order={txInfo} />
   }
 
-  // ? when can a multiSend call take no parameters?
-  if (!txData.dataDecoded?.parameters) {
-    if (txData.hexData) {
-      return <HexEncodedData title="Data (hex encoded)" hexData={txData.hexData} />
-    }
-    return null
+  if (isSwapTxInfo(txInfo)) {
+    return <SellOrder order={txInfo} />
   }
-
-  return <SellOrder order={txInfo} />
+  return null
 }
 
 export default SwapOrder

--- a/src/features/swap/components/SwapOrder/swap.stories.tsx
+++ b/src/features/swap/components/SwapOrder/swap.stories.tsx
@@ -39,8 +39,6 @@ const FulfilledSwapOrder = swapOrderBuilder()
     fullAppData: appDataBuilder('market').build(),
   })
 
-console.log(FulfilledSwapOrder)
-
 const NonFulfilledSwapOrder = {
   ...FulfilledSwapOrder.build(),
   status: 'open' as OrderStatuses,

--- a/src/features/swap/components/SwapOrder/twap.stories.tsx
+++ b/src/features/swap/components/SwapOrder/twap.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { TwapOrder as TwapOrderComponent } from './index'
+import { Paper } from '@mui/material'
+import type { OrderStatuses } from '@safe-global/safe-gateway-typescript-sdk'
+import {
+  appDataBuilder,
+  orderTokenBuilder,
+  swapOrderBuilder,
+  twapOrderBuilder,
+} from '@/features/swap/helpers/swapOrderBuilder'
+import { StoreDecorator } from '@/stories/storeDecorator'
+
+const FullfilledTwapOrder = twapOrderBuilder()
+  .with({ status: 'fulfilled' })
+  .with({ kind: 'sell' })
+  .with({ orderClass: 'limit' })
+  .with({ sellAmount: '10000000000000000' })
+  .with({ executedSellAmount: '10000000000000000' })
+  .with({ buyAmount: '3388586928324482608' })
+  .with({ executedBuyAmount: '3388586928324482608' })
+  .with({ validUntil: 1713520008 })
+  .with({
+    sellToken: {
+      ...orderTokenBuilder().build(),
+      logoUri:
+        'https://safe-transaction-assets.staging.5afe.dev/tokens/logos/0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14.png',
+    },
+  })
+  .with({
+    buyToken: {
+      ...orderTokenBuilder().build(),
+      logoUri:
+        'https://safe-transaction-assets.staging.5afe.dev/tokens/logos/0xbe72E441BF55620febc26715db68d3494213D8Cb.png',
+    },
+  })
+  .with({ numberOfParts: 2 })
+
+  .with({ partSellAmount: '5000000000000000' })
+  .with({ minPartLimit: '1694293464162241304' })
+  .with({ timeBetweenParts: '1800' })
+  .with({
+    fullAppData: appDataBuilder('twap').build(),
+  })
+
+
+const meta = {
+  component: TwapOrderComponent,
+  parameters: {
+    componentSubtitle: 'Renders a Status label with icon and text for a swap order',
+  },
+
+  decorators: [
+    (Story) => {
+      return (
+        <StoreDecorator initialState={{}}>
+          <Paper sx={{ padding: 2 }}>
+            <Story />
+          </Paper>
+        </StoreDecorator>
+      )
+    },
+  ],
+  tags: ['autodocs'],
+  // excludeStories: ['SwapOrderProps'],
+} satisfies Meta<typeof TwapOrderComponent>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const ExecutedTwap: Story = {
+  args: {
+    order: FullfilledTwapOrder.build(),
+  },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/VyA38zUPbJ2zflzCIYR6Nu/Swap?node-id=6655-24390&t=pg5ZPJArWFJOiEsn-4',
+    },
+  },
+}

--- a/src/features/swap/components/SwapOrder/twap.stories.tsx
+++ b/src/features/swap/components/SwapOrder/twap.stories.tsx
@@ -1,13 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { TwapOrder as TwapOrderComponent } from './index'
 import { Paper } from '@mui/material'
-import type { OrderStatuses } from '@safe-global/safe-gateway-typescript-sdk'
-import {
-  appDataBuilder,
-  orderTokenBuilder,
-  swapOrderBuilder,
-  twapOrderBuilder,
-} from '@/features/swap/helpers/swapOrderBuilder'
+import { appDataBuilder, orderTokenBuilder, twapOrderBuilder } from '@/features/swap/helpers/swapOrderBuilder'
 import { StoreDecorator } from '@/stories/storeDecorator'
 
 const FullfilledTwapOrder = twapOrderBuilder()
@@ -41,7 +35,6 @@ const FullfilledTwapOrder = twapOrderBuilder()
   .with({
     fullAppData: appDataBuilder('twap').build(),
   })
-
 
 const meta = {
   component: TwapOrderComponent,

--- a/src/features/swap/components/SwapProgress/index.tsx
+++ b/src/features/swap/components/SwapProgress/index.tsx
@@ -1,9 +1,9 @@
 import { getFilledAmount, getFilledPercentage } from '@/features/swap/helpers/utils'
 import { formatAmount } from '@/utils/formatNumber'
 import { LinearProgress, Stack, Typography } from '@mui/material'
-import type { SwapOrder } from '@safe-global/safe-gateway-typescript-sdk'
+import type { Order } from '@safe-global/safe-gateway-typescript-sdk'
 
-const SwapProgress = ({ order }: { order: SwapOrder }) => {
+const SwapProgress = ({ order }: { order: Order }) => {
   const filledPercentage = getFilledPercentage(order)
   const filledAmount = formatAmount(getFilledAmount(order))
 

--- a/src/features/swap/components/SwapTxInfo/SwapTx.tsx
+++ b/src/features/swap/components/SwapTxInfo/SwapTx.tsx
@@ -1,0 +1,50 @@
+import type { Order } from '@safe-global/safe-gateway-typescript-sdk'
+import type { ReactElement } from 'react'
+import { capitalize } from '@/hooks/useMnemonicName'
+import { Box, Typography } from '@mui/material'
+import TokenIcon from '@/components/common/TokenIcon'
+import { formatVisualAmount } from '@/utils/formatters'
+
+export const SwapTx = ({ info }: { info: Order }): ReactElement => {
+  const { kind, sellToken, sellAmount, buyToken } = info
+  const orderKindLabel = capitalize(kind)
+  const isSellOrder = kind === 'sell'
+
+  let from = (
+    <>
+      <Box style={{ paddingRight: 5, display: 'inline-block' }}>
+        <TokenIcon logoUri={sellToken.logoUri || undefined} tokenSymbol={sellToken.symbol} />
+      </Box>
+      <Typography component="span" fontWeight="bold">
+        {formatVisualAmount(sellAmount, sellToken.decimals)} {sellToken.symbol}{' '}
+      </Typography>
+    </>
+  )
+
+  let to = (
+    <>
+      <Box style={{ paddingLeft: 5, paddingRight: 5, display: 'inline-block' }}>
+        <TokenIcon logoUri={buyToken.logoUri || undefined} tokenSymbol={buyToken.symbol} />
+      </Box>{' '}
+      <Typography component="span" fontWeight="bold">
+        {buyToken.symbol}
+      </Typography>
+    </>
+  )
+  if (!isSellOrder) {
+    // switch them around for buy order
+    ;[from, to] = [to, from]
+  }
+
+  return (
+    <Box display="flex">
+      <Typography component="div" display="flex" alignItems="center" fontWeight="bold">
+        {from}
+        <Typography component="span" ml={0.5}>
+          to
+        </Typography>
+        {to}
+      </Typography>
+    </Box>
+  )
+}

--- a/src/features/swap/components/SwapTxInfo/interactWith.tsx
+++ b/src/features/swap/components/SwapTxInfo/interactWith.tsx
@@ -1,8 +1,8 @@
 import type { TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
-import EthHashInfo from '@/components/common/EthHashInfo'
 import { Box, Typography } from '@mui/material'
+import EthHashInfo from '@/components/common/EthHashInfo'
 
-const SwapTxInfo = ({ txData }: { txData: TransactionDetails['txData'] }) => {
+const InteractWith = ({ txData }: { txData: TransactionDetails['txData'] }) => {
   if (!txData) return null
 
   return (
@@ -20,5 +20,4 @@ const SwapTxInfo = ({ txData }: { txData: TransactionDetails['txData'] }) => {
     </Typography>
   )
 }
-
-export default SwapTxInfo
+export default InteractWith

--- a/src/features/swap/helpers/swapOrderBuilder.ts
+++ b/src/features/swap/helpers/swapOrderBuilder.ts
@@ -1,14 +1,17 @@
 import { Builder, type IBuilder } from '@/tests/Builder'
 import { faker } from '@faker-js/faker'
-import type {
-  SwapOrder,
-  OrderToken,
-  TransactionInfoType,
+import {
   CowSwapConfirmationView,
+  DurationType,
+  OrderToken,
+  StartTimeValue,
+  SwapOrder,
+  TransactionInfoType,
+  TwapOrder,
 } from '@safe-global/safe-gateway-typescript-sdk'
 
 export function appDataBuilder(
-  orderClass: 'limit' | 'market' | 'liquidity' = 'limit',
+  orderClass: 'limit' | 'market' | 'twap' | 'liquidity' = 'limit',
 ): IBuilder<Record<string, unknown>> {
   return Builder.new<Record<string, unknown>>().with({
     appCode: 'Safe Wallet Swaps',
@@ -62,6 +65,39 @@ export function swapOrderBuilder(): IBuilder<SwapOrder> {
       'https://explorer.cow.fi/orders/0x03a5d561ad2452d719a0d075573f4bed68217c696b52f151122c30e3e4426f1b05e6b5eb1d0e6aabab082057d5bb91f2ee6d11be66223d88',
     executedSurplusFee: faker.string.numeric(),
     fullAppData: appDataBuilder().build(),
+  })
+}
+
+export function twapOrderBuilder(): IBuilder<TwapOrder> {
+  return Builder.new<TwapOrder>().with({
+    type: 'TwapOrder' as TransactionInfoType.TWAP_ORDER,
+    status: faker.helpers.arrayElement(['presignaturePending', 'open', 'cancelled', 'fulfilled', 'expired']),
+    kind: faker.helpers.arrayElement(['buy', 'sell']),
+    orderClass: faker.helpers.arrayElement(['limit', 'market', 'liquidity']),
+    validUntil: faker.date.future().getTime(),
+    sellAmount: faker.string.numeric(),
+    buyAmount: faker.string.numeric(),
+    executedSellAmount: faker.string.numeric(),
+    executedBuyAmount: faker.string.numeric(),
+    sellToken: orderTokenBuilder().build(),
+    buyToken: orderTokenBuilder().build(),
+    executedSurplusFee: faker.string.numeric(),
+    fullAppData: appDataBuilder().build(),
+    numberOfParts: faker.number.int({ min: 1, max: 10 }),
+    /** @description The amount of sellToken to sell in each part */
+    partSellAmount: faker.string.numeric(),
+    /** @description The amount of buyToken that must be bought in each part */
+    minPartLimit: faker.string.numeric(),
+    /** @description The duration of the TWAP interval */
+    timeBetweenParts: faker.string.numeric(),
+    /** @description Whether the TWAP is valid for the entire interval or not */
+    durationOfPart: {
+      durationType: DurationType.Auto,
+    },
+    /** @description The start time of the TWAP */
+    startTime: {
+      startType: StartTimeValue.AtMiningTime,
+    },
   })
 }
 

--- a/src/features/swap/helpers/swapOrderBuilder.ts
+++ b/src/features/swap/helpers/swapOrderBuilder.ts
@@ -1,14 +1,13 @@
 import { Builder, type IBuilder } from '@/tests/Builder'
 import { faker } from '@faker-js/faker'
-import {
+import type {
   CowSwapConfirmationView,
-  DurationType,
   OrderToken,
-  StartTimeValue,
   SwapOrder,
   TransactionInfoType,
   TwapOrder,
 } from '@safe-global/safe-gateway-typescript-sdk'
+import { DurationType, StartTimeValue } from '@safe-global/safe-gateway-typescript-sdk'
 
 export function appDataBuilder(
   orderClass: 'limit' | 'market' | 'twap' | 'liquidity' = 'limit',

--- a/src/features/swap/helpers/utils.ts
+++ b/src/features/swap/helpers/utils.ts
@@ -1,4 +1,4 @@
-import type { SwapOrder } from '@safe-global/safe-gateway-typescript-sdk'
+import type { Order as SwapOrder } from '@safe-global/safe-gateway-typescript-sdk'
 import { formatUnits } from 'ethers'
 import type { AnyAppDataDocVersion, latest } from '@cowprotocol/app-data'
 

--- a/src/features/swap/hooks/useIsExpiredSwap.ts
+++ b/src/features/swap/hooks/useIsExpiredSwap.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import type { TransactionInfo } from '@safe-global/safe-gateway-typescript-sdk'
-import { isSwapTxInfo } from '@/utils/transaction-guards'
+import { isSwapOrderTxInfo } from '@/utils/transaction-guards'
 import useIntervalCounter from '@/hooks/useIntervalCounter'
 
 const INTERVAL_IN_MS = 10_000
@@ -15,7 +15,7 @@ const useIsExpiredSwap = (txInfo: TransactionInfo) => {
   const [counter] = useIntervalCounter(INTERVAL_IN_MS)
 
   useEffect(() => {
-    if (!isSwapTxInfo(txInfo)) return
+    if (!isSwapOrderTxInfo(txInfo)) return
 
     setIsExpired(Date.now() > txInfo.validUntil * 1000)
   }, [counter, txInfo])

--- a/src/features/swap/index.tsx
+++ b/src/features/swap/index.tsx
@@ -1,11 +1,10 @@
 import { FEATURES } from '@/utils/chains'
 import { CowSwapWidget } from '@cowprotocol/widget-react'
 import { type CowSwapWidgetParams, TradeType } from '@cowprotocol/widget-lib'
-import { CowEvents, type CowEventListeners } from '@cowprotocol/events'
-import { useState, useEffect, type MutableRefObject, useMemo } from 'react'
-import { Container, Grid, useTheme } from '@mui/material'
-import { useRef } from 'react'
-import { Box } from '@mui/material'
+import type { OnTradeParamsPayload } from '@cowprotocol/events'
+import { type CowEventListeners, CowEvents } from '@cowprotocol/events'
+import { type MutableRefObject, useEffect, useMemo, useRef, useState } from 'react'
+import { Box, Container, Grid, useTheme } from '@mui/material'
 import {
   SafeAppAccessPolicyTypes,
   type SafeAppData,
@@ -75,7 +74,7 @@ const SwapWidget = ({ sell }: Params) => {
   const wallet = useWallet()
   const { isConsentAccepted, onAccept } = useSwapConsent()
   // useRefs as they don't trigger re-renders
-  const tradeTypeRef = useRef<TradeType>(tradeType)
+  const tradeTypeRef = useRef<TradeType>(tradeType === 'twap' ? TradeType.ADVANCED : TradeType.SWAP)
   const sellTokenRef = useRef<Params['sell']>(
     sell || {
       asset: '',
@@ -162,7 +161,7 @@ const SwapWidget = ({ sell }: Params) => {
       },
       {
         event: CowEvents.ON_CHANGE_TRADE_PARAMS,
-        handler: (newTradeParams) => {
+        handler: (newTradeParams: OnTradeParamsPayload) => {
           const { orderType: tradeType, recipient, sellToken, sellTokenAmount } = newTradeParams
           dispatch(setSwapParams({ tradeType }))
 
@@ -203,7 +202,7 @@ const SwapWidget = ({ sell }: Params) => {
           ? BASE_URL + '/images/common/swap-empty-dark.svg'
           : BASE_URL + '/images/common/swap-empty-light.svg',
       },
-      enabledTradeTypes: [TradeType.SWAP, TradeType.LIMIT],
+      enabledTradeTypes: [TradeType.SWAP, TradeType.LIMIT, TradeType.ADVANCED],
       theme: {
         baseTheme: darkMode ? 'dark' : 'light',
         primary: palette.primary.main,

--- a/src/features/swap/store/swapParamsSlice.ts
+++ b/src/features/swap/store/swapParamsSlice.ts
@@ -6,6 +6,7 @@ import { createSlice } from '@reduxjs/toolkit'
 enum TradeType {
   SWAP = 'swap',
   LIMIT = 'limit',
+  TWAP = 'twap',
 }
 
 export type SwapState = {

--- a/src/hooks/useTransactionStatus.ts
+++ b/src/hooks/useTransactionStatus.ts
@@ -1,7 +1,7 @@
 import { ReplaceTxHoverContext } from '@/components/transactions/GroupedTxListItems/ReplaceTxHoverProvider'
 import { useAppSelector } from '@/store'
 import { PendingStatus, selectPendingTxById } from '@/store/pendingTxsSlice'
-import { isCancelledSwap, isSignableBy } from '@/utils/transaction-guards'
+import { isCancelledSwapOrder, isSignableBy } from '@/utils/transaction-guards'
 import type { TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import { TransactionStatus } from '@safe-global/safe-gateway-typescript-sdk'
 import { useContext } from 'react'
@@ -37,7 +37,7 @@ const useTransactionStatus = (txSummary: TransactionSummary): string => {
   const wallet = useWallet()
   const pendingTx = useAppSelector((state) => selectPendingTxById(state, id))
 
-  if (isCancelledSwap(txSummary.txInfo)) {
+  if (isCancelledSwapOrder(txSummary.txInfo)) {
     return STATUS_LABELS['CANCELLED']
   }
 

--- a/src/hooks/useTransactionType.ts
+++ b/src/hooks/useTransactionType.ts
@@ -73,7 +73,7 @@ export const getTransactionType = (tx: TransactionSummary, addressBook: AddressB
     case 'TwapOrder': {
       return {
         icon: '/images/common/swap.svg',
-        text: 'Twap order',
+        text: 'TWAP order',
       }
     }
     case TransactionInfoType.CUSTOM: {

--- a/src/hooks/useTransactionType.ts
+++ b/src/hooks/useTransactionType.ts
@@ -70,6 +70,12 @@ export const getTransactionType = (tx: TransactionSummary, addressBook: AddressB
         text: orderClass === 'limit' ? 'Limit order' : 'Swap order',
       }
     }
+    case 'TwapOrder': {
+      return {
+        icon: '/images/common/swap.svg',
+        text: 'Twap order',
+      }
+    }
     case TransactionInfoType.CUSTOM: {
       if (isModuleExecutionInfo(tx.executionInfo)) {
         return {

--- a/src/services/analytics/tx-tracking.ts
+++ b/src/services/analytics/tx-tracking.ts
@@ -8,7 +8,7 @@ import {
   isTransferTxInfo,
   isCustomTxInfo,
   isCancellationTxInfo,
-  isSwapTxInfo,
+  isSwapOrderTxInfo,
 } from '@/utils/transaction-guards'
 
 export const getTransactionTrackingType = async (chainId: string, txId: string): Promise<string> => {
@@ -29,7 +29,7 @@ export const getTransactionTrackingType = async (chainId: string, txId: string):
     return TX_TYPES.transfer_token
   }
 
-  if (isSwapTxInfo(txInfo)) {
+  if (isSwapOrderTxInfo(txInfo)) {
     return TX_TYPES.native_swap
   }
 

--- a/src/store/swapOrderSlice.ts
+++ b/src/store/swapOrderSlice.ts
@@ -2,7 +2,7 @@ import type { listenerMiddlewareInstance } from '@/store'
 import { createSelector, createSlice } from '@reduxjs/toolkit'
 import type { OrderStatuses } from '@safe-global/safe-gateway-typescript-sdk'
 import type { RootState } from '@/store'
-import { isSwapTxInfo, isTransactionListItem } from '@/utils/transaction-guards'
+import { isSwapOrderTxInfo, isTransactionListItem } from '@/utils/transaction-guards'
 import { txHistorySlice } from '@/store/txHistorySlice'
 import { showNotification } from '@/store/notificationsSlice'
 import { selectSafeInfo } from '@/store/safeInfoSlice'
@@ -197,7 +197,7 @@ export const swapOrderListener = (listenerMiddleware: typeof listenerMiddlewareI
           continue
         }
 
-        if (isSwapTxInfo(result.transaction.txInfo)) {
+        if (isSwapOrderTxInfo(result.transaction.txInfo)) {
           const swapOrder = result.transaction.txInfo
           const oldStatus = selectSwapOrderStatus(listenerApi.getOriginalState(), swapOrder.uid)
 

--- a/src/tests/mocks/chains.ts
+++ b/src/tests/mocks/chains.ts
@@ -51,6 +51,10 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       FEATURES.SPENDING_LIMIT,
       FEATURES.TX_SIMULATION,
     ],
+    balancesProvider: {
+      chainName: null,
+      enabled: false,
+    },
   },
   {
     transactionService: 'https://safe-transaction.xdai.gnosis.io',
@@ -100,6 +104,10 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       FEATURES.SPENDING_LIMIT,
       FEATURES.TX_SIMULATION,
     ],
+    balancesProvider: {
+      chainName: null,
+      enabled: false,
+    },
   },
   {
     transactionService: 'https://safe-transaction.polygon.gnosis.io',
@@ -155,6 +163,10 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       FEATURES.SPENDING_LIMIT,
       FEATURES.TX_SIMULATION,
     ],
+    balancesProvider: {
+      chainName: null,
+      enabled: false,
+    },
   },
   {
     transactionService: 'https://safe-transaction.bsc.gnosis.io',
@@ -206,6 +218,10 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       FEATURES.SPENDING_LIMIT,
       FEATURES.TX_SIMULATION,
     ],
+    balancesProvider: {
+      chainName: null,
+      enabled: false,
+    },
   },
   {
     transactionService: 'https://safe-transaction.ewc.gnosis.io',
@@ -255,6 +271,10 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       FEATURES.SAFE_TX_GAS_OPTIONAL,
       FEATURES.SPENDING_LIMIT,
     ],
+    balancesProvider: {
+      chainName: null,
+      enabled: false,
+    },
   },
   {
     transactionService: 'https://safe-transaction.arbitrum.gnosis.io',
@@ -297,6 +317,10 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       'walletLink',
     ],
     features: [FEATURES.ERC721, FEATURES.SAFE_APPS, FEATURES.SAFE_TX_GAS_OPTIONAL, FEATURES.TX_SIMULATION],
+    balancesProvider: {
+      chainName: null,
+      enabled: false,
+    },
   },
   {
     transactionService: 'https://safe-transaction.aurora.gnosis.io',
@@ -340,6 +364,10 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       'walletLink',
     ],
     features: [FEATURES.CONTRACT_INTERACTION, FEATURES.ERC721, FEATURES.SAFE_APPS, FEATURES.SAFE_TX_GAS_OPTIONAL],
+    balancesProvider: {
+      chainName: null,
+      enabled: false,
+    },
   },
   {
     transactionService: 'https://safe-transaction.avalanche.gnosis.io',
@@ -394,6 +422,10 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       FEATURES.SPENDING_LIMIT,
       FEATURES.TX_SIMULATION,
     ],
+    balancesProvider: {
+      chainName: null,
+      enabled: false,
+    },
   },
   {
     transactionService: 'https://safe-transaction.optimism.gnosis.io',
@@ -436,6 +468,10 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       'walletLink',
     ],
     features: [FEATURES.ERC721, FEATURES.SAFE_APPS, FEATURES.SAFE_TX_GAS_OPTIONAL, FEATURES.TX_SIMULATION],
+    balancesProvider: {
+      chainName: null,
+      enabled: false,
+    },
   },
   {
     transactionService: 'https://safe-transaction.goerli.gnosis.io/',
@@ -486,6 +522,10 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       FEATURES.SPENDING_LIMIT,
       FEATURES.TX_SIMULATION,
     ],
+    balancesProvider: {
+      chainName: null,
+      enabled: false,
+    },
   },
   {
     transactionService: 'https://safe-transaction.rinkeby.gnosis.io',
@@ -526,6 +566,10 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       FEATURES.SPENDING_LIMIT,
       FEATURES.TX_SIMULATION,
     ],
+    balancesProvider: {
+      chainName: null,
+      enabled: false,
+    },
   },
   {
     transactionService: 'https://safe-transaction.volta.gnosis.io',
@@ -575,6 +619,10 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       FEATURES.SAFE_TX_GAS_OPTIONAL,
       FEATURES.SPENDING_LIMIT,
     ],
+    balancesProvider: {
+      chainName: null,
+      enabled: false,
+    },
   },
 ]
 

--- a/src/tests/mocks/transactions.ts
+++ b/src/tests/mocks/transactions.ts
@@ -23,6 +23,7 @@ const mockTransferInfo: TransferInfo = {
   tokenAddress: 'string',
   value: 'string',
   trusted: true,
+  imitation: false,
 }
 
 const mockTxInfo: TransactionInfo = {

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -27,7 +27,7 @@ import type {
   SwapOrder,
   DecodedDataResponse,
   BaselineConfirmationView,
-  CowSwapConfirmationView,
+  CowSwapConfirmationView, TwapOrder, Order,
 } from '@safe-global/safe-gateway-typescript-sdk'
 import { TransferDirection } from '@safe-global/safe-gateway-typescript-sdk'
 import {
@@ -92,8 +92,16 @@ export const isMultiSendTxInfo = (value: TransactionInfo): value is MultiSend =>
   )
 }
 
+export const isCoWOrderTxInfo = (value: TransactionInfo): value is Order => {
+  return isSwapTxInfo(value) || isTwapTxInfo(value)
+}
+
 export const isSwapTxInfo = (value: TransactionInfo): value is SwapOrder => {
   return value.type === TransactionInfoType.SWAP_ORDER
+}
+
+export const isTwapTxInfo = (value: TransactionInfo): value is TwapOrder => {
+  return value.type === TransactionInfoType.TWAP_ORDER
 }
 
 export const isSwapConfirmationViewOrder = (

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -94,15 +94,15 @@ export const isMultiSendTxInfo = (value: TransactionInfo): value is MultiSend =>
   )
 }
 
-export const isCoWOrderTxInfo = (value: TransactionInfo): value is Order => {
-  return isSwapTxInfo(value) || isTwapTxInfo(value)
+export const isOrderTxInfo = (value: TransactionInfo): value is Order => {
+  return isSwapOrderTxInfo(value) || isTwapOrderTxInfo(value)
 }
 
-export const isSwapTxInfo = (value: TransactionInfo): value is SwapOrder => {
+export const isSwapOrderTxInfo = (value: TransactionInfo): value is SwapOrder => {
   return value.type === TransactionInfoType.SWAP_ORDER
 }
 
-export const isTwapTxInfo = (value: TransactionInfo): value is TwapOrder => {
+export const isTwapOrderTxInfo = (value: TransactionInfo): value is TwapOrder => {
   return value.type === TransactionInfoType.TWAP_ORDER
 }
 
@@ -116,12 +116,12 @@ export const isSwapConfirmationViewOrder = (
   return false
 }
 
-export const isCancelledSwap = (value: TransactionInfo) => {
-  return isSwapTxInfo(value) && value.status === 'cancelled'
+export const isCancelledSwapOrder = (value: TransactionInfo) => {
+  return isSwapOrderTxInfo(value) && value.status === 'cancelled'
 }
 
-export const isOpenSwap = (value: TransactionInfo) => {
-  return isSwapTxInfo(value) && value.status === 'open'
+export const isOpenSwapOrder = (value: TransactionInfo) => {
+  return isSwapOrderTxInfo(value) && value.status === 'open'
 }
 
 export const isCancellationTxInfo = (value: TransactionInfo): value is Cancellation => {

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -27,7 +27,9 @@ import type {
   SwapOrder,
   DecodedDataResponse,
   BaselineConfirmationView,
-  CowSwapConfirmationView, TwapOrder, Order,
+  CowSwapConfirmationView,
+  TwapOrder,
+  Order,
 } from '@safe-global/safe-gateway-typescript-sdk'
 import { TransferDirection } from '@safe-global/safe-gateway-typescript-sdk'
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4156,10 +4156,10 @@
   dependencies:
     semver "^7.6.0"
 
-"@safe-global/safe-gateway-typescript-sdk@3.21.2":
-  version "3.21.2"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.21.2.tgz#2123a7429c2d9713365f51c359bfc055d4c8e913"
-  integrity sha512-N9Y2CKPBVbc8FbOKzqepy8TJUY2VILX7bmxV4ruByLJvR9PBnGvGfnOhw975cDn6PmSziXL0RaUWHpSW23rsng==
+"@safe-global/safe-gateway-typescript-sdk@^3.21.5":
+  version "3.21.5"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.21.5.tgz#8fc96719a9ac81d1070ad61987c7b49c5324a83e"
+  integrity sha512-KZOAfHDzXCmxVB7SpG6OnRUZontIatwe312NrG7XekmdldCxU78HHecb/tflRZTwJUZhD/USGGZezE7pqjESqQ==
 
 "@safe-global/safe-gateway-typescript-sdk@^3.5.3":
   version "3.21.2"


### PR DESCRIPTION

## What it solves
- [x] Adds decoding of twaps on history 
- [x] Adds decoding of twaps in queue

Resolves #
https://www.notion.so/safe-global/76f265123c0a4ad680947ce489804342?v=17c30f9503cd4d48a622209408de56d6&p=0f273a0f06f2465589628c7299f44e05&pm=s

## How to test it
Create a twap order throw the native swap feature. 

## Screenshots
<img width="1331" alt="grafik" src="https://github.com/safe-global/safe-wallet-web/assets/693770/81ee6d75-2a30-4576-a0aa-591e83ece1f0">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
