### PR TITLE
Fix: align assets table

### DIFF
--- a/src/components/balances/AssetsTable/index.tsx
+++ b/src/components/balances/AssetsTable/index.tsx
@@ -164,7 +164,7 @@ const AssetsTable = ({
                           inheritViewBox
                           color="error"
                           fontSize="small"
-                          sx={{ verticalAlign: 'middle', ml: 0.5, mr: '-20px' }}
+                          sx={{ verticalAlign: 'middle', ml: 0.5, mr: [0, '-20px'] }}
                         />
                       </span>
                     </Tooltip>

--- a/src/components/balances/AssetsTable/index.tsx
+++ b/src/components/balances/AssetsTable/index.tsx
@@ -164,7 +164,7 @@ const AssetsTable = ({
                           inheritViewBox
                           color="error"
                           fontSize="small"
-                          sx={{ verticalAlign: 'middle', marginLeft: 0.5 }}
+                          sx={{ verticalAlign: 'middle', ml: 0.5, mr: '-20px' }}
                         />
                       </span>
                     </Tooltip>

--- a/src/components/common/EnhancedTable/index.tsx
+++ b/src/components/common/EnhancedTable/index.tsx
@@ -88,7 +88,7 @@ function EnhancedTableHead(props: EnhancedTableHeadProps) {
                   active={orderBy === headCell.id}
                   direction={orderBy === headCell.id ? order : 'asc'}
                   onClick={createSortHandler(headCell.id)}
-                  sx={{ mr: '-26px' }}
+                  sx={{ mr: [0, '-26px'] }}
                 >
                   {headCell.label}
                   {orderBy === headCell.id ? (

--- a/src/components/common/EnhancedTable/index.tsx
+++ b/src/components/common/EnhancedTable/index.tsx
@@ -88,6 +88,7 @@ function EnhancedTableHead(props: EnhancedTableHeadProps) {
                   active={orderBy === headCell.id}
                   direction={orderBy === headCell.id ? order : 'asc'}
                   onClick={createSortHandler(headCell.id)}
+                  sx={{ mr: '-26px' }}
                 >
                   {headCell.label}
                   {orderBy === headCell.id ? (

--- a/src/components/transactions/TxDetails/styles.module.css
+++ b/src/components/transactions/TxDetails/styles.module.css
@@ -33,7 +33,7 @@
   margin-left: calc(var(--space-2) * -1);
   margin-right: calc(var(--space-2) * -1);
   padding: var(--space-2);
-  padding-top: var(--space-3)
+  padding-top: var(--space-3);
 }
 .txData,
 .swapOrder {


### PR DESCRIPTION
## What it solves

Visually align columns and headers in the assets table.

Before:
<img width="1007" alt="Screenshot 2024-07-23 at 09 27 32" src="https://github.com/user-attachments/assets/cdabcb69-9f82-44be-91e5-233da41a8b8b">

After:
<img width="1055" alt="Screenshot 2024-07-23 at 09 35 51" src="https://github.com/user-attachments/assets/6c81193c-8b4d-427f-bd44-efb2e29a084d">