### PR TITLE
Fix: do not show redefine block when no scan is performed

### DIFF
--- a/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
+++ b/src/components/tx-flow/flows/SignMessage/SignMessage.tsx
@@ -305,7 +305,7 @@ const SignMessage = ({ message, safeAppId, requestId }: ProposeProps | ConfirmPr
           </Typography>
           <DecodedMsg message={decodedMessage} isInModal />
 
-          <Accordion sx={{ my: 2, '&.Mui-expanded': { mt: 2 } }}>
+          <Accordion sx={{ mt: 2 }}>
             <AccordionSummary data-testid="message-details" expandIcon={<ExpandMoreIcon />}>
               SafeMessage details
             </AccordionSummary>
@@ -315,7 +315,9 @@ const SignMessage = ({ message, safeAppId, requestId }: ProposeProps | ConfirmPr
             </AccordionDetails>
           </Accordion>
 
-          <Redefine />
+          <Box sx={{ '&:not(:empty)': { mt: 2 } }}>
+            <Redefine />
+          </Box>
         </CardContent>
       </TxCard>
 

--- a/src/components/tx/security/redefine/index.tsx
+++ b/src/components/tx/security/redefine/index.tsx
@@ -48,6 +48,10 @@ const RedefineBlock = () => {
     }
   }, [isRiskIgnored, checkboxRef])
 
+  if (!severityProps && !isLoading && !error) {
+    return null
+  }
+
   return (
     <div className={css.wrapperBox}>
       <Paper
@@ -56,7 +60,7 @@ const RedefineBlock = () => {
         sx={needsRiskConfirmation ? { borderTop: 'none', borderLeft: 'none', borderRight: 'none' } : { border: 'none' }}
       >
         <div>
-          <Typography variant="body2" fontWeight={700}>
+          <Typography variant="body2" fontWeight={700} sx={{ position: 'relative', zIndex: 1 }}>
             Scan for risks
             <Tooltip
               title={


### PR DESCRIPTION
## What it solves

Resolves #3622

Also fixes the tooltip being partially obscured by the redefine logo, causing the tooltip text to not show up when hovering over the bottom part of the tooltip icon.

## How this PR fixes it
- If there is nothing to show in the redefine block then don't render the component at all.
- set z-index on the tooltip icon so the tooltip text always shows up.

## How to test it
- Open the message signing confirmation screen for a message where redefine checks are not performed. For example signing in to opensea.
- See that the redefine block is not shown. [1]
- When the redefine block is shown (eg. executing a send tx on a supported network), see that the redefine tooltip text is shown when hovering over any part of the tooltip icon. [2]

## Screenshots
[1]
![image](https://github.com/user-attachments/assets/9ccc3b20-9e52-49ca-989a-6973c42f164f)

[2] 
![image](https://github.com/user-attachments/assets/4cd888c6-95b6-403f-a34e-b31aa174076a)



## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
