### PR TITLE
fix: don’t display widget fee, if it is not on [SW-64]

### DIFF
--- a/src/features/swap/components/SwapOrderConfirmationView/OrderFeeConfirmationView.tsx
+++ b/src/features/swap/components/SwapOrderConfirmationView/OrderFeeConfirmationView.tsx
@@ -5,13 +5,12 @@ import { HelpCenterArticle } from '@/config/constants'
 import { HelpIconTooltip } from '@/features/swap/components/HelpIconTooltip'
 import MUILink from '@mui/material/Link'
 
-export const OrderFeeConfirmationView = ({
-  order,
-}: {
-  order: Pick<OrderConfirmationView, 'fullAppData'>
-  hideWhenNonFulfilled?: boolean
-}) => {
+export const OrderFeeConfirmationView = ({ order }: { order: Pick<OrderConfirmationView, 'fullAppData'> }) => {
   const bps = getOrderFeeBps(order)
+
+  if (Number(bps) === 0) {
+    return null
+  }
 
   const title = (
     <>

--- a/src/features/swap/components/SwapOrderConfirmationView/index.tsx
+++ b/src/features/swap/components/SwapOrderConfirmationView/index.tsx
@@ -93,7 +93,7 @@ export const SwapOrderConfirmationView = ({ order, settlementContract }: SwapOrd
           ) : (
             <></>
           ),
-          <OrderFeeConfirmationView key="SurplusFee" order={order} hideWhenNonFulfilled={false} />,
+          <OrderFeeConfirmationView key="SurplusFee" order={order} />,
           <DataRow key="Interact with" title="Interact with">
             <NamedAddress address={settlementContract} onlyName hasExplorer shortAddress={false} avatarSize={24} />
           </DataRow>,


### PR DESCRIPTION
## What it solves
Don't display a widget fee on the confirmation screen if it the feature is the order doesn't have any widget fee applied

## How to test it
You would need access to config server. Disable widget fee. Make a swap, on the confirmation view you shouldn't see a fee.


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
