### PR TITLE
Feat: full amount tooltip

### DIFF
--- a/src/components/common/FiatValue/index.tsx
+++ b/src/components/common/FiatValue/index.tsx
@@ -1,8 +1,9 @@
 import type { CSSProperties, ReactElement } from 'react'
 import { useMemo } from 'react'
+import { Tooltip } from '@mui/material'
 import { useAppSelector } from '@/store'
 import { selectCurrency } from '@/store/settingsSlice'
-import { formatCurrency } from '@/utils/formatNumber'
+import { formatCurrency, formatCurrencyPrecise } from '@/utils/formatNumber'
 
 const style = { whiteSpace: 'nowrap' } as CSSProperties
 
@@ -13,10 +14,16 @@ const FiatValue = ({ value, maxLength }: { value: string | number; maxLength?: n
     return formatCurrency(value, currency, maxLength)
   }, [value, currency, maxLength])
 
+  const preciseFiat = useMemo(() => {
+    return formatCurrencyPrecise(value, currency)
+  }, [value, currency])
+
   return (
-    <span suppressHydrationWarning style={style}>
-      {fiat}
-    </span>
+    <Tooltip title={preciseFiat}>
+      <span suppressHydrationWarning style={style}>
+        {fiat}
+      </span>
+    </Tooltip>
   )
 }
 

--- a/src/components/common/TokenAmount/index.tsx
+++ b/src/components/common/TokenAmount/index.tsx
@@ -1,4 +1,5 @@
 import { type ReactElement } from 'react'
+import { Tooltip } from '@mui/material'
 import { TransferDirection } from '@safe-global/safe-gateway-typescript-sdk'
 import css from './styles.module.css'
 import { formatVisualAmount } from '@/utils/formatters'
@@ -27,15 +28,18 @@ const TokenAmount = ({
   const sign = direction === TransferDirection.OUTGOING ? '-' : ''
   const amount =
     decimals !== undefined ? formatVisualAmount(value, decimals, preciseAmount ? PRECISION : undefined) : value
+  const fullAmount = sign + formatVisualAmount(value, decimals, PRECISION) + ' ' + tokenSymbol
 
   return (
-    <span className={classNames(css.container, { [css.verticalAlign]: logoUri })}>
-      {logoUri && <TokenIcon logoUri={logoUri} tokenSymbol={tokenSymbol} fallbackSrc={fallbackSrc} />}
-      <b>
-        {sign}
-        {amount} {tokenSymbol}
-      </b>
-    </span>
+    <Tooltip title={fullAmount}>
+      <span className={classNames(css.container, { [css.verticalAlign]: logoUri })}>
+        {logoUri && <TokenIcon logoUri={logoUri} tokenSymbol={tokenSymbol} fallbackSrc={fallbackSrc} />}
+        <b>
+          {sign}
+          {amount} {tokenSymbol}
+        </b>
+      </span>
+    </Tooltip>
   )
 }
 

--- a/src/components/transactions/TxInfo/index.tsx
+++ b/src/components/transactions/TxInfo/index.tsx
@@ -73,6 +73,7 @@ export const TransferTx = ({
           withLogo ? 16 : 100,
         )}
         value="1"
+        decimals={0}
         direction={undefined}
         logoUri={withLogo ? transfer?.logoUri : undefined}
         fallbackSrc="/images/common/nft-placeholder.png"

--- a/src/features/swap/components/SwapOrder/index.tsx
+++ b/src/features/swap/components/SwapOrder/index.tsx
@@ -1,4 +1,3 @@
-import TokenIcon from '@/components/common/TokenIcon'
 import OrderId from '@/features/swap/components/OrderId'
 import StatusLabel from '@/features/swap/components/StatusLabel'
 import SwapProgress from '@/features/swap/components/SwapProgress'

--- a/src/features/swap/components/SwapOrder/index.tsx
+++ b/src/features/swap/components/SwapOrder/index.tsx
@@ -18,7 +18,6 @@ import { compareAsc } from 'date-fns'
 import css from './styles.module.css'
 import { Typography } from '@mui/material'
 import { formatAmount } from '@/utils/formatNumber'
-import { formatVisualAmount } from '@/utils/formatters'
 import {
   getExecutionPrice,
   getLimitPrice,
@@ -28,6 +27,7 @@ import {
   isOrderPartiallyFilled,
 } from '@/features/swap/helpers/utils'
 import EthHashInfo from '@/components/common/EthHashInfo'
+import TokenAmount from '@/components/common/TokenAmount'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { isSwapOrderTxInfo, isSwapTransferOrderTxInfo, isTwapOrderTxInfo } from '@/utils/transaction-guards'
 import { EmptyRow } from '@/components/common/Table/EmptyRow'
@@ -50,19 +50,23 @@ const AmountRow = ({ order }: { order: Order }) => {
         <div>
           <span className={css.value}>
             {isSellOrder ? 'Sell' : 'For at most'}{' '}
-            {sellToken.logoUri && <TokenIcon logoUri={sellToken.logoUri} size={24} />}{' '}
-            <Typography component="span" fontWeight="bold">
-              {formatVisualAmount(sellAmount, sellToken.decimals)} {sellToken.symbol}
-            </Typography>
+            <TokenAmount
+              value={sellAmount}
+              decimals={sellToken.decimals}
+              tokenSymbol={sellToken.symbol}
+              logoUri={sellToken.logoUri ?? undefined}
+            />
           </span>
         </div>
         <div>
           <span className={css.value}>
             {isSellOrder ? 'for at least' : 'Buy'}{' '}
-            {buyToken.logoUri && <TokenIcon logoUri={buyToken.logoUri} size={24} />}
-            <Typography component="span" fontWeight="bold">
-              {formatVisualAmount(buyAmount, buyToken.decimals)} {buyToken.symbol}
-            </Typography>
+            <TokenAmount
+              value={buyAmount}
+              decimals={buyToken.decimals}
+              tokenSymbol={buyToken.symbol}
+              logoUri={buyToken.logoUri ?? undefined}
+            />
           </span>
         </div>
       </Stack>

--- a/src/features/swap/components/SwapTxInfo/SwapTx.tsx
+++ b/src/features/swap/components/SwapTxInfo/SwapTx.tsx
@@ -14,7 +14,10 @@ const Amount = ({ value, token }: { value: string; token: OrderToken }) => (
 )
 
 const OnlyToken = ({ token }: { token: OrderToken }) => (
-  <TokenIcon tokenSymbol={token.symbol} logoUri={token.logoUri ?? undefined} />
+  <Typography fontWeight="bold" component="span" display="flex" alignItems="center" gap={1}>
+    <TokenIcon tokenSymbol={token.symbol} logoUri={token.logoUri ?? undefined} />
+    {token.symbol}
+  </Typography>
 )
 
 export const SwapTx = ({ info }: { info: Order }): ReactElement => {
@@ -32,7 +35,9 @@ export const SwapTx = ({ info }: { info: Order }): ReactElement => {
   return (
     <Typography component="div" display="flex" alignItems="center" fontWeight="bold">
       {from}
-      <Typography component="span">&nbsp;to&nbsp;</Typography>
+      <Typography component="span" mx={0.5}>
+        &nbsp;to&nbsp;
+      </Typography>
       {to}
     </Typography>
   )

--- a/src/features/swap/components/SwapTxInfo/SwapTx.tsx
+++ b/src/features/swap/components/SwapTxInfo/SwapTx.tsx
@@ -1,26 +1,39 @@
-import type { Order } from '@safe-global/safe-gateway-typescript-sdk'
+import type { Order, OrderToken } from '@safe-global/safe-gateway-typescript-sdk'
 import type { ReactElement } from 'react'
-import { Box, Typography } from '@mui/material'
+import { Typography } from '@mui/material'
 import TokenAmount from '@/components/common/TokenAmount'
+import TokenIcon from '@/components/common/TokenIcon'
+
+const Amount = ({ value, token }: { value: string; token: OrderToken }) => (
+  <TokenAmount
+    value={value}
+    decimals={token.decimals}
+    tokenSymbol={token.symbol}
+    logoUri={token.logoUri ?? undefined}
+  />
+)
+
+const OnlyToken = ({ token }: { token: OrderToken }) => (
+  <TokenIcon tokenSymbol={token.symbol} logoUri={token.logoUri ?? undefined} />
+)
 
 export const SwapTx = ({ info }: { info: Order }): ReactElement => {
   const { kind, sellToken, sellAmount, buyToken, buyAmount } = info
   const isSellOrder = kind === 'sell'
 
-  let from = <TokenAmount value={sellAmount} decimals={sellToken.decimals} logoUri={sellToken.logoUri ?? undefined} />
-  let to = <TokenAmount value={buyAmount} decimals={buyToken.decimals} logoUri={buyToken.logoUri ?? undefined} />
+  let from = <Amount value={sellAmount} token={sellToken} />
+  let to = <OnlyToken token={buyToken} />
 
   if (!isSellOrder) {
-    ;[from, to] = [to, from]
+    from = <OnlyToken token={sellToken} />
+    to = <Amount value={buyAmount} token={buyToken} />
   }
 
   return (
-    <Box display="flex">
-      <Typography component="div" display="flex" alignItems="center" fontWeight="bold">
-        {from}
-        <Typography component="span">&nbsp;to&nbsp;</Typography>
-        {to}
-      </Typography>
-    </Box>
+    <Typography component="div" display="flex" alignItems="center" fontWeight="bold">
+      {from}
+      <Typography component="span">&nbsp;to&nbsp;</Typography>
+      {to}
+    </Typography>
   )
 }

--- a/src/features/swap/components/SwapTxInfo/SwapTx.tsx
+++ b/src/features/swap/components/SwapTxInfo/SwapTx.tsx
@@ -1,65 +1,24 @@
 import type { Order } from '@safe-global/safe-gateway-typescript-sdk'
 import type { ReactElement } from 'react'
 import { Box, Typography } from '@mui/material'
-import TokenIcon from '@/components/common/TokenIcon'
-import { formatVisualAmount } from '@/utils/formatters'
+import TokenAmount from '@/components/common/TokenAmount'
 
 export const SwapTx = ({ info }: { info: Order }): ReactElement => {
   const { kind, sellToken, sellAmount, buyToken, buyAmount } = info
   const isSellOrder = kind === 'sell'
 
-  let from = (
-    <>
-      <Box style={{ paddingRight: 5, display: 'inline-block' }}>
-        <TokenIcon logoUri={sellToken.logoUri || undefined} tokenSymbol={sellToken.symbol} />
-      </Box>
-      <Typography component="span" fontWeight="bold">
-        {formatVisualAmount(sellAmount, sellToken.decimals)} {sellToken.symbol}{' '}
-      </Typography>
-    </>
-  )
-
-  let to = (
-    <>
-      <Box style={{ paddingLeft: 5, paddingRight: 5, display: 'inline-block' }}>
-        <TokenIcon logoUri={buyToken.logoUri || undefined} tokenSymbol={buyToken.symbol} />
-      </Box>{' '}
-      <Typography component="span" fontWeight="bold">
-        {buyToken.symbol}
-      </Typography>
-    </>
-  )
+  let from = <TokenAmount value={sellAmount} decimals={sellToken.decimals} logoUri={sellToken.logoUri ?? undefined} />
+  let to = <TokenAmount value={buyAmount} decimals={buyToken.decimals} logoUri={buyToken.logoUri ?? undefined} />
 
   if (!isSellOrder) {
-    from = (
-      <>
-        <Box style={{ paddingRight: 5, display: 'inline-block' }}>
-          <TokenIcon logoUri={sellToken.logoUri || undefined} tokenSymbol={sellToken.symbol} />
-        </Box>
-        <Typography component="span" fontWeight="bold">
-          {sellToken.symbol}
-        </Typography>
-      </>
-    )
-    to = (
-      <>
-        <Box style={{ paddingLeft: 5, paddingRight: 5, display: 'inline-block' }}>
-          <TokenIcon logoUri={buyToken.logoUri || undefined} tokenSymbol={buyToken.symbol} />
-        </Box>{' '}
-        <Typography component="span" fontWeight="bold">
-          {formatVisualAmount(buyAmount, buyToken.decimals)} {buyToken.symbol}{' '}
-        </Typography>
-      </>
-    )
+    ;[from, to] = [to, from]
   }
 
   return (
     <Box display="flex">
       <Typography component="div" display="flex" alignItems="center" fontWeight="bold">
         {from}
-        <Typography component="span" ml={0.5}>
-          to
-        </Typography>
+        <Typography component="span">&nbsp;to&nbsp;</Typography>
         {to}
       </Typography>
     </Box>

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -1,4 +1,36 @@
+import memoize from 'lodash/memoize'
+
 const locale = typeof navigator !== 'undefined' ? navigator.language : undefined
+
+const _getNumberFormatter = (maximumFractionDigits?: number, compact?: boolean) => {
+  return new Intl.NumberFormat(locale, {
+    style: 'decimal',
+    maximumFractionDigits,
+    notation: compact ? 'compact' : 'standard',
+  })
+}
+const getNumberFormatter = memoize(_getNumberFormatter, (...args: Parameters<typeof _getNumberFormatter>) =>
+  args.join(''),
+)
+
+const _getCurrencyFormatter = (
+  currency: string,
+  compact?: boolean,
+  maximumFractionDigits?: number,
+  minimumFractionDigits?: number,
+) => {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+    currencyDisplay: 'narrowSymbol',
+    maximumFractionDigits,
+    minimumFractionDigits,
+    notation: compact ? 'compact' : 'standard',
+  })
+}
+const getCurrencyFormatter = memoize(_getCurrencyFormatter, (...args: Parameters<typeof _getCurrencyFormatter>) =>
+  args.join(''),
+)
 
 /**
  * Intl.NumberFormat number formatter that adheres to our style guide
@@ -10,19 +42,12 @@ export const formatAmount = (number: string | number, precision = 5, maxLength =
   if (float === Math.round(float)) precision = 0
   if (Math.abs(float) < 0.00001) return '< 0.00001'
 
-  const fullNum = new Intl.NumberFormat(locale, {
-    style: 'decimal',
-    maximumFractionDigits: precision,
-  }).format(float)
+  const fullNum = getNumberFormatter(precision).format(float)
 
   // +3 for the decimal point and the two decimal places
   if (fullNum.length <= maxLength + 3) return fullNum
 
-  return new Intl.NumberFormat(locale, {
-    style: 'decimal',
-    notation: 'compact',
-    maximumFractionDigits: 2,
-  }).format(float)
+  return getNumberFormatter(2, true).format(float)
 }
 
 /**
@@ -31,10 +56,7 @@ export const formatAmount = (number: string | number, precision = 5, maxLength =
  * @param precision Fraction digits to show
  */
 export const formatAmountPrecise = (number: string | number, precision?: number): string => {
-  return new Intl.NumberFormat(locale, {
-    style: 'decimal',
-    maximumFractionDigits: precision,
-  }).format(Number(number))
+  return getNumberFormatter(precision).format(Number(number))
 }
 
 /**
@@ -43,25 +65,19 @@ export const formatAmountPrecise = (number: string | number, precision?: number)
  * @param currency ISO 4217 currency code
  */
 export const formatCurrency = (number: string | number, currency: string, maxLength = 6): string => {
-  let float = Number(number)
+  const float = Number(number)
 
-  let result = new Intl.NumberFormat(locale, {
-    style: 'currency',
-    currency,
-    currencyDisplay: 'narrowSymbol',
-    maximumFractionDigits: Math.abs(float) >= 1 || float === 0 ? 0 : 2,
-  }).format(float)
+  let result = getCurrencyFormatter(currency, false, Math.abs(float) >= 1 || float === 0 ? 0 : 2).format(float)
 
   // +1 for the currency symbol
   if (result.length > maxLength + 1) {
-    result = new Intl.NumberFormat(locale, {
-      style: 'currency',
-      currency,
-      currencyDisplay: 'narrowSymbol',
-      notation: 'compact',
-      maximumFractionDigits: 2,
-    }).format(float)
+    result = getCurrencyFormatter(currency, true, 2).format(float)
   }
 
+  return result.replace(/^(\D+)/, '$1 ')
+}
+
+export const formatCurrencyPrecise = (number: string | number, currency: string): string => {
+  const result = getCurrencyFormatter(currency, false, 2, 2).format(Number(number))
   return result.replace(/^(\D+)/, '$1 ')
 }


### PR DESCRIPTION
## What it solves

Resolves #3978

## How this PR fixes it

Show precise full token and fiat amounts on hover.

<img width="789" alt="Screenshot 2024-07-22 at 14 51 52" src="https://github.com/user-attachments/assets/8542fe7d-2980-43fb-9df7-f006c20851b5">
