### PR TITLE
Fix: limit safeViewRedirectURL redirects to Safe App URLs

### DIFF
--- a/src/components/new-safe/create/logic/index.test.ts
+++ b/src/components/new-safe/create/logic/index.test.ts
@@ -5,7 +5,7 @@ import type { CompatibilityFallbackHandlerContractImplementationType } from '@sa
 import { EMPTY_DATA, ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 import * as web3 from '@/hooks/wallets/web3'
 import * as sdkHelpers from '@/services/tx/tx-sender/sdk'
-import { relaySafeCreation } from '@/components/new-safe/create/logic/index'
+import { getRedirect, relaySafeCreation } from '@/components/new-safe/create/logic/index'
 import { relayTransaction } from '@safe-global/safe-gateway-typescript-sdk'
 import { toBeHex } from 'ethers'
 import {
@@ -102,5 +102,28 @@ describe('createNewSafeViaRelayer', () => {
     jest.spyOn(gateway, 'relayTransaction').mockRejectedValue(relayFailedError)
 
     expect(relaySafeCreation(mockChainInfo, [owner1, owner2], 1, 69)).rejects.toEqual(relayFailedError)
+  })
+
+  describe('getRedirect', () => {
+    it("should redirect to home for any redirect that doesn't start with /apps", () => {
+      const expected = {
+        pathname: '/home',
+        query: {
+          safe: 'sep:0x1234',
+        },
+      }
+      expect(getRedirect('sep', '0x1234', 'https://google.com')).toEqual(expected)
+      expect(getRedirect('sep', '0x1234', '/queue')).toEqual(expected)
+    })
+
+    it('should redirect to an app if an app URL is passed', () => {
+      expect(getRedirect('sep', '0x1234', '/apps?appUrl=https://safe-eth.everstake.one/?chain=eth')).toEqual(
+        '/apps?appUrl=https://safe-eth.everstake.one/?chain=eth&safe=sep:0x1234',
+      )
+
+      expect(getRedirect('sep', '0x1234', '/apps?appUrl=https://safe-eth.everstake.one')).toEqual(
+        '/apps?appUrl=https://safe-eth.everstake.one&safe=sep:0x1234',
+      )
+    })
   })
 })

--- a/src/components/new-safe/create/logic/index.ts
+++ b/src/components/new-safe/create/logic/index.ts
@@ -157,17 +157,14 @@ export const getRedirect = (
   if (!chainPrefix) return AppRoutes.index
 
   // Go to the dashboard if no specific redirect is provided
-  if (!redirectUrl) {
+  if (!redirectUrl || !redirectUrl.startsWith(AppRoutes.apps.index)) {
     return { pathname: AppRoutes.home, query: { safe: address } }
   }
 
   // Otherwise, redirect to the provided URL (e.g. from a Safe App)
 
   // Track the redirect to Safe App
-  // TODO: Narrow this down to /apps only
-  if (redirectUrl.includes('apps')) {
-    trackEvent(SAFE_APPS_EVENTS.SHARED_APP_OPEN_AFTER_SAFE_CREATION)
-  }
+  trackEvent(SAFE_APPS_EVENTS.SHARED_APP_OPEN_AFTER_SAFE_CREATION)
 
   // We're prepending the safe address directly here because the `router.push` doesn't parse
   // The URL for already existing query params

--- a/src/components/new-safe/create/steps/StatusStep/index.tsx
+++ b/src/components/new-safe/create/steps/StatusStep/index.tsx
@@ -54,7 +54,10 @@ export const CreateSafeStatus = ({
 
     if (status === SafeCreationEvent.SUCCESS) {
       dispatch(updateAddressBook(chain.chainId, safeAddress, data.name, data.owners, data.threshold))
-      router.push(getRedirect(chain.shortName, safeAddress, router.query?.safeViewRedirectURL))
+      const redirect = getRedirect(chain.shortName, safeAddress, router.query?.safeViewRedirectURL)
+      if (typeof redirect !== 'string' || redirect.startsWith('/')) {
+        router.push(redirect)
+      }
     }
   }, [dispatch, chain, data.name, data.owners, data.threshold, router, safeAddress, status])
 


### PR DESCRIPTION
## What it solves

Limits redirects to known URLs.

## How this PR fixes it

The redirect was introduced here: #519 – to allow creating a Safe from a Safe App share URL and then going back to that Safe App.

## How to test it
* Open a share link of any Safe App, e.g. https://app.safe.global/share/safe-app?appUrl=https%3A%2F%2Fsafe-eth.everstake.one%2F&chain=eth
* Connect a wallet that doesn't have Safes on that chain
* Click on Create new Safe Account
* Complete a Safe creation
* You'll be redirected back to that Safe App

<img width="912" alt="Screenshot 2024-08-22 at 12 43 42" src="https://github.com/user-attachments/assets/07e20baa-a988-4891-b0e5-473a2e2d17f9">