### PR TITLE
fix: correctly format native transfer amounts

### DIFF
--- a/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
@@ -7,7 +7,6 @@ import {
 } from '@safe-global/safe-gateway-typescript-sdk'
 import type { AccordionProps } from '@mui/material/Accordion/Accordion'
 import { useCurrentChain } from '@/hooks/useChains'
-import { safeFormatUnits } from '@/utils/formatters'
 import { MethodDetails } from '@/components/transactions/TxDetails/TxData/DecodedData/MethodDetails'
 import { HexEncodedData } from '@/components/transactions/HexEncodedData'
 import { isDeleteAllowance, isSetAllowance } from '@/utils/transaction-guards'
@@ -43,8 +42,7 @@ export const SingleTxDecoded = ({
   const chain = useCurrentChain()
   const isNativeTransfer = tx.value !== '0' && (!tx.data || isEmptyHexData(tx.data))
   const method = tx.dataDecoded?.method || (isNativeTransfer ? 'native transfer' : 'contract interaction')
-  const { decimals } = chain?.nativeCurrency || {}
-  const amount = tx.value ? safeFormatUnits(tx.value, decimals) : 0
+  const amountInWei = tx.value ?? '0'
 
   let details
   if (tx.dataDecoded) {
@@ -77,9 +75,9 @@ export const SingleTxDecoded = ({
         {isDelegateCall && <DelegateCallWarning showWarning={!txData.trustedDelegateCallTarget} />}
         {!isSpendingLimitMethod && (
           <Stack spacing={1}>
-            {amount !== '0' && (
+            {amountInWei !== '0' && (
               <SendAmountBlock
-                amount={amount}
+                amountInWei={amountInWei}
                 tokenInfo={{
                   type: TokenType.NATIVE_TOKEN,
                   address: ZERO_ADDRESS,

--- a/src/components/transactions/TxDetails/TxData/DecodedData/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/index.tsx
@@ -4,7 +4,7 @@ import { TokenType, type TransactionDetails } from '@safe-global/safe-gateway-ty
 import { HexEncodedData } from '@/components/transactions/HexEncodedData'
 import { MethodDetails } from '@/components/transactions/TxDetails/TxData/DecodedData/MethodDetails'
 import { useCurrentChain } from '@/hooks/useChains'
-import { formatVisualAmount } from '@/utils/formatters'
+import { safeFormatUnits } from '@/utils/formatters'
 import SendAmountBlock from '@/components/tx-flow/flows/TokenTransfer/SendAmountBlock'
 import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 import SendToBlock from '@/components/tx/SendToBlock'
@@ -31,7 +31,7 @@ export const DecodedData = ({ txData, txInfo }: Props): ReactElement | null => {
     decodedData = <HexEncodedData title="Data (hex encoded)" hexData={txData.hexData} />
   }
 
-  const amount = txData.value ? formatVisualAmount(txData.value, chainInfo?.nativeCurrency.decimals) : '0'
+  const amount = txData.value ? safeFormatUnits(txData.value, chainInfo?.nativeCurrency.decimals) : '0'
   // we render the decoded data
   return (
     <Stack spacing={1}>

--- a/src/components/transactions/TxDetails/TxData/DecodedData/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/index.tsx
@@ -4,7 +4,6 @@ import { TokenType, type TransactionDetails } from '@safe-global/safe-gateway-ty
 import { HexEncodedData } from '@/components/transactions/HexEncodedData'
 import { MethodDetails } from '@/components/transactions/TxDetails/TxData/DecodedData/MethodDetails'
 import { useCurrentChain } from '@/hooks/useChains'
-import { safeFormatUnits } from '@/utils/formatters'
 import SendAmountBlock from '@/components/tx-flow/flows/TokenTransfer/SendAmountBlock'
 import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 import SendToBlock from '@/components/tx/SendToBlock'
@@ -31,13 +30,13 @@ export const DecodedData = ({ txData, txInfo }: Props): ReactElement | null => {
     decodedData = <HexEncodedData title="Data (hex encoded)" hexData={txData.hexData} />
   }
 
-  const amount = txData.value ? safeFormatUnits(txData.value, chainInfo?.nativeCurrency.decimals) : '0'
+  const amountInWei = txData.value ?? '0'
   // we render the decoded data
   return (
     <Stack spacing={1}>
-      {amount !== '0' && (
+      {amountInWei !== '0' && (
         <SendAmountBlock
-          amount={amount}
+          amountInWei={amountInWei}
           tokenInfo={{
             type: TokenType.NATIVE_TOKEN,
             address: ZERO_ADDRESS,

--- a/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
+++ b/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
@@ -13,7 +13,7 @@ import useChainId from '@/hooks/useChainId'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 import { createNewSpendingLimitTx } from '@/services/tx/tx-sender'
 import { selectSpendingLimits } from '@/store/spendingLimitsSlice'
-import { formatVisualAmount } from '@/utils/formatters'
+import { formatVisualAmount, safeParseUnits } from '@/utils/formatters'
 import type { NewSpendingLimitFlowProps } from '.'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { SafeTxContext } from '../../SafeTxProvider'
@@ -27,6 +27,11 @@ export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowPr
   const { setSafeTx, setSafeTxError } = useContext(SafeTxContext)
   const token = balances.items.find((item) => item.tokenInfo.address === params.tokenAddress)
   const { decimals } = token?.tokenInfo || {}
+
+  const amountInWei = useMemo(
+    () => safeParseUnits(params.amount, token?.tokenInfo.decimals)?.toString() || '0',
+    [params.amount, token?.tokenInfo.decimals],
+  )
 
   const existingSpendingLimit = useMemo(() => {
     return spendingLimits.find(
@@ -76,7 +81,7 @@ export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowPr
   return (
     <SignOrExecuteForm onSubmit={onFormSubmit}>
       {token && (
-        <SendAmountBlock amount={params.amount} tokenInfo={token.tokenInfo} title="Amount">
+        <SendAmountBlock amountInWei={amountInWei} tokenInfo={token.tokenInfo} title="Amount">
           {existingAmount && existingAmount !== params.amount && (
             <>
               <Typography

--- a/src/components/tx-flow/flows/RemoveSpendingLimit/RemoveSpendingLimit.tsx
+++ b/src/components/tx-flow/flows/RemoveSpendingLimit/RemoveSpendingLimit.tsx
@@ -1,7 +1,7 @@
 import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import { getSpendingLimitInterface, getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimitContracts'
 import useChainId from '@/hooks/useChainId'
-import { useContext, useEffect } from 'react'
+import { useContext, useEffect, useMemo } from 'react'
 import { SafeTxContext } from '../../SafeTxProvider'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { Grid, Typography } from '@mui/material'
@@ -10,7 +10,7 @@ import { relativeTime } from '@/utils/date'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 import useBalances from '@/hooks/useBalances'
 import SendAmountBlock from '@/components/tx-flow/flows/TokenTransfer/SendAmountBlock'
-import { safeFormatUnits } from '@/utils/formatters'
+import { safeParseUnits } from '@/utils/formatters'
 import SpendingLimitLabel from '@/components/common/SpendingLimitLabel'
 import { createTx } from '@/services/tx/tx-sender'
 
@@ -23,6 +23,11 @@ export const RemoveSpendingLimit = ({ params }: { params: SpendingLimitState }) 
   const chainId = useChainId()
   const { balances } = useBalances()
   const token = balances.items.find((item) => item.tokenInfo.address === params.token.address)
+
+  const amountInWei = useMemo(
+    () => safeParseUnits(params.amount, token?.tokenInfo.decimals)?.toString() || '0',
+    [params.amount, token?.tokenInfo.decimals],
+  )
 
   useEffect(() => {
     const spendingLimitAddress = getSpendingLimitModuleAddress(chainId)
@@ -48,13 +53,7 @@ export const RemoveSpendingLimit = ({ params }: { params: SpendingLimitState }) 
 
   return (
     <SignOrExecuteForm onSubmit={onFormSubmit}>
-      {token && (
-        <SendAmountBlock
-          amount={safeFormatUnits(params.amount, token.tokenInfo.decimals)}
-          tokenInfo={token.tokenInfo}
-          title="Amount"
-        />
-      )}
+      {token && <SendAmountBlock amountInWei={amountInWei} tokenInfo={token.tokenInfo} title="Amount" />}
 
       <Grid container gap={1} alignItems="center">
         <Grid item md>

--- a/src/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx.tsx
@@ -28,6 +28,7 @@ import { TxModalContext } from '@/components/tx-flow'
 import { type SubmitCallback } from '@/components/tx/SignOrExecuteForm'
 import { TX_EVENTS, TX_TYPES } from '@/services/analytics/events/transactions'
 import { isWalletRejection } from '@/utils/wallets'
+import { safeParseUnits } from '@/utils/formatters'
 
 export type SpendingLimitTxParams = {
   safeAddress: string
@@ -58,6 +59,11 @@ const ReviewSpendingLimitTx = ({
   const { balances } = useBalances()
   const token = balances.items.find((item) => item.tokenInfo.address === params.tokenAddress)
   const spendingLimit = useSpendingLimit(token?.tokenInfo)
+
+  const amountInWei = useMemo(
+    () => safeParseUnits(params.amount, token?.tokenInfo.decimals)?.toString() || '0',
+    [params.amount, token?.tokenInfo.decimals],
+  )
 
   const txParams: SpendingLimitTxParams = useMemo(
     () => ({
@@ -127,7 +133,7 @@ const ReviewSpendingLimitTx = ({
           Blockchain Explorer.
         </Typography>
 
-        {token && <SendAmountBlock amount={params.amount} tokenInfo={token.tokenInfo} />}
+        {token && <SendAmountBlock amountInWei={amountInWei} tokenInfo={token.tokenInfo} />}
 
         <SendToBlock address={params.recipient} />
 

--- a/src/components/tx-flow/flows/TokenTransfer/ReviewTokenTransfer.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/ReviewTokenTransfer.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from 'react'
+import { useContext, useEffect, useMemo } from 'react'
 import useBalances from '@/hooks/useBalances'
 import SignOrExecuteForm, { type SubmitCallback } from '@/components/tx/SignOrExecuteForm'
 import SendAmountBlock from '@/components/tx-flow/flows/TokenTransfer/SendAmountBlock'
@@ -7,6 +7,7 @@ import { createTokenTransferParams } from '@/services/tx/tokenTransferParams'
 import { createTx } from '@/services/tx/tx-sender'
 import type { TokenTransferParams } from '.'
 import { SafeTxContext } from '../../SafeTxProvider'
+import { safeParseUnits } from '@/utils/formatters'
 
 const ReviewTokenTransfer = ({
   params,
@@ -20,6 +21,11 @@ const ReviewTokenTransfer = ({
   const { setSafeTx, setSafeTxError, setNonce } = useContext(SafeTxContext)
   const { balances } = useBalances()
   const token = balances.items.find((item) => item.tokenInfo.address === params.tokenAddress)
+
+  const amountInWei = useMemo(
+    () => safeParseUnits(params.amount, token?.tokenInfo.decimals)?.toString() || '0',
+    [params.amount, token?.tokenInfo.decimals],
+  )
 
   useEffect(() => {
     if (txNonce !== undefined) {
@@ -40,7 +46,7 @@ const ReviewTokenTransfer = ({
 
   return (
     <SignOrExecuteForm onSubmit={onSubmit}>
-      {token && <SendAmountBlock amount={params.amount} tokenInfo={token.tokenInfo} />}
+      {token && <SendAmountBlock amountInWei={amountInWei} tokenInfo={token.tokenInfo} />}
 
       <SendToBlock address={params.recipient} />
     </SignOrExecuteForm>

--- a/src/components/tx-flow/flows/TokenTransfer/SendAmountBlock.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/SendAmountBlock.tsx
@@ -2,17 +2,17 @@ import { type ReactNode } from 'react'
 import { type TokenInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { Box, Typography } from '@mui/material'
 import TokenIcon from '@/components/common/TokenIcon'
-import { formatAmountPrecise } from '@/utils/formatNumber'
-import { PSEUDO_APPROVAL_VALUES } from '@/components/tx/ApprovalEditor/utils/approvals'
 import FieldsGrid from '@/components/tx/FieldsGrid'
+import { formatVisualAmount } from '@/utils/formatters'
 
 const SendAmountBlock = ({
-  amount,
+  amountInWei,
   tokenInfo,
   children,
   title = 'Send',
 }: {
-  amount: number | string
+  /** Amount in WEI */
+  amountInWei: number | string
   tokenInfo: Omit<TokenInfo, 'name' | 'logoUri'> & { logoUri?: string }
   children?: ReactNode
   title?: string
@@ -26,11 +26,9 @@ const SendAmountBlock = ({
 
         {children}
 
-        {amount === PSEUDO_APPROVAL_VALUES.UNLIMITED ? (
-          <Typography>{PSEUDO_APPROVAL_VALUES.UNLIMITED}</Typography>
-        ) : (
-          <Typography data-testid="token-amount">{formatAmountPrecise(amount, tokenInfo.decimals)}</Typography>
-        )}
+        <Typography data-testid="token-amount">
+          {formatVisualAmount(amountInWei, tokenInfo.decimals, tokenInfo.decimals)}
+        </Typography>
       </Box>
     </FieldsGrid>
   )

--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -33,7 +33,6 @@ import ExternalLink from '@/components/common/ExternalLink'
 import { HelpCenterArticle } from '@/config/constants'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import accordionCss from '@/styles/accordion.module.css'
-import { safeFormatUnits } from '@/utils/formatters'
 import SendAmountBlock from '@/components/tx-flow/flows/TokenTransfer/SendAmountBlock'
 import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 
@@ -75,7 +74,7 @@ const DecodedTx = ({
 
   if (!decodedData) return null
 
-  const amount = tx?.data.value ? safeFormatUnits(tx.data.value, chain?.nativeCurrency.decimals) : '0'
+  const amount = tx?.data.value ?? '0'
 
   return (
     <Stack spacing={2}>
@@ -83,7 +82,7 @@ const DecodedTx = ({
         <>
           {amount !== '0' && (
             <SendAmountBlock
-              amount={amount}
+              amountInWei={amount}
               tokenInfo={{
                 type: TokenType.NATIVE_TOKEN,
                 address: ZERO_ADDRESS,

--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -33,7 +33,7 @@ import ExternalLink from '@/components/common/ExternalLink'
 import { HelpCenterArticle } from '@/config/constants'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import accordionCss from '@/styles/accordion.module.css'
-import { formatVisualAmount } from '@/utils/formatters'
+import { safeFormatUnits } from '@/utils/formatters'
 import SendAmountBlock from '@/components/tx-flow/flows/TokenTransfer/SendAmountBlock'
 import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 
@@ -75,7 +75,7 @@ const DecodedTx = ({
 
   if (!decodedData) return null
 
-  const amount = tx?.data.value ? formatVisualAmount(tx.data.value, chain?.nativeCurrency.decimals) : '0'
+  const amount = tx?.data.value ? safeFormatUnits(tx.data.value, chain?.nativeCurrency.decimals) : '0'
 
   return (
     <Stack spacing={2}>

--- a/src/utils/__tests__/formatters.test.ts
+++ b/src/utils/__tests__/formatters.test.ts
@@ -1,4 +1,5 @@
 import * as formatters from '@/utils/formatters'
+import { parseEther } from 'ethers'
 
 describe('formatters', () => {
   describe('removeTrailingZeros', () => {
@@ -65,6 +66,39 @@ describe('formatters', () => {
 
       // @ts-ignore - Invalid type
       expect(formatters.shortenAddress(null, 5)).toEqual('')
+    })
+  })
+
+  describe('formatVisualAmount', () => {
+    it('should format with different decimals', () => {
+      expect(formatters.formatVisualAmount('123456789', 0, 10)).toEqual('123,456,789')
+      expect(formatters.formatVisualAmount('123456789', 1, 10)).toEqual('12,345,678.9')
+      expect(formatters.formatVisualAmount('123456789', 2, 10)).toEqual('1,234,567.89')
+      expect(formatters.formatVisualAmount('123456789', 3, 10)).toEqual('123,456.789')
+      expect(formatters.formatVisualAmount('123456789', 4, 10)).toEqual('12,345.6789')
+      expect(formatters.formatVisualAmount('123456789', 5, 10)).toEqual('1,234.56789')
+      expect(formatters.formatVisualAmount('123456789', 6, 10)).toEqual('123.456789')
+      expect(formatters.formatVisualAmount('123456789', 7, 10)).toEqual('12.3456789')
+      expect(formatters.formatVisualAmount('123456789', 8, 10)).toEqual('1.23456789')
+      expect(formatters.formatVisualAmount('123456789', 9, 10)).toEqual('0.123456789')
+    })
+
+    it('should format with different precisions', () => {
+      expect(formatters.formatVisualAmount('123456789', 6, 0)).toEqual('123')
+      expect(formatters.formatVisualAmount('123456789', 6, 1)).toEqual('123.5')
+      expect(formatters.formatVisualAmount('123456789', 6, 2)).toEqual('123.46')
+      expect(formatters.formatVisualAmount('123456789', 6, 3)).toEqual('123.457')
+      expect(formatters.formatVisualAmount('123456789', 6, 4)).toEqual('123.4568')
+      expect(formatters.formatVisualAmount('123456789', 6, 5)).toEqual('123.45679')
+      expect(formatters.formatVisualAmount('123456789', 6, 6)).toEqual('123.456789')
+    })
+
+    it('should format wei correctly', () => {
+      expect(formatters.formatVisualAmount(parseEther('1'), 18, 18)).toEqual('1')
+      expect(formatters.formatVisualAmount(parseEther('10'), 18, 18)).toEqual('10')
+      expect(formatters.formatVisualAmount(parseEther('1000'), 18, 18)).toEqual('1,000')
+      expect(formatters.formatVisualAmount(parseEther('0.00001'), 18, 18)).toEqual('0.00001')
+      expect(formatters.formatVisualAmount('1', 18, 18)).toEqual('0.000000000000000001')
     })
   })
 })

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -39,7 +39,7 @@ export const formatVisualAmount = (
   precision?: number,
 ): string => {
   const amount = safeFormatUnits(value, decimals)
-  return precision ? formatAmountPrecise(amount, precision) : formatAmount(amount)
+  return precision !== undefined ? formatAmountPrecise(amount, precision) : formatAmount(amount)
 }
 
 export const safeParseUnits = (value: string, decimals: number | string = GWEI): bigint | undefined => {


### PR DESCRIPTION
## What it solves
On some locales native values are displayed as NaN.

## How this PR fixes it
Always uses `safeFormatUnits` instead of `formatVisualAmount` before passing the value to `SendAmountBlock`

## How to test this PR
1. On firefox open the tx builder Safe app
2. Enter any EOA address as `to` address
3. Enter a big amount (e.g. 123456789 - your Safe does not need to actually hold this amount as we just want to see the decoding)
4. Witness `NaN` on prod but now the correct amount in this PR deployment

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
