### PR TITLE
fix: Make transaction details scrollable during creation

### DIFF
--- a/src/components/common/Table/styles.module.css
+++ b/src/components/common/Table/styles.module.css
@@ -4,6 +4,7 @@
   gap: var(--space-1);
   justify-content: flex-start;
   max-width: 900px;
+  overflow-x: auto;
 }
 
 .gridEmptyRow {


### PR DESCRIPTION
## What it solves

Resolves #2682 

## How this PR fixes it

- Adds `overflow-x: auto` property to `DataRow` component

## How to test it

1. Create a swap on Curve
2. Observe the tx details in the review screen can be fully viewed by scrolling
3. The `TxDataRow` / `DataRow` component is also used for Swaps, TxSummary, MsgDetails, RecoveryDetails. Make sure these places still work as expected

## Screenshots


https://github.com/safe-global/safe-wallet-web/assets/5880855/d19435a6-8df8-4f34-b07f-e136b8f1ef0d



## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
