### PR TITLE
removed border from messages txs

### DIFF
--- a/src/components/safe-messages/MsgListItem/ExpandableMsgItem.tsx
+++ b/src/components/safe-messages/MsgListItem/ExpandableMsgItem.tsx
@@ -10,7 +10,12 @@ import txListItemCss from '@/components/transactions/TxListItem/styles.module.cs
 
 const ExpandableMsgItem = ({ msg }: { msg: SafeMessage }): ReactElement => {
   return (
-    <Accordion disableGutters elevation={0} className={txListItemCss.accordion}>
+    <Accordion
+      disableGutters
+      elevation={0}
+      className={txListItemCss.accordion}
+      sx={{ border: 'none', '&:before': { display: 'none' } }}
+    >
       <AccordionSummary
         data-testid="message-item"
         expandIcon={<ExpandMoreIcon />}


### PR DESCRIPTION
## What it solves
It will remove the border from the transactions in Messages tab.

Issue #3871
Resolves # 3871

## How this PR fixes it

The `sx` prop is part of the MUI system, which allows you to apply styles to components directly I have put the border to none there.
I have put code I below the `Accordion` element, which will remove the border and ensure that the pseudo-element is also removed.
```
sx={{ border: 'none', '&:before': { display: 'none' } }}
```


## How to test it

you can visit `https://app.safe.global/transactions/messages?safe=eth:0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6` URL where you will use list of transaction without border.

## Screenshots

![Screenshot 2024-06-26 at 6 51 36 PM](https://github.com/safe-global/safe-wallet-web/assets/68734123/3eee87db-356e-4e7a-9453-24a2e0803446)


## Checklist
* [Done] I've tested the branch on mobile 📱
* [No] I've documented how it affects the analytics (if at all) 📊
* [No(Not applicable)] I've written a unit/e2e test for it (if applicable) 🧑‍💻
