### PR TITLE
Tests: fix create_safe_simple

### DIFF
--- a/cypress/support/utils/wallet.js
+++ b/cypress/support/utils/wallet.js
@@ -32,6 +32,7 @@ export function connectSigner(signer) {
   function enterPrivateKey() {
     cy.wait(1000)
     cy.get(connectWalletBtn)
+      .eq(0)
       .should('be.enabled')
       .and('be.visible')
       .click()


### PR DESCRIPTION
## What it solves

Smoke tests were failing because the connect wallet action was finding more than one Connect button.