### PR TITLE
Fix: allow keyboard scrolling for in Dialog

### DIFF
--- a/src/components/common/TxModalDialog/index.tsx
+++ b/src/components/common/TxModalDialog/index.tsx
@@ -1,6 +1,6 @@
-import { type ReactElement } from 'react'
-import { IconButton, Dialog, DialogTitle, type DialogProps } from '@mui/material'
+import { Dialog, DialogContent, DialogContentText, DialogTitle, IconButton, type DialogProps } from '@mui/material'
 import classnames from 'classnames'
+import type { ReactElement } from 'react'
 import CloseIcon from '@mui/icons-material/Close'
 import css from './styles.module.css'
 
@@ -42,8 +42,9 @@ const TxModalDialog = ({
           </IconButton>
         </div>
       </DialogTitle>
-
-      {children}
+      <DialogContent dividers={false}>
+        <DialogContentText tabIndex={-1}>{children}</DialogContentText>
+      </DialogContent>
     </Dialog>
   )
 }

--- a/src/services/safe-wallet-provider/useSafeWalletProvider.test.tsx
+++ b/src/services/safe-wallet-provider/useSafeWalletProvider.test.tsx
@@ -299,7 +299,6 @@ describe('useSafeWalletProvider', () => {
         push: mockPush,
       } as unknown as router.NextRouter)
 
-      // @ts-expect-error - auto accept prompt
       jest.spyOn(window, 'confirm').mockReturnValue(true)
 
       const { result } = renderHook(() => _useTxFlowApi('1', '0x1234567890000000000000000000000000000000'), {


### PR DESCRIPTION
## What it solves
Cannot use keyboard scroll in the tx modal.
Resolves #2690

## How this PR fixes it
- Wrap the dialog contents in the DialogContent and DialogContentText components to get the default MUI modal behaviour.

## How to test it
- Create a transaction with many steps (https://github.com/safe-global/safe-wallet-web/issues/2690#issuecomment-1945821479)
- Open the tx modal. Focus on the modal (click or tab).
- Scroll using the arrow buttons should work. Scrolling to the end of the page using `CMD`+`down` or `end` should also work.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
