### PR TITLE
fix: swap token selection flickers

### DIFF
--- a/src/features/swap/components/SwapButton/index.tsx
+++ b/src/features/swap/components/SwapButton/index.tsx
@@ -37,7 +37,7 @@ const SwapButton = ({
                 pathname: AppRoutes.swap,
                 query: {
                   ...router.query,
-                  token: tokenInfo.symbol,
+                  token: tokenInfo.address,
                   amount,
                 },
               })

--- a/src/features/swap/index.tsx
+++ b/src/features/swap/index.tsx
@@ -52,6 +52,7 @@ const CANCEL_ORDER_SIGHASH = id('invalidateOrder(bytes)').slice(0, 10)
 
 type Params = {
   sell?: {
+    // The token address
     asset: string
     amount: string
   }
@@ -237,10 +238,10 @@ const SwapWidget = ({ sell }: Params) => {
               bps: newFeeBps,
             },
             sell: {
-              asset: sellToken?.symbol,
+              asset: sellToken?.address,
             },
             buy: {
-              asset: buyToken?.symbol,
+              asset: buyToken?.address,
             },
           }))
 


### PR DESCRIPTION


## What it solves
Tokens can end up having the same token abbreviation, but they always have different token addresses. If the user select a token that has the same abbreviation as another token in the list the widget starts flickering between the selected tokens and resets to WETH for input token and no selected output token. By opting to use addresses instead the problem seems to be resolved.

## How to test it
Go to the swaps page.
For source token select: USDC
for target token select: APE

Without this commit the token selection will flicker and would reset to WETH for source token and nothing for output token. With this PR source token would be USDC and target token would be the APE token selected.

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
