### PR TITLE
fix: Use text color for tx dialog content element

### DIFF
--- a/src/components/common/TxModalDialog/index.tsx
+++ b/src/components/common/TxModalDialog/index.tsx
@@ -43,7 +43,9 @@ const TxModalDialog = ({
         </div>
       </DialogTitle>
       <DialogContent dividers={false}>
-        <DialogContentText tabIndex={-1}>{children}</DialogContentText>
+        <DialogContentText component="div" tabIndex={-1} color="text.primary">
+          {children}
+        </DialogContentText>
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
## What it solves

Resolves #3985 

## How this PR fixes it

- Changes the dialog element to a `div` to resolve react errors
- Explicitely adds `text.primary` as color for this element so that child elements inherit it

## How to test it

1. Open a Safe
2. Create a new transaction
3. Observe the title and network name are readable

## Screenshots
![Screenshot 2024-07-23 at 13 31 18](https://github.com/user-attachments/assets/b5f8c5f0-0ce5-457c-a710-e03efa7eb824)


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
