### PR TITLE
fix: Don't parse amount when removing spending limit

### DIFF
--- a/src/components/tx-flow/flows/RemoveSpendingLimit/RemoveSpendingLimit.tsx
+++ b/src/components/tx-flow/flows/RemoveSpendingLimit/RemoveSpendingLimit.tsx
@@ -1,7 +1,7 @@
 import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import { getSpendingLimitInterface, getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimitContracts'
 import useChainId from '@/hooks/useChainId'
-import { useContext, useEffect, useMemo } from 'react'
+import { useContext, useEffect } from 'react'
 import { SafeTxContext } from '../../SafeTxProvider'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { Grid, Typography } from '@mui/material'
@@ -10,7 +10,6 @@ import { relativeTime } from '@/utils/date'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 import useBalances from '@/hooks/useBalances'
 import SendAmountBlock from '@/components/tx-flow/flows/TokenTransfer/SendAmountBlock'
-import { safeParseUnits } from '@/utils/formatters'
 import SpendingLimitLabel from '@/components/common/SpendingLimitLabel'
 import { createTx } from '@/services/tx/tx-sender'
 
@@ -24,10 +23,7 @@ export const RemoveSpendingLimit = ({ params }: { params: SpendingLimitState }) 
   const { balances } = useBalances()
   const token = balances.items.find((item) => item.tokenInfo.address === params.token.address)
 
-  const amountInWei = useMemo(
-    () => safeParseUnits(params.amount, token?.tokenInfo.decimals)?.toString() || '0',
-    [params.amount, token?.tokenInfo.decimals],
-  )
+  const amountInWei = params.amount
 
   useEffect(() => {
     const spendingLimitAddress = getSpendingLimitModuleAddress(chainId)


### PR DESCRIPTION
## What it solves

Resolves #3992

## How this PR fixes it

- The amount when removing a spending limit is already in wei so no need to parse it

## How to test it

1. Open a safe with a spending limit
2. Remove the spending limit
3. Observe the amount is shown correctly

## Screenshots
<img width="718" alt="Screenshot 2024-07-24 at 15 29 23" src="https://github.com/user-attachments/assets/a60f2321-7d93-4ebd-bb38-ac1dfb0c93c6">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
