### PR TITLE
Feat: total asset value cents in grey

### DIFF
--- a/src/components/common/FiatValue/FiatValue.test.tsx
+++ b/src/components/common/FiatValue/FiatValue.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@/tests/test-utils'
+
+const normalizer = (text: string) => text.replace(/\u200A/g, ' ')
+
+describe('FiatValue', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'navigator', {
+      value: {
+        language: 'en-US',
+      },
+      writable: true,
+    })
+  })
+
+  it('should render fiat value', () => {
+    const FiatValue = require('.').default
+    const { getByText } = render(<FiatValue value={100} />)
+    const span = getByText((content) => normalizer(content) === '$ 100', { normalizer })
+    expect(span).toBeInTheDocument()
+    expect(span).toHaveAttribute('aria-label', '$ 100.00')
+  })
+
+  it('should render a big fiat value', () => {
+    const FiatValue = require('.').default
+    const { getByText } = render(<FiatValue value={100_285_367} />)
+    const span = getByText((content) => normalizer(content) === '$ 100.29M', { normalizer })
+    expect(span).toBeInTheDocument()
+    expect(span).toHaveAttribute('aria-label', '$ 100,285,367.00')
+  })
+
+  it('should render fiat value with precise=true', () => {
+    const FiatValue = require('.').default
+    const { getByText } = render(<FiatValue value={100.35} precise />)
+    expect(getByText((content) => normalizer(content) === '$ 100', { normalizer })).toBeInTheDocument()
+    expect(getByText('.35')).toBeInTheDocument()
+  })
+})

--- a/src/components/common/FiatValue/index.tsx
+++ b/src/components/common/FiatValue/index.tsx
@@ -1,13 +1,21 @@
 import type { CSSProperties, ReactElement } from 'react'
 import { useMemo } from 'react'
-import { Tooltip } from '@mui/material'
+import { Tooltip, Typography } from '@mui/material'
 import { useAppSelector } from '@/store'
 import { selectCurrency } from '@/store/settingsSlice'
 import { formatCurrency, formatCurrencyPrecise } from '@/utils/formatNumber'
 
 const style = { whiteSpace: 'nowrap' } as CSSProperties
 
-const FiatValue = ({ value, maxLength }: { value: string | number; maxLength?: number }): ReactElement => {
+const FiatValue = ({
+  value,
+  maxLength,
+  precise,
+}: {
+  value: string | number
+  maxLength?: number
+  precise?: boolean
+}): ReactElement => {
   const currency = useAppSelector(selectCurrency)
 
   const fiat = useMemo(() => {
@@ -18,10 +26,26 @@ const FiatValue = ({ value, maxLength }: { value: string | number; maxLength?: n
     return formatCurrencyPrecise(value, currency)
   }, [value, currency])
 
+  const [whole, decimals] = useMemo(() => {
+    const match = preciseFiat.match(/(.+)(\D\d+)$/)
+    return match ? match.slice(1) : [preciseFiat, '']
+  }, [preciseFiat])
+
   return (
-    <Tooltip title={preciseFiat}>
+    <Tooltip title={precise ? undefined : preciseFiat}>
       <span suppressHydrationWarning style={style}>
-        {fiat}
+        {precise ? (
+          <>
+            {whole}
+            {decimals && (
+              <Typography component="span" color="text.secondary" fontSize="inherit">
+                {decimals}
+              </Typography>
+            )}
+          </>
+        ) : (
+          fiat
+        )}
       </span>
     </Tooltip>
   )

--- a/src/components/common/FiatValue/index.tsx
+++ b/src/components/common/FiatValue/index.tsx
@@ -38,7 +38,7 @@ const FiatValue = ({
           <>
             {whole}
             {decimals && (
-              <Typography component="span" color="text.secondary" fontSize="inherit">
+              <Typography component="span" color="text.secondary" fontSize="inherit" fontWeight="inherit">
                 {decimals}
               </Typography>
             )}

--- a/src/components/common/FiatValue/index.tsx
+++ b/src/components/common/FiatValue/index.tsx
@@ -26,9 +26,9 @@ const FiatValue = ({
     return formatCurrencyPrecise(value, currency)
   }, [value, currency])
 
-  const [whole, decimals] = useMemo(() => {
-    const match = preciseFiat.match(/(.+)(\D\d+)$/)
-    return match ? match.slice(1) : [preciseFiat, '']
+  const [whole, decimals, endCurrency] = useMemo(() => {
+    const match = preciseFiat.match(/(.+)(\D\d+)(\D+)?$/)
+    return match ? match.slice(1) : ['', preciseFiat, '', '']
   }, [preciseFiat])
 
   return (
@@ -42,6 +42,7 @@ const FiatValue = ({
                 {decimals}
               </Typography>
             )}
+            {endCurrency}
           </>
         ) : (
           fiat

--- a/src/components/dashboard/Overview/Overview.tsx
+++ b/src/components/dashboard/Overview/Overview.tsx
@@ -72,7 +72,7 @@ const Overview = (): ReactElement => {
                 </Typography>
                 <Typography component="div" variant="h1" fontSize={44} lineHeight="40px">
                   {safe.deployed ? (
-                    <FiatValue value={balances.fiatTotal} maxLength={20} />
+                    <FiatValue value={balances.fiatTotal} maxLength={20} precise />
                   ) : (
                     <TokenAmount
                       value={balances.items[0].balance}

--- a/src/utils/__tests__/formatNumber.test.ts
+++ b/src/utils/__tests__/formatNumber.test.ts
@@ -31,31 +31,31 @@ describe('formatNumber', () => {
 
   describe('formatCurrency', () => {
     it('should format a 0', () => {
-      expect(formatCurrency(0, 'USD')).toBe('$ 0')
+      expect(formatCurrency(0, 'USD')).toBe('$ 0')
     })
 
     it('should format a number below 1', () => {
-      expect(formatCurrency(0.5678, 'USD')).toBe('$ 0.57')
+      expect(formatCurrency(0.5678, 'USD')).toBe('$ 0.57')
     })
 
     it('should format a number above 1', () => {
-      expect(formatCurrency(285.1257657, 'EUR')).toBe('€ 285')
+      expect(formatCurrency(285.1257657, 'EUR')).toBe('€ 285')
     })
 
     it('should abbreviate billions', () => {
-      expect(formatCurrency(12_345_678_901, 'USD')).toBe('$ 12.35B')
+      expect(formatCurrency(12_345_678_901, 'USD')).toBe('$ 12.35B')
     })
 
     it('should abbreviate millions', () => {
-      expect(formatCurrency(9_589_009.543645, 'EUR')).toBe('€ 9.59M')
+      expect(formatCurrency(9_589_009.543645, 'EUR')).toBe('€ 9.59M')
     })
 
     it('should abbreviate thousands', () => {
-      expect(formatCurrency(119_589.543645, 'EUR')).toBe('€ 119.59K')
+      expect(formatCurrency(119_589.543645, 'EUR')).toBe('€ 119.59K')
     })
 
     it('should abbreviate a number with more than a given amount of digits', () => {
-      expect(formatCurrency(1234.12, 'USD', 4)).toBe('$ 1.23K')
+      expect(formatCurrency(1234.12, 'USD', 4)).toBe('$ 1.23K')
     })
   })
 })

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -74,10 +74,10 @@ export const formatCurrency = (number: string | number, currency: string, maxLen
     result = getCurrencyFormatter(currency, true, 2).format(float)
   }
 
-  return result.replace(/^(\D+)/, '$1 ')
+  return result.replace(/^(\D+)/, '$1 ')
 }
 
 export const formatCurrencyPrecise = (number: string | number, currency: string): string => {
   const result = getCurrencyFormatter(currency, false, 2, 2).format(Number(number))
-  return result.replace(/^(\D+)/, '$1 ')
+  return result.replace(/^(\D+)/, '$1 ')
 }


### PR DESCRIPTION
## What it solves

A bit of extra precision in the total asset value.

<img width="647" alt="Screenshot 2024-08-05 at 12 04 34" src="https://github.com/user-attachments/assets/6493b633-d8ca-49e8-83bd-ba6a910a38c0">
