### PR TITLE
Fix: allow Safe Apps from localhost:<port>

### DIFF
--- a/src/config/securityHeaders.ts
+++ b/src/config/securityHeaders.ts
@@ -17,7 +17,7 @@ export const ContentSecurityPolicy = `
      ? "'unsafe-eval'" // Dev server and cypress need unsafe-eval
      : "'wasm-unsafe-eval'"
  };
- frame-src http://* https://*;
+ frame-src http: https:;
  style-src 'self' 'unsafe-inline' https://*.getbeamer.com https://*.googleapis.com;
  font-src 'self' data:;
  worker-src 'self' blob:;


### PR DESCRIPTION
## What it solves

Resolves #4079

## How this PR fixes it

The previously used syntax doesn't work for URLs with a port specified.

## How to test it

Try to open a localhost URL as a Safe App.