### PR TITLE
Revert "Chore: switch to pull_request_target"

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,7 +1,7 @@
 name: Deploy to dev/staging
 
 on:
-  pull_request_target:
+  pull_request:
 
   push:
     branches:

--- a/.github/workflows/e2e-regression.yml
+++ b/.github/workflows/e2e-regression.yml
@@ -1,7 +1,7 @@
 name: Regression tests
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - 'release**'
       - 'release/**'

--- a/.github/workflows/e2e-safe-apps.yml
+++ b/.github/workflows/e2e-safe-apps.yml
@@ -1,7 +1,7 @@
 name: Safe Apps e2e
 
 on:
-  pull_request_target:
+  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,7 +1,7 @@
 name: Smoke tests
 
 on:
-  pull_request_target:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -4,7 +4,7 @@
 name: 'Next.js Bundle Analysis'
 
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches:
       - dev

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,6 +1,6 @@
 name: Unit tests
 on:
-  pull_request_target:
+  pull_request:
 
   push:
     branches:


### PR DESCRIPTION
Reverts safe-global/safe-wallet-web#3966
We didn't achieve the expected outcome. It turned out that code from the PR was completely ignored and instead the base branch was used for the deployment.