### PR TITLE
fix: Harden condition for loading spending limits

### DIFF
--- a/src/hooks/loadables/useLoadSpendingLimits.ts
+++ b/src/hooks/loadables/useLoadSpendingLimits.ts
@@ -103,7 +103,7 @@ export const useLoadSpendingLimits = (): AsyncResult<SpendingLimitState[]> => {
 
   const [data, error, loading] = useAsync<SpendingLimitState[] | undefined>(
     () => {
-      if (!provider || !safeLoaded || !safe.modules || !tokenInfoFromBalances) return
+      if (!provider || !safeLoaded || !safe.modules || tokenInfoFromBalances.length === 0) return
 
       return getSpendingLimits(provider, safe.modules, safeAddress, chainId, tokenInfoFromBalances)
     },


### PR DESCRIPTION
## What it solves

Part of #2414 

## How this PR fixes it

- `getSpendingLimits` was called twice because the condition only checked for the existence of `tokenInfoFromBalances` but the initial value is an empty array so it should check the length of the array instead

## How to test it

1. Open a Safe with a spending limit
2. It should still be visible under settings and when trying to create a transaction

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
