### PR TITLE
Fix: rm unnecessary border in decoded tx

### DIFF
--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -68,11 +68,7 @@ const DecodedTx = ({
 
   return (
     <Stack spacing={2}>
-      {!isMethodCallInAdvanced && (
-        <Box border="1px solid var(--color-border-light)" borderRadius={1} p={2}>
-          {decodedDataBlock}
-        </Box>
-      )}
+      {!isMethodCallInAdvanced && decodedDataBlock}
 
       {isMultisend && showMultisend && <Multisend txData={txDetails?.txData || txData} compact />}
 


### PR DESCRIPTION
## What it solves

A border was unintentionally added in #3967.

## How this PR fixes it

Removes the border.

Before:
<img width="743" alt="Screenshot 2024-08-21 at 15 38 02" src="https://github.com/user-attachments/assets/6222f73a-28d5-4f3a-9ef2-71a4479f549a">

After:
<img width="708" alt="Screenshot 2024-08-21 at 15 38 12" src="https://github.com/user-attachments/assets/5a6f4e25-9642-40ce-a8c6-1ffbcea40547">
