### PR TITLE
Analytcs: restore WalletConnect tx origin

### DIFF
--- a/src/features/walletconnect/__tests__/WalletConnectContext.test.tsx
+++ b/src/features/walletconnect/__tests__/WalletConnectContext.test.tsx
@@ -357,7 +357,7 @@ describe('WalletConnectProvider', () => {
             metadata: {
               name: 'name',
               description: 'description',
-              url: 'https://apps-portal.safe.global/wallet-connect',
+              url: 'https://safe-apps.dev.5afe.dev/wallet-connect',
               icons: ['iconUrl'],
             },
           },
@@ -412,7 +412,7 @@ describe('WalletConnectProvider', () => {
         {
           name: 'name',
           description: 'description',
-          url: 'https://apps-portal.safe.global/wallet-connect',
+          url: 'https://safe-apps.dev.5afe.dev/wallet-connect',
           iconUrl: 'iconUrl',
         },
       )
@@ -432,7 +432,7 @@ describe('WalletConnectProvider', () => {
             metadata: {
               name: 'name',
               description: 'description',
-              url: 'https://apps-portal.safe.global/wallet-connect',
+              url: 'https://safe-apps.dev.5afe.dev/wallet-connect',
               icons: ['iconUrl'],
             },
           },

--- a/src/features/walletconnect/__tests__/WalletConnectContext.test.tsx
+++ b/src/features/walletconnect/__tests__/WalletConnectContext.test.tsx
@@ -357,7 +357,7 @@ describe('WalletConnectProvider', () => {
             metadata: {
               name: 'name',
               description: 'description',
-              url: 'https://safe-apps.dev.5afe.dev/wallet-connect',
+              url: 'https://apps-portal.safe.global/wallet-connect',
               icons: ['iconUrl'],
             },
           },
@@ -412,7 +412,7 @@ describe('WalletConnectProvider', () => {
         {
           name: 'name',
           description: 'description',
-          url: 'https://safe-apps.dev.5afe.dev/wallet-connect',
+          url: 'https://apps-portal.safe.global/wallet-connect',
           iconUrl: 'iconUrl',
         },
       )
@@ -432,7 +432,7 @@ describe('WalletConnectProvider', () => {
             metadata: {
               name: 'name',
               description: 'description',
-              url: 'https://safe-apps.dev.5afe.dev/wallet-connect',
+              url: 'https://apps-portal.safe.global/wallet-connect',
               icons: ['iconUrl'],
             },
           },

--- a/src/features/walletconnect/components/WalletConnectProvider/index.tsx
+++ b/src/features/walletconnect/components/WalletConnectProvider/index.tsx
@@ -23,6 +23,12 @@ export enum WCLoadingState {
   DISCONNECT = 'Disconnect',
 }
 
+// The URL of the former WalletConnect Safe App
+// This is still used to differentiate these txs from Safe App txs in the analytics
+const LEGACY_WC_APP_URL = IS_PRODUCTION
+  ? 'https://apps-portal.safe.global/wallet-connect'
+  : 'https://safe-apps.dev.5afe.dev/wallet-connect'
+
 const walletConnectSingleton = new WalletConnectWallet()
 
 const getWrongChainError = (dappName: string): Error => {
@@ -88,7 +94,7 @@ export const WalletConnectProvider = ({ children }: { children: ReactNode }) => 
 
         // Get response from Safe Wallet Provider
         return safeWalletProvider.request(event.id, event.params.request, {
-          url: session.peer.metadata.url,
+          url: LEGACY_WC_APP_URL, // required for server-side analytics
           name: getPeerName(session.peer) || 'WalletConnect',
           description: session.peer.metadata.description,
           iconUrl: session.peer.metadata.icons[0],

--- a/src/features/walletconnect/components/WalletConnectProvider/index.tsx
+++ b/src/features/walletconnect/components/WalletConnectProvider/index.tsx
@@ -25,9 +25,7 @@ export enum WCLoadingState {
 
 // The URL of the former WalletConnect Safe App
 // This is still used to differentiate these txs from Safe App txs in the analytics
-const LEGACY_WC_APP_URL = IS_PRODUCTION
-  ? 'https://apps-portal.safe.global/wallet-connect'
-  : 'https://safe-apps.dev.5afe.dev/wallet-connect'
+const LEGACY_WC_APP_URL = 'https://apps-portal.safe.global/wallet-connect'
 
 const walletConnectSingleton = new WalletConnectWallet()
 


### PR DESCRIPTION
## What it solves

Resolves #4043

## How this PR fixes it

To the app, it doesn't matter what URL is being sent in the `origin` of WC-initialted tx proposals. The old WC Safe App doesn't exist anymore, so CGW won't match these txs to anything.
But it matters for data analysis on the backend, so we're restoring the behavior unintentionally altered in #3760.

## How to test it

* Create any transaction via WalletConnect
* Filter the Network Requests in devtools by "propose"
* Observe that the `origin` field in the propose request is set to `https://apps-portal.safe.global/wallet-connect`

