### PR TITLE
fix: Add padding to swap tx details

### DIFF
--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -76,7 +76,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
       {/* /Details */}
       <div className={`${css.details} ${isUnsigned ? css.noSigners : ''}`}>
         {isOrderTxInfo(txDetails.txInfo) && (
-          <div>
+          <div className={css.swapOrder}>
             <ErrorBoundary fallback={<div>Error parsing data</div>}>
               <SwapOrder txData={txDetails.txData} txInfo={txDetails.txInfo} />
             </ErrorBoundary>


### PR DESCRIPTION
## What it solves

Resolves #4000

Fixes a regression introduced in #3893 

## How this PR fixes it

- Adds back the `swapOrder` class to the wrapper element

## How to test it

1. Open a Safe with a TWAP order in the history or queue
2. Observe there is padding in the tx details

## Screenshots
<img width="848" alt="Screenshot 2024-07-29 at 15 38 22" src="https://github.com/user-attachments/assets/7d2eea81-f3fc-4378-8575-5847846f2b6e">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
