### PR TITLE
Tests: Update cookies acceptance in safe apps

### DIFF
--- a/cypress/e2e/regression/swaps.cy.js
+++ b/cypress/e2e/regression/swaps.cy.js
@@ -42,7 +42,7 @@ describe('Swaps tests', () => {
       swaps.clickOnSettingsBtn()
       swaps.selectInputCurrency(swaps.swapTokens.cow)
       swaps.checkTokenBalance(staticSafes.SEP_STATIC_SAFE_1.substring(4), swaps.swapTokens.cow)
-      swaps.setInputValue(4)
+      swaps.setInputValue(20)
       swaps.selectOutputCurrency(swaps.swapTokens.dai)
       swaps.checkSwapBtnIsVisible()
       swaps.isInputGreaterZero(swaps.outputCurrencyInput).then((isGreaterThanZero) => {
@@ -141,7 +141,7 @@ describe('Swaps tests', () => {
       swaps.setSlippage('0.30')
       swaps.setExpiry('2')
       swaps.clickOnSettingsBtn()
-      swaps.setInputValue(4)
+      swaps.setInputValue(20)
       swaps.selectOutputCurrency(swaps.swapTokens.dai)
       swaps.checkSwapBtnIsVisible()
       swaps.isInputGreaterZero(swaps.outputCurrencyInput).then((isGreaterThanZero) => {
@@ -173,7 +173,7 @@ describe('Swaps tests', () => {
       main.getIframeBody(iframeSelector).then(($frame) => {
         cy.wrap($frame).within(() => {
           swaps.selectInputCurrency(swaps.swapTokens.cow)
-          swaps.setInputValue(4)
+          swaps.setInputValue(20)
           swaps.selectOutputCurrency(swaps.swapTokens.dai)
           swaps.checkSwapBtnIsVisible()
           swaps.clickOnSettingsBtn()

--- a/cypress/e2e/safe-apps/apps_list.cy.js
+++ b/cypress/e2e/safe-apps/apps_list.cy.js
@@ -2,6 +2,7 @@ import * as constants from '../../support/constants'
 import * as main from '../pages/main.page'
 import * as safeapps from '../pages/safeapps.pages'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
+import * as ls from '../../support/localstorage_data.js'
 
 const myCustomAppTitle = 'Cypress Test App'
 const myCustomAppDescrAdded = 'Cypress Test App Description'
@@ -14,11 +15,12 @@ describe('Safe Apps list tests', () => {
   })
 
   beforeEach(() => {
-    cy.clearLocalStorage()
+    cy.clearLocalStorage().then(() => {
+      main.addToLocalStorage(constants.localStorageKeys.SAFE_v2_cookies_1_1, ls.cookies.acceptedCookies)
+    })
     cy.visit(`${constants.appsUrl}?safe=${staticSafes.SEP_STATIC_SAFE_1}`, {
       failOnStatusCode: false,
     })
-    main.acceptCookies()
   })
 
   it('Verify app list can be filtered by app name', () => {

--- a/cypress/e2e/safe-apps/drain_account.spec.cy.js
+++ b/cypress/e2e/safe-apps/drain_account.spec.cy.js
@@ -4,13 +4,21 @@ import * as main from '../pages/main.page'
 import * as safeapps from '../pages/safeapps.pages'
 import * as navigation from '../pages/navigation.page'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
+import * as ls from '../../support/localstorage_data.js'
 
 let safeAppSafes = []
 let iframeSelector
 
-describe('Drain Account tests', { defaultCommandTimeout: 12000 }, () => {
+describe('Drain Account tests', () => {
   before(async () => {
     safeAppSafes = await getSafes(CATEGORIES.safeapps)
+    cy.clearLocalStorage().then(() => {
+      main.addToLocalStorage(constants.localStorageKeys.SAFE_v2_cookies_1_1, ls.cookies.acceptedCookies)
+      main.addToLocalStorage(
+        constants.localStorageKeys.SAFE_v2__SafeApps__infoModal,
+        ls.appPermissions(constants.safeTestAppurl).infoModalAccepted,
+      )
+    })
   })
 
   beforeEach(() => {
@@ -22,10 +30,7 @@ describe('Drain Account tests', { defaultCommandTimeout: 12000 }, () => {
       fixture: 'balances.json',
     })
 
-    cy.clearLocalStorage()
     cy.visit(visitUrl)
-    main.acceptCookies()
-    safeapps.clickOnContinueBtn()
   })
 
   it('Verify drain can be created', () => {

--- a/cypress/e2e/safe-apps/preview_drawer.cy.js
+++ b/cypress/e2e/safe-apps/preview_drawer.cy.js
@@ -2,20 +2,22 @@ import * as constants from '../../support/constants'
 import * as main from '../pages/main.page'
 import * as safeapps from '../pages/safeapps.pages'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
+import * as ls from '../../support/localstorage_data.js'
 
 let staticSafes = []
 
 describe('Preview drawer tests', () => {
   before(async () => {
     staticSafes = await getSafes(CATEGORIES.static)
+    cy.clearLocalStorage().then(() => {
+      main.addToLocalStorage(constants.localStorageKeys.SAFE_v2_cookies_1_1, ls.cookies.acceptedCookies)
+    })
   })
 
   beforeEach(() => {
-    cy.clearLocalStorage()
     cy.visit(`${constants.appsUrl}?safe=${staticSafes.SEP_STATIC_SAFE_2}`, {
       failOnStatusCode: false,
     })
-    main.acceptCookies()
   })
 
   it('Verify the preview drawer is displayed when opening a Safe App from the app list', () => {

--- a/cypress/e2e/safe-apps/safe_permissions.cy.js
+++ b/cypress/e2e/safe-apps/safe_permissions.cy.js
@@ -1,10 +1,16 @@
 import * as constants from '../../support/constants'
 import * as safeapps from '../pages/safeapps.pages'
 import * as main from '../pages/main.page'
+import * as ls from '../../support/localstorage_data.js'
 
 describe('Safe permissions system tests', () => {
+  before(async () => {
+    cy.clearLocalStorage().then(() => {
+      main.addToLocalStorage(constants.localStorageKeys.SAFE_v2_cookies_1_1, ls.cookies.acceptedCookies)
+    })
+  })
+
   beforeEach(() => {
-    cy.clearLocalStorage()
     cy.fixture('safe-app').then((html) => {
       cy.intercept('GET', `${constants.testAppUrl}/*`, html)
       cy.intercept('GET', `*/manifest.json`, {
@@ -17,11 +23,6 @@ describe('Safe permissions system tests', () => {
 
   it('Verify that requesting permissions with wallet_requestPermissions shows the permissions prompt and return the permissions on accept', () => {
     cy.visitSafeApp(constants.testAppUrl + constants.requestPermissionsUrl)
-    main.acceptCookies()
-    safeapps.clickOnContinueBtn()
-    safeapps.verifyWarningDefaultAppMsgIsDisplayed()
-    safeapps.clickOnContinueBtn()
-
     safeapps.verifyPermissionsRequestExists()
     safeapps.verifyAccessToAddressBookExists()
     safeapps.clickOnAcceptBtn()
@@ -56,11 +57,6 @@ describe('Safe permissions system tests', () => {
     })
 
     cy.visitSafeApp(constants.testAppUrl + constants.getPermissionsUrl)
-    main.acceptCookies()
-    safeapps.clickOnContinueBtn()
-    safeapps.verifyWarningDefaultAppMsgIsDisplayed()
-    safeapps.clickOnContinueBtn()
-
     cy.get('@safeAppsMessage').should('have.been.calledWithMatch', {
       data: [
         {

--- a/cypress/e2e/safe-apps/tx-builder.spec.cy.js
+++ b/cypress/e2e/safe-apps/tx-builder.spec.cy.js
@@ -5,6 +5,7 @@ import * as safeapps from '../pages/safeapps.pages'
 import * as createtx from '../../e2e/pages/create_tx.pages'
 import * as navigation from '../pages/navigation.page'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
+import * as ls from '../../support/localstorage_data.js'
 
 let safeAppSafes = []
 let iframeSelector
@@ -12,17 +13,20 @@ let iframeSelector
 describe('Transaction Builder tests', { defaultCommandTimeout: 20000 }, () => {
   before(async () => {
     safeAppSafes = await getSafes(CATEGORIES.safeapps)
+    cy.clearLocalStorage().then(() => {
+      main.addToLocalStorage(constants.localStorageKeys.SAFE_v2_cookies_1_1, ls.cookies.acceptedCookies)
+      main.addToLocalStorage(
+        constants.localStorageKeys.SAFE_v2__SafeApps__infoModal,
+        ls.appPermissions(constants.safeTestAppurl).infoModalAccepted,
+      )
+    })
   })
 
   beforeEach(() => {
     const appUrl = constants.TX_Builder_url
     iframeSelector = `iframe[id="iframe-${appUrl}"]`
     const visitUrl = `/apps/open?safe=${safeAppSafes.SEP_SAFEAPP_SAFE_1}&appUrl=${encodeURIComponent(appUrl)}`
-
-    cy.clearLocalStorage()
     cy.visit(visitUrl)
-    main.acceptCookies()
-    safeapps.clickOnContinueBtn()
   })
 
   it('Verify a simple batch can be created', () => {

--- a/cypress/e2e/safe-apps/tx_modal.cy.js
+++ b/cypress/e2e/safe-apps/tx_modal.cy.js
@@ -1,6 +1,6 @@
 import * as constants from '../../support/constants'
 import * as main from '../pages/main.page'
-import * as safeapps from '../pages/safeapps.pages'
+import * as ls from '../../support/localstorage_data.js'
 
 const testAppName = 'Cypress Test App'
 const testAppDescr = 'Cypress Test App Description'
@@ -8,8 +8,17 @@ const unknownApp = 'unknown'
 const confirmTx = 'Confirm transaction'
 
 describe('Transaction modal tests', () => {
+  before(async () => {
+    cy.clearLocalStorage().then(() => {
+      main.addToLocalStorage(constants.localStorageKeys.SAFE_v2_cookies_1_1, ls.cookies.acceptedCookies)
+      main.addToLocalStorage(
+        constants.localStorageKeys.SAFE_v2__SafeApps__infoModal,
+        ls.appPermissions(constants.safeTestAppurl).infoModalAccepted,
+      )
+    })
+  })
+
   beforeEach(() => {
-    cy.clearLocalStorage()
     cy.fixture('safe-app').then((html) => {
       cy.intercept('GET', `${constants.testAppUrl}/*`, html)
       cy.intercept('GET', `*/manifest.json`, {
@@ -25,10 +34,6 @@ describe('Transaction modal tests', () => {
     { defaultCommandTimeout: 12000 },
     () => {
       cy.visitSafeApp(`${constants.testAppUrl}/dummy`)
-      main.acceptCookies()
-      safeapps.clickOnContinueBtn()
-      safeapps.verifyWarningDefaultAppMsgIsDisplayed()
-      safeapps.clickOnContinueBtn()
       cy.findByRole('dialog').within(() => {
         cy.findByText(confirmTx)
         cy.findByText(unknownApp)

--- a/cypress/support/safe-apps-commands.js
+++ b/cypress/support/safe-apps-commands.js
@@ -8,7 +8,7 @@ Cypress.Commands.add('visitSafeApp', (appUrl) => {
     window.localStorage.setItem(
       INFO_MODAL_KEY,
       JSON.stringify({
-        5: { consentsAccepted: true, warningCheckedCustomApps: allowedApps },
+        11155111: { consentsAccepted: true, warningCheckedCustomApps: allowedApps },
       }),
     )
   })


### PR DESCRIPTION
## What it solves

## How this PR fixes it

- Add cookie acceptance via local storage
- Increase swap value to avoid insufficient balance when swapping 

## How to test it

- Run Cypress tests and observe outcome
