### PR TITLE
Refactor: use the new Client Gateway SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "react-hook-form": "7.41.1",
     "react-papaparse": "^4.0.2",
     "react-redux": "^9.1.2",
+    "safe-client-gateway-sdk": "git+https://github.com/safe-global/safe-client-gateway-sdk.git",
     "semver": "^7.5.2",
     "zodiac-roles-deployments": "^2.2.5"
   },

--- a/src/components/balances/CurrencySelect/useCurrencies.ts
+++ b/src/components/balances/CurrencySelect/useCurrencies.ts
@@ -1,5 +1,4 @@
 import { useEffect } from 'react'
-import type { FiatCurrencies } from '@safe-global/safe-gateway-typescript-sdk'
 import { getFiatCurrencies } from '@safe-global/safe-gateway-typescript-sdk'
 import useAsync from '@/hooks/useAsync'
 import { Errors, logError } from '@/services/exceptions'
@@ -9,15 +8,14 @@ import { Errors, logError } from '@/services/exceptions'
 // we filter them out because the frontend only supports ISO 4217 currencies
 // and they have to be exactly 3 characters long
 // if that is not the case Intl.NumberFormat will throw an error and crash the app
-const getISO4217Currencies = async (): Promise<FiatCurrencies> => {
+const getISO4217Currencies = async () => {
   const currencies = await getFiatCurrencies()
-
   return currencies.filter((currency) => currency.length === 3)
 }
 
-const useCurrencies = (): FiatCurrencies | undefined => {
+const useCurrencies = (): string[] | undefined => {
   // Re-fetch assets when the entire SafeInfo updates
-  const [data, error] = useAsync<FiatCurrencies>(getISO4217Currencies, [])
+  const [data, error] = useAsync(getISO4217Currencies, [])
 
   // Log errors
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14293,6 +14293,18 @@ open@^8.0.4, open@^8.4.0:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
+openapi-fetch@^0.10.5:
+  version "0.10.6"
+  resolved "https://registry.yarnpkg.com/openapi-fetch/-/openapi-fetch-0.10.6.tgz#255017e3e609c5e7be16bc1ed7a973977c085cdc"
+  integrity sha512-6xXfvIEL/POtLGOaFPsp3O+pDe+J3DZYxbD9BrsQHXOTeNK8z/gsWHT6adUy1KcpQOhmkerMzlQrJM6DbN55dQ==
+  dependencies:
+    openapi-typescript-helpers "^0.0.11"
+
+openapi-typescript-helpers@^0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.11.tgz#d05e88216b8f3771d5df41c863ebc5c9d10e2954"
+  integrity sha512-xofUHlVFq+BMquf3nh9I8N2guHckW6mrDO/F3kaFgrL7MGbjldDnQ9TIT+rkH/+H0LiuO+RuZLnNmsJwsjwUKg==
+
 opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
@@ -15953,6 +15965,12 @@ safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, 
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+"safe-client-gateway-sdk@git+https://github.com/safe-global/safe-client-gateway-sdk.git":
+  version "1.53.0-next-bb7812c"
+  resolved "git+https://github.com/safe-global/safe-client-gateway-sdk.git#ce0bf13e5e985d4c4688c05b49e5cd9b674e4a0e"
+  dependencies:
+    openapi-fetch "^0.10.5"
 
 safe-regex-test@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
## What it solves

An initial implementation of the new Client Gateway SDK.

Feedback documented here: https://github.com/safe-global/safe-client-gateway-sdk/issues/1