### PR TITLE
fix: Close notification center when a notification is opened

### DIFF
--- a/src/components/notification-center/NotificationCenter/index.tsx
+++ b/src/components/notification-center/NotificationCenter/index.tsx
@@ -110,6 +110,9 @@ const NotificationCenter = (): ReactElement => {
       </ButtonBase>
 
       <Popover
+        // Clicking the "view transaction" link doesn't remove the popover even though
+        // handleClose is called which results in the UI not being clickable anymore
+        // so by adding a key we force a re-render
         key={Number(open)}
         open={open}
         anchorEl={anchorEl}

--- a/src/components/notification-center/NotificationCenter/index.tsx
+++ b/src/components/notification-center/NotificationCenter/index.tsx
@@ -110,6 +110,7 @@ const NotificationCenter = (): ReactElement => {
       </ButtonBase>
 
       <Popover
+        key={Number(open)}
         open={open}
         anchorEl={anchorEl}
         onClose={handleClose}


### PR DESCRIPTION
## What it solves

Resolves #3810 

## How this PR fixes it

- I don't think this fixes the root of the problem which has something to do with having an `onClick` handler in a nested `NextLink` but it rerenders the `Popover` whenever the `open` state changes which also solves the issue

## How to test it

1. Create a transaction
2. Open the transaction detail page
3. Open the notification center
4. Press "View transaction"
5. Observe that the UI is still clickable

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
