### PR TITLE
fix: usdt missing from stablecoins array on arbitrum

### DIFF
--- a/src/features/swap/helpers/data/stablecoins.ts
+++ b/src/features/swap/helpers/data/stablecoins.ts
@@ -91,6 +91,11 @@ export const stableCoinAddresses: {
     symbol: 'usdc',
     chains: ['arbitrum-one'],
   },
+  '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9': {
+    name: 'USDT',
+    symbol: 'usdt',
+    chains: ['arbitrum-one'],
+  },
   '0x6b175474e89094c44da98b954eedeac495271d0f': {
     name: 'Dai',
     symbol: 'dai',


### PR DESCRIPTION
## What it solves
USDT is missing from the stablecoins array on arbiturm and because of this we apply wrong fee for stablecoin swaps

## How to test it
1. Open the swaps widget with an arbitrum safe - try to swap USDT for another stable -> you should get the stable rates for the swap.

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
