### PR TITLE
fix: safe creation for chains without 1.4.1 deployed

### DIFF
--- a/src/components/new-safe/create/AdvancedCreateSafe.tsx
+++ b/src/components/new-safe/create/AdvancedCreateSafe.tsx
@@ -14,14 +14,15 @@ import { CREATE_SAFE_CATEGORY } from '@/services/analytics'
 import type { CreateSafeInfoItem } from '@/components/new-safe/create/CreateSafeInfos'
 import CreateSafeInfos from '@/components/new-safe/create/CreateSafeInfos'
 import { useState } from 'react'
-import { LATEST_SAFE_VERSION } from '@/config/constants'
 import { type NewSafeFormData } from '.'
-import { type SafeVersion } from '@safe-global/safe-core-sdk-types'
 import AdvancedOptionsStep from './steps/AdvancedOptionsStep'
+import { getLatestSafeVersion } from '@/utils/chains'
+import { useCurrentChain } from '@/hooks/useChains'
 
 const AdvancedCreateSafe = () => {
   const router = useRouter()
   const wallet = useWallet()
+  const chain = useCurrentChain()
 
   const [safeName, setSafeName] = useState('')
   const [dynamicHint, setDynamicHint] = useState<CreateSafeInfoItem>()
@@ -86,7 +87,7 @@ const AdvancedCreateSafe = () => {
     owners: [],
     threshold: 1,
     saltNonce: 0,
-    safeVersion: LATEST_SAFE_VERSION as SafeVersion,
+    safeVersion: getLatestSafeVersion(chain),
   }
 
   const onClose = () => {

--- a/src/components/new-safe/create/index.tsx
+++ b/src/components/new-safe/create/index.tsx
@@ -17,8 +17,10 @@ import type { CreateSafeInfoItem } from '@/components/new-safe/create/CreateSafe
 import CreateSafeInfos from '@/components/new-safe/create/CreateSafeInfos'
 import { type ReactElement, useMemo, useState } from 'react'
 import ExternalLink from '@/components/common/ExternalLink'
-import { HelpCenterArticle, LATEST_SAFE_VERSION } from '@/config/constants'
+import { HelpCenterArticle } from '@/config/constants'
 import { type SafeVersion } from '@safe-global/safe-core-sdk-types'
+import { getLatestSafeVersion } from '@/utils/chains'
+import { useCurrentChain } from '@/hooks/useChains'
 
 export type NewSafeFormData = {
   name: string
@@ -99,6 +101,7 @@ const staticHints: Record<
 const CreateSafe = () => {
   const router = useRouter()
   const wallet = useWallet()
+  const chain = useCurrentChain()
 
   const [safeName, setSafeName] = useState('')
   const [dynamicHint, setDynamicHint] = useState<CreateSafeInfoItem>()
@@ -158,7 +161,7 @@ const CreateSafe = () => {
     owners: [],
     threshold: 1,
     saltNonce: Date.now(),
-    safeVersion: LATEST_SAFE_VERSION as SafeVersion,
+    safeVersion: getLatestSafeVersion(chain) as SafeVersion,
   }
 
   const onClose = () => {

--- a/src/components/new-safe/create/steps/StatusStep/index.tsx
+++ b/src/components/new-safe/create/steps/StatusStep/index.tsx
@@ -17,8 +17,7 @@ import { Alert, AlertTitle, Box, Button, Paper, Stack, SvgIcon, Typography } fro
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
-import { LATEST_SAFE_VERSION } from '@/config/constants'
-import { type SafeVersion } from '@safe-global/safe-core-sdk-types'
+import { getLatestSafeVersion } from '@/utils/chains'
 
 const SPEED_UP_THRESHOLD_IN_SECONDS = 15
 
@@ -85,7 +84,7 @@ export const CreateSafeStatus = ({
       threshold: pendingSafe.props.safeAccountConfig.threshold,
       saltNonce: Number(pendingSafe.props.safeDeploymentConfig?.saltNonce),
       safeAddress,
-      safeVersion: pendingSafe.props.safeDeploymentConfig?.safeVersion ?? (LATEST_SAFE_VERSION as SafeVersion),
+      safeVersion: pendingSafe.props.safeDeploymentConfig?.safeVersion ?? getLatestSafeVersion(chain),
     })
   }
 

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -4,6 +4,7 @@ import { getExplorerLink } from './gateway'
 import { type SafeVersion } from '@safe-global/safe-core-sdk-types'
 import { getSafeSingletonDeployment } from '@safe-global/safe-deployments'
 import semverSatisfies from 'semver/functions/satisfies'
+import { LATEST_SAFE_VERSION } from '@/config/constants'
 
 /** This version is used if a network does not have the LATEST_SAFE_VERSION deployed yet */
 const FALLBACK_SAFE_VERSION = '1.3.0' as const
@@ -62,7 +63,7 @@ export const isRouteEnabled = (route: string, chain?: ChainInfo) => {
 }
 
 export const getLatestSafeVersion = (chain: ChainInfo | undefined): SafeVersion => {
-  const latestSafeVersion = chain && hasFeature(chain, FEATURES.SAFE_141) ? '1.4.1' : '1.3.0'
+  const latestSafeVersion = chain && hasFeature(chain, FEATURES.SAFE_141) ? LATEST_SAFE_VERSION : FALLBACK_SAFE_VERSION
   // Without version filter it will always return the LATEST_SAFE_VERSION constant to avoid automatically updating to the newest version if the deployments change
   const latestDeploymentVersion = (getSafeSingletonDeployment({ network: chain?.chainId, released: true })?.version ??
     FALLBACK_SAFE_VERSION) as SafeVersion


### PR DESCRIPTION
## What it solves
Safe creation was broken for chains without 1.4.1 deployed.

## How this PR fixes it
- Removes `LATEST_SAFE_VERSION` usage and replaces it with `getLatestSafeVersion`

## How to test it
- Create a Safe on e.g. zkSyncEra (Pay later suffices)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
