### PR TITLE
Analytics: restore safe address in the safe_created event

### DIFF
--- a/src/features/counterfactual/hooks/usePendingSafeStatuses.ts
+++ b/src/features/counterfactual/hooks/usePendingSafeStatuses.ts
@@ -19,6 +19,7 @@ import { CREATE_SAFE_EVENTS, trackEvent } from '@/services/analytics'
 import { useAppDispatch, useAppSelector } from '@/store'
 import { useEffect, useRef } from 'react'
 import { isSmartContract } from '@/utils/wallets'
+import { gtmSetSafeAddress } from '@/services/analytics/gtm'
 
 export const safeCreationPendingStatuses: Partial<Record<SafeCreationEvent, PendingSafeStatus | null>> = {
   [SafeCreationEvent.PROCESSING]: PendingSafeStatus.PROCESSING,
@@ -109,6 +110,8 @@ const usePendingSafeStatus = (): void => {
     const unsubFns = Object.entries(safeCreationPendingStatuses).map(([event, status]) =>
       safeCreationSubscribe(event as SafeCreationEvent, async (detail) => {
         if (event === SafeCreationEvent.SUCCESS) {
+          gtmSetSafeAddress(detail.safeAddress)
+
           // TODO: Possible to add a label with_tx, without_tx?
           trackEvent(CREATE_SAFE_EVENTS.ACTIVATED_SAFE)
 


### PR DESCRIPTION
## What it solves

#3954 restored the `safe_created` event but not the safe address for it.

## How this PR fixes it

I've added a `gtmSetSafeAddress` call right before the `safe_created` event is emitted.
