### PR TITLE
Fix: restore "native transfer"; wrap "Interacted with"

### DIFF
--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -87,6 +87,7 @@ const DecodedTx = ({
             <HelpToolTip />
             <Box flexGrow={1} />
             {isMethodCallInAdvanced && decodedData?.method}
+            {!showMethodCall && !decodedData?.method && tx?.data.value && 'native transfer'}
           </AccordionSummary>
 
           <AccordionDetails data-testid="decoded-tx-details">

--- a/src/components/tx/FieldsGrid/index.tsx
+++ b/src/components/tx/FieldsGrid/index.tsx
@@ -5,7 +5,7 @@ const minWidth = { xl: '25%', lg: '2vw' }
 
 const FieldsGrid = ({ title, children }: { title: string; children: ReactNode }) => {
   return (
-    <Grid container alignItems="center" gap={1} wrap="nowrap">
+    <Grid container alignItems="center" gap={1}>
       <Grid item minWidth={minWidth}>
         <Typography color="primary.light" noWrap>
           {title}


### PR DESCRIPTION
## What it solves

1. Restore "native transfer" in the Advanced details title:
<img width="706" alt="Screenshot 2024-08-12 at 10 30 38" src="https://github.com/user-attachments/assets/82113db3-d853-4f26-8209-ac9ad1588f98">

2. Wrap "Interacted with" to the next line if it doesn't fit:
<img width="614" alt="Screenshot 2024-08-12 at 10 33 04" src="https://github.com/user-attachments/assets/60de4863-1b4b-462b-b044-e9e36ee177c7">
