### PR TITLE
fix: update terms page last updated date

### DIFF
--- a/src/components/common/CookieAndTermBanner/index.tsx
+++ b/src/components/common/CookieAndTermBanner/index.tsx
@@ -75,7 +75,7 @@ export const CookieAndTermBanner = ({
           <Grid item xs>
             <Typography variant="body2" mb={2}>
               By browsing this page, you accept our{' '}
-              <ExternalLink href={AppRoutes.terms}>Terms & Conditions</ExternalLink> (last updated July 2024) and the
+              <ExternalLink href={AppRoutes.terms}>Terms & Conditions</ExternalLink> (last updated August 2024) and the
               use of necessary cookies. By clicking &quot;Accept all&quot; you additionally agree to the use of Beamer
               and Analytics cookies as listed below. <ExternalLink href={AppRoutes.cookie}>Cookie policy</ExternalLink>
             </Typography>

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -12,7 +12,7 @@ const SafeTerms = () => (
     <Typography variant="h1" mb={2}>
       Terms and Conditions
     </Typography>
-    <p>Last updated: July 2024.</p>
+    <p>Last updated: August 2024.</p>
 
     <h3>1. What is the scope of the Terms?</h3>
     <ol start={1}>


### PR DESCRIPTION
## What it solves
Since the latest release went out later than expected, the changes to the terms page went live in August rather than July. 

## How this PR fixes it
Update the 'last updated' date in the terms popup and the terms page itself
