### PR TITLE
Tests: mock fetch in PermissionsCheck tests

### DIFF
--- a/src/components/tx/SignOrExecuteForm/PermissionsCheck/__test__/PermissionsCheck.test.tsx
+++ b/src/components/tx/SignOrExecuteForm/PermissionsCheck/__test__/PermissionsCheck.test.tsx
@@ -18,6 +18,17 @@ import { FEATURES } from '@/utils/chains'
 import { chainBuilder } from '@/tests/builders/chains'
 import { useHasFeature } from '@/hooks/useChains'
 
+// Mock fetch
+Object.defineProperty(window, 'fetch', {
+  writable: true,
+  value: jest.fn(() =>
+    Promise.resolve({
+      ok: false,
+      json: () => Promise.resolve({}),
+    }),
+  ),
+})
+
 // We assume that CheckWallet always returns true
 jest.mock('@/components/common/CheckWallet', () => ({
   __esModule: true,

--- a/src/services/safe-wallet-provider/useSafeWalletProvider.test.tsx
+++ b/src/services/safe-wallet-provider/useSafeWalletProvider.test.tsx
@@ -299,7 +299,6 @@ describe('useSafeWalletProvider', () => {
         push: mockPush,
       } as unknown as router.NextRouter)
 
-      // @ts-expect-error - auto accept prompt
       jest.spyOn(window, 'confirm').mockReturnValue(true)
 
       const { result } = renderHook(() => _useTxFlowApi('1', '0x1234567890000000000000000000000000000000'), {

--- a/src/tests/mocks/chains.ts
+++ b/src/tests/mocks/chains.ts
@@ -1,9 +1,22 @@
 import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { FEATURES, GAS_PRICE_TYPE, RPC_AUTHENTICATION } from '@safe-global/safe-gateway-typescript-sdk'
 
+const contractAddresses = {
+  createCallAddress: null,
+  fallbackHandlerAddress: null,
+  multiSendAddress: null,
+  multiSendCallOnlyAddress: null,
+  safeProxyFactoryAddress: null,
+  safeSingletonAddress: null,
+  safeWebAuthnSignerFactoryAddress: null,
+  signMessageLibAddress: null,
+  simulateTxAccessorAddress: null,
+}
+
 const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
   {
     transactionService: 'https://safe-transaction.mainnet.gnosis.io',
+    contractAddresses,
     chainId: '1',
     chainName: 'Ethereum',
     chainLogoUri: '',
@@ -58,6 +71,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
   },
   {
     transactionService: 'https://safe-transaction.xdai.gnosis.io',
+    contractAddresses,
     chainId: '100',
     chainName: 'Gnosis Chain',
     chainLogoUri: '',
@@ -111,6 +125,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
   },
   {
     transactionService: 'https://safe-transaction.polygon.gnosis.io',
+    contractAddresses,
     chainId: '137',
     chainName: 'Polygon',
     chainLogoUri: '',
@@ -170,6 +185,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
   },
   {
     transactionService: 'https://safe-transaction.bsc.gnosis.io',
+    contractAddresses,
     chainId: '56',
     chainName: 'BNB Smart Chain',
     chainLogoUri: '',
@@ -225,6 +241,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
   },
   {
     transactionService: 'https://safe-transaction.ewc.gnosis.io',
+    contractAddresses,
     chainId: '246',
     chainName: 'Energy Web Chain',
     chainLogoUri: '',
@@ -278,6 +295,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
   },
   {
     transactionService: 'https://safe-transaction.arbitrum.gnosis.io',
+    contractAddresses,
     chainId: '42161',
     chainName: 'Arbitrum',
     chainLogoUri: '',
@@ -324,6 +342,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
   },
   {
     transactionService: 'https://safe-transaction.aurora.gnosis.io',
+    contractAddresses,
     chainId: '1313161554',
     chainName: 'Aurora',
     chainLogoUri: '',
@@ -371,6 +390,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
   },
   {
     transactionService: 'https://safe-transaction.avalanche.gnosis.io',
+    contractAddresses,
     chainId: '43114',
     chainName: 'Avalanche',
     chainLogoUri: '',
@@ -429,6 +449,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
   },
   {
     transactionService: 'https://safe-transaction.optimism.gnosis.io',
+    contractAddresses,
     chainId: '10',
     chainName: 'Optimism',
     chainLogoUri: '',
@@ -475,6 +496,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
   },
   {
     transactionService: 'https://safe-transaction.goerli.gnosis.io/',
+    contractAddresses,
     chainId: '5',
     chainName: 'Goerli',
     chainLogoUri: '',
@@ -529,6 +551,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
   },
   {
     transactionService: 'https://safe-transaction.rinkeby.gnosis.io',
+    contractAddresses,
     chainId: '4',
     chainName: 'Rinkeby',
     chainLogoUri: '',
@@ -573,6 +596,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
   },
   {
     transactionService: 'https://safe-transaction.volta.gnosis.io',
+    contractAddresses,
     chainId: '73799',
     chainName: 'Volta',
     chainLogoUri: '',


### PR DESCRIPTION
## What it solves

The PermissionsCheck tests were doing actual fetch requests to a gas oracle which sometimes failed on CI. Fetch is now mocked to return an empty object.