### PR TITLE
fix: Hide add to address book button if address already in address book

### DIFF
--- a/src/components/common/AddressBookInput/index.tsx
+++ b/src/components/common/AddressBookInput/index.tsx
@@ -93,7 +93,7 @@ const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canA
                 name={name}
                 onOpenListClick={hasVisibleOptions ? handleOpenAutocomplete : undefined}
                 isAutocompleteOpen={open}
-                onAddressBookClick={onAddressBookClick}
+                onAddressBookClick={canAdd && !isInAddressBook ? onAddressBookClick : undefined}
               />
             )}
           />


### PR DESCRIPTION
## What it solves

Resolves #3826 

## How this PR fixes it

- Hides the Add to address book icon in the address input field if an address already exists in the address book

## How to test it

1. Open a Safe
2. Create a transaction
3. Select a recipient from the address book
4. Observe there is no icon button next to the address
5. Type in an address thats not in the address book yet
6. Either press the icon next to the address or the link below the input field
7. Observe that the address is pre-populated in the form

## Screenshots

<img width="693" alt="Screenshot 2024-07-03 at 10 55 07" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/d8a19a28-6a13-4eb8-8719-b2e2d2549949">
<img width="767" alt="Screenshot 2024-07-03 at 10 56 26" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/0dd5dd34-71f3-4474-a3ce-6777fa3196c5">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
