### PR TITLE
Fix: valueDecoded must be an array

### DIFF
--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -113,17 +113,17 @@ export const SignOrExecuteForm = ({
 
         <ErrorBoundary fallback={<div>Error parsing data</div>}>
           <ApprovalEditor safeTransaction={safeTx} />
-        </ErrorBoundary>
 
-        <DecodedTx
-          tx={safeTx}
-          txId={props.txId}
-          decodedData={decodedData}
-          decodedDataError={decodedDataError}
-          decodedDataLoading={decodedDataLoading}
-          showMultisend={!props.isBatch}
-          showToBlock={props.showToBlock}
-        />
+          <DecodedTx
+            tx={safeTx}
+            txId={props.txId}
+            decodedData={decodedData}
+            decodedDataError={decodedDataError}
+            decodedDataLoading={decodedDataLoading}
+            showMultisend={!props.isBatch}
+            showToBlock={props.showToBlock}
+          />
+        </ErrorBoundary>
 
         {!isCounterfactualSafe && <RedefineBalanceChanges />}
       </TxCard>

--- a/src/features/swap/helpers/utils.ts
+++ b/src/features/swap/helpers/utils.ts
@@ -196,14 +196,16 @@ export const UiOrderTypeToOrderType = (orderType: UiOrderType): TradeType => {
 
 export const isSettingTwapFallbackHandler = (decodedData: DecodedDataResponse | undefined) => {
   return (
-    decodedData?.parameters?.some((item) =>
-      item.valueDecoded?.some(
-        (decoded) =>
-          decoded.dataDecoded?.method === 'setFallbackHandler' &&
-          decoded.dataDecoded.parameters?.some(
-            (parameter) => parameter.name === 'handler' && parameter.value === TWAP_FALLBACK_HANDLER,
-          ),
-      ),
+    decodedData?.parameters?.some(
+      (item) =>
+        Array.isArray(item?.valueDecoded) &&
+        item.valueDecoded.some(
+          (decoded) =>
+            decoded.dataDecoded?.method === 'setFallbackHandler' &&
+            decoded.dataDecoded.parameters?.some(
+              (parameter) => parameter.name === 'handler' && parameter.value === TWAP_FALLBACK_HANDLER,
+            ),
+        ),
     ) || false
   )
 }


### PR DESCRIPTION
## What it solves

When valueDecoded isn't an array, it crashes the whole page. Our types apparently are wrong for this object.

Sentry: https://safe-global-eu.sentry.io/issues/2398958/?project=4507215200256080&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=5