### PR TITLE
fix: Hide native swaps card from custom apps list

### DIFF
--- a/src/components/safe-apps/SafeAppList/index.tsx
+++ b/src/components/safe-apps/SafeAppList/index.tsx
@@ -72,7 +72,7 @@ const SafeAppList = ({
             </li>
           ))}
 
-        {!isFiltered && <NativeSwapsCard />}
+        {!isFiltered && !addCustomApp && <NativeSwapsCard />}
 
         {/* Flat list filtered by search query */}
         {safeAppsList.map((safeApp) => (


### PR DESCRIPTION
## What it solves

Resolves #3887

## How this PR fixes it

- Hides the native swaps card in the custom apps list

## How to test it

1. Open the custom apps list
2. Observe no native swaps card

## Screenshots

<img width="655" alt="Screenshot 2024-07-03 at 11 03 13" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/99a23878-b705-4cfe-b5aa-089c72a5409c">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
