### PR TITLE
feat: upgrade zodiac to enable recovery on Base

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@emotion/react": "^11.11.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.11.0",
-    "@gnosis.pm/zodiac": "^4.0.1",
+    "@gnosis.pm/zodiac": "^4.0.3",
     "@mui/icons-material": "^5.14.20",
     "@mui/material": "^5.14.20",
     "@mui/x-date-pickers": "^5.0.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2916,10 +2916,10 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-contracts/-/safe-contracts-1.3.0.tgz#316741a7690d8751a1f701538cfc9ec80866eedc"
   integrity sha512-1p+1HwGvxGUVzVkFjNzglwHrLNA67U/axP0Ct85FzzH8yhGJb4t9jDjPYocVMzLorDoWAfKicGy1akPY9jXRVw==
 
-"@gnosis.pm/zodiac@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/zodiac/-/zodiac-4.0.1.tgz#a117d972b8cc361d097246fff0815c1badca3990"
-  integrity sha512-zq8PSr3uNmMjlZxmG3Rq9V5dHINeeyAe7smNMD+m0UlRGjrcffT29gg9pLyV6RNYR+8VpG7ehv4AJZ02DccscQ==
+"@gnosis.pm/zodiac@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/zodiac/-/zodiac-4.0.3.tgz#3323f496cda279e2a68ca2bf726ad840388e8229"
+  integrity sha512-yliHytBRlb4wNkeiYsaaAvYZC5VwiUBVfJ+HLEmjnWPG2EHB5tvAOUboDU7XvSQ4GUJAz8h2YUrph0XkH+/xfA==
   dependencies:
     "@gnosis.pm/mock-contract" "^4.0.0"
     "@gnosis.pm/safe-contracts" "1.3.0"


### PR DESCRIPTION
## What it solves

Resolves #4061 

## How this PR fixes it
Upgrades Zodiac to 4.0.3

## How to test it
- Enable Recovery on Base (Feature flag)
- Test recovery

## Screenshots
![Screenshot 2024-08-12 at 14 48 20](https://github.com/user-attachments/assets/3f723967-0640-482f-9aaf-f87a13161795)


## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
