### PR TITLE
Chore: switch to pull_request_target

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,7 +1,7 @@
 name: Deploy to dev/staging
 
 on:
-  pull_request:
+  pull_request_target:
 
   push:
     branches:

--- a/.github/workflows/e2e-regression.yml
+++ b/.github/workflows/e2e-regression.yml
@@ -1,7 +1,7 @@
 name: Regression tests
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - 'release**'
       - 'release/**'

--- a/.github/workflows/e2e-safe-apps.yml
+++ b/.github/workflows/e2e-safe-apps.yml
@@ -1,7 +1,7 @@
 name: Safe Apps e2e
 
 on:
-  pull_request:
+  pull_request_target:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,7 +1,7 @@
 name: Smoke tests
 
 on:
-  pull_request:
+  pull_request_target:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -4,7 +4,7 @@
 name: 'Next.js Bundle Analysis'
 
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - dev

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,6 +1,6 @@
 name: Unit tests
 on:
-  pull_request:
+  pull_request_target:
 
   push:
     branches:


### PR DESCRIPTION
Github actions on forks fail, because they require secrets that are not available. By relying on pull_request_target maintainers will be able to start those action workflows and they shouldn’t fail.

From the [github docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target):
This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. This event allows your workflow to do things like label or comment on pull requests from forks.

## What it solves
With this we should be able to manually run actions on github PR from forks. This will allow for unit tests, preview deployments to work.

## How to test
I think that we can only test it by first merging and then trying to create a PR from a fork.


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
