### PR TITLE
Fix: wrong number formatting in SingleTxDecoded

### DIFF
--- a/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
@@ -7,7 +7,7 @@ import {
 } from '@safe-global/safe-gateway-typescript-sdk'
 import type { AccordionProps } from '@mui/material/Accordion/Accordion'
 import { useCurrentChain } from '@/hooks/useChains'
-import { formatVisualAmount } from '@/utils/formatters'
+import { safeFormatUnits } from '@/utils/formatters'
 import { MethodDetails } from '@/components/transactions/TxDetails/TxData/DecodedData/MethodDetails'
 import { HexEncodedData } from '@/components/transactions/HexEncodedData'
 import { isDeleteAllowance, isSetAllowance } from '@/utils/transaction-guards'
@@ -43,8 +43,8 @@ export const SingleTxDecoded = ({
   const chain = useCurrentChain()
   const isNativeTransfer = tx.value !== '0' && (!tx.data || isEmptyHexData(tx.data))
   const method = tx.dataDecoded?.method || (isNativeTransfer ? 'native transfer' : 'contract interaction')
-  const { decimals, symbol } = chain?.nativeCurrency || {}
-  const amount = tx.value ? formatVisualAmount(tx.value, decimals) : 0
+  const { decimals } = chain?.nativeCurrency || {}
+  const amount = tx.value ? safeFormatUnits(tx.value, decimals) : 0
 
   let details
   if (tx.dataDecoded) {
@@ -56,7 +56,6 @@ export const SingleTxDecoded = ({
 
   const addressInfo = txData.addressInfoIndex?.[tx.to]
   const name = addressInfo?.name
-  const avatarUrl = addressInfo?.logoUri
   const isDelegateCall = tx.operation === Operation.DELEGATE && showDelegateCallWarning
   const isSpendingLimitMethod = isSetAllowance(tx.dataDecoded?.method) || isDeleteAllowance(tx.dataDecoded?.method)
 

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -50,7 +50,7 @@ export const formatCurrency = (number: string | number, currency: string, maxLen
     currency,
     currencyDisplay: 'narrowSymbol',
     maximumFractionDigits: Math.abs(float) >= 1 || float === 0 ? 0 : 2,
-  }).format(Number(number))
+  }).format(float)
 
   // +1 for the currency symbol
   if (result.length > maxLength + 1) {
@@ -60,7 +60,7 @@ export const formatCurrency = (number: string | number, currency: string, maxLen
       currencyDisplay: 'narrowSymbol',
       notation: 'compact',
       maximumFractionDigits: 2,
-    }).format(Number(number))
+    }).format(float)
   }
 
   return result.replace(/^(\D+)/, '$1 ')


### PR DESCRIPTION
## What it solves

The wrong number formatting function was called in SingleTxDecoded. It resulted in double formatting which failed in locales where the decimal separator is a comma (e.g. pt-PT).

## How to test it

* Set your browser language to Portuguese (Portugal)
* Go to tx history and expand a multisend transaction containing fractional amount transfers
* In prod: they would be displayed as NaN
* On this branch: they are displayed correctly
