### PR TITLE
fix: hide twap status when we don’t know the state

### DIFF
--- a/src/features/swap/components/SwapOrder/index.tsx
+++ b/src/features/swap/components/SwapOrder/index.tsx
@@ -42,6 +42,8 @@ type SwapOrderProps = {
   txInfo?: Order
 }
 
+const TWAP_PARTS_STATUS_THRESHOLD = 10
+
 const AmountRow = ({ order }: { order: Order }) => {
   const { sellToken, buyToken, sellAmount, buyAmount, kind } = order
   const isSellOrder = kind === 'sell'
@@ -214,9 +216,9 @@ export const TwapOrder = ({ order }: { order: SwapTwapOrder }) => {
   const isPartiallyFilled = isOrderPartiallyFilled(order)
   const expires = new Date(validUntil * 1000)
   const now = new Date()
-
   const orderKindLabel = capitalize(kind)
 
+  const isStatusKnown = Number(numberOfParts) <= TWAP_PARTS_STATUS_THRESHOLD
   return (
     <DataTable
       header={`${orderKindLabel} order`}
@@ -253,9 +255,13 @@ export const TwapOrder = ({ order }: { order: SwapTwapOrder }) => {
             {formatDateTime(validUntil * 1000)}
           </DataRow>
         ),
-        <DataRow key="Status" title="Status">
-          <StatusLabel status={isPartiallyFilled ? 'partiallyFilled' : status} />
-        </DataRow>,
+        isStatusKnown ? (
+          <DataRow key="Status" title="Status">
+            <StatusLabel status={isPartiallyFilled ? 'partiallyFilled' : status} />
+          </DataRow>
+        ) : (
+          <Fragment key="status" />
+        ),
       ]}
     />
   )


### PR DESCRIPTION
TWAP orders are missing a backend service where we can ask for the status. In reality to determine the current twap status we have to iterrate through all twap parts and look at their individual statuses. This is not a viable solution for twap orders with many parts, so we’ve decided to not display the status until CoW comes up with a backend service.

## What it solves
TWAP orders with more than 10 parts have wrong status

## How this PR fixes it
Right now it is impossible for us to determine the twap status if the we have more than 10 parts. For such "large orders" we hide the status.

## How to test it
This order https://safe-wallet-web.dev.5afe.dev/transactions/tx?safe=gno:0x23b4f73fb31e89b27de17f9c5de2660cc1fb0cdf&id=multisig_0x23b4f73FB31e89B27De17f9c5DE2660cc1FB0CdF_0x54b00ae268f3f3e84a2323fc8e03043437b64442e13232b14488bbed74da10d2

shows status "Pending execution" - which is wrong anyway...

With the changes in this branch the order won't have any status displayed.

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
