### PR TITLE
Fix: make swap icon white in dark mode [SW-81]

### DIFF
--- a/src/components/transactions/TxType/index.tsx
+++ b/src/components/transactions/TxType/index.tsx
@@ -3,6 +3,7 @@ import type { TransactionSummary } from '@safe-global/safe-gateway-typescript-sd
 import { Box } from '@mui/material'
 import css from './styles.module.css'
 import SafeAppIconCard from '@/components/safe-apps/SafeAppIconCard'
+import { isValidElement } from 'react'
 
 type TxTypeProps = {
   tx: TransactionSummary
@@ -13,13 +14,17 @@ const TxType = ({ tx }: TxTypeProps) => {
 
   return (
     <Box className={css.txType}>
-      <SafeAppIconCard
-        src={type.icon}
-        alt={type.text}
-        width={16}
-        height={16}
-        fallback="/images/transactions/custom.svg"
-      />
+      {isValidElement(type.icon) && type.icon}
+      {typeof type.icon == 'string' && (
+        <SafeAppIconCard
+          src={type.icon}
+          alt={type.text}
+          width={16}
+          height={16}
+          fallback="/images/transactions/custom.svg"
+        />
+      )}
+
       <span className={css.txTypeText}>{type.text}</span>
     </Box>
   )

--- a/src/components/transactions/TxType/index.tsx
+++ b/src/components/transactions/TxType/index.tsx
@@ -14,8 +14,9 @@ const TxType = ({ tx }: TxTypeProps) => {
 
   return (
     <Box className={css.txType}>
-      {isValidElement(type.icon) && type.icon}
-      {typeof type.icon == 'string' && (
+      {isValidElement(type.icon) ? (
+        type.icon
+      ) : typeof type.icon == 'string' ? (
         <SafeAppIconCard
           src={type.icon}
           alt={type.text}
@@ -23,7 +24,7 @@ const TxType = ({ tx }: TxTypeProps) => {
           height={16}
           fallback="/images/transactions/custom.svg"
         />
-      )}
+      ) : null}
 
       <span className={css.txTypeText}>{type.text}</span>
     </Box>

--- a/src/hooks/useTransactionType.tsx
+++ b/src/hooks/useTransactionType.tsx
@@ -1,4 +1,5 @@
 import { getOrderClass } from '@/features/swap/helpers/utils'
+import type { ReactElement } from 'react'
 import { useMemo } from 'react'
 import {
   type AddressEx,
@@ -6,11 +7,13 @@ import {
   TransactionInfoType,
   type TransactionSummary,
 } from '@safe-global/safe-gateway-typescript-sdk'
+import SwapIcon from '@/public/images/common/swap.svg'
 
 import { isCancellationTxInfo, isModuleExecutionInfo, isOutgoingTransfer, isTxQueued } from '@/utils/transaction-guards'
 import useAddressBook from './useAddressBook'
 import type { AddressBook } from '@/store/addressBookSlice'
 import { TWAP_ORDER_TITLE } from '@/features/swap/constants'
+import { SvgIcon } from '@mui/material'
 
 const getTxTo = ({ txInfo }: Pick<TransactionSummary, 'txInfo'>): AddressEx | undefined => {
   switch (txInfo.type) {
@@ -30,7 +33,7 @@ const getTxTo = ({ txInfo }: Pick<TransactionSummary, 'txInfo'>): AddressEx | un
 }
 
 type TxType = {
-  icon: string
+  icon: string | ReactElement
   text: string
 }
 
@@ -66,10 +69,11 @@ export const getTransactionType = (tx: TransactionSummary, addressBook: AddressB
     }
     case TransactionInfoType.SWAP_ORDER: {
       const orderClass = getOrderClass(tx.txInfo)
+      const altText = orderClass === 'limit' ? 'Limit order' : 'Swap order'
 
       return {
-        icon: '/images/common/swap.svg',
-        text: orderClass === 'limit' ? 'Limit order' : 'Swap order',
+        icon: <SvgIcon component={SwapIcon} inheritViewBox fontSize="small" alt={altText} />,
+        text: altText,
       }
     }
     case TransactionInfoType.TWAP_ORDER: {


### PR DESCRIPTION
## What it solves
In the transaction summary, the swap icon is black in dark mode.

## How this PR fixes it
- Use MUI SvgIcon to render the swap icon so that it changes color according to the theme.

## How to test it
- Find or create a swap transaction in the tx history.
- See the the icon is the correct color in both light and dark mode. Make sure the other tx icons are unaffected.

## Screenshots
![image](https://github.com/user-attachments/assets/12bdaefb-f549-48ad-8c8e-324c54980163)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
