### PR TITLE
Analytcs: execution via role event

### DIFF
--- a/src/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx.tsx
@@ -119,7 +119,7 @@ const ReviewSpendingLimitTx = ({
     }
 
     trackEvent({ ...TX_EVENTS.CREATE, label: TX_TYPES.transfer_token })
-    trackEvent({ ...TX_EVENTS.EXECUTE, label: TX_TYPES.transfer_token })
+    trackEvent({ ...TX_EVENTS.EXECUTE_SPENDING_LIMIT, label: TX_TYPES.transfer_token })
   }
 
   const submitDisabled = !isSubmittable || gasLimitLoading

--- a/src/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx.tsx
+++ b/src/components/tx-flow/flows/TokenTransfer/ReviewSpendingLimitTx.tsx
@@ -116,10 +116,11 @@ const ReviewSpendingLimitTx = ({
         setSubmitError(err)
       }
       setIsSubmittable(true)
+      return
     }
 
-    trackEvent({ ...TX_EVENTS.CREATE, label: TX_TYPES.transfer_token })
-    trackEvent({ ...TX_EVENTS.EXECUTE_SPENDING_LIMIT, label: TX_TYPES.transfer_token })
+    trackEvent({ ...TX_EVENTS.CREATE_VIA_SPENDING_LIMTI, label: TX_TYPES.transfer_token })
+    trackEvent({ ...TX_EVENTS.EXECUTE_VIA_SPENDING_LIMIT, label: TX_TYPES.transfer_token })
   }
 
   const submitDisabled = !isSubmittable || gasLimitLoading

--- a/src/components/tx/SignOrExecuteForm/ExecuteThroughRoleForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteThroughRoleForm/index.tsx
@@ -23,7 +23,6 @@ import { TxSecurityContext } from '../../security/shared/TxSecurityContext'
 
 import WalletRejectionError from '@/components/tx/SignOrExecuteForm/WalletRejectionError'
 import { pollModuleTransactionId, useExecuteThroughRole, useGasLimit, useMetaTransactions, type Role } from './hooks'
-import { TX_EVENTS } from '@/services/analytics/events/transactions'
 import { decodeBytes32String } from 'ethers'
 import useOnboard from '@/hooks/wallets/useOnboard'
 import useWallet from '@/hooks/wallets/useWallet'
@@ -131,7 +130,7 @@ export const ExecuteThroughRoleForm = ({
       throw new Error('Transaction service not found')
     }
     const txId = await pollModuleTransactionId(chainId, safe.address.value, txHash)
-    onSubmit?.(txId, true, TX_EVENTS.EXECUTE_VIA_ROLE)
+    onSubmit?.(txId, true)
 
     // Update the success screen so it shows a link to the transaction
     setTxFlow(<SuccessScreenFlow txId={txId} />, undefined, false)

--- a/src/components/tx/SignOrExecuteForm/ExecuteThroughRoleForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteThroughRoleForm/index.tsx
@@ -23,8 +23,6 @@ import { TxSecurityContext } from '../../security/shared/TxSecurityContext'
 
 import WalletRejectionError from '@/components/tx/SignOrExecuteForm/WalletRejectionError'
 import { pollModuleTransactionId, useExecuteThroughRole, useGasLimit, useMetaTransactions, type Role } from './hooks'
-import { getTransactionTrackingType } from '@/services/analytics/tx-tracking'
-import { trackEvent } from '@/services/analytics'
 import { TX_EVENTS } from '@/services/analytics/events/transactions'
 import { decodeBytes32String } from 'ethers'
 import useOnboard from '@/hooks/wallets/useOnboard'
@@ -133,11 +131,7 @@ export const ExecuteThroughRoleForm = ({
       throw new Error('Transaction service not found')
     }
     const txId = await pollModuleTransactionId(chainId, safe.address.value, txHash)
-    onSubmit?.(txId, true)
-
-    // Track tx event
-    const txType = await getTransactionTrackingType(chainId, txId)
-    trackEvent({ ...TX_EVENTS.EXECUTE_THROUGH_ROLE, label: txType })
+    onSubmit?.(txId, true, TX_EVENTS.EXECUTE_VIA_ROLE)
 
     // Update the success screen so it shows a link to the transaction
     setTxFlow(<SuccessScreenFlow txId={txId} />, undefined, false)

--- a/src/services/analytics/events/transactions.ts
+++ b/src/services/analytics/events/transactions.ts
@@ -53,6 +53,11 @@ export const TX_EVENTS = {
     action: 'Speed up transaction',
     category: TX_CATEGORY,
   },
+  EXECUTE_SPENDING_LIMIT: {
+    event: EventType.TX_EXECUTED,
+    action: 'Execute via spending limit',
+    category: TX_CATEGORY,
+  },
   EXECUTE_VIA_ROLE: {
     event: EventType.TX_EXECUTED,
     action: 'Execute via role',

--- a/src/services/analytics/events/transactions.ts
+++ b/src/services/analytics/events/transactions.ts
@@ -38,6 +38,16 @@ export const TX_EVENTS = {
     category: TX_CATEGORY,
     // label: TX_TYPES,
   },
+  CREATE_VIA_ROLE: {
+    event: EventType.TX_CREATED,
+    action: 'Create via role',
+    category: TX_CATEGORY,
+  },
+  CREATE_VIA_SPENDING_LIMTI: {
+    event: EventType.TX_CREATED,
+    action: 'Create via spending limit',
+    category: TX_CATEGORY,
+  },
   CONFIRM: {
     event: EventType.TX_CONFIRMED,
     action: 'Confirm transaction',
@@ -53,7 +63,7 @@ export const TX_EVENTS = {
     action: 'Speed up transaction',
     category: TX_CATEGORY,
   },
-  EXECUTE_SPENDING_LIMIT: {
+  EXECUTE_VIA_SPENDING_LIMIT: {
     event: EventType.TX_EXECUTED,
     action: 'Execute via spending limit',
     category: TX_CATEGORY,

--- a/src/services/analytics/events/transactions.ts
+++ b/src/services/analytics/events/transactions.ts
@@ -53,9 +53,9 @@ export const TX_EVENTS = {
     action: 'Speed up transaction',
     category: TX_CATEGORY,
   },
-  EXECUTE_THROUGH_ROLE: {
-    event: EventType.TX_EXECUTED_THROUGH_ROLE,
-    action: 'Execute transaction through role',
+  EXECUTE_VIA_ROLE: {
+    event: EventType.TX_EXECUTED,
+    action: 'Execute via role',
     category: TX_CATEGORY,
   },
 }

--- a/src/services/analytics/types.ts
+++ b/src/services/analytics/types.ts
@@ -13,7 +13,6 @@ export enum EventType {
   TX_CREATED = 'tx_created',
   TX_CONFIRMED = 'tx_confirmed',
   TX_EXECUTED = 'tx_executed',
-  TX_EXECUTED_THROUGH_ROLE = 'tx_executed_through_role',
 }
 
 export type EventLabel = string | number | boolean | null


### PR DESCRIPTION
## What it solves

Role-based executions were previously tracked as separate events preceding a `tx_executed` event but it's more inline with our existing events to track them as `tx_executed` with a custom `eventAction`.

Edit: extended the same to spending limit transactions.

## How to test it

### 1
* Make a token transfer using Spending Limits
* In the console, the `tx_created` and `tx_executed` events should have a `Created/Executed via spending limit` action

### 2
* Create a Roles-based tx and execute it
* In the console, the `tx_created` and `tx_executed` events should have a `Created/Executed via role` action