### PR TITLE
fix: mark imitation txs opaque

### DIFF
--- a/src/components/transactions/TxSummary/index.tsx
+++ b/src/components/transactions/TxSummary/index.tsx
@@ -44,7 +44,7 @@ const TxSummary = ({ item, isConflictGroup, isBulkGroup }: TxSummaryProps): Reac
         [css.history]: !isQueue,
         [css.conflictGroup]: isConflictGroup,
         [css.bulkGroup]: isBulkGroup,
-        [css.untrusted]: !isTrusted,
+        [css.untrusted]: !isTrusted || isImitationTransaction,
       })}
       id={tx.id}
     >


### PR DESCRIPTION
## What it solves
Our previous address poisoning and spam protection made transactions slightly opaque in the history to help users quickly distinguish them.
The new address poisoning flagging does not make them opaque at the moment.

## How this PR fixes it
- Makes txs opaque for imitations as well

## How to test it
Find a Safe with transactions that only get flagged through our new detection: Address poisoning attempts which actually transfer legit tokens.

## Screenshots
Before:
<img width="1260" alt="Screenshot 2024-07-04 at 21 25 15" src="https://github.com/safe-global/safe-wallet-web/assets/2670790/cc1f4f29-8fcb-4165-841a-152bf9b25f32">

After:
<img width="1260" alt="Screenshot 2024-07-04 at 21 25 03" src="https://github.com/safe-global/safe-wallet-web/assets/2670790/cd554081-7699-4b00-97cf-d06d570c8252">


## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
