### PR TITLE
Fix: ellipsis for Safe names

### DIFF
--- a/src/components/welcome/MyAccounts/AccountItem.tsx
+++ b/src/components/welcome/MyAccounts/AccountItem.tsx
@@ -81,7 +81,7 @@ const AccountItem = ({ onLinkClick, safeItem, safeOverview }: AccountItemProps) 
 
           <Typography variant="body2" component="div" className={css.safeAddress}>
             {name && (
-              <Typography variant="subtitle2" component="p" fontWeight="bold">
+              <Typography variant="subtitle2" component="p" fontWeight="bold" className={css.safeName}>
                 {name}
               </Typography>
             )}

--- a/src/components/welcome/MyAccounts/styles.module.css
+++ b/src/components/welcome/MyAccounts/styles.module.css
@@ -79,6 +79,7 @@
   }
 }
 
+.safeName,
 .safeAddress {
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
## What it solves

A small fix for long Safe names that weren't truncated.

<img width="464" alt="Screenshot 2024-08-15 at 11 05 46" src="https://github.com/user-attachments/assets/fa9a9ecd-457e-40f3-8d59-59a147a1ca4f">