### PR TITLE
Fix: avoid duplication in Safe creation tx summary

### DIFF
--- a/cypress/fixtures/txhistory_data_data.json
+++ b/cypress/fixtures/txhistory_data_data.json
@@ -10,7 +10,7 @@
       "executedBy": "Executed"
     },
     "accountCreation": {
-      "actionsSummary": "Safe Account created by 0xC16D...6fED",
+      "actionsSummary": "Created by 0xC16D...6fED",
       "transactionSafehash": {},
       "summaryTime": "10:30 AM",
       "title": "Safe Account created",

--- a/src/components/transactions/TxInfo/index.tsx
+++ b/src/components/transactions/TxInfo/index.tsx
@@ -88,7 +88,7 @@ const CustomTx = ({ info }: { info: Custom }): ReactElement => {
 }
 
 const CreationTx = ({ info }: { info: Creation }): ReactElement => {
-  return <>Safe Account created by {shortenAddress(info.creator.value)}</>
+  return <>Created by {shortenAddress(info.creator.value)}</>
 }
 
 const MultiSendTx = ({ info }: { info: MultiSend }): ReactElement => {


### PR DESCRIPTION
## What it solves

Resolves #3198

## How this PR fixes it

I removed the redundant part from the tx summary.

<img width="1402" alt="Screenshot 2024-07-15 at 17 05 44" src="https://github.com/user-attachments/assets/498ce468-ca62-4f7f-8167-13df0ef8ac1f">
