### PR TITLE
fix: Show DateTime tooltip even for older transactions

### DIFF
--- a/src/components/common/DateTime/DateTime.tsx
+++ b/src/components/common/DateTime/DateTime.tsx
@@ -9,8 +9,10 @@ type DateTimeProps = {
 }
 
 export const DateTime = ({ value, showDateTime, showTime }: DateTimeProps): ReactElement => {
+  const showTooltip = !showDateTime || showTime
+
   return (
-    <Tooltip title={showDateTime ? '' : formatDateTime(value)} placement="top">
+    <Tooltip title={showTooltip && formatDateTime(value)} placement="top">
       <span>{showTime ? formatTime(value) : showDateTime ? formatDateTime(value) : formatTimeInWords(value)}</span>
     </Tooltip>
   )


### PR DESCRIPTION
## What it solves

Resolves #3115

Transactions are displayed either with a **timestamp in hours**, a **datetime** or **time in words**

timestamp in hours
-> In the tx history and only if no filter is applied

datetime
-> In the tx queue if older than 60 days
-> In the tx history if a filter is applied

time in words
-> In the tx queue if within 60 days

The tooltip contains the datetime so it should only be visible if either timestamp in hours is shown or time in words

## How this PR fixes it

- Adjusts the condition to include the case where a transaction is older than 60 days but where the timestamp in hours is still shown

## How to test it

1. Open the tx history
2. Scroll enough to get to transactions older than 60 days
3. Hover the timestamp
4. Observe a tooltip with datetime showing

## Screenshots
<img width="1279" alt="Screenshot 2024-07-03 at 15 22 53" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/f053df5d-f2ad-4f95-aa50-deb5bcbe5fc0">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
