### PR TITLE
fix: format value in sidebar only if decimals exist

### DIFF
--- a/src/components/common/TokenAmount/index.tsx
+++ b/src/components/common/TokenAmount/index.tsx
@@ -28,7 +28,8 @@ const TokenAmount = ({
   const sign = direction === TransferDirection.OUTGOING ? '-' : ''
   const amount =
     decimals !== undefined ? formatVisualAmount(value, decimals, preciseAmount ? PRECISION : undefined) : value
-  const fullAmount = sign + formatVisualAmount(value, decimals, PRECISION) + ' ' + tokenSymbol
+  const fullAmount =
+    decimals !== undefined ? sign + formatVisualAmount(value, decimals, PRECISION) + ' ' + tokenSymbol : value
 
   return (
     <Tooltip title={fullAmount}>


### PR DESCRIPTION
## What it solves

Resolves [RC comment](https://github.com/safe-global/safe-wallet-web/pull/4012#issuecomment-2259523123)

## How this PR fixes it

- Adds the same decimals check for computing the `fullAmount` as is present for `amount`

## How to test it

1. Create a new Safe
2. Observe no formatting units error in the console after creation

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
