### PR TITLE
fix: useIsExpiredSwap causing too many rerenders

### DIFF
--- a/src/features/swap/hooks/useIsExpiredSwap.ts
+++ b/src/features/swap/hooks/useIsExpiredSwap.ts
@@ -1,9 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { TransactionInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { isSwapOrderTxInfo } from '@/utils/transaction-guards'
-import useIntervalCounter from '@/hooks/useIntervalCounter'
-
-const INTERVAL_IN_MS = 10_000
 
 /**
  * Checks the expiry time of a swap every 10s
@@ -12,13 +9,33 @@ const INTERVAL_IN_MS = 10_000
  */
 const useIsExpiredSwap = (txInfo: TransactionInfo) => {
   const [isExpired, setIsExpired] = useState<boolean>(false)
-  const [counter] = useIntervalCounter(INTERVAL_IN_MS)
+  const timerRef = useRef<NodeJS.Timeout | null>(null)
 
   useEffect(() => {
     if (!isSwapOrderTxInfo(txInfo)) return
 
-    setIsExpired(Date.now() > txInfo.validUntil * 1000)
-  }, [counter, txInfo])
+    const checkExpiry = () => {
+      const now = Date.now()
+      const expiryTime = txInfo.validUntil * 1000
+
+      if (now > expiryTime) {
+        setIsExpired(true)
+      } else {
+        // Set a timeout for the exact moment it will expire
+        timerRef.current = setTimeout(() => {
+          setIsExpired(true)
+        }, expiryTime - now)
+      }
+    }
+
+    checkExpiry()
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+      }
+    }
+  }, [txInfo])
 
   return isExpired
 }

--- a/src/features/swap/hooks/useIsExpiredSwap.ts
+++ b/src/features/swap/hooks/useIsExpiredSwap.ts
@@ -3,8 +3,8 @@ import type { TransactionInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { isSwapOrderTxInfo } from '@/utils/transaction-guards'
 
 /**
- * Checks the expiry time of a swap every 10s
- * and returns true if the swap expired
+ * Checks whether a swap has expired and if it hasn't it sets a timeout
+ * for the exact moment it will expire
  * @param txInfo
  */
 const useIsExpiredSwap = (txInfo: TransactionInfo) => {


### PR DESCRIPTION
## What it solves
The Hook was using IntervalCounter and despite the state of the hook not changing, the interval counter was being updated, which in turn caused every component using this hook to rerender.

Since this hook is used in TXSummary it meant that the whole TX History or TX Queue were rerendered every 10s degrading the performance.

No unnecessary rerenders every 10s

## How to test it
Easiest way to see the improvement is to use the react devtools extension and make sure that "highlight updates when component render" is turned on. Without the fixes in this PR you will see the History page constantly rerenering
![grafik](https://github.com/user-attachments/assets/cf975fab-99b3-4cb0-9444-a218468bc64e)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
