### PR TITLE
Refactor: update react-redux and redux-toolkit to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@mui/icons-material": "^5.14.20",
     "@mui/material": "^5.14.20",
     "@mui/x-date-pickers": "^5.0.20",
-    "@reduxjs/toolkit": "^1.9.5",
+    "@reduxjs/toolkit": "^2.2.6",
     "@safe-global/api-kit": "^2.3.2",
     "@safe-global/protocol-kit": "^3.1.1",
     "@safe-global/safe-apps-sdk": "^9.1.0",
@@ -90,7 +90,7 @@
     "react-gtm-module": "^2.0.11",
     "react-hook-form": "7.41.1",
     "react-papaparse": "^4.0.2",
-    "react-redux": "^8.0.5",
+    "react-redux": "^9.1.2",
     "semver": "^7.5.2",
     "zodiac-roles-deployments": "^2.2.5"
   },

--- a/src/features/counterfactual/store/undeployedSafesSlice.ts
+++ b/src/features/counterfactual/store/undeployedSafesSlice.ts
@@ -2,6 +2,7 @@ import type { PayMethod } from '@/features/counterfactual/PayNowPayLater'
 import { type RootState } from '@/store'
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import type { PredictedSafeProps } from '@safe-global/protocol-kit'
+import { selectChainIdAndSafeAddress } from '@/store/common'
 
 export enum PendingSafeStatus {
   AWAITING_EXECUTION = 'AWAITING_EXECUTION',
@@ -91,7 +92,7 @@ export const selectUndeployedSafes = (state: RootState): UndeployedSafesState =>
 }
 
 export const selectUndeployedSafe = createSelector(
-  [selectUndeployedSafes, (_, chainId: string, address: string) => [chainId, address]],
+  [selectUndeployedSafes, selectChainIdAndSafeAddress],
   (undeployedSafes, [chainId, address]): UndeployedSafe | undefined => {
     return undeployedSafes[chainId]?.[address]
   },

--- a/src/hooks/useDraftBatch.ts
+++ b/src/hooks/useDraftBatch.ts
@@ -7,6 +7,7 @@ import { selectBatchBySafe, addTx, removeTx } from '@/store/batchSlice'
 import { type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 import { BATCH_EVENTS, trackEvent } from '@/services/analytics'
 import { txDispatch, TxEvent } from '@/services/tx/txEvents'
+import { shallowEqual } from 'react-redux'
 
 export const useUpdateBatch = () => {
   const chainId = useChainId()
@@ -49,6 +50,6 @@ export const useUpdateBatch = () => {
 export const useDraftBatch = (): DraftBatchItem[] => {
   const chainId = useChainId()
   const safeAddress = useSafeAddress()
-  const batch = useAppSelector((state) => selectBatchBySafe(state, chainId, safeAddress))
+  const batch = useAppSelector((state) => selectBatchBySafe(state, chainId, safeAddress), shallowEqual)
   return batch
 }

--- a/src/hooks/usePendingTxs.ts
+++ b/src/hooks/usePendingTxs.ts
@@ -15,11 +15,12 @@ import {
   isTransactionListItem,
 } from '@/utils/transaction-guards'
 import useSafeInfo from './useSafeInfo'
+import { shallowEqual } from 'react-redux'
 
 const usePendingTxIds = (): Array<TransactionSummary['id']> => {
   const { safe, safeAddress } = useSafeInfo()
   const { chainId } = safe
-  return useAppSelector((state) => selectPendingTxIdsBySafe(state, chainId, safeAddress))
+  return useAppSelector((state) => selectPendingTxIdsBySafe(state, chainId, safeAddress), shallowEqual)
 }
 
 export const useHasPendingTxs = (): boolean => {

--- a/src/services/safe-wallet-provider/useSafeWalletProvider.test.tsx
+++ b/src/services/safe-wallet-provider/useSafeWalletProvider.test.tsx
@@ -9,6 +9,7 @@ import { act, renderHook } from '@/tests/test-utils'
 import { TxModalContext } from '@/components/tx-flow'
 import useSafeWalletProvider, { _useTxFlowApi } from './useSafeWalletProvider'
 import { SafeWalletProvider } from '.'
+import type { RootState } from '@/store'
 import { makeStore } from '@/store'
 import * as messages from '@/utils/safe-messages'
 import { faker } from '@faker-js/faker'
@@ -111,10 +112,19 @@ describe('useSafeWalletProvider', () => {
 
       const mockSetTxFlow = jest.fn()
 
+      const testStore = makeStore({
+        settings: {
+          signing: {
+            onChainSigning: false,
+            blindSigning: false,
+          },
+        },
+      } as Partial<RootState>)
+
       const { result } = renderHook(() => _useTxFlowApi('1', '0x1234567890000000000000000000000000000000'), {
         // TODO: Improve render/renderHook to allow custom wrappers within the "defaults"
         wrapper: ({ children }) => (
-          <Provider store={makeStore({ settings: { signing: { useOnChainSigning: false } } })}>
+          <Provider store={testStore}>
             <TxModalContext.Provider value={{ setTxFlow: mockSetTxFlow } as any}>{children}</TxModalContext.Provider>
           </Provider>
         ),

--- a/src/store/__tests__/swapOrderSlice.test.ts
+++ b/src/store/__tests__/swapOrderSlice.test.ts
@@ -8,11 +8,22 @@ import {
 } from '@safe-global/safe-gateway-typescript-sdk'
 import * as notificationsSlice from '@/store/notificationsSlice'
 
+import { type TypedStartListening } from '@reduxjs/toolkit'
+import { type RootState, type AppDispatch } from '@/store' // adjust the import path as needed
+
+type StartListeningType = TypedStartListening<RootState, AppDispatch> & {
+  withTypes: () => TypedStartListening<RootState, AppDispatch>
+} & jest.Mock
+const createStartListeningMock = () => {
+  const mock = jest.fn() as unknown as StartListeningType
+  mock.withTypes = jest.fn().mockReturnValue(mock)
+  return mock
+}
 describe('swapOrderSlice', () => {
   describe('swapOrderListener', () => {
     const listenerMiddleware = listenerMiddlewareInstance
     const mockDispatch = jest.fn()
-    const startListeningMock = jest.fn()
+    const startListeningMock = createStartListeningMock()
 
     beforeEach(() => {
       jest.clearAllMocks()
@@ -158,7 +169,7 @@ describe('swapOrderSlice', () => {
     const listenerMiddleware = listenerMiddlewareInstance
     const mockDispatch = jest.fn()
     const showNotificationSpy = jest.spyOn(notificationsSlice, 'showNotification')
-    const startListeningMock = jest.fn()
+    const startListeningMock = createStartListeningMock()
 
     beforeEach(() => {
       jest.clearAllMocks()

--- a/src/store/batchSlice.ts
+++ b/src/store/batchSlice.ts
@@ -1,6 +1,7 @@
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import type { TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 import type { RootState } from '.'
+import { selectChainIdAndSafeAddress } from '@/store/common'
 
 export type DraftBatchItem = {
   id: string
@@ -65,7 +66,7 @@ const selectAllBatches = (state: RootState): BatchTxsState => {
 }
 
 export const selectBatchBySafe = createSelector(
-  [selectAllBatches, (_, chainId: string, safeAddress: string) => [chainId, safeAddress]],
+  [selectAllBatches, selectChainIdAndSafeAddress],
   (allBatches, [chainId, safeAddress]): DraftBatchItem[] => {
     return allBatches[chainId]?.[safeAddress] || []
   },

--- a/src/store/broadcast.ts
+++ b/src/store/broadcast.ts
@@ -1,22 +1,23 @@
 import type { Store } from 'redux'
-import type { Middleware, PreloadedState } from '@reduxjs/toolkit'
+import type { Middleware } from '@reduxjs/toolkit'
 import type { RootState } from '@/store'
-
-type PreloadedRootState = PreloadedState<RootState>
 
 const BC_NAME = 'SAFE__store-updates'
 const tabId = Math.random().toString(32).slice(2)
 let broadcast: BroadcastChannel | undefined
 
-export const broadcastState = <K extends keyof PreloadedRootState>(sliceNames: K[]): Middleware<{}, RootState> => {
-  return (_) => (next) => (action) => {
+export const broadcastState = <K extends keyof RootState>(sliceNames: K[]): Middleware<{}, RootState> => {
+  return (_) => (next) => (action: unknown) => {
     const result = next(action)
 
     // Broadcast actions that aren't being already broadcasted
-    if (!action._isBroadcasted) {
-      const sliceType = action.type.split('/')[0]
-      if (sliceNames.includes(sliceType)) {
-        broadcast?.postMessage({ action, tabId })
+    if (typeof action === 'object' && action !== null) {
+      const actionObj = action as { _isBroadcasted?: boolean; type?: string }
+      if (!actionObj._isBroadcasted && actionObj.type) {
+        const sliceType = actionObj.type.split('/')[0]
+        if (sliceNames.includes(sliceType as K)) {
+          broadcast?.postMessage({ action, tabId })
+        }
       }
     }
 

--- a/src/store/common.ts
+++ b/src/store/common.ts
@@ -1,4 +1,5 @@
-import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { RootState } from '@/store/index'
 
 export type Loadable<T> = {
   data: T
@@ -32,3 +33,9 @@ export const makeLoadableSlice = <N extends string, T>(name: N, data: T) => {
     selector,
   }
 }
+
+// Memoized selector for chainId and safeAddress
+export const selectChainIdAndSafeAddress = createSelector(
+  [(_: RootState, chainId: string) => chainId, (_: RootState, _chainId: string, safeAddress: string) => safeAddress],
+  (chainId, safeAddress) => [chainId, safeAddress] as const,
+)

--- a/src/store/pendingTxsSlice.ts
+++ b/src/store/pendingTxsSlice.ts
@@ -2,6 +2,7 @@ import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolki
 
 import type { RootState } from '@/store'
 import { sameAddress } from '@/utils/addresses'
+import { selectChainIdAndSafeAddress } from '@/store/common'
 
 export enum PendingStatus {
   SIGNING = 'SIGNING',
@@ -106,9 +107,10 @@ export const selectPendingTxById = createSelector(
 )
 
 export const selectPendingTxIdsBySafe = createSelector(
-  [selectPendingTxs, (_: RootState, chainId: string, safeAddress: string) => [chainId, safeAddress]],
-  (pendingTxs, [chainId, safeAddress]) =>
-    Object.keys(pendingTxs).filter(
+  [selectPendingTxs, selectChainIdAndSafeAddress],
+  (pendingTxs, [chainId, safeAddress]) => {
+    return Object.keys(pendingTxs).filter(
       (id) => pendingTxs[id].chainId === chainId && sameAddress(pendingTxs[id].safeAddress, safeAddress),
-    ),
+    )
+  },
 )

--- a/src/store/persistStore.ts
+++ b/src/store/persistStore.ts
@@ -1,13 +1,11 @@
-import type { Middleware, PreloadedState } from '@reduxjs/toolkit'
+import type { Middleware } from '@reduxjs/toolkit'
 
 import local from '@/services/local-storage/local'
 import type { RootState } from '@/store'
 
-type PreloadedRootState = PreloadedState<RootState>
-
-export const getPreloadedState = <K extends keyof PreloadedRootState>(sliceNames: K[]): PreloadedRootState => {
-  return sliceNames.reduce<PreloadedRootState>((preloadedState, sliceName) => {
-    const sliceState = local.getItem<PreloadedRootState[K]>(sliceName)
+export const getPreloadedState = <K extends keyof RootState>(sliceNames: K[]): Partial<RootState> => {
+  return sliceNames.reduce<Partial<RootState>>((preloadedState, sliceName) => {
+    const sliceState = local.getItem<RootState[K]>(sliceName as string)
 
     if (sliceState) {
       preloadedState[sliceName] = sliceState
@@ -17,24 +15,26 @@ export const getPreloadedState = <K extends keyof PreloadedRootState>(sliceNames
   }, {})
 }
 
-export const persistState = <K extends keyof PreloadedRootState>(sliceNames: K[]): Middleware<{}, RootState> => {
+export const persistState = <K extends keyof RootState>(sliceNames: K[]): Middleware<{}, RootState> => {
   return (store) => (next) => (action) => {
     const result = next(action)
 
-    // No need to persist broadcasted actions because they are persisted in another tab
-    if (action._isBroadcasted) return result
+    if (typeof action === 'object' && action !== null && 'type' in action) {
+      // No need to persist broadcasted actions because they are persisted in another tab
+      if ('_isBroadcasted' in action && action._isBroadcasted) return result
 
-    const sliceType = action.type.split('/')[0]
-    const name = sliceNames.find((slice) => slice === sliceType)
+      const sliceType = (action as { type: string }).type.split('/')[0]
+      const name = sliceNames.find((slice) => slice === sliceType)
 
-    if (name) {
-      const state = store.getState()
-      const sliceState = state[name]
+      if (name) {
+        const state = store.getState()
+        const sliceState = state[name]
 
-      if (sliceState) {
-        local.setItem(name, sliceState)
-      } else {
-        local.removeItem(name)
+        if (sliceState) {
+          local.setItem(name as string, sliceState)
+        } else {
+          local.removeItem(name as string)
+        }
       }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1104,7 +1104,7 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.6", "@babel/runtime@^7.17.2", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.21.0", "@babel/runtime@^7.22.6", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.6", "@babel/runtime@^7.17.2", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.21.0", "@babel/runtime@^7.22.6", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.24.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.4.tgz#de795accd698007a66ba44add6cc86542aff1edd"
   integrity sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==
@@ -4055,15 +4055,15 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-compose-refs" "1.0.1"
 
-"@reduxjs/toolkit@^1.9.5":
-  version "1.9.7"
-  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.9.7.tgz#7fc07c0b0ebec52043f8cb43510cf346405f78a6"
-  integrity sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==
+"@reduxjs/toolkit@^2.2.6":
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-2.2.6.tgz#4a8356dad9d0c1ab255607a555d492168e0e3bc1"
+  integrity sha512-kH0r495c5z1t0g796eDQAkYbEQ3a1OLYN9o8jQQVZyKyw367pfRGS+qZLkHYvFHiUUdafpoSlQ2QYObIApjPWA==
   dependencies:
-    immer "^9.0.21"
-    redux "^4.2.1"
-    redux-thunk "^2.4.2"
-    reselect "^4.1.8"
+    immer "^10.0.3"
+    redux "^5.0.1"
+    redux-thunk "^3.1.0"
+    reselect "^5.1.0"
 
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
@@ -5832,14 +5832,6 @@
   integrity sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==
   dependencies:
     "@types/unist" "*"
-
-"@types/hoist-non-react-statics@^3.3.1":
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.3.tgz#8bb41d9a88164f82dd2745ff05e637e655f34d19"
-  integrity sha512-Wny3a2UXn5FEA1l7gc6BbpoV5mD1XijZqgkp4TRgDCDL5r3B5ieOFGUX5h3n78Tr1MEG7BfvoM8qeztdvNU0fw==
-  dependencies:
-    "@types/react" "*"
-    hoist-non-react-statics "^3.3.0"
 
 "@types/html-minifier-terser@^6.0.0":
   version "6.1.0"
@@ -11878,7 +11870,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -12141,10 +12133,10 @@ image-size@~0.5.0:
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
   integrity sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==
 
-immer@^9.0.21:
-  version "9.0.21"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.21.tgz#1e025ea31a40f24fb064f1fef23e931496330176"
-  integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==
+immer@^10.0.3:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-10.1.1.tgz#206f344ea372d8ea176891545ee53ccc062db7bc"
+  integrity sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==
 
 immutable@^4.0.0:
   version "4.3.4"
@@ -15937,16 +15929,12 @@ react-qr-reader@^2.2.1:
     prop-types "^15.7.2"
     webrtc-adapter "^7.2.1"
 
-react-redux@^8.0.5:
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-8.1.3.tgz#4fdc0462d0acb59af29a13c27ffef6f49ab4df46"
-  integrity sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==
+react-redux@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-9.1.2.tgz#deba38c64c3403e9abd0c3fbeab69ffd9d8a7e4b"
+  integrity sha512-0OA4dhM1W48l3uzmv6B7TXPCGmokUU4p1M44DGN2/D9a1FjVPukVjER1PcPX97jIg6aUeLq1XJo1IpfbgULn0w==
   dependencies:
-    "@babel/runtime" "^7.12.1"
-    "@types/hoist-non-react-statics" "^3.3.1"
     "@types/use-sync-external-store" "^0.0.3"
-    hoist-non-react-statics "^3.3.2"
-    react-is "^18.0.0"
     use-sync-external-store "^1.0.0"
 
 react-refresh@^0.14.0:
@@ -16107,17 +16095,15 @@ reduce-flatten@^2.0.0:
   resolved "https://registry.yarnpkg.com/reduce-flatten/-/reduce-flatten-2.0.0.tgz#734fd84e65f375d7ca4465c69798c25c9d10ae27"
   integrity sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==
 
-redux-thunk@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.2.tgz#b9d05d11994b99f7a91ea223e8b04cf0afa5ef3b"
-  integrity sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==
+redux-thunk@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-3.1.0.tgz#94aa6e04977c30e14e892eae84978c1af6058ff3"
+  integrity sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==
 
-redux@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
-  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
-  dependencies:
-    "@babel/runtime" "^7.9.2"
+redux@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-5.0.1.tgz#97fa26881ce5746500125585d5642c77b6e9447b"
+  integrity sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==
 
 reflect.getprototypeof@^1.0.4:
   version "1.0.4"
@@ -16291,10 +16277,10 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
-reselect@^4.1.8:
-  version "4.1.8"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.8.tgz#3f5dc671ea168dccdeb3e141236f69f02eaec524"
-  integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==
+reselect@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-5.1.1.tgz#c766b1eb5d558291e5e550298adb0becc24bb72e"
+  integrity sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==
 
 reserved-words@^0.1.2:
   version "0.1.2"
@@ -18438,10 +18424,15 @@ usb@^2.9.0:
     node-addon-api "^7.0.0"
     node-gyp-build "^4.5.0"
 
-use-sync-external-store@1.2.0, use-sync-external-store@^1.0.0:
+use-sync-external-store@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
+use-sync-external-store@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz#c3b6390f3a30eba13200d2302dcdf1e7b57b2ef9"
+  integrity sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==
 
 utf-8-validate@^5.0.2:
   version "5.0.10"


### PR DESCRIPTION
## What it solves
While I was tracking why a component re-renders I found out that it is due to a reducer always returning a new array. Those kind of errors should actually be reported in dev mode, but our version of redux-tookit was not doing that. After I quickly looked at the changelog it seemed that the relevant code for this was added in redux tookit version 5, but we were on 4. 

I had to bite the bullet and do the update. I did try to do this in the past, but back then didn't want to deal with the type problems this update was bringing with it... Now I no longer had a choice. :)


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
