### PR TITLE
fix: Hide transaction checks block if features are disabled

### DIFF
--- a/src/components/tx-flow/flows/RecoverAccount/RecoverAccountFlowReview.tsx
+++ b/src/components/tx-flow/flows/RecoverAccount/RecoverAccountFlowReview.tsx
@@ -140,9 +140,7 @@ export function RecoverAccountFlowReview({ params }: { params: RecoverAccountFlo
         <RedefineBalanceChanges />
       </TxCard>
 
-      <TxCard>
-        <TxChecks executionOwner={safe.owners[0].value} />
-      </TxCard>
+      <TxChecks executionOwner={safe.owners[0].value} />
 
       <TxCard>
         <>

--- a/src/components/tx/SignOrExecuteForm/TxChecks.tsx
+++ b/src/components/tx/SignOrExecuteForm/TxChecks.tsx
@@ -1,16 +1,27 @@
+import { isTxSimulationEnabled } from '@/components/tx/security/tenderly/utils'
+import { useCurrentChain, useHasFeature } from '@/hooks/useChains'
+import { FEATURES } from '@/utils/chains'
 import { type ReactElement, useContext } from 'react'
 import { TxSimulation, TxSimulationMessage } from '@/components/tx/security/tenderly'
+import TxCard from '@/components/tx-flow/common/TxCard'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { Box, Typography } from '@mui/material'
 import { Redefine, RedefineMessage } from '@/components/tx/security/redefine'
 
 import css from './styles.module.css'
 
-const TxChecks = ({ executionOwner }: { executionOwner?: string }): ReactElement => {
+const TxChecks = ({ executionOwner }: { executionOwner?: string }): ReactElement | null => {
   const { safeTx } = useContext(SafeTxContext)
+  const chain = useCurrentChain()
+  const isRiskMitigationFeatureEnabled = useHasFeature(FEATURES.RISK_MITIGATION)
+  const isTxSimulationFeatureEnabled = isTxSimulationEnabled(chain)
+
+  if (!isTxSimulationFeatureEnabled && !isRiskMitigationFeatureEnabled) {
+    return null
+  }
 
   return (
-    <>
+    <TxCard>
       <Typography variant="h5">Transaction checks</Typography>
 
       <TxSimulation disabled={false} transactions={safeTx} executionOwner={executionOwner} />
@@ -24,7 +35,7 @@ const TxChecks = ({ executionOwner }: { executionOwner?: string }): ReactElement
       <Box className={css.mobileTxCheckMessages}>
         <RedefineMessage />
       </Box>
-    </>
+    </TxCard>
   )
 }
 

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -142,11 +142,7 @@ export const SignOrExecuteForm = ({
         {!isCounterfactualSafe && <RedefineBalanceChanges />}
       </TxCard>
 
-      {!isCounterfactualSafe && (
-        <TxCard>
-          <TxChecks />
-        </TxCard>
-      )}
+      {!isCounterfactualSafe && <TxChecks />}
 
       <TxCard>
         <ConfirmationTitle


### PR DESCRIPTION
## What it solves

Resolves #3584

## How this PR fixes it

- Hides the Transaction checks block if both redefine and simulation flags are disabled

## How to test it

1. Open a safe on a network without stransaction checks like zksync era
2. Create a transaction
3. Observe no Transaction checks block

## Screenshots
<img width="727" alt="Screenshot 2024-07-29 at 19 12 00" src="https://github.com/user-attachments/assets/08ae272d-5e6c-4973-9792-71490f08ea51">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
