### PR TITLE
Fix buy order [SW-50]

### DIFF
--- a/src/features/swap/components/SwapTxInfo/SwapTx.tsx
+++ b/src/features/swap/components/SwapTxInfo/SwapTx.tsx
@@ -1,13 +1,11 @@
 import type { Order } from '@safe-global/safe-gateway-typescript-sdk'
 import type { ReactElement } from 'react'
-import { capitalize } from '@/hooks/useMnemonicName'
 import { Box, Typography } from '@mui/material'
 import TokenIcon from '@/components/common/TokenIcon'
 import { formatVisualAmount } from '@/utils/formatters'
 
 export const SwapTx = ({ info }: { info: Order }): ReactElement => {
-  const { kind, sellToken, sellAmount, buyToken } = info
-  const orderKindLabel = capitalize(kind)
+  const { kind, sellToken, sellAmount, buyToken, buyAmount } = info
   const isSellOrder = kind === 'sell'
 
   let from = (
@@ -31,9 +29,23 @@ export const SwapTx = ({ info }: { info: Order }): ReactElement => {
       </Typography>
     </>
   )
+
   if (!isSellOrder) {
-    // switch them around for buy order
-    ;[from, to] = [to, from]
+    from = (
+      <Box style={{ paddingRight: 5, display: 'inline-block' }}>
+        <TokenIcon logoUri={sellToken.logoUri || undefined} tokenSymbol={sellToken.symbol} />
+      </Box>
+    )
+    to = (
+      <>
+        <Box style={{ paddingLeft: 5, paddingRight: 5, display: 'inline-block' }}>
+          <TokenIcon logoUri={buyToken.logoUri || undefined} tokenSymbol={buyToken.symbol} />
+        </Box>{' '}
+        <Typography component="span" fontWeight="bold">
+          {formatVisualAmount(buyAmount, buyToken.decimals)} {buyToken.symbol}{' '}
+        </Typography>
+      </>
+    )
   }
 
   return (


### PR DESCRIPTION
## What it solves
We were displaying wrong amount in the queue and history when the user was making a buy order.

![grafik](https://github.com/safe-global/safe-wallet-web/assets/693770/57df7597-01e4-470c-9bec-70300272097b)


## How to test it
1. Create a buy order
2. in queue and history you should see "{sell token icon} to {buy token icon} {amount buy token}"
![grafik](https://github.com/safe-global/safe-wallet-web/assets/693770/ada0fd8a-3dac-4ea1-9f44-430585bde65c)

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
