### PR TITLE
Display swap info on sent/receive events [SW-3]

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@safe-global/protocol-kit": "^3.1.1",
     "@safe-global/safe-apps-sdk": "^9.1.0",
     "@safe-global/safe-deployments": "^1.36.0",
-    "@safe-global/safe-gateway-typescript-sdk": "3.21.7",
+    "@safe-global/safe-gateway-typescript-sdk": "3.21.8",
     "@safe-global/safe-modules-deployments": "^1.2.0",
     "@sentry/react": "^7.91.0",
     "@spindl-xyz/attribution-lite": "^1.4.0",

--- a/src/components/transactions/BulkTxListGroup/index.tsx
+++ b/src/components/transactions/BulkTxListGroup/index.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react'
 import { Box, Paper, SvgIcon, Typography } from '@mui/material'
-import type { Transaction } from '@safe-global/safe-gateway-typescript-sdk'
+import type { Order, Transaction } from '@safe-global/safe-gateway-typescript-sdk'
 import { isMultisigExecutionInfo, isSwapTransferOrderTxInfo } from '@/utils/transaction-guards'
 import ExpandableTransactionItem from '@/components/transactions/TxListItem/ExpandableTransactionItem'
 import BatchIcon from '@/public/images/common/batch.svg'
@@ -8,6 +8,19 @@ import css from './styles.module.css'
 import ExplorerButton from '@/components/common/ExplorerButton'
 import { getBlockExplorerLink } from '@/utils/chains'
 import { useCurrentChain } from '@/hooks/useChains'
+import { getOrderClass } from '@/features/swap/helpers/utils'
+
+const orderClassTitles: Record<string, string> = {
+  limit: 'Limit order settlement',
+  twap: 'TWAP order settlement',
+  liquidity: 'Liquidity order settlement',
+  market: 'Swap order settlement',
+}
+
+const getSettlementOrderTitle = (order: Order): string => {
+  const orderClass = getOrderClass(order)
+  return orderClassTitles[orderClass] || orderClassTitles['market']
+}
 
 const GroupedTxListItems = ({
   groupedListItems,
@@ -19,16 +32,18 @@ const GroupedTxListItems = ({
   const chain = useCurrentChain()
   const explorerLink = chain && getBlockExplorerLink(chain, transactionHash)?.href
   if (groupedListItems.length === 0) return null
-
+  let title = 'Bulk transactions'
   const isSwapTransfer = isSwapTransferOrderTxInfo(groupedListItems[0].transaction.txInfo)
-
+  if (isSwapTransfer) {
+    title = getSettlementOrderTitle(groupedListItems[0].transaction.txInfo as Order)
+  }
   return (
     <Paper className={css.container}>
       <Box gridArea="icon">
         <SvgIcon className={css.icon} component={BatchIcon} inheritViewBox fontSize="medium" />
       </Box>
       <Box gridArea="info">
-        <Typography noWrap>{isSwapTransfer ? 'Swap order' : 'Bulk transactions'}</Typography>
+        <Typography noWrap>{title}</Typography>
       </Box>
       <Box className={css.action}>{groupedListItems.length} transactions</Box>
       <Box className={css.hash}>

--- a/src/components/transactions/BulkTxListGroup/index.tsx
+++ b/src/components/transactions/BulkTxListGroup/index.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react'
 import { Box, Paper, SvgIcon, Typography } from '@mui/material'
 import type { Transaction } from '@safe-global/safe-gateway-typescript-sdk'
-import { isMultisigExecutionInfo } from '@/utils/transaction-guards'
+import { isMultisigExecutionInfo, isSwapTransferOrderTxInfo } from '@/utils/transaction-guards'
 import ExpandableTransactionItem from '@/components/transactions/TxListItem/ExpandableTransactionItem'
 import BatchIcon from '@/public/images/common/batch.svg'
 import css from './styles.module.css'
@@ -20,13 +20,15 @@ const GroupedTxListItems = ({
   const explorerLink = chain && getBlockExplorerLink(chain, transactionHash)?.href
   if (groupedListItems.length === 0) return null
 
+  const isSwapTransfer = isSwapTransferOrderTxInfo(groupedListItems[0].transaction.txInfo)
+
   return (
     <Paper className={css.container}>
       <Box gridArea="icon">
         <SvgIcon className={css.icon} component={BatchIcon} inheritViewBox fontSize="medium" />
       </Box>
       <Box gridArea="info">
-        <Typography noWrap>Bulk transactions</Typography>
+        <Typography noWrap>{isSwapTransfer ? 'Swap order' : 'Bulk transactions'}</Typography>
       </Box>
       <Box className={css.action}>{groupedListItems.length} transactions</Box>
       <Box className={css.hash}>

--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -20,6 +20,7 @@ import {
   isMultisigExecutionInfo,
   isOpenSwapOrder,
   isTxQueued,
+  isSwapTransferOrderTxInfo,
 } from '@/utils/transaction-guards'
 import { InfoDetails } from '@/components/transactions/InfoDetails'
 import EthHashInfo from '@/components/common/EthHashInfo'
@@ -89,6 +90,13 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
         <div className={css.txData}>
           <ErrorBoundary fallback={<div>Error parsing data</div>}>
             <TxData txDetails={txDetails} trusted={isTrustedTransfer} imitation={isImitationTransaction} />
+            {isSwapTransferOrderTxInfo(txDetails.txInfo) && (
+              <div className={css.swapOrderTransfer}>
+                <ErrorBoundary fallback={<div>Error parsing data</div>}>
+                  <SwapOrder txData={txDetails.txData} txInfo={txDetails.txInfo} />
+                </ErrorBoundary>
+              </div>
+            )}
           </ErrorBoundary>
         </div>
 

--- a/src/components/transactions/TxDetails/styles.module.css
+++ b/src/components/transactions/TxDetails/styles.module.css
@@ -27,6 +27,14 @@
   padding: var(--space-2);
 }
 
+.swapOrderTransfer {
+  border-top: 1px solid var(--color-border-light);
+  margin-top: var(--space-2);
+  margin-left: calc(var(--space-2) * -1);
+  margin-right: calc(var(--space-2) * -1);
+  padding: var(--space-2);
+  padding-top: var(--space-3)
+}
 .txData,
 .swapOrder {
   border-bottom: 1px solid var(--color-border-light);

--- a/src/features/swap/components/SwapOrder/index.tsx
+++ b/src/features/swap/components/SwapOrder/index.tsx
@@ -11,7 +11,6 @@ import {
   type SwapOrder as SwapOrderType,
   type Order,
   type TransactionData,
-  TransactionInfoType,
 } from '@safe-global/safe-gateway-typescript-sdk'
 import { DataRow } from '@/components/common/Table/DataRow'
 import { DataTable } from '@/components/common/Table/DataTable'
@@ -30,7 +29,7 @@ import {
 } from '@/features/swap/helpers/utils'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import { isSwapOrderTxInfo, isTwapOrderTxInfo } from '@/utils/transaction-guards'
+import { isSwapOrderTxInfo, isSwapTransferOrderTxInfo, isTwapOrderTxInfo } from '@/utils/transaction-guards'
 import { EmptyRow } from '@/components/common/Table/EmptyRow'
 import { PartDuration } from '@/features/swap/components/SwapOrder/rows/PartDuration'
 import { PartSellAmount } from '@/features/swap/components/SwapOrder/rows/PartSellAmount'
@@ -43,7 +42,6 @@ type SwapOrderProps = {
 
 const AmountRow = ({ order }: { order: Order }) => {
   const { sellToken, buyToken, sellAmount, buyAmount, kind } = order
-  const orderKindLabel = capitalize(kind)
   const isSellOrder = kind === 'sell'
   return (
     <DataRow key="Amount" title="Amount">
@@ -150,7 +148,7 @@ const FilledRow = ({ order }: { order: Order }) => {
 }
 
 const OrderUidRow = ({ order }: { order: Order }) => {
-  if (order.type === TransactionInfoType.SWAP_ORDER) {
+  if (isSwapOrderTxInfo(order) || isSwapTransferOrderTxInfo(order)) {
     const { uid, explorerUrl } = order
     return (
       <DataRow key="Order ID" title="Order ID">
@@ -256,13 +254,13 @@ export const TwapOrder = ({ order }: { order: SwapTwapOrder }) => {
 }
 
 export const SwapOrder = ({ txData, txInfo }: SwapOrderProps): ReactElement | null => {
-  if (!txData || !txInfo) return null
+  if (!txInfo) return null
 
   if (isTwapOrderTxInfo(txInfo)) {
     return <TwapOrder order={txInfo} />
   }
 
-  if (isSwapOrderTxInfo(txInfo)) {
+  if (isSwapOrderTxInfo(txInfo) || isSwapTransferOrderTxInfo(txInfo)) {
     return <SellOrder order={txInfo} />
   }
   return null

--- a/src/features/swap/components/SwapOrder/index.tsx
+++ b/src/features/swap/components/SwapOrder/index.tsx
@@ -253,7 +253,7 @@ export const TwapOrder = ({ order }: { order: SwapTwapOrder }) => {
   )
 }
 
-export const SwapOrder = ({ txData, txInfo }: SwapOrderProps): ReactElement | null => {
+export const SwapOrder = ({ txInfo }: SwapOrderProps): ReactElement | null => {
   if (!txInfo) return null
 
   if (isTwapOrderTxInfo(txInfo)) {

--- a/src/hooks/useTransactionType.ts
+++ b/src/hooks/useTransactionType.ts
@@ -45,6 +45,7 @@ export const getTransactionType = (tx: TransactionSummary, addressBook: AddressB
         text: 'Safe Account created',
       }
     }
+    case TransactionInfoType.SWAP_TRANSFER:
     case TransactionInfoType.TRANSFER: {
       const isSendTx = isOutgoingTransfer(tx.txInfo)
 

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -1,10 +1,12 @@
 import type {
   AddressEx,
+  BaselineConfirmationView,
   Cancellation,
   ConflictHeader,
   Creation,
   Custom,
   DateLabel,
+  DecodedDataResponse,
   DetailedExecutionInfo,
   Erc20Transfer,
   Erc721Transfer,
@@ -16,32 +18,30 @@ import type {
   MultisigExecutionDetails,
   MultisigExecutionInfo,
   NativeCoinTransfer,
+  Order,
+  OrderConfirmationView,
   SafeInfo,
   SettingsChange,
+  SwapOrder,
+  SwapOrderConfirmationView,
   Transaction,
   TransactionInfo,
   TransactionListItem,
   TransactionSummary,
   Transfer,
   TransferInfo,
-  SwapOrder,
-  DecodedDataResponse,
-  BaselineConfirmationView,
-  OrderConfirmationView,
   TwapOrder,
-  Order,
-  SwapOrderConfirmationView,
   TwapOrderConfirmationView,
 } from '@safe-global/safe-gateway-typescript-sdk'
-import { ConfirmationViewTypes } from '@safe-global/safe-gateway-typescript-sdk'
-import { TransferDirection } from '@safe-global/safe-gateway-typescript-sdk'
 import {
+  ConfirmationViewTypes,
   ConflictType,
   DetailedExecutionInfoType,
   TransactionInfoType,
   TransactionListItemType,
   TransactionStatus,
   TransactionTokenType,
+  TransferDirection,
 } from '@safe-global/safe-gateway-typescript-sdk'
 import { getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimitContracts'
 import { sameAddress } from '@/utils/addresses'
@@ -78,7 +78,17 @@ export const isModuleDetailedExecutionInfo = (value?: DetailedExecutionInfo): va
 
 // TransactionInfo type guards
 export const isTransferTxInfo = (value: TransactionInfo): value is Transfer => {
-  return value.type === TransactionInfoType.TRANSFER
+  return value.type === TransactionInfoType.TRANSFER || isSwapTransferOrderTxInfo(value)
+}
+
+/**
+ * A fulfillment transaction for swap, limit or twap order is always a SwapOrder
+ * It cannot be a TWAP order
+ *
+ * @param value
+ */
+export const isSwapTransferOrderTxInfo = (value: TransactionInfo): value is SwapOrder => {
+  return value.type === TransactionInfoType.SWAP_TRANSFER
 }
 
 export const isSettingsChangeTxInfo = (value: TransactionInfo): value is SettingsChange => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4156,10 +4156,10 @@
   dependencies:
     semver "^7.6.0"
 
-"@safe-global/safe-gateway-typescript-sdk@3.21.7":
-  version "3.21.7"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.21.7.tgz#4592677dee4f9e3c86befce659b361f37133578a"
-  integrity sha512-V9vOqQjb/O0Ylt5sKUtVl6f7fKDpH7HUQUCEON42BXk4PUpcKWdmziQjmf3/PR3OnkahcmXb7ULNwUi+04HmCw==
+"@safe-global/safe-gateway-typescript-sdk@3.21.8":
+  version "3.21.8"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.21.8.tgz#f90eb668dd620d0c5578f02f7040169610a0eda1"
+  integrity sha512-n/fYgiqbuzAQuK0bgny6GBYvb585ETxKURa5Kb9hBV3fa47SvJo/dpGq275fJUn0e3Hh1YqETiLGj4HVJjHiTA==
 
 "@safe-global/safe-gateway-typescript-sdk@^3.5.3":
   version "3.21.2"


### PR DESCRIPTION
## What it solves
Displays swap info on sent/receive events

## How to test it
sent/receive events that are created in response to a swap order should display additional info about the swap

## 
![grafik](https://github.com/safe-global/safe-wallet-web/assets/693770/b1d23ebc-5661-4935-b5c4-27c1da4cb1df)


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
