### PR TITLE
Fix terms [SW-43]

### DIFF
--- a/src/features/swap/components/LegalDisclaimer/index.tsx
+++ b/src/features/swap/components/LegalDisclaimer/index.tsx
@@ -25,8 +25,11 @@ const LegalDisclaimerContent = () => (
         contain more detailed provisions binding on you relating to such third party content.
       </Typography>
       <Typography>
-        By clicking &quot;continue&quot; you re-confirm to have read and understood our terms and this message, and
-        agree to them.
+        By clicking &quot;continue&quot; you re-confirm to have read and understood our{' '}
+        <ExternalLink href={AppRoutes.terms} sx={{ textDecoration: 'none' }}>
+          terms
+        </ExternalLink>{' '}
+        and this message, and agree to them.
       </Typography>
     </div>
   </div>


### PR DESCRIPTION
## What it solves
Second usage of terms in the disclaimer had to also be a link to the terms page.
![grafik](https://github.com/safe-global/safe-wallet-web/assets/693770/67258527-1757-416a-9e13-05cd48b4bd6a)


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
