### PR TITLE
feat: redesign HexEncodedData

### DIFF
--- a/src/components/transactions/HexEncodedData/index.tsx
+++ b/src/components/transactions/HexEncodedData/index.tsx
@@ -23,7 +23,7 @@ export const HexEncodedData = ({ hexData, title, limit = 20 }: Props): ReactElem
   }
 
   const firstBytes = (
-    <Tooltip title="The first 4 bytes determine the method that gets called" arrow>
+    <Tooltip title="The first 4 bytes determine the contract method that is being called" arrow>
       <b style={{ fontFamily: 'monospace' }}>{hexData.slice(0, FIRST_BYTES)}</b>
     </Tooltip>
   )

--- a/src/components/transactions/HexEncodedData/index.tsx
+++ b/src/components/transactions/HexEncodedData/index.tsx
@@ -1,9 +1,10 @@
 import { shortenText } from '@/utils/formatters'
-import { Box, Link } from '@mui/material'
+import { Box, Link, Tooltip } from '@mui/material'
 import type { ReactElement } from 'react'
 import { useState } from 'react'
 import css from './styles.module.css'
 import CopyButton from '@/components/common/CopyButton'
+import FieldsGrid from '@/components/tx/FieldsGrid'
 
 interface Props {
   hexData: string
@@ -21,30 +22,27 @@ export const HexEncodedData = ({ hexData, title, limit = 20 }: Props): ReactElem
     setShowTxData((val) => !val)
   }
 
-  const firstBytes = <b>{hexData.slice(0, FIRST_BYTES)}</b>
+  const firstBytes = (
+    <Tooltip title="The first 4 bytes determine the method that gets called" arrow>
+      <b style={{ fontFamily: 'monospace' }}>{hexData.slice(0, FIRST_BYTES)}</b>
+    </Tooltip>
+  )
   const restBytes = hexData.slice(FIRST_BYTES)
 
-  return (
+  const content = (
     <Box data-testid="tx-hexData" className={css.encodedData}>
-      {title && (
-        <span>
-          <b>{title}: </b>
-        </span>
-      )}
-
       <CopyButton text={hexData} />
 
-      {firstBytes}
-      {showExpandBtn ? (
-        <>
-          {showTxData ? restBytes : shortenText(restBytes, limit - FIRST_BYTES)}{' '}
+      <>
+        {firstBytes} {showTxData || !showExpandBtn ? restBytes : shortenText(restBytes, limit - FIRST_BYTES)}{' '}
+        {showExpandBtn && (
           <Link component="button" onClick={toggleExpanded} type="button" sx={{ verticalAlign: 'text-top' }}>
             Show {showTxData ? 'less' : 'more'}
           </Link>
-        </>
-      ) : (
-        <span>{restBytes}</span>
-      )}
+        )}
+      </>
     </Box>
   )
+
+  return title ? <FieldsGrid title={title}>{content}</FieldsGrid> : content
 }

--- a/src/components/transactions/HexEncodedData/index.tsx
+++ b/src/components/transactions/HexEncodedData/index.tsx
@@ -24,7 +24,7 @@ export const HexEncodedData = ({ hexData, title, limit = 20 }: Props): ReactElem
 
   const firstBytes = (
     <Tooltip title="The first 4 bytes determine the contract method that is being called" arrow>
-      <b style={{ fontFamily: 'monospace' }}>{hexData.slice(0, FIRST_BYTES)}</b>
+      <b>{hexData.slice(0, FIRST_BYTES)}</b>
     </Tooltip>
   )
   const restBytes = hexData.slice(FIRST_BYTES)


### PR DESCRIPTION
## What this PR changes
Makes small adjustments to HexEncodedData:

- Tooltip explaining why first 10 chars are highlighted
- Uses the FieldGrid component for the title

## Screenshots
Before:
![Screenshot 2024-07-23 at 15 35 06](https://github.com/user-attachments/assets/778112cc-4a69-4b32-a262-013835cb9cbe)

After:
![Screenshot 2024-07-23 at 15 32 58](https://github.com/user-attachments/assets/d242d519-68b3-42ac-8202-bf32dae72b5b)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
