### PR TITLE
fix: Display cow fallback handler message [SW-33]

### DIFF
--- a/src/components/settings/FallbackHandler/index.tsx
+++ b/src/components/settings/FallbackHandler/index.tsx
@@ -1,3 +1,4 @@
+import { TWAP_FALLBACK_HANDLER } from '@/features/swap/helpers/utils'
 import NextLink from 'next/link'
 import { Typography, Box, Grid, Paper, Link, Alert } from '@mui/material'
 import semverSatisfies from 'semver/functions/satisfies'
@@ -30,6 +31,7 @@ export const FallbackHandler = (): ReactElement | null => {
   const hasFallbackHandler = !!safe.fallbackHandler
   const isOfficial =
     hasFallbackHandler && safe.fallbackHandler?.value === fallbackHandlerDeployment?.networkAddresses[safe.chainId]
+  const isTWAPFallbackHandler = safe.fallbackHandler?.value === TWAP_FALLBACK_HANDLER
 
   const warning = !hasFallbackHandler ? (
     <>
@@ -45,6 +47,8 @@ export const FallbackHandler = (): ReactElement | null => {
         </>
       )}
     </>
+  ) : isTWAPFallbackHandler ? (
+    <>This is CoW&apos;s fallback handler. It is needed for this Safe to be able to use the TWAP feature for Swaps.</>
   ) : !isOfficial ? (
     <>
       An <b>unofficial</b> fallback handler is currently set.
@@ -78,7 +82,10 @@ export const FallbackHandler = (): ReactElement | null => {
               <ExternalLink href={HelpCenterArticle.FALLBACK_HANDLER}>here</ExternalLink>
             </Typography>
 
-            <Alert severity={!hasFallbackHandler ? 'warning' : isOfficial ? 'success' : 'info'} sx={{ mt: 2 }}>
+            <Alert
+              severity={!hasFallbackHandler ? 'warning' : isOfficial || isTWAPFallbackHandler ? 'success' : 'info'}
+              sx={{ mt: 2 }}
+            >
               {warning && <Typography mb={hasFallbackHandler ? 2 : 0}>{warning}</Typography>}
 
               {safe.fallbackHandler && (

--- a/src/components/settings/FallbackHandler/index.tsx
+++ b/src/components/settings/FallbackHandler/index.tsx
@@ -65,6 +65,8 @@ export const FallbackHandler = (): ReactElement | null => {
     </>
   ) : undefined
 
+  console.log(safe.fallbackHandler, fallbackHandlerDeployment)
+
   return (
     <Paper sx={{ padding: 4 }}>
       <Grid container direction="row" justifyContent="space-between" spacing={3}>
@@ -84,9 +86,14 @@ export const FallbackHandler = (): ReactElement | null => {
 
             <Alert
               severity={!hasFallbackHandler ? 'warning' : isOfficial || isTWAPFallbackHandler ? 'success' : 'info'}
+              icon={false}
               sx={{ mt: 2 }}
             >
-              {warning && <Typography mb={hasFallbackHandler ? 2 : 0}>{warning}</Typography>}
+              {warning && (
+                <Typography mb={hasFallbackHandler ? 1 : 0} variant="body2">
+                  {warning}
+                </Typography>
+              )}
 
               {safe.fallbackHandler && (
                 <EthHashInfo

--- a/src/features/swap/helpers/utils.ts
+++ b/src/features/swap/helpers/utils.ts
@@ -20,6 +20,8 @@ function asDecimal(amount: number | bigint, decimals: number): number {
   return Number(formatUnits(amount, decimals))
 }
 
+export const TWAP_FALLBACK_HANDLER = '0x2f55e8b20D0B9FEFA187AA7d00B6Cbe563605bF5'
+
 export const getExecutionPrice = (
   order: Pick<SwapOrder, 'executedSellAmount' | 'executedBuyAmount' | 'buyToken' | 'sellToken'>,
 ): number => {


### PR DESCRIPTION
## What it solves

Resolves [SW-33](https://www.notion.so/safe-global/CoW-s-fallback-handler-99044779a28d46cfb69552103bee6e68)

## How this PR fixes it

- Checks if the fallback handler is cows fallback handler for TWAPs and displays a message instead of the unofficial fallback handler warning
- Removes the check icon and adjusts the spacing according to Figma design

## How to test it

1. Open a Safe that has TWAP enabled
2. Go to Settings -> Modules
3. Observe a green message above the fallback handler address

## Screenshots
<img width="1260" alt="Screenshot 2024-07-01 at 16 50 58" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/e49a87af-7f05-470f-a14a-0359bde100fd">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
