### PR TITLE
fix: Hide burger menu on non-sidebar routes

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -61,10 +61,12 @@ const Header = ({ onMenuToggle, onBatchToggle }: HeaderProps): ReactElement => {
 
   return (
     <Paper className={css.container}>
-      <div className={classnames(css.element, css.menuButton, !onMenuToggle ? css.hideSidebarMobile : null)}>
-        <IconButton onClick={handleMenuToggle} size="large" color="default" aria-label="menu">
-          <MenuIcon />
-        </IconButton>
+      <div className={classnames(css.element, css.menuButton)}>
+        {onMenuToggle && (
+          <IconButton onClick={handleMenuToggle} size="large" color="default" aria-label="menu">
+            <MenuIcon />
+          </IconButton>
+        )}
       </div>
 
       <div className={classnames(css.element, css.hideMobile, css.logo)}>

--- a/src/components/common/Header/styles.module.css
+++ b/src/components/common/Header/styles.module.css
@@ -73,8 +73,4 @@
   .hideMobile {
     display: none;
   }
-
-  .hideSidebarMobile {
-    visibility: hidden;
-  }
 }


### PR DESCRIPTION
## What it solves

Resolves #3251 

## How this PR fixes it

- Only displays the burger menu if `onMenuToggle` is passed to `Header`

## How to test it

1. Open the welcome page or any other route where there is no sidebar
2. Decrease the viewport width
3. Observe no burger menu appearing in the header

## Screenshots

<img width="397" alt="Screenshot 2024-07-03 at 12 13 50" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/a0626fd8-548f-46bb-8db4-9339f1140c09">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
