### PR TITLE
Fix: swap tooltip

### DIFF
--- a/src/features/swap/components/SwapOrderConfirmationView/OrderFeeConfirmationView.tsx
+++ b/src/features/swap/components/SwapOrderConfirmationView/OrderFeeConfirmationView.tsx
@@ -18,9 +18,10 @@ export const OrderFeeConfirmationView = ({ order }: { order: Pick<OrderConfirmat
       <HelpIconTooltip
         title={
           <>
-            The tiered widget fees incurred here will contribute to a license fee that supports the Safe community.
-            Neither Safe Ecosystem Foundation nor {`Safe{Wallet}`}
-            operate the CoW Swap Widget and/or CoW Swap.{` `}
+            The tiered widget fee incurred here is charged by CoW Protocol for the operation of this widget. The fee is
+            automatically calculated into this quote. Part of the fee will contribute to a license fee that supports the
+            Safe Community. Neither the Safe Ecosystem Foundation nor {`Safe{Wallet}`} operate the CoW Swap Widget
+            and/or CoW Swap.
             <MUILink href={HelpCenterArticle.SWAP_WIDGET_FEES} target="_blank" rel="noopener noreferrer">
               Learn more
             </MUILink>


### PR DESCRIPTION
## What this PR changes
Adjusts the tooltip in the order confirmation view to match the widget one.

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
