### PR TITLE
Fix: tx-details redesign fixes

### DIFF
--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -87,6 +87,7 @@ const DecodedTx = ({
             <HelpToolTip />
             <Box flexGrow={1} />
             {isMethodCallInAdvanced && decodedData?.method}
+            {!showMethodCall && !decodedData?.method && tx?.data.value && 'native transfer'}
           </AccordionSummary>
 
           <AccordionDetails data-testid="decoded-tx-details">

--- a/src/components/tx/FieldsGrid/index.tsx
+++ b/src/components/tx/FieldsGrid/index.tsx
@@ -5,7 +5,7 @@ const minWidth = { xl: '25%', lg: '2vw' }
 
 const FieldsGrid = ({ title, children }: { title: string; children: ReactNode }) => {
   return (
-    <Grid container alignItems="center" gap={1} wrap="nowrap">
+    <Grid container alignItems="center" gap={1}>
       <Grid item minWidth={minWidth}>
         <Typography color="primary.light" noWrap>
           {title}

--- a/src/components/tx/FieldsGrid/index.tsx
+++ b/src/components/tx/FieldsGrid/index.tsx
@@ -1,11 +1,12 @@
 import { type ReactNode } from 'react'
 import { Grid, Typography } from '@mui/material'
 
-const minWidth = { xl: '25%', lg: '2vw' }
+const minWidth = { xl: '25%', lg: '100px' }
+const wrap = { flexWrap: { xl: 'nowrap' } }
 
 const FieldsGrid = ({ title, children }: { title: string; children: ReactNode }) => {
   return (
-    <Grid container alignItems="center" gap={1}>
+    <Grid container alignItems="center" gap={1} sx={wrap}>
       <Grid item minWidth={minWidth}>
         <Typography color="primary.light" noWrap>
           {title}

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -130,6 +130,8 @@ export const SignOrExecuteForm = ({
     [onFormSubmit],
   )
 
+  const approvalEditor = <ApprovalEditor safeTransaction={safeTx} />
+
   return (
     <>
       <TxCard>
@@ -144,7 +146,7 @@ export const SignOrExecuteForm = ({
         )}
 
         <ErrorBoundary fallback={<div>Error parsing data</div>}>
-          <ApprovalEditor safeTransaction={safeTx} />
+          {approvalEditor}
 
           {showTxDetails && <TxData txDetails={txDetails} imitation={false} trusted />}
 
@@ -153,7 +155,7 @@ export const SignOrExecuteForm = ({
             txId={props.txId}
             decodedData={decodedData}
             showMultisend={!props.isBatch}
-            showMethodCall={props.showMethodCall && !showTxDetails && !isSwapOrder}
+            showMethodCall={props.showMethodCall && !showTxDetails && !isSwapOrder && !approvalEditor}
           />
         </ErrorBoundary>
 

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -35,6 +35,7 @@ import { TwapFallbackHandlerWarning } from '@/features/swap/components/TwapFallb
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import useTxDetails from '@/hooks/useTxDetails'
 import TxData from '@/components/transactions/TxDetails/TxData'
+import { useApprovalInfos } from '../ApprovalEditor/hooks/useApprovalInfos'
 
 export type SubmitCallback = (txId: string, isExecuted?: boolean) => void
 
@@ -94,6 +95,8 @@ export const SignOrExecuteForm = ({
   const isSwapOrder = isConfirmationViewOrder(decodedData)
   const [txDetails] = useTxDetails(props.txId)
   const showTxDetails = props.txId && txDetails && !isCustomTxInfo(txDetails.txInfo)
+  const [readableApprovals] = useApprovalInfos({ safeTransaction: safeTx })
+  const isApproval = readableApprovals && readableApprovals.length > 0
 
   const { safe } = useSafeInfo()
   const isSafeOwner = useIsSafeOwner()
@@ -130,8 +133,6 @@ export const SignOrExecuteForm = ({
     [onFormSubmit],
   )
 
-  const approvalEditor = <ApprovalEditor safeTransaction={safeTx} />
-
   return (
     <>
       <TxCard>
@@ -146,7 +147,7 @@ export const SignOrExecuteForm = ({
         )}
 
         <ErrorBoundary fallback={<div>Error parsing data</div>}>
-          {approvalEditor}
+          {isApproval && <ApprovalEditor safeTransaction={safeTx} />}
 
           {showTxDetails && <TxData txDetails={txDetails} imitation={false} trusted />}
 
@@ -155,7 +156,7 @@ export const SignOrExecuteForm = ({
             txId={props.txId}
             decodedData={decodedData}
             showMultisend={!props.isBatch}
-            showMethodCall={props.showMethodCall && !showTxDetails && !isSwapOrder && !approvalEditor}
+            showMethodCall={props.showMethodCall && !showTxDetails && !isSwapOrder && !isApproval}
           />
         </ErrorBoundary>
 


### PR DESCRIPTION
## What it solves
Fixes for the issues reported [on notion](https://www.notion.so/safe-global/Tx-details-redesign-issues-ef226c9c47f04e4d8c7c891886a66985).

## How this PR fixes it
1. The method call details are moved to the Advanced details for approvals:
<img width="735" alt="Screenshot 2024-08-09 at 16 49 09" src="https://github.com/user-attachments/assets/53354ff0-d284-40e8-bedc-48630a66b794">

2. Restore "native transfer" in the Advanced details title:
<img width="706" alt="Screenshot 2024-08-12 at 10 30 38" src="https://github.com/user-attachments/assets/82113db3-d853-4f26-8209-ac9ad1588f98">

3. Wrap "Interacted with" to the next line if it doesn't fit:
<img width="614" alt="Screenshot 2024-08-12 at 10 33 04" src="https://github.com/user-attachments/assets/60de4863-1b4b-462b-b044-e9e36ee177c7">