### PR TITLE
Tests: Add tags to test types

### DIFF
--- a/.github/workflows/cypress/action.yml
+++ b/.github/workflows/cypress/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Cypress cloud record key'
     required: false
 
+  tag:
+    description: 'Cypress cloud tag key'
+    required: false
+
 runs:
   using: 'composite'
   steps:

--- a/.github/workflows/cypress/action.yml
+++ b/.github/workflows/cypress/action.yml
@@ -54,6 +54,7 @@ runs:
         parallel: true
         browser: chrome
         record: true
+        tag: ${{ inputs.tag }}
         config: baseUrl=http://localhost:8080
       env:
         CYPRESS_RECORD_KEY: ${{ inputs.record_key || fromJSON(inputs.secrets).CYPRESS_RECORD_KEY }}

--- a/.github/workflows/e2e-hp-ondemand.yml
+++ b/.github/workflows/e2e-hp-ondemand.yml
@@ -26,6 +26,7 @@ jobs:
           spec: |
             cypress/e2e/happypath/*.cy.js
           group: 'Happy path on demand tests'
+          tag: 'happypath'
 
       - name: Python setup
         if: always()

--- a/.github/workflows/e2e-ondemand.yml
+++ b/.github/workflows/e2e-ondemand.yml
@@ -27,7 +27,9 @@ jobs:
             cypress/e2e/regression/*.cy.js
             cypress/e2e/safe-apps/*.cy.js
             cypress/e2e/smoke/*.cy.js
+            cypress/e2e/prodhealthcheck/*.cy.js
           group: 'Regression on demand tests'
+          tag: 'regression'
 
       - name: Python setup
         if: always()

--- a/.github/workflows/e2e-regression.yml
+++ b/.github/workflows/e2e-regression.yml
@@ -26,3 +26,4 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           spec: cypress/e2e/**/*.cy.js
           group: 'Regression tests'
+          tag: 'regression'

--- a/.github/workflows/e2e-safe-apps.yml
+++ b/.github/workflows/e2e-safe-apps.yml
@@ -26,4 +26,4 @@ jobs:
           group: 'Safe Apps tests'
           project_id: okn21k
           record_key: ${{ secrets.CYPRESS_SAFE_APPS_RECORD_KEY }}
-
+          tag: 'safeapps'

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -25,3 +25,4 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           spec: cypress/e2e/smoke/*.cy.js
           group: 'Smoke tests'
+          tag: 'smoke'


### PR DESCRIPTION
## What it solves

## How this PR fixes it

- Add tags to test types in workflows.

## How to test it

- Run Cypress tests and observe outcome.
