### PR TITLE
Tests: Set specific cypress version

### DIFF
--- a/.github/workflows/cypress/action.yml
+++ b/.github/workflows/cypress/action.yml
@@ -38,12 +38,6 @@ runs:
         curl -O 'https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb'
         sudo apt-get install ./google-chrome-stable_current_amd64.deb
 
-    - name: Install Chrome 127
-      run: |
-        curl -O https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_127.0.0.0-1_amd64.deb
-        sudo apt-get install -y ./google-chrome-stable_127.0.0.0-1_amd64.deb
-      shell: bash
-
     - name: Install Cypress 13.13.1
       shell: bash
       run: npm install cypress@13.13.1 --legacy-peer-deps

--- a/.github/workflows/cypress/action.yml
+++ b/.github/workflows/cypress/action.yml
@@ -38,6 +38,12 @@ runs:
         curl -O 'https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb'
         sudo apt-get install ./google-chrome-stable_current_amd64.deb
 
+    - name: Install Chrome 127
+      run: |
+        curl -O https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_127.0.0.0-1_amd64.deb
+        sudo apt-get install -y ./google-chrome-stable_127.0.0.0-1_amd64.deb
+      shell: bash
+
     - name: Install Cypress 13.13.1
       shell: bash
       run: npm install cypress@13.13.1 --legacy-peer-deps

--- a/.github/workflows/cypress/action.yml
+++ b/.github/workflows/cypress/action.yml
@@ -40,7 +40,7 @@ runs:
 
     - name: Install Cypress 13.13.1
       shell: bash
-      run: npm install cypress@13.13.1
+      run: npm install cypress@13.13.1 --legacy-peer-deps
 
     - uses: ./.github/workflows/build
       with:

--- a/.github/workflows/cypress/action.yml
+++ b/.github/workflows/cypress/action.yml
@@ -39,6 +39,7 @@ runs:
         sudo apt-get install ./google-chrome-stable_current_amd64.deb
 
     - name: Install Cypress 13.13.1
+      shell: bash
       run: npm install cypress@13.13.1
 
     - uses: ./.github/workflows/build

--- a/.github/workflows/cypress/action.yml
+++ b/.github/workflows/cypress/action.yml
@@ -38,6 +38,9 @@ runs:
         curl -O 'https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb'
         sudo apt-get install ./google-chrome-stable_current_amd64.deb
 
+    - name: Install Cypress 13.13.1
+      run: npm install cypress@13.13.1
+
     - uses: ./.github/workflows/build
       with:
         secrets: ${{ inputs.secrets }}

--- a/.github/workflows/e2e-ondemand.yml
+++ b/.github/workflows/e2e-ondemand.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   e2e:
     runs-on: ubuntu-20.04
+    timeout-minutes: 40
     name: Cypress Regression on demand tests
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -10,6 +10,7 @@ concurrency:
 jobs:
   e2e:
     runs-on: ubuntu-20.04
+    timeout-minutes: 30
     name: Cypress Smoke tests
 
     strategy:


### PR DESCRIPTION
## How this PR fixes it

- Update to Cypress v.13.13.1
- Add timeouts to test runs to avoid pending tests for a long time

## How to test it

- Run Cypress tests and observe outcome
