### PR TITLE
Bump safe-deployments from 1.36.0 to 1.37.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@safe-global/api-kit": "^2.3.2",
     "@safe-global/protocol-kit": "^3.1.1",
     "@safe-global/safe-apps-sdk": "^9.1.0",
-    "@safe-global/safe-deployments": "^1.36.0",
+    "@safe-global/safe-deployments": "^1.37.1",
     "@safe-global/safe-gateway-typescript-sdk": "3.21.8",
     "@safe-global/safe-modules-deployments": "^1.2.0",
     "@sentry/react": "^7.91.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4156,6 +4156,13 @@
   dependencies:
     semver "^7.6.0"
 
+"@safe-global/safe-deployments@^1.37.1":
+  version "1.37.1"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.1.tgz#d8293c421b1b7445899aec720061be26bb3c4976"
+  integrity sha512-duCCQghqw9B/MmHPMXlkPpZwyq3T92unWVnwwhiA8alhush2FZ22+x6uF8bQtk/RYJzkpYzV1tPL/VBLt9U9XQ==
+  dependencies:
+    semver "^7.6.2"
+
 "@safe-global/safe-gateway-typescript-sdk@3.21.8":
   version "3.21.8"
   resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.21.8.tgz#f90eb668dd620d0c5578f02f7040169610a0eda1"
@@ -16729,6 +16736,11 @@ semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.2, semve
   integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^7.6.2:
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.2.tgz#1e3b34759f896e8f14d6134732ce798aeb0c6e13"
+  integrity sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==
 
 send@0.18.0:
   version "0.18.0"


### PR DESCRIPTION
## What it solves

Bump [`safe-deployments`](https://github.com/safe-global/safe-deployments) from `v1.36.0` to `v1.37.1` so teams that recently deployed Safe{Core} on their new chain can run safe-wallet-web properly.

Resolves # N/A

## How this PR fixes it

N/A

## How to test it

Make sure that recent network deployments are included in the package `node_modules/@safe-global/safe-deployments/dist/assets/v1.x.x/xxxxxx.json` (e.g L3X testnet | ChainID: `12325`)

## Screenshots

N/A

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
