### PR TITLE
fix: Add CREATED_SAFE event back for normal safe creation

### DIFF
--- a/src/features/counterfactual/hooks/usePendingSafeStatuses.ts
+++ b/src/features/counterfactual/hooks/usePendingSafeStatuses.ts
@@ -1,4 +1,5 @@
 import { pollSafeInfo } from '@/components/new-safe/create/logic'
+import { PayMethod } from '@/features/counterfactual/PayNowPayLater'
 import {
   safeCreationDispatch,
   SafeCreationEvent,
@@ -49,7 +50,7 @@ const usePendingSafeMonitor = (): void => {
 
         const monitorPendingSafe = async () => {
           const {
-            status: { status, txHash, taskId, startBlock },
+            status: { status, txHash, taskId, startBlock, type },
           } = undeployedSafe
 
           const isProcessing = status === PendingSafeStatus.PROCESSING && txHash !== undefined
@@ -61,11 +62,11 @@ const usePendingSafeMonitor = (): void => {
           monitoredSafes.current[safeAddress] = true
 
           if (isProcessing) {
-            checkSafeActivation(provider, txHash, safeAddress, startBlock)
+            checkSafeActivation(provider, txHash, safeAddress, type, startBlock)
           }
 
           if (isRelaying) {
-            checkSafeActionViaRelay(taskId, safeAddress)
+            checkSafeActionViaRelay(taskId, safeAddress, type)
           }
         }
 
@@ -109,6 +110,12 @@ const usePendingSafeStatus = (): void => {
         if (event === SafeCreationEvent.SUCCESS) {
           // TODO: Possible to add a label with_tx, without_tx?
           trackEvent(CREATE_SAFE_EVENTS.ACTIVATED_SAFE)
+
+          // Not a counterfactual deployment
+          if ('type' in detail && detail.type === PayMethod.PayNow) {
+            trackEvent(CREATE_SAFE_EVENTS.CREATED_SAFE)
+          }
+
           pollSafeInfo(chainId, detail.safeAddress).finally(() => {
             safeCreationDispatch(SafeCreationEvent.INDEXED, {
               groupKey: detail.groupKey,

--- a/src/features/counterfactual/services/safeCreationEvents.ts
+++ b/src/features/counterfactual/services/safeCreationEvents.ts
@@ -1,3 +1,4 @@
+import type { PayMethod } from '@/features/counterfactual/PayNowPayLater'
 import EventBus from '@/services/EventBus'
 
 export enum SafeCreationEvent {
@@ -23,6 +24,7 @@ export interface SafeCreationEvents {
   [SafeCreationEvent.SUCCESS]: {
     groupKey: string
     safeAddress: string
+    type: PayMethod
   }
   [SafeCreationEvent.INDEXED]: {
     groupKey: string

--- a/src/features/counterfactual/utils.ts
+++ b/src/features/counterfactual/utils.ts
@@ -204,6 +204,7 @@ export const checkSafeActivation = async (
   provider: Provider,
   txHash: string,
   safeAddress: string,
+  type: PayMethod,
   startBlock?: number,
 ) => {
   try {
@@ -228,6 +229,7 @@ export const checkSafeActivation = async (
     safeCreationDispatch(SafeCreationEvent.SUCCESS, {
       groupKey: CF_TX_GROUP_KEY,
       safeAddress,
+      type,
     })
   } catch (err) {
     const _err = err as EthersError
@@ -236,6 +238,7 @@ export const checkSafeActivation = async (
       safeCreationDispatch(SafeCreationEvent.SUCCESS, {
         groupKey: CF_TX_GROUP_KEY,
         safeAddress,
+        type,
       })
       return
     }
@@ -257,7 +260,7 @@ export const checkSafeActivation = async (
   }
 }
 
-export const checkSafeActionViaRelay = (taskId: string, safeAddress: string) => {
+export const checkSafeActionViaRelay = (taskId: string, safeAddress: string, type: PayMethod) => {
   const TIMEOUT_TIME = 2 * 60 * 1000 // 2 minutes
 
   let intervalId: NodeJS.Timeout
@@ -274,6 +277,7 @@ export const checkSafeActionViaRelay = (taskId: string, safeAddress: string) => 
         safeCreationDispatch(SafeCreationEvent.SUCCESS, {
           groupKey: CF_TX_GROUP_KEY,
           safeAddress,
+          type,
         })
         break
       case TaskState.ExecReverted:

--- a/src/services/safe-wallet-provider/useSafeWalletProvider.test.tsx
+++ b/src/services/safe-wallet-provider/useSafeWalletProvider.test.tsx
@@ -299,7 +299,6 @@ describe('useSafeWalletProvider', () => {
         push: mockPush,
       } as unknown as router.NextRouter)
 
-      // @ts-expect-error - auto accept prompt
       jest.spyOn(window, 'confirm').mockReturnValue(true)
 
       const { result } = renderHook(() => _useTxFlowApi('1', '0x1234567890000000000000000000000000000000'), {


### PR DESCRIPTION
## What it solves

This fixes a regression that was introduced in #3778

## How this PR fixes it

#3778 consolidated the logic of counterfactual and normal safe deployment and as such removed existing hooks like `useSafeCreationEffects`. This hook contained the logic to emit a `CREATED_SAFE` event on successful creation.

This PR adds this back for normal safe deployments. For counterfactual safe deployments this event is emitted immediately which is as expected.

## How to test it

1. Create a safe and choose pay now
2. Observe a `CREATED_SAFE` event after successful deployment

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
