### PR TITLE
fix: account list address and balance are misaligned for smaller screens

### DIFF
--- a/src/components/welcome/MyAccounts/styles.module.css
+++ b/src/components/welcome/MyAccounts/styles.module.css
@@ -72,6 +72,7 @@
   }
   .safeLink :nth-child(3) {
     grid-area: c;
+    text-align: left;
   }
   .safeLink :nth-child(4) {
     grid-area: d;


### PR DESCRIPTION
## What it solves

Resolves #3970

## How this PR fixes it
- Stack the balance underneath the address for smaller screens

## How to test it
- open the safe list in the sidebar or the accounts page
- resize the screen to be < 500px
- See that the address and balance are displayed on top of one another.

## Screenshots
![image](https://github.com/user-attachments/assets/affe3b9b-25bf-477e-9725-c80db8849fce)


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
