### PR TITLE
feat: automatically migrate incompatible Safes from L1 to L2 if possible

### DIFF
--- a/src/components/tx-flow/SafeTxProvider.tsx
+++ b/src/components/tx-flow/SafeTxProvider.tsx
@@ -1,10 +1,18 @@
-import { createContext, useState, useEffect } from 'react'
+import { createContext, useState, useEffect, useCallback } from 'react'
 import type { Dispatch, ReactNode, SetStateAction, ReactElement } from 'react'
-import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
-import { createTx } from '@/services/tx/tx-sender'
+import type { MetaTransactionData, SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import { __unsafe_createMultiSendTx, createTx } from '@/services/tx/tx-sender'
 import { useRecommendedNonce, useSafeTxGas } from '../tx/SignOrExecuteForm/hooks'
 import { Errors, logError } from '@/services/exceptions'
 import type { EIP712TypedData } from '@safe-global/safe-gateway-typescript-sdk'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import { isMultiSendCalldata } from '@/utils/transaction-calldata'
+import { getSafeContractDeployment } from '@/services/contracts/deployments'
+import { decodeMultiSendData } from '@safe-global/protocol-kit/dist/src/utils'
+import { useCurrentChain } from '@/hooks/useChains'
+import { sameAddress } from '@/utils/addresses'
+import { Interface } from 'ethers'
+import { isValidMasterCopy } from '@/services/contracts/safeContracts'
 
 export const SafeTxContext = createContext<{
   safeTx?: SafeTransaction
@@ -34,6 +42,10 @@ export const SafeTxContext = createContext<{
   setSafeTxGas: () => {},
 })
 
+// TODO: Get from safe-deployments once available
+const SAFE_TO_L2_MIGRATION_ADDRESS = '0x7Baec386CAF8e02B0BB4AFc98b4F9381EEeE283C'
+const SAFE_TO_L2_INTERFACE = new Interface(['function migrateToL2(address l2Singleton)'])
+
 const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => {
   const [safeTx, setSafeTx] = useState<SafeTransaction>()
   const [safeMessage, setSafeMessage] = useState<EIP712TypedData>()
@@ -41,6 +53,87 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
   const [nonce, setNonce] = useState<number>()
   const [nonceNeeded, setNonceNeeded] = useState<boolean>(true)
   const [safeTxGas, setSafeTxGas] = useState<string>()
+
+  const { safe } = useSafeInfo()
+  const chain = useCurrentChain()
+
+  const setAndMigrateSafeTx: Dispatch<SetStateAction<SafeTransaction | undefined>> = useCallback(
+    (
+      value: SafeTransaction | undefined | ((prevState: SafeTransaction | undefined) => SafeTransaction | undefined),
+    ) => {
+      if (!chain) {
+        throw new Error('No Network information available')
+      }
+
+      let safeTx: SafeTransaction | undefined
+      if (typeof value === 'function') {
+        safeTx = value(safeTx)
+      } else {
+        safeTx = value
+      }
+
+      if (
+        !safeTx ||
+        safeTx.signatures.size > 0 ||
+        !chain.l2 ||
+        safe.nonce > 0 ||
+        isValidMasterCopy(safe.implementationVersionState)
+      ) {
+        // We do not migrate on L1s
+        // We cannot migrate if the nonce is > 0
+        // We do not modify already signed txs
+        // We do not modify supported masterCopies
+        setSafeTx(safeTx)
+        return
+      }
+
+      const safeL2Deployment = getSafeContractDeployment(chain, safe.version)
+      const safeL2DeploymentAddress = safeL2Deployment?.networkAddresses[chain.chainId]
+
+      if (!safeL2DeploymentAddress) {
+        throw new Error('No L2 MasterCopy found')
+      }
+
+      if (sameAddress(safe.implementation.value, safeL2DeploymentAddress)) {
+        // Safe already has the correct L2 masterCopy
+        // This should in theory never happen if the implementationState is valid
+        setSafeTx(safeTx)
+        return
+      }
+
+      // If the Safe is a L1 masterCopy on a L2 network and still has nonce 0, we prepend a call to the migration contract to the safeTx.
+      const txData = safeTx.data.data
+
+      let internalTxs: MetaTransactionData[]
+
+      if (isMultiSendCalldata(txData)) {
+        // Check if the first tx is already a call to the migration contract
+        internalTxs = decodeMultiSendData(txData)
+        const firstTx = internalTxs[0]
+        if (sameAddress(firstTx?.to, SAFE_TO_L2_MIGRATION_ADDRESS)) {
+          // We already migrate. Nothing to do.
+          setSafeTx(safeTx)
+          return
+        }
+      } else {
+        internalTxs = [{ to: safeTx.data.to, operation: safeTx.data.operation, value: safeTx.data.value, data: txData }]
+      }
+
+      // Prepend the migration tx
+      const newTxs: MetaTransactionData[] = [
+        {
+          operation: 1, // DELEGATE CALL REQUIRED
+          data: SAFE_TO_L2_INTERFACE.encodeFunctionData('migrateToL2', [safeL2DeploymentAddress]),
+          to: SAFE_TO_L2_MIGRATION_ADDRESS,
+          value: '0',
+        },
+        ...internalTxs,
+      ]
+
+      __unsafe_createMultiSendTx(newTxs).then(setSafeTx)
+    },
+    [chain, safe.implementation.value, safe.implementationVersionState, safe.nonce, safe.version],
+  )
 
   // Signed txs cannot be updated
   const isSigned = safeTx && safeTx.signatures.size > 0
@@ -73,7 +166,7 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
       value={{
         safeTx,
         safeTxError,
-        setSafeTx,
+        setSafeTx: setAndMigrateSafeTx,
         setSafeTxError,
         safeMessage,
         setSafeMessage,

--- a/src/services/contracts/deployments.ts
+++ b/src/services/contracts/deployments.ts
@@ -3,6 +3,7 @@ import {
   getSafeSingletonDeployment,
   getSafeL2SingletonDeployment,
   getMultiSendCallOnlyDeployment,
+  getMultiSendDeployment,
   getFallbackHandlerDeployment,
   getProxyFactoryDeployment,
   getSignMessageLibDeployment,
@@ -66,6 +67,10 @@ export const getSafeContractDeployment = (
 
 export const getMultiSendCallOnlyContractDeployment = (chain: ChainInfo, safeVersion: SafeInfo['version']) => {
   return _tryDeploymentVersions(getMultiSendCallOnlyDeployment, chain, safeVersion)
+}
+
+export const getMultiSendContractDeployment = (chain: ChainInfo, safeVersion: SafeInfo['version']) => {
+  return _tryDeploymentVersions(getMultiSendDeployment, chain, safeVersion)
 }
 
 export const getFallbackHandlerContractDeployment = (chain: ChainInfo, safeVersion: SafeInfo['version']) => {

--- a/src/services/tx/tx-sender/create.ts
+++ b/src/services/tx/tx-sender/create.ts
@@ -25,6 +25,17 @@ export const createMultiSendCallOnlyTx = async (txParams: MetaTransactionData[])
   return safeSDK.createTransaction({ transactions: txParams, onlyCalls: true })
 }
 
+/**
+ * Create a multiSend transaction from an array of MetaTransactionData and options
+ * If only one tx is passed it will be created without multiSend and without onlyCalls.
+ *
+ * This function can create delegateCalls, which is usually not necessary
+ */
+export const __unsafe_createMultiSendTx = async (txParams: MetaTransactionData[]): Promise<SafeTransaction> => {
+  const safeSDK = getAndValidateSafeSDK()
+  return safeSDK.createTransaction({ transactions: txParams, onlyCalls: false })
+}
+
 export const createRemoveOwnerTx = async (txParams: RemoveOwnerTxParams): Promise<SafeTransaction> => {
   const safeSDK = getAndValidateSafeSDK()
   return safeSDK.createRemoveOwnerTx(txParams)


### PR DESCRIPTION
## ATTENTION THIS IS A DRAFT PR AND NOT MEANT TO BE MERGED YET
This PR hardcodes some addresses and is using an un-audited contract.
DO NOT MERGE.

## What it solves
Makes replayed Mainnet Safes compatible on L2s.

## How this PR fixes it
- If a Safe is using an incompatible MasterCopy on a L2 chain, a migration delegateCall is prepended to the first transaction the Safe creates
- This only works for Safes which are still at nonce 0

## How to test it
- Replay a L1 Safe on Polygon or Optimism
- Create any transaction in that new Safe and observe a migration tx being added to it.

## Screenshots

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
