### PR TITLE
Fix: multisend position in tx details; "to" field wrapping on small screens; 

### DIFF
--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -112,6 +112,11 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
           </div>
         )}
 
+        <div className={css.txSummary}>
+          {isUntrusted && !isPending && <UnsignedWarning />}
+          <Summary txDetails={txDetails} />
+        </div>
+
         {(isMultiSendTxInfo(txDetails.txInfo) || isOrderTxInfo(txDetails.txInfo)) && (
           <div className={css.multiSend}>
             <ErrorBoundary fallback={<div>Error parsing data</div>}>
@@ -119,11 +124,6 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
             </ErrorBoundary>
           </div>
         )}
-
-        <div className={css.txSummary}>
-          {isUntrusted && !isPending && <UnsignedWarning />}
-          <Summary txDetails={txDetails} />
-        </div>
       </div>
 
       {/* Signers */}

--- a/src/components/tx/FieldsGrid/index.tsx
+++ b/src/components/tx/FieldsGrid/index.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from 'react'
 import { Grid, Typography } from '@mui/material'
 
-const minWidth = { xl: '25%', lg: '3vw' }
+const minWidth = { xl: '25%', lg: '2vw' }
 
 const FieldsGrid = ({ title, children }: { title: string; children: ReactNode }) => {
   return (

--- a/src/components/tx/FieldsGrid/index.tsx
+++ b/src/components/tx/FieldsGrid/index.tsx
@@ -1,10 +1,12 @@
 import { type ReactNode } from 'react'
 import { Grid, Typography } from '@mui/material'
 
+const minWidth = { xl: '25%', lg: '3vw' }
+
 const FieldsGrid = ({ title, children }: { title: string; children: ReactNode }) => {
   return (
-    <Grid container alignItems="center">
-      <Grid item width="25%" minWidth={90}>
+    <Grid container alignItems="center" gap={1} wrap="nowrap">
+      <Grid item minWidth={minWidth}>
         <Typography color="primary.light" noWrap>
           {title}
         </Typography>


### PR DESCRIPTION
## What it solves

A follow-up on #3967.

Moved multisend to the very bottom (like it was before) and fixed the "To" field wrapping on small screens.


![Screenshot 2024-08-03 at 08 53 27](https://github.com/user-attachments/assets/76fd1d96-4df9-4a0e-85fa-cc882c104039)

![Screenshot 2024-08-03 at 08 52 54](https://github.com/user-attachments/assets/bdb41433-85dc-4f09-b9e3-3969d8c7f7ea)
