### PR TITLE
Fix: display swap fees using the correct token [SW-67]

### DIFF
--- a/src/features/swap/components/SwapOrder/rows/SurplusFee.tsx
+++ b/src/features/swap/components/SwapOrder/rows/SurplusFee.tsx
@@ -10,12 +10,8 @@ export const SurplusFee = ({
   order: Pick<Order, 'fullAppData' | 'sellToken' | 'buyToken' | 'status' | 'executedSurplusFee' | 'kind'>
 }) => {
   const bps = getOrderFeeBps(order)
-  const { executedSurplusFee, status, sellToken, buyToken, kind } = order
+  const { executedSurplusFee, sellToken } = order
   let token = sellToken
-
-  if (kind === 'buy') {
-    token = buyToken
-  }
 
   if (executedSurplusFee === null || typeof executedSurplusFee === 'undefined' || executedSurplusFee === '0') {
     return null
@@ -30,7 +26,7 @@ export const SurplusFee = ({
             title={
               <>
                 The amount of fees paid for this order.
-                {bps > 0 && `This includes a Widget fee of ${bps / 100} % and network fees.`}
+                {bps > 0 && ` This includes a Widget fee of ${bps / 100} % and network fees.`}
               </>
             }
           />

--- a/src/features/swap/components/SwapOrder/rows/SurplusFee.tsx
+++ b/src/features/swap/components/SwapOrder/rows/SurplusFee.tsx
@@ -26,7 +26,7 @@ export const SurplusFee = ({
             title={
               <>
                 The amount of fees paid for this order.
-                {bps > 0 && ` This includes a Widget fee of ${bps / 100} % and network fees.`}
+                {bps > 0 && ` This includes a Widget fee of ${bps / 100}% and network fees.`}
               </>
             }
           />


### PR DESCRIPTION
## What it solves
For buy orders the fee was being displayed in the wrong token.

## How this PR fixes it
- For both buy and sell orders, the fee is displayed in the sell token.
- Also fixes some formatting in the fee tooltip text.

## How to test it
- Go to a buy order with fees, [example](https://release--walletweb.review.5afe.dev/transactions/tx?safe=sep:0x8f4A19C85b39032A37f7a6dCc65234f966F72551&id=multisig_0x8f4A19C85b39032A37f7a6dCc65234f966F72551_0x7175d1355f355353403449f68b14229cbf9ecc8291baa431753ac0a5efdb36e6)
- See that the fee is displayed with the correct token and amount. It should match the cowswap order.


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
