### PR TITLE
fix:Copy safe address on mobile view

### DIFF
--- a/src/components/common/CopyButton/index.tsx
+++ b/src/components/common/CopyButton/index.tsx
@@ -10,7 +10,7 @@ export interface ButtonProps {
   children?: ReactNode
   initialToolTipText?: string
   ariaLabel?: string
-  onCopy?: () => void
+  onCopy?: (e: React.SyntheticEvent) => void
   dialogContent?: ReactElement
 }
 
@@ -19,7 +19,7 @@ const CopyButton = ({
   className,
   children,
   initialToolTipText = 'Copy to clipboard',
-  onCopy,
+  onCopy = () => {},
   dialogContent,
 }: ButtonProps): ReactElement => {
   return (


### PR DESCRIPTION
## What it solves
Copy safe address on mobile view doesn't work #3988

## How this PR fixes it
- I have added a fallback function for IOS devices and ensure that it copied the address for every device.
## How to test it
- Open the Safari browser on your mobile device or the simulator from the Safari browser if you have XCode from the App Store.
- Connect your wallet (metamask) or view any account (0x17D47f5a76e9601C4179963E18cc17918564864F) on sepolia.
- Open the sidebar and click on the copy icon.
- Now the safe address is copied.

## Screenshots


https://github.com/user-attachments/assets/c2712aee-a037-40b4-8eac-6719260cef93



## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
