### PR TITLE
fix: accept canonical mastercopy

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@safe-global/api-kit": "^2.3.2",
     "@safe-global/protocol-kit": "^4.0.1",
     "@safe-global/safe-apps-sdk": "^9.1.0",
-    "@safe-global/safe-deployments": "^1.37.1",
+    "@safe-global/safe-deployments": "^1.37.2",
     "@safe-global/safe-gateway-typescript-sdk": "3.22.1",
     "@safe-global/safe-modules-deployments": "^1.2.0",
     "@sentry/react": "^7.91.0",

--- a/src/hooks/coreSDK/__tests__/safeCoreSDK.test.ts
+++ b/src/hooks/coreSDK/__tests__/safeCoreSDK.test.ts
@@ -215,6 +215,29 @@ describe('safeCoreSDK', () => {
           safeAddress: expect.anything(),
         })
       })
+
+      it('should return an L1 SDK instance for a canonical mastercopy on optimism', async () => {
+        const chainId = '10' // Optimism mainnet
+        const version = '1.3.0'
+
+        const mockProvider = getMockProvider(chainId, version)
+        mockProvider.getNetwork = jest.fn().mockReturnValue({ chainId: BigInt(chainId) })
+
+        await initSafeSDK({
+          provider: mockProvider,
+          chainId,
+          address: toBeHex('0x1', 20),
+          version,
+          implementation: MAINNET_MASTER_COPY,
+          implementationVersionState: ImplementationVersionState.UNKNOWN,
+        })
+
+        expect(Safe.init).toHaveBeenCalledWith({
+          isL1SafeSingleton: true,
+          provider: expect.anything(),
+          safeAddress: expect.anything(),
+        })
+      })
     })
 
     describe('Unsupported contracts', () => {

--- a/src/hooks/coreSDK/safeCoreSDK.ts
+++ b/src/hooks/coreSDK/safeCoreSDK.ts
@@ -59,7 +59,9 @@ export const initSafeSDK = async ({
     const safeL1Deployment = getSafeSingletonDeployment({ network: chainId, version: safeVersion })
     const safeL2Deployment = getSafeL2SingletonDeployment({ network: chainId, version: safeVersion })
 
-    isL1SafeSingleton = masterCopy === safeL1Deployment?.networkAddresses[chainId]
+    isL1SafeSingleton =
+      masterCopy === safeL1Deployment?.networkAddresses[chainId] ||
+      masterCopy === safeL1Deployment?.deployments.canonical?.address
     const isL2SafeMasterCopy = masterCopy === safeL2Deployment?.networkAddresses[chainId]
 
     // Unknown deployment, which we do not want to support
@@ -79,11 +81,16 @@ export const initSafeSDK = async ({
       predictedSafe: undeployedSafe.props,
     })
   }
-
   return Safe.init({
     provider: provider._getConnection().url,
     safeAddress: address,
     isL1SafeSingleton,
+    // @ts-ignore
+    contractNetworks: {
+      [chainId]: {
+        safeSingletonAddress: implementation,
+      },
+    },
   })
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4176,10 +4176,17 @@
   dependencies:
     semver "^7.6.0"
 
-"@safe-global/safe-deployments@^1.37.0", "@safe-global/safe-deployments@^1.37.1":
+"@safe-global/safe-deployments@^1.37.0":
   version "1.37.1"
   resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.1.tgz#d8293c421b1b7445899aec720061be26bb3c4976"
   integrity sha512-duCCQghqw9B/MmHPMXlkPpZwyq3T92unWVnwwhiA8alhush2FZ22+x6uF8bQtk/RYJzkpYzV1tPL/VBLt9U9XQ==
+  dependencies:
+    semver "^7.6.2"
+
+"@safe-global/safe-deployments@^1.37.2":
+  version "1.37.2"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.2.tgz#d63947bf631d63f5991f3732fad08b17b7264505"
+  integrity sha512-kWRim5vY9W/yNKUUehUQDhCHz7NWzXjhkpMDvvnrrkEn9U461zwCcmJmPVnPrjnaY4dPpJsGZSzUuU4+uxH+vg==
   dependencies:
     semver "^7.6.2"
 


### PR DESCRIPTION
## What it solves
Safe deployments 1.37.2 adds canonical deployment addresses.
Those are used when i.e. replaying a 1.3.0 L1 Safe on a L2 chain and on some networks such as Optimism they are not detected currently.

## How this PR fixes it
- Updates safe-deployments
- Also accepts the canonical L1 master copy address

## How to test it
- Open a replayed 1.3.0 L1 Safe on e.g. Optimism

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
