### PR TITLE
fix: Hide onboarding tooltip behind transaction modal

### DIFF
--- a/src/components/common/OnboardingTooltip/index.tsx
+++ b/src/components/common/OnboardingTooltip/index.tsx
@@ -33,6 +33,7 @@ export const OnboardingTooltip = ({
     <Tooltip
       PopperProps={{
         className,
+        disablePortal: true,
       }}
       open
       placement={placement}
@@ -40,7 +41,7 @@ export const OnboardingTooltip = ({
       title={
         <Box display="flex" alignItems="center" gap={1} padding={1}>
           <SvgIcon component={InfoIcon} inheritViewBox fontSize="small" />
-          <span>{text}</span>
+          <div style={{ minWidth: '150px' }}>{text}</div>
           <Button
             size="small"
             color={isDarkMode ? 'background' : 'secondary'}


### PR DESCRIPTION
## What it solves

Resolves #3798 

## How this PR fixes it

- Adds `disablePortal` to the Tooltip element so that it is not rendered at the top of the DOM anymore
- Adds a `minWidth` to its text to make the tooltip a bit wider again

## How to test it

1. Open a Safe with a clean local storage
2. Go to Assets
3. Observe the tooltip showing
4. Press Create transaction
5. Observe the tooltip is not visible anymore

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
