### PR TITLE
fix: Append timestamp to static files for cache busting

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -34,7 +34,7 @@ const nextConfig = {
   experimental: {
     optimizePackageImports: ['@mui/material', '@mui/icons-material', 'lodash', 'date-fns', '@sentry/react', '@gnosis.pm/zodiac'],
   },
-  webpack(config) {
+  webpack(config, {dev}) {
     config.module.rules.push({
       test: /\.svg$/i,
       issuer: { and: [/\.(js|ts|md)x?$/] },
@@ -64,6 +64,12 @@ const nextConfig = {
       ...config.resolve.alias,
       'bn.js': path.resolve('./node_modules/bn.js/lib/bn.js'),
       'mainnet.json': path.resolve('./node_modules/@ethereumjs/common/dist.browser/genesisStates/mainnet.json'),
+    }
+
+    if (!dev && config.output.filename.startsWith('static')) {
+      const timestamp = new Date().getTime();
+      config.output.filename = config.output.filename.replace('[name]', `[name]-${timestamp}`);
+      config.output.chunkFilename = config.output.chunkFilename.replace('[name]', `[name]-${timestamp}`);
     }
 
     return config

--- a/src/services/safe-wallet-provider/useSafeWalletProvider.test.tsx
+++ b/src/services/safe-wallet-provider/useSafeWalletProvider.test.tsx
@@ -299,7 +299,6 @@ describe('useSafeWalletProvider', () => {
         push: mockPush,
       } as unknown as router.NextRouter)
 
-      // @ts-expect-error - auto accept prompt
       jest.spyOn(window, 'confirm').mockReturnValue(true)
 
       const { result } = renderHook(() => _useTxFlowApi('1', '0x1234567890000000000000000000000000000000'), {


### PR DESCRIPTION
## What it solves

Resolves #3944

## How this PR fixes it

- Appens the current timestamp to all static files on build step

## How to test it

1. Inspect network requests of the deployed PR
2. Observe static files contain a timestamp in their filename

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
