### PR TITLE
Fix: remove "could not coalesce error" prefix from error messages

### DIFF
--- a/src/components/tx/ErrorMessage/index.tsx
+++ b/src/components/tx/ErrorMessage/index.tsx
@@ -5,6 +5,8 @@ import WarningIcon from '@/public/images/notifications/warning.svg'
 import InfoIcon from '@/public/images/notifications/info.svg'
 import css from './styles.module.css'
 
+const ETHERS_PREFIX = 'could not coalesce error'
+
 const ErrorMessage = ({
   children,
   error,
@@ -46,7 +48,7 @@ const ErrorMessage = ({
 
           {error && showDetails && (
             <Typography variant="body2" className={css.details}>
-              {error.reason || error.message.slice(0, 300)}
+              {(error.reason || error.message).replace(ETHERS_PREFIX, '').trim().slice(0, 500)}
             </Typography>
           )}
         </div>


### PR DESCRIPTION
## What it solves

Resolves #3935

## How this PR fixes it

Ethers adds `could not coalesce error` in the beginning of error messages which isn't useful to the user. This PR simply cuts it off.