### PR TITLE
feat: SetupToL2 during Safe creation

### DIFF
--- a/src/features/counterfactual/ActivateAccountFlow.tsx
+++ b/src/features/counterfactual/ActivateAccountFlow.tsx
@@ -1,4 +1,4 @@
-import { createNewSafe, relaySafeCreation } from '@/components/new-safe/create/logic'
+import { createNewSafe, relaySafeCreation, SAFE_TO_L2_SETUP_ADDRESS } from '@/components/new-safe/create/logic'
 import NetworkWarning from '@/components/new-safe/create/NetworkWarning'
 import { NetworkFee, SafeSetupOverview } from '@/components/new-safe/create/steps/ReviewStep'
 import ReviewRow from '@/components/new-safe/ReviewRow'
@@ -31,6 +31,7 @@ import type { DeploySafeProps } from '@safe-global/protocol-kit'
 import { FEATURES } from '@/utils/chains'
 import React, { useContext, useState } from 'react'
 import { getLatestSafeVersion } from '@/utils/chains'
+import { sameAddress } from '@/utils/addresses'
 
 const useActivateAccount = () => {
   const chain = useCurrentChain()
@@ -70,6 +71,8 @@ const ActivateAccountFlow = () => {
   const { options, totalFee, walletCanPay } = useActivateAccount()
 
   const ownerAddresses = undeployedSafe?.props.safeAccountConfig.owners || []
+  // TODO: Maybe also verify the data?
+  const isMultichainSafe = sameAddress(undeployedSafe?.props.safeAccountConfig.to, SAFE_TO_L2_SETUP_ADDRESS)
   const [minRelays] = useLeastRemainingRelays(ownerAddresses)
 
   // Every owner has remaining relays and relay method is selected
@@ -116,6 +119,7 @@ const ActivateAccountFlow = () => {
             callback: onSubmit,
           },
           safeVersion ?? getLatestSafeVersion(chain),
+          isMultichainSafe ? true : undefined,
         )
       }
     } catch (_err) {

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -64,12 +64,16 @@ export const getCurrentGnosisSafeContract = async (safe: SafeInfo, provider: str
   return getGnosisSafeContract(safe, safeProvider)
 }
 
-export const getReadOnlyGnosisSafeContract = async (chain: ChainInfo, safeVersion: SafeInfo['version']) => {
+export const getReadOnlyGnosisSafeContract = async (
+  chain: ChainInfo,
+  safeVersion: SafeInfo['version'],
+  isL1?: boolean,
+) => {
   const version = safeVersion ?? getLatestSafeVersion(chain)
 
   const safeProvider = getSafeProvider()
 
-  const isL1SafeSingleton = !_isL2(chain, _getValidatedGetContractProps(version).safeVersion)
+  const isL1SafeSingleton = isL1 ?? !_isL2(chain, _getValidatedGetContractProps(version).safeVersion)
 
   return getSafeContractInstance(
     _getValidatedGetContractProps(version).safeVersion,


### PR DESCRIPTION
## ATTENTION THIS IS A DRAFT PR AND NOT MEANT TO BE MERGED YET
This PR hardcodes some addresses and is using an un-audited contract.
DO NOT MERGE.

## What this PR changes
Changes the Safe creation transaction for new Safes to use the SafeToL2Setup library

## How to test it

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
