### PR TITLE
fix: address poison copy confirmation modal

### DIFF
--- a/src/components/transactions/TxDetails/TxData/Transfer/index.test.tsx
+++ b/src/components/transactions/TxDetails/TxData/Transfer/index.test.tsx
@@ -1,0 +1,276 @@
+import { render } from '@/tests/test-utils'
+import TransferTxInfo from '.'
+import {
+  TransactionInfoType,
+  TransactionStatus,
+  TransactionTokenType,
+  TransferDirection,
+} from '@safe-global/safe-gateway-typescript-sdk'
+import { faker } from '@faker-js/faker'
+import { parseUnits } from 'ethers'
+import { chainBuilder } from '@/tests/builders/chains'
+
+jest.mock('@/hooks/useChains', () => ({
+  __esModule: true,
+  useChainId: () => '1',
+  useChain: () => chainBuilder().with({ chainId: '1' }).build(),
+  useCurrentChain: () => chainBuilder().with({ chainId: '1' }).build(),
+  default: () => ({
+    loading: false,
+    error: undefined,
+    configs: [chainBuilder().with({ chainId: '1' }).build()],
+  }),
+}))
+
+describe('TransferTxInfo', () => {
+  describe('should render non-malicious', () => {
+    it('outgoing tx', () => {
+      const recipient = faker.finance.ethereumAddress()
+      const sender = faker.finance.ethereumAddress()
+      const tokenAddress = faker.finance.ethereumAddress()
+
+      const result = render(
+        <TransferTxInfo
+          imitation={false}
+          trusted
+          txInfo={{
+            direction: TransferDirection.OUTGOING,
+            recipient: { value: recipient },
+            sender: { value: sender },
+            type: TransactionInfoType.TRANSFER,
+            transferInfo: {
+              tokenAddress,
+              trusted: true,
+              type: TransactionTokenType.ERC20,
+              decimals: 18,
+              value: parseUnits('1', 18).toString(),
+              tokenName: 'Test',
+              tokenSymbol: 'TST',
+              imitation: false,
+            },
+          }}
+          txStatus={TransactionStatus.SUCCESS}
+        />,
+      )
+
+      expect(result.getByText('1 TST')).toBeInTheDocument()
+      expect(result.getByText(recipient)).toBeInTheDocument()
+      expect(result.queryByText('malicious', { exact: false })).toBeNull()
+      expect(result.queryByLabelText('This token is unfamiliar', { exact: false })).toBeNull()
+    })
+
+    it('incoming tx', () => {
+      const recipient = faker.finance.ethereumAddress()
+      const sender = faker.finance.ethereumAddress()
+      const tokenAddress = faker.finance.ethereumAddress()
+
+      const result = render(
+        <TransferTxInfo
+          imitation={false}
+          trusted
+          txInfo={{
+            direction: TransferDirection.INCOMING,
+            recipient: { value: recipient },
+            sender: { value: sender },
+            type: TransactionInfoType.TRANSFER,
+            transferInfo: {
+              tokenAddress,
+              trusted: true,
+              type: TransactionTokenType.ERC20,
+              decimals: 18,
+              value: parseUnits('12.34', 18).toString(),
+              tokenName: 'Test',
+              tokenSymbol: 'TST',
+              imitation: false,
+            },
+          }}
+          txStatus={TransactionStatus.SUCCESS}
+        />,
+      )
+
+      expect(result.getByText('12.34 TST')).toBeInTheDocument()
+      expect(result.getByText(sender)).toBeInTheDocument()
+      expect(result.queryByText('malicious', { exact: false })).toBeNull()
+      expect(result.queryByLabelText('This token is unfamiliar', { exact: false })).toBeNull()
+    })
+  })
+
+  describe('should render untrusted', () => {
+    it('outgoing tx', () => {
+      const recipient = faker.finance.ethereumAddress()
+      const sender = faker.finance.ethereumAddress()
+      const tokenAddress = faker.finance.ethereumAddress()
+
+      const result = render(
+        <TransferTxInfo
+          imitation={false}
+          trusted={false}
+          txInfo={{
+            direction: TransferDirection.OUTGOING,
+            recipient: { value: recipient },
+            sender: { value: sender },
+            type: TransactionInfoType.TRANSFER,
+            transferInfo: {
+              tokenAddress,
+              trusted: false,
+              type: TransactionTokenType.ERC20,
+              decimals: 18,
+              value: parseUnits('1', 18).toString(),
+              tokenName: 'Test',
+              tokenSymbol: 'TST',
+              imitation: false,
+            },
+          }}
+          txStatus={TransactionStatus.SUCCESS}
+        />,
+      )
+
+      expect(result.getByText('1 TST')).toBeInTheDocument()
+      expect(result.getByText(recipient)).toBeInTheDocument()
+      expect(result.queryByText('malicious', { exact: false })).toBeNull()
+      expect(result.getByLabelText('This token is unfamiliar', { exact: false })).toBeInTheDocument()
+    })
+
+    it('incoming tx', () => {
+      const recipient = faker.finance.ethereumAddress()
+      const sender = faker.finance.ethereumAddress()
+      const tokenAddress = faker.finance.ethereumAddress()
+
+      const result = render(
+        <TransferTxInfo
+          imitation={false}
+          trusted={false}
+          txInfo={{
+            direction: TransferDirection.INCOMING,
+            recipient: { value: recipient },
+            sender: { value: sender },
+            type: TransactionInfoType.TRANSFER,
+            transferInfo: {
+              tokenAddress,
+              trusted: true,
+              type: TransactionTokenType.ERC20,
+              decimals: 18,
+              value: parseUnits('12.34', 18).toString(),
+              tokenName: 'Test',
+              tokenSymbol: 'TST',
+              imitation: false,
+            },
+          }}
+          txStatus={TransactionStatus.SUCCESS}
+        />,
+      )
+
+      expect(result.getByText('12.34 TST')).toBeInTheDocument()
+      expect(result.getByText(sender)).toBeInTheDocument()
+      expect(result.queryByText('malicious', { exact: false })).toBeNull()
+      expect(result.queryByLabelText('This token is unfamiliar', { exact: false })).toBeInTheDocument()
+    })
+  })
+
+  describe('should render imitations', () => {
+    it('outgoing tx', () => {
+      const recipient = faker.finance.ethereumAddress()
+      const sender = faker.finance.ethereumAddress()
+      const tokenAddress = faker.finance.ethereumAddress()
+
+      const result = render(
+        <TransferTxInfo
+          imitation
+          trusted
+          txInfo={{
+            direction: TransferDirection.OUTGOING,
+            recipient: { value: recipient },
+            sender: { value: sender },
+            type: TransactionInfoType.TRANSFER,
+            transferInfo: {
+              tokenAddress,
+              trusted: true,
+              type: TransactionTokenType.ERC20,
+              decimals: 18,
+              value: parseUnits('1', 18).toString(),
+              tokenName: 'Test',
+              tokenSymbol: 'TST',
+              imitation: true,
+            },
+          }}
+          txStatus={TransactionStatus.SUCCESS}
+        />,
+      )
+
+      expect(result.getByText('1 TST')).toBeInTheDocument()
+      expect(result.getByText(recipient)).toBeInTheDocument()
+      expect(result.getByText('malicious', { exact: false })).toBeInTheDocument()
+      expect(result.queryByLabelText('This token is unfamiliar', { exact: false })).toBeNull()
+    })
+
+    it('incoming tx', () => {
+      const recipient = faker.finance.ethereumAddress()
+      const sender = faker.finance.ethereumAddress()
+      const tokenAddress = faker.finance.ethereumAddress()
+
+      const result = render(
+        <TransferTxInfo
+          imitation
+          trusted
+          txInfo={{
+            direction: TransferDirection.INCOMING,
+            recipient: { value: recipient },
+            sender: { value: sender },
+            type: TransactionInfoType.TRANSFER,
+            transferInfo: {
+              tokenAddress,
+              trusted: true,
+              type: TransactionTokenType.ERC20,
+              decimals: 18,
+              value: parseUnits('12.34', 18).toString(),
+              tokenName: 'Test',
+              tokenSymbol: 'TST',
+              imitation: true,
+            },
+          }}
+          txStatus={TransactionStatus.SUCCESS}
+        />,
+      )
+
+      expect(result.getByText('12.34 TST')).toBeInTheDocument()
+      expect(result.getByText(sender)).toBeInTheDocument()
+      expect(result.getByText('malicious', { exact: false })).toBeInTheDocument()
+      expect(result.queryByLabelText('This token is unfamiliar', { exact: false })).toBeNull()
+    })
+
+    it('untrusted and imitation tx', () => {
+      const recipient = faker.finance.ethereumAddress()
+      const sender = faker.finance.ethereumAddress()
+      const tokenAddress = faker.finance.ethereumAddress()
+
+      const result = render(
+        <TransferTxInfo
+          imitation
+          trusted={false}
+          txInfo={{
+            direction: TransferDirection.INCOMING,
+            recipient: { value: recipient },
+            sender: { value: sender },
+            type: TransactionInfoType.TRANSFER,
+            transferInfo: {
+              tokenAddress,
+              trusted: true,
+              type: TransactionTokenType.ERC20,
+              decimals: 18,
+              value: parseUnits('12.34', 18).toString(),
+              tokenName: 'Test',
+              tokenSymbol: 'TST',
+              imitation: true,
+            },
+          }}
+          txStatus={TransactionStatus.SUCCESS}
+        />,
+      )
+
+      expect(result.getByText('12.34 TST')).toBeInTheDocument()
+      expect(result.getByText(sender)).toBeInTheDocument()
+      expect(result.getByText('malicious', { exact: false })).toBeInTheDocument()
+      expect(result.queryByLabelText('This token is unfamiliar', { exact: false })).toBeNull()
+    })
+  })
+})

--- a/src/components/transactions/TxDetails/TxData/Transfer/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/Transfer/index.tsx
@@ -49,7 +49,7 @@ const TransferTxInfo = ({ txInfo, txStatus, trusted, imitation }: TransferTxInfo
           shortAddress={false}
           hasExplorer
           showCopyButton
-          trusted={trusted}
+          trusted={trusted && !imitation}
         >
           <TransferActions address={address.value} txInfo={txInfo} trusted={trusted} />
         </EthHashInfo>


### PR DESCRIPTION
## What it solves
We currently do not show the "Before you copy" confirmation modal for transactions using real tokens to perform address poisoning.

## How this PR fixes it
Show the Copy modal warning for transactions that are detected as imitations but use trusted tokens.

## How to test it
Open a Safe with an address poisoning attempt using a real token (e.g. USDC)

## Screenshots

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
