### PR TITLE
fix: sell tooken was not being shown [SW-76]

### DIFF
--- a/src/features/swap/components/SwapTxInfo/SwapTx.tsx
+++ b/src/features/swap/components/SwapTxInfo/SwapTx.tsx
@@ -32,9 +32,14 @@ export const SwapTx = ({ info }: { info: Order }): ReactElement => {
 
   if (!isSellOrder) {
     from = (
-      <Box style={{ paddingRight: 5, display: 'inline-block' }}>
-        <TokenIcon logoUri={sellToken.logoUri || undefined} tokenSymbol={sellToken.symbol} />
-      </Box>
+      <>
+        <Box style={{ paddingRight: 5, display: 'inline-block' }}>
+          <TokenIcon logoUri={sellToken.logoUri || undefined} tokenSymbol={sellToken.symbol} />
+        </Box>
+        <Typography component="span" fontWeight="bold">
+          {sellToken.symbol}
+        </Typography>
+      </>
     )
     to = (
       <>


### PR DESCRIPTION
## What it solves
For buy orders we were only showing the sell token icon, but not the sell token name

Resolves #

## How this PR fixes it

## How to test it
Make a buy order and you should now in the queue/history see the sell token name.

## Screenshots
<img width="774" alt="grafik" src="https://github.com/safe-global/safe-wallet-web/assets/693770/cb26cbd7-0570-4f59-9e2e-a45f37770829">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
