### PR TITLE
Fix: Add title for limit order cancellations [SW-68]

### DIFF
--- a/src/features/swap/index.tsx
+++ b/src/features/swap/index.tsx
@@ -46,7 +46,7 @@ const PRE_SIGN_SIGHASH = id('setPreSignature(bytes,bool)').slice(0, 10)
 const WRAP_SIGHASH = id('deposit()').slice(0, 10)
 const UNWRAP_SIGHASH = id('withdraw(uint256)').slice(0, 10)
 const CREATE_WITH_CONTEXT_SIGHASH = id('createWithContext((address,bytes32,bytes),address,bytes,bool)').slice(0, 10)
-const CANCEL_LIMIT_ORDER_SIGHASH = id('invalidateOrder(bytes)').slice(0, 10)
+const CANCEL_ORDER_SIGHASH = id('invalidateOrder(bytes)').slice(0, 10)
 
 type Params = {
   sell?: {
@@ -62,7 +62,7 @@ export const getSwapTitle = (tradeType: SwapState['tradeType'], txs: BaseTransac
     [WRAP_SIGHASH]: 'Wrap',
     [UNWRAP_SIGHASH]: 'Unwrap',
     [CREATE_WITH_CONTEXT_SIGHASH]: TWAP_ORDER_TITLE,
-    [CANCEL_LIMIT_ORDER_SIGHASH]: 'Cancel Limit Order',
+    [CANCEL_ORDER_SIGHASH]: 'Cancel Order',
   }
 
   const swapTitle = txs

--- a/src/features/swap/index.tsx
+++ b/src/features/swap/index.tsx
@@ -45,7 +45,8 @@ const BASE_URL = typeof window !== 'undefined' && window.location.origin ? windo
 const PRE_SIGN_SIGHASH = id('setPreSignature(bytes,bool)').slice(0, 10)
 const WRAP_SIGHASH = id('deposit()').slice(0, 10)
 const UNWRAP_SIGHASH = id('withdraw(uint256)').slice(0, 10)
-const CREATE_WITH_CONTEXT = id('createWithContext((address,bytes32,bytes),address,bytes,bool)').slice(0, 10)
+const CREATE_WITH_CONTEXT_SIGHASH = id('createWithContext((address,bytes32,bytes),address,bytes,bool)').slice(0, 10)
+const CANCEL_LIMIT_ORDER_SIGHASH = id('invalidateOrder(bytes)').slice(0, 10)
 
 type Params = {
   sell?: {
@@ -60,7 +61,8 @@ export const getSwapTitle = (tradeType: SwapState['tradeType'], txs: BaseTransac
     [APPROVAL_SIGNATURE_HASH]: 'Approve',
     [WRAP_SIGHASH]: 'Wrap',
     [UNWRAP_SIGHASH]: 'Unwrap',
-    [CREATE_WITH_CONTEXT]: TWAP_ORDER_TITLE,
+    [CREATE_WITH_CONTEXT_SIGHASH]: TWAP_ORDER_TITLE,
+    [CANCEL_LIMIT_ORDER_SIGHASH]: 'Cancel Limit Order',
   }
 
   const swapTitle = txs


### PR DESCRIPTION
Adds a title to the execute transaction screen when cancelling a limit order

## Screenshots
![image](https://github.com/safe-global/safe-wallet-web/assets/17801424/30c4471f-cb36-4e4b-bad0-90fcce9de608)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
