### PR TITLE
fix: reduce rpc batch size

### DIFF
--- a/src/hooks/wallets/web3.ts
+++ b/src/hooks/wallets/web3.ts
@@ -6,8 +6,10 @@ import ExternalStore from '@/services/ExternalStore'
 /**
  * Infura and other RPC providers limit the max amount included in a batch RPC call.
  * Ethers uses 100 by default which is too high for i.e. Infura.
+ *
+ * Some networks like Scroll only support a batch size of 3.
  */
-const BATCH_MAX_COUNT = 10
+const BATCH_MAX_COUNT = 3
 
 // RPC helpers
 const formatRpcServiceUrl = ({ authentication, value }: RpcUri, token: string): string => {


### PR DESCRIPTION
## What it solves
Issues with Scroll network due to a too high RPC batch size

## How this PR fixes it
Reduces the RPC batch size from 10 to 3.

## How to test it
- Use scroll network

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
