### PR TITLE
feat: add a warning if changing the fallback handler [SW-53]

### DIFF
--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -29,6 +29,8 @@ import useChainId from '@/hooks/useChainId'
 import PermissionsCheck from './PermissionsCheck'
 import { isConfirmationViewOrder } from '@/utils/transaction-guards'
 import SwapOrderConfirmationView from '@/features/swap/components/SwapOrderConfirmationView'
+import { isSettingTwapFallbackHandler } from '@/features/swap/helpers/utils'
+import { TwapFallbackHandlerWarning } from '@/features/swap/components/TwapFallbackHandlerWarning'
 
 export type SubmitCallback = (txId: string, isExecuted?: boolean) => void
 
@@ -80,6 +82,7 @@ export const SignOrExecuteForm = ({
 
   const { safe } = useSafeInfo()
   const isCounterfactualSafe = !safe.deployed
+  const isChangingFallbackHandler = isSettingTwapFallbackHandler(decodedData)
 
   // If checkbox is checked and the transaction is executable, execute it, otherwise sign it
   const canExecute = isCorrectNonce && (props.isExecutable || isNewExecutableTx)
@@ -99,6 +102,8 @@ export const SignOrExecuteForm = ({
     <>
       <TxCard>
         {props.children}
+
+        {isChangingFallbackHandler && <TwapFallbackHandlerWarning />}
 
         {isSwapOrder && (
           <ErrorBoundary fallback={<></>}>

--- a/src/features/swap/components/TwapFallbackHandlerWarning/index.tsx
+++ b/src/features/swap/components/TwapFallbackHandlerWarning/index.tsx
@@ -1,0 +1,15 @@
+import { Alert, Box, SvgIcon } from '@mui/material'
+import InfoOutlinedIcon from '@/public/images/notifications/info.svg'
+
+export const TwapFallbackHandlerWarning = () => {
+  return (
+    <Box mt={1} mb={1}>
+      <Alert severity="warning" icon={<SvgIcon component={InfoOutlinedIcon} inheritViewBox color="error" />}>
+        <b>Enable TWAPs and submit order.</b>
+        {` `}
+        To enable TWAP orders you need to set a custom fallback handler. This software is developed by CoW Swap and Safe
+        will not be responsible for any possible issues with it.
+      </Alert>
+    </Box>
+  )
+}

--- a/src/features/swap/helpers/__tests__/utils.test.ts
+++ b/src/features/swap/helpers/__tests__/utils.test.ts
@@ -5,7 +5,10 @@ import {
   getPartiallyFilledSurplus,
   getSurplusPrice,
   isOrderPartiallyFilled,
+  isSettingTwapFallbackHandler,
+  TWAP_FALLBACK_HANDLER,
 } from '../utils'
+import type { DecodedDataResponse } from '@safe-global/safe-gateway-typescript-sdk'
 import { type SwapOrder } from '@safe-global/safe-gateway-typescript-sdk'
 
 describe('Swap helpers', () => {
@@ -312,6 +315,97 @@ describe('Swap helpers', () => {
       const result = getPartiallyFilledSurplus(mockOrder)
 
       expect(result).toEqual(5)
+    })
+  })
+
+  describe('isSettingTwapFallbackHandler', () => {
+    it('should return true when handler is TWAP_FALLBACK_HANDLER', () => {
+      const decodedData = {
+        parameters: [
+          {
+            valueDecoded: [
+              {
+                dataDecoded: {
+                  method: 'setFallbackHandler',
+                  parameters: [{ name: 'handler', value: TWAP_FALLBACK_HANDLER }],
+                },
+              },
+            ],
+          },
+        ],
+      } as unknown as DecodedDataResponse
+      expect(isSettingTwapFallbackHandler(decodedData)).toBe(true)
+    })
+
+    it('should return false when handler is not TWAP_FALLBACK_HANDLER', () => {
+      const decodedData = {
+        parameters: [
+          {
+            valueDecoded: [
+              {
+                dataDecoded: {
+                  method: 'setFallbackHandler',
+                  parameters: [{ name: 'handler', value: '0xDifferentHandler' }],
+                },
+              },
+            ],
+          },
+        ],
+      } as unknown as DecodedDataResponse
+      expect(isSettingTwapFallbackHandler(decodedData)).toBe(false)
+    })
+
+    it('should return false when method is not setFallbackHandler', () => {
+      const decodedData = {
+        parameters: [
+          {
+            valueDecoded: [
+              {
+                dataDecoded: {
+                  method: 'differentMethod',
+                  parameters: [{ name: 'handler', value: TWAP_FALLBACK_HANDLER }],
+                },
+              },
+            ],
+          },
+        ],
+      } as unknown as DecodedDataResponse
+      expect(isSettingTwapFallbackHandler(decodedData)).toBe(false)
+    })
+
+    it('should return false when decodedData is undefined', () => {
+      expect(isSettingTwapFallbackHandler(undefined)).toBe(false)
+    })
+
+    it('should return false when parameters are missing', () => {
+      const decodedData = {} as unknown as DecodedDataResponse
+      expect(isSettingTwapFallbackHandler(decodedData)).toBe(false)
+    })
+
+    it('should return false when valueDecoded is missing', () => {
+      const decodedData = {
+        parameters: [
+          {
+            valueDecoded: null,
+          },
+        ],
+      } as unknown as DecodedDataResponse
+      expect(isSettingTwapFallbackHandler(decodedData)).toBe(false)
+    })
+
+    it('should return false when dataDecoded is missing', () => {
+      const decodedData = {
+        parameters: [
+          {
+            valueDecoded: [
+              {
+                dataDecoded: null,
+              },
+            ],
+          },
+        ],
+      } as unknown as DecodedDataResponse
+      expect(isSettingTwapFallbackHandler(decodedData)).toBe(false)
     })
   })
 })

--- a/src/features/swap/helpers/utils.ts
+++ b/src/features/swap/helpers/utils.ts
@@ -1,4 +1,4 @@
-import type { Order as SwapOrder } from '@safe-global/safe-gateway-typescript-sdk'
+import type { DecodedDataResponse, Order as SwapOrder } from '@safe-global/safe-gateway-typescript-sdk'
 import { formatUnits } from 'ethers'
 import type { AnyAppDataDocVersion, latest, LatestAppDataDocVersion } from '@cowprotocol/app-data'
 
@@ -182,6 +182,7 @@ export const isOrderPartiallyFilled = (
 
   return BigInt(executedSellAmount) !== 0n && executedSellAmount < sellAmount
 }
+
 export const UiOrderTypeToOrderType = (orderType: UiOrderType): TradeType => {
   switch (orderType) {
     case UiOrderType.SWAP:
@@ -191,4 +192,18 @@ export const UiOrderTypeToOrderType = (orderType: UiOrderType): TradeType => {
     case UiOrderType.TWAP:
       return TradeType.ADVANCED
   }
+}
+
+export const isSettingTwapFallbackHandler = (decodedData: DecodedDataResponse | undefined) => {
+  return (
+    decodedData?.parameters?.some((item) =>
+      item.valueDecoded?.some(
+        (decoded) =>
+          decoded.dataDecoded?.method === 'setFallbackHandler' &&
+          decoded.dataDecoded.parameters?.some(
+            (parameter) => parameter.name === 'handler' && parameter.value === TWAP_FALLBACK_HANDLER,
+          ),
+      ),
+    ) || false
+  )
 }


### PR DESCRIPTION
## What it solves
If the user is submitting a TWAP order for the first time he would most probably need to change his safe's fallback handler. Whenever we detect this we now show a warning:
<img width="694" alt="grafik" src="https://github.com/safe-global/safe-wallet-web/assets/693770/4301fc47-2615-4157-b92c-ac47f06571b9">


Resolves #

## How this PR fixes it

## How to test it
Try to create a TWAP order on a safe that has the standard fallback handler. The first tx should display the warning in the screenshot.

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
