### PR TITLE
feat: show multichain accounts in sidebar

### DIFF
--- a/public/images/sidebar/multichain-account.svg
+++ b/public/images/sidebar/multichain-account.svg
@@ -1,0 +1,8 @@
+<svg width="26" height="26" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13 0.5C6.09644 0.5 0.5 6.09644 0.5 13C0.5 19.9036 6.09644 25.5 13 25.5C19.9036 25.5 25.5 19.9036 25.5 13C25.5 6.09644 19.9036 0.5 13 0.5Z" fill="#B0FFC9"/>
+<path d="M13 0.5C6.09644 0.5 0.5 6.09644 0.5 13C0.5 19.9036 6.09644 25.5 13 25.5C19.9036 25.5 25.5 19.9036 25.5 13C25.5 6.09644 19.9036 0.5 13 0.5Z" stroke="white"/>
+<rect x="8" y="8" width="4" height="4" rx="0.666667" fill="black"/>
+<rect x="8" y="14" width="4" height="4" rx="0.666667" fill="black"/>
+<rect x="14" y="8" width="4" height="4" rx="0.666667" fill="black"/>
+<rect x="14" y="14" width="4" height="4" rx="0.666667" fill="black"/>
+</svg>

--- a/src/components/common/SafeIcon/index.tsx
+++ b/src/components/common/SafeIcon/index.tsx
@@ -1,8 +1,9 @@
 import type { ReactElement } from 'react'
-import { Box } from '@mui/material'
+import { Box, Skeleton } from '@mui/material'
 
 import css from './styles.module.css'
 import Identicon, { type IdenticonProps } from '../Identicon'
+import { useChain } from '@/hooks/useChains'
 
 interface ThresholdProps {
   threshold: number | string
@@ -18,13 +19,35 @@ interface SafeIconProps extends IdenticonProps {
   threshold?: ThresholdProps['threshold']
   owners?: ThresholdProps['owners']
   size?: number
+  chainId?: string
+  isSubItem?: boolean
 }
 
-const SafeIcon = ({ address, threshold, owners, size }: SafeIconProps): ReactElement => (
-  <div className={css.container}>
-    {threshold && owners ? <Threshold threshold={threshold} owners={owners} /> : null}
-    <Identicon address={address} size={size} />
-  </div>
-)
+const ChainIcon = ({ chainId }: { chainId: string }) => {
+  const chainConfig = useChain(chainId)
+
+  if (!chainConfig) {
+    return <Skeleton variant="circular" width={40} height={40} />
+  }
+
+  return (
+    <img
+      src={chainConfig.chainLogoUri ?? undefined}
+      alt={`${chainConfig.chainName} Logo`}
+      width={40}
+      height={40}
+      loading="lazy"
+    />
+  )
+}
+
+const SafeIcon = ({ address, threshold, owners, size, chainId, isSubItem = false }: SafeIconProps): ReactElement => {
+  return (
+    <div className={css.container}>
+      {threshold && owners ? <Threshold threshold={threshold} owners={owners} /> : null}
+      {isSubItem && chainId ? <ChainIcon chainId={chainId} /> : <Identicon address={address} size={size} />}
+    </div>
+  )
+}
 
 export default SafeIcon

--- a/src/components/welcome/MyAccounts/AccountItem.tsx
+++ b/src/components/welcome/MyAccounts/AccountItem.tsx
@@ -1,7 +1,7 @@
 import { LoopIcon } from '@/features/counterfactual/CounterfactualStatusButton'
 import { selectUndeployedSafe } from '@/features/counterfactual/store/undeployedSafesSlice'
-import type { ChainInfo, SafeOverview } from '@safe-global/safe-gateway-typescript-sdk'
-import { useCallback, useMemo } from 'react'
+import type { SafeOverview } from '@safe-global/safe-gateway-typescript-sdk'
+import { useMemo } from 'react'
 import { ListItemButton, Box, Typography, Chip, Skeleton } from '@mui/material'
 import Link from 'next/link'
 import SafeIcon from '@/components/common/SafeIcon'
@@ -24,6 +24,7 @@ import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
 import type { SafeItem } from './useAllSafes'
 import FiatValue from '@/components/common/FiatValue'
 import QueueActions from './QueueActions'
+import { useGetHref } from './useGetHref'
 
 type AccountItemProps = {
   safeItem: SafeItem
@@ -40,24 +41,10 @@ const AccountItem = ({ onLinkClick, safeItem, safeOverview }: AccountItemProps) 
   const router = useRouter()
   const isCurrentSafe = chainId === currChainId && sameAddress(safeAddress, address)
   const isWelcomePage = router.pathname === AppRoutes.welcome.accounts
-  const isSingleTxPage = router.pathname === AppRoutes.transactions.tx
 
   const trackingLabel = isWelcomePage ? OVERVIEW_LABELS.login_page : OVERVIEW_LABELS.sidebar
 
-  /**
-   * Navigate to the dashboard when selecting a safe on the welcome page,
-   * navigate to the history when selecting a safe on a single tx page,
-   * otherwise keep the current route
-   */
-  const getHref = useCallback(
-    (chain: ChainInfo, address: string) => {
-      return {
-        pathname: isWelcomePage ? AppRoutes.home : isSingleTxPage ? AppRoutes.transactions.history : router.pathname,
-        query: { ...router.query, safe: `${chain.shortName}:${address}` },
-      }
-    },
-    [isWelcomePage, isSingleTxPage, router.pathname, router.query],
-  )
+  const getHref = useGetHref(router)
 
   const href = useMemo(() => {
     return chain ? getHref(chain, address) : ''

--- a/src/components/welcome/MyAccounts/MultiAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/MultiAccountItem.tsx
@@ -1,4 +1,4 @@
-import { selectUndeployedSafesByAddress } from '@/features/counterfactual/store/undeployedSafesSlice'
+import { selectUndeployedSafes } from '@/features/counterfactual/store/undeployedSafesSlice'
 import type { SafeOverview } from '@safe-global/safe-gateway-typescript-sdk'
 import { useMemo, useState } from 'react'
 import {
@@ -39,7 +39,7 @@ type MultiAccountItemProps = {
 
 const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, safeOverviews }: MultiAccountItemProps) => {
   const { address, safes } = multiSafeAccountItem
-  const undeployedSafes = useAppSelector((state) => selectUndeployedSafesByAddress(state, address))
+  const undeployedSafes = useAppSelector(selectUndeployedSafes)
   const safeAddress = useSafeAddress()
   const router = useRouter()
   const isCurrentSafe = sameAddress(safeAddress, address)
@@ -59,7 +59,7 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, safeOverviews }: 
   }, [address, allAddressBooks])
 
   const sharedSetup = useMemo(
-    () => getSharedSetup(safes, safeOverviews ?? [], undeployedSafes[0]),
+    () => getSharedSetup(safes, safeOverviews ?? [], undeployedSafes),
     [safeOverviews, safes, undeployedSafes],
   )
 

--- a/src/components/welcome/MyAccounts/MultiAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/MultiAccountItem.tsx
@@ -1,0 +1,147 @@
+import { selectUndeployedSafesByAddress } from '@/features/counterfactual/store/undeployedSafesSlice'
+import type { SafeOverview } from '@safe-global/safe-gateway-typescript-sdk'
+import { useMemo, useState } from 'react'
+import {
+  ListItemButton,
+  Box,
+  Typography,
+  Skeleton,
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Divider,
+  Button,
+} from '@mui/material'
+import SafeIcon from '@/components/common/SafeIcon'
+import { OVERVIEW_EVENTS, OVERVIEW_LABELS, trackEvent } from '@/services/analytics'
+import { AppRoutes } from '@/config/routes'
+import { useAppSelector } from '@/store'
+import css from './styles.module.css'
+import { selectAllAddressBooks } from '@/store/addressBookSlice'
+import useSafeAddress from '@/hooks/useSafeAddress'
+import { sameAddress } from '@/utils/addresses'
+import classnames from 'classnames'
+import { useRouter } from 'next/router'
+import FiatValue from '@/components/common/FiatValue'
+import { type MultiChainSafeItem } from './useAllSafesGrouped'
+import MultiChainIcon from '@/public/images/sidebar/multichain-account.svg'
+import { shortenAddress } from '@/utils/formatters'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import { type SafeItem } from './useAllSafes'
+import SubAccountItem from './SubAccountItem'
+import { getSharedSetup } from './utils/multiChainSafe'
+
+type MultiAccountItemProps = {
+  multiSafeAccountItem: MultiChainSafeItem
+  safeOverviews?: SafeOverview[]
+  onLinkClick?: () => void
+}
+
+const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, safeOverviews }: MultiAccountItemProps) => {
+  const { address, safes } = multiSafeAccountItem
+  const undeployedSafes = useAppSelector((state) => selectUndeployedSafesByAddress(state, address))
+  const safeAddress = useSafeAddress()
+  const router = useRouter()
+  const isCurrentSafe = sameAddress(safeAddress, address)
+  const isWelcomePage = router.pathname === AppRoutes.welcome.accounts
+  const [expanded, setExpanded] = useState(isCurrentSafe)
+
+  const trackingLabel = isWelcomePage ? OVERVIEW_LABELS.login_page : OVERVIEW_LABELS.sidebar
+
+  const toggleExpand = () => {
+    trackEvent({ ...OVERVIEW_EVENTS.EXPAND_MULTI_SAFE, label: trackingLabel })
+    setExpanded((prev) => !prev)
+  }
+
+  const allAddressBooks = useAppSelector(selectAllAddressBooks)
+  const name = useMemo(() => {
+    return Object.values(allAddressBooks).find((ab) => ab[address] !== undefined)?.[address]
+  }, [address, allAddressBooks])
+
+  const sharedSetup = useMemo(
+    () => getSharedSetup(safes, safeOverviews ?? [], undeployedSafes[0]),
+    [safeOverviews, safes, undeployedSafes],
+  )
+
+  const totalFiatValue = useMemo(
+    () => safeOverviews?.reduce((prev, current) => prev + Number(current.fiatTotal), 0),
+    [safeOverviews],
+  )
+
+  const findOverview = (item: SafeItem) => {
+    return safeOverviews?.find(
+      (overview) => item.chainId === overview.chainId && sameAddress(overview.address.value, item.address),
+    )
+  }
+
+  return (
+    <ListItemButton
+      data-testid="safe-list-item"
+      selected={isCurrentSafe}
+      className={classnames(css.listItem, { [css.currentListItem]: isCurrentSafe })}
+      sx={{ p: 0 }}
+    >
+      <Accordion expanded={expanded} sx={{ border: 'none' }}>
+        <AccordionSummary
+          onClick={toggleExpand}
+          expandIcon={<ExpandMoreIcon />}
+          sx={{
+            pl: 0,
+            '& .MuiAccordionSummary-content': { m: 0 },
+            '&.Mui-expanded': { backgroundColor: 'transparent !important' },
+          }}
+        >
+          <Box className={css.safeLink} width="100%">
+            <Box pr={2.5}>
+              <SafeIcon address={address} owners={sharedSetup?.owners.length} threshold={sharedSetup?.threshold} />
+            </Box>
+
+            <Typography variant="body2" component="div" className={css.safeAddress}>
+              {name && (
+                <Typography variant="subtitle2" component="p" fontWeight="bold" className={css.safeName}>
+                  {name}
+                </Typography>
+              )}
+              <Typography color="var(--color-primary-light)" fontSize="inherit" component="span">
+                {shortenAddress(address)}
+              </Typography>
+            </Typography>
+
+            <Typography variant="body2" fontWeight="bold" textAlign="right" pr={4}>
+              {totalFiatValue !== undefined ? (
+                <FiatValue value={totalFiatValue} />
+              ) : (
+                <Skeleton variant="text" sx={{ ml: 'auto' }} />
+              )}
+            </Typography>
+
+            <MultiChainIcon />
+          </Box>
+        </AccordionSummary>
+        <AccordionDetails sx={{ padding: 0 }}>
+          <Box sx={{ padding: '0px 0px 0px 36px' }}>
+            {safes.map((safeItem) => (
+              <SubAccountItem
+                onLinkClick={onLinkClick}
+                safeItem={safeItem}
+                key={`${safeItem.chainId}:${safeItem.address}`}
+                safeOverview={findOverview(safeItem)}
+              />
+            ))}
+          </Box>
+          <Divider />
+          <Box display="flex" alignItems="center" justifyContent="center">
+            {/* TODO: Trigger Safe creation flow with a new network */}
+            <Button variant="text" fullWidth>
+              + Add another network
+            </Button>
+          </Box>
+        </AccordionDetails>
+      </Accordion>
+
+      {/* <SafeListContextMenu name={name ?? ''} address={address} chainId={chainId} />  */}
+    </ListItemButton>
+  )
+}
+
+export default MultiAccountItem

--- a/src/components/welcome/MyAccounts/MultiAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/MultiAccountItem.tsx
@@ -138,8 +138,6 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, safeOverviews }: 
           </Box>
         </AccordionDetails>
       </Accordion>
-
-      {/* <SafeListContextMenu name={name ?? ''} address={address} chainId={chainId} />  */}
     </ListItemButton>
   )
 }

--- a/src/components/welcome/MyAccounts/SubAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/SubAccountItem.tsx
@@ -10,10 +10,8 @@ import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
 import { AppRoutes } from '@/config/routes'
 import { useAppSelector } from '@/store'
 import { selectChainById } from '@/store/chainsSlice'
-import ChainIndicator from '@/components/common/ChainIndicator'
 import css from './styles.module.css'
 import { selectAllAddressBooks } from '@/store/addressBookSlice'
-import { shortenAddress } from '@/utils/formatters'
 import SafeListContextMenu from '@/components/sidebar/SafeListContextMenu'
 import useSafeAddress from '@/hooks/useSafeAddress'
 import useChainId from '@/hooks/useChainId'
@@ -25,13 +23,13 @@ import type { SafeItem } from './useAllSafes'
 import FiatValue from '@/components/common/FiatValue'
 import QueueActions from './QueueActions'
 
-type AccountItemProps = {
+type SubAccountItem = {
   safeItem: SafeItem
   safeOverview?: SafeOverview
   onLinkClick?: () => void
 }
 
-const AccountItem = ({ onLinkClick, safeItem, safeOverview }: AccountItemProps) => {
+const SubAccountItem = ({ onLinkClick, safeItem, safeOverview }: SubAccountItem) => {
   const { chainId, address } = safeItem
   const chain = useAppSelector((state) => selectChainById(state, chainId))
   const undeployedSafe = useAppSelector((state) => selectUndeployedSafe(state, chainId, address))
@@ -71,7 +69,7 @@ const AccountItem = ({ onLinkClick, safeItem, safeOverview }: AccountItemProps) 
     <ListItemButton
       data-testid="safe-list-item"
       selected={isCurrentSafe}
-      className={classnames(css.listItem, { [css.currentListItem]: isCurrentSafe })}
+      className={classnames(css.listItem, { [css.currentListItem]: isCurrentSafe }, css.subItem)}
     >
       <Track {...OVERVIEW_EVENTS.OPEN_SAFE} label={trackingLabel}>
         <Link onClick={onLinkClick} href={href} className={css.safeLink}>
@@ -80,6 +78,7 @@ const AccountItem = ({ onLinkClick, safeItem, safeOverview }: AccountItemProps) 
               address={address}
               owners={safeOverview?.owners.length ?? undeployedSafe?.props.safeAccountConfig.owners.length}
               threshold={safeOverview?.threshold ?? undeployedSafe?.props.safeAccountConfig.threshold}
+              isSubItem
               chainId={chainId}
             />
           </Box>
@@ -90,9 +89,8 @@ const AccountItem = ({ onLinkClick, safeItem, safeOverview }: AccountItemProps) 
                 {name}
               </Typography>
             )}
-            {chain?.shortName}:
             <Typography color="var(--color-primary-light)" fontSize="inherit" component="span">
-              {shortenAddress(address)}
+              {chain?.chainName}
             </Typography>
             {undeployedSafe && (
               <div>
@@ -121,8 +119,6 @@ const AccountItem = ({ onLinkClick, safeItem, safeOverview }: AccountItemProps) 
               <Skeleton variant="text" />
             )}
           </Typography>
-
-          <ChainIndicator chainId={chainId} responsive />
         </Link>
       </Track>
 
@@ -134,8 +130,9 @@ const AccountItem = ({ onLinkClick, safeItem, safeOverview }: AccountItemProps) 
         safeAddress={address}
         chainShortName={chain?.shortName || ''}
       />
+      <div className={css.borderLeft} />
     </ListItemButton>
   )
 }
 
-export default AccountItem
+export default SubAccountItem

--- a/src/components/welcome/MyAccounts/SubAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/SubAccountItem.tsx
@@ -1,7 +1,7 @@
 import { LoopIcon } from '@/features/counterfactual/CounterfactualStatusButton'
 import { selectUndeployedSafe } from '@/features/counterfactual/store/undeployedSafesSlice'
-import type { ChainInfo, SafeOverview } from '@safe-global/safe-gateway-typescript-sdk'
-import { useCallback, useMemo } from 'react'
+import type { SafeOverview } from '@safe-global/safe-gateway-typescript-sdk'
+import { useMemo } from 'react'
 import { ListItemButton, Box, Typography, Chip, Skeleton } from '@mui/material'
 import Link from 'next/link'
 import SafeIcon from '@/components/common/SafeIcon'
@@ -22,6 +22,7 @@ import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
 import type { SafeItem } from './useAllSafes'
 import FiatValue from '@/components/common/FiatValue'
 import QueueActions from './QueueActions'
+import { useGetHref } from './useGetHref'
 
 type SubAccountItem = {
   safeItem: SafeItem
@@ -38,24 +39,10 @@ const SubAccountItem = ({ onLinkClick, safeItem, safeOverview }: SubAccountItem)
   const router = useRouter()
   const isCurrentSafe = chainId === currChainId && sameAddress(safeAddress, address)
   const isWelcomePage = router.pathname === AppRoutes.welcome.accounts
-  const isSingleTxPage = router.pathname === AppRoutes.transactions.tx
 
   const trackingLabel = isWelcomePage ? OVERVIEW_LABELS.login_page : OVERVIEW_LABELS.sidebar
 
-  /**
-   * Navigate to the dashboard when selecting a safe on the welcome page,
-   * navigate to the history when selecting a safe on a single tx page,
-   * otherwise keep the current route
-   */
-  const getHref = useCallback(
-    (chain: ChainInfo, address: string) => {
-      return {
-        pathname: isWelcomePage ? AppRoutes.home : isSingleTxPage ? AppRoutes.transactions.history : router.pathname,
-        query: { ...router.query, safe: `${chain.shortName}:${address}` },
-      }
-    },
-    [isWelcomePage, isSingleTxPage, router.pathname, router.query],
-  )
+  const getHref = useGetHref(router)
 
   const href = useMemo(() => {
     return chain ? getHref(chain, address) : ''

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import { Box, Button, Link, SvgIcon, Typography } from '@mui/material'
 import madProps from '@/utils/mad-props'
 import CreateButton from './CreateButton'
-import useAllSafes, { type SafeItems } from './useAllSafes'
 import Track from '@/components/common/Track'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
 import { DataWidget } from '@/components/welcome/MyAccounts/DataWidget'
@@ -15,20 +14,44 @@ import ConnectWalletButton from '@/components/common/ConnectWallet/ConnectWallet
 import useWallet from '@/hooks/wallets/useWallet'
 import { useRouter } from 'next/router'
 import useTrackSafesCount from './useTrackedSafesCount'
+import { type AllSafesGrouped, useAllSafesGrouped, type MultiChainSafeItem } from './useAllSafesGrouped'
+import { type SafeItem } from './useAllSafes'
 
 const NO_SAFES_MESSAGE = "You don't have any Safe Accounts yet"
 const NO_WATCHED_MESSAGE = 'Watch any Safe Account to keep an eye on its activity'
 
 type AccountsListProps = {
-  safes?: SafeItems | undefined
+  safes: AllSafesGrouped
   onLinkClick?: () => void
 }
 const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
   const wallet = useWallet()
   const router = useRouter()
 
-  const ownedSafes = useMemo(() => safes?.filter(({ isWatchlist }) => !isWatchlist), [safes])
-  const watchlistSafes = useMemo(() => safes?.filter(({ isWatchlist }) => isWatchlist), [safes])
+  // We consider a multiChain account owned if at least one of the multiChain accounts is not on the watchlist
+  const ownedMultiChainSafes = useMemo(
+    () => safes.allMultiChainSafes?.filter((account) => account.safes.some(({ isWatchlist }) => !isWatchlist)),
+    [safes],
+  )
+
+  // If all safes of a multichain account are on the watchlist we put the entire account on the watchlist
+  const watchlistMultiChainSafes = useMemo(
+    () => safes.allMultiChainSafes?.filter((account) => !account.safes.some(({ isWatchlist }) => !isWatchlist)),
+    [safes],
+  )
+
+  const ownedSafes = useMemo<(MultiChainSafeItem | SafeItem)[]>(
+    () => [...(ownedMultiChainSafes ?? []), ...(safes.allSingleSafes?.filter(({ isWatchlist }) => !isWatchlist) ?? [])],
+    [safes, ownedMultiChainSafes],
+  )
+  const watchlistSafes = useMemo<(MultiChainSafeItem | SafeItem)[]>(
+    () => [
+      ...(watchlistMultiChainSafes ?? []),
+      ...(safes.allSingleSafes?.filter(({ isWatchlist }) => isWatchlist) ?? []),
+    ],
+    [safes, watchlistMultiChainSafes],
+  )
+
   useTrackSafesCount(ownedSafes, watchlistSafes, wallet)
 
   const isLoginPage = router.pathname === AppRoutes.welcome.accounts
@@ -97,7 +120,7 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
 }
 
 const MyAccounts = madProps(AccountsList, {
-  safes: useAllSafes,
+  safes: useAllSafesGrouped,
 })
 
 export default MyAccounts

--- a/src/components/welcome/MyAccounts/styles.module.css
+++ b/src/components/welcome/MyAccounts/styles.module.css
@@ -83,10 +83,10 @@
   top: 0;
   bottom: 0;
   position: absolute;
-  border-left: 2px solid var(--color-border-light);
+  border-left: 1px solid var(--color-border-light);
 }
 .subItem.currentListItem .borderLeft {
-  border-left: 2px solid var(--color-secondary-light);
+  border-left: 1px solid var(--color-secondary-light);
 }
 
 .subItem:last-child {

--- a/src/components/welcome/MyAccounts/styles.module.css
+++ b/src/components/welcome/MyAccounts/styles.module.css
@@ -44,6 +44,60 @@
   background-color: var(--color-background-light) !important;
 }
 
+.listItem :global .MuiAccordion-root,
+.listItem :global .MuiAccordion-root:hover > .MuiAccordionSummary-root {
+  background-color: transparent;
+}
+
+.listItem :global .MuiAccordion-root.Mui-expanded {
+  background-color: var(--color-background-paper);
+}
+
+.listItem.subItem {
+  border: none;
+  margin-bottom: 0px;
+  border-radius: 0px;
+}
+
+.subItem:before {
+  content: '';
+  display: block;
+  width: 8px;
+  height: 1px;
+  background: var(--color-border-light);
+  left: 0;
+  top: 50%;
+  position: absolute;
+}
+
+.subItem.currentListItem {
+  border: none;
+}
+
+.subItem.currentListItem:before {
+  background: var(--color-secondary-light);
+  height: 1px;
+}
+
+.subItem .borderLeft {
+  top: 0;
+  bottom: 0;
+  position: absolute;
+  border-left: 2px solid var(--color-border-light);
+}
+.subItem.currentListItem .borderLeft {
+  border-left: 2px solid var(--color-secondary-light);
+}
+
+.subItem:last-child {
+  border-left: none;
+}
+
+.subItem:last-child .borderLeft {
+  top: 0%;
+  bottom: 50%;
+}
+
 .listItem > :first-child {
   flex: 1;
   width: 90%;

--- a/src/components/welcome/MyAccounts/useAllSafesGrouped.ts
+++ b/src/components/welcome/MyAccounts/useAllSafesGrouped.ts
@@ -1,0 +1,40 @@
+import { groupBy } from 'lodash'
+import useAllSafes, { type SafeItem, type SafeItems } from './useAllSafes'
+import { useMemo } from 'react'
+import { sameAddress } from '@/utils/addresses'
+
+export type MultiChainSafeItem = { address: string; safes: SafeItem[] }
+
+export type AllSafesGrouped = {
+  allSingleSafes: SafeItems | undefined
+  allMultiChainSafes: MultiChainSafeItem[] | undefined
+}
+
+const getMultiChainAccounts = (safes: SafeItems): MultiChainSafeItem[] => {
+  const groupedByAddress = groupBy(safes, (safe) => safe.address)
+  const multiChainSafeItems = Object.entries(groupedByAddress)
+    .filter((entry) => entry[1].length > 1)
+    .map((entry): MultiChainSafeItem => ({ address: entry[0], safes: entry[1] }))
+
+  return multiChainSafeItems
+}
+
+export const useAllSafesGrouped = () => {
+  const allSafes = useAllSafes()
+
+  return useMemo<AllSafesGrouped>(() => {
+    if (!allSafes) {
+      return { allMultiChainSafes: undefined, allSingleSafes: undefined }
+    }
+    // Extract all multichain Accounts and single Safes
+    const allMultiChainSafes = getMultiChainAccounts(allSafes)
+    const allSingleSafes = allSafes.filter(
+      (safe) => !allMultiChainSafes.some((multiSafe) => sameAddress(multiSafe.address, safe.address)),
+    )
+
+    return {
+      allMultiChainSafes,
+      allSingleSafes,
+    }
+  }, [allSafes])
+}

--- a/src/components/welcome/MyAccounts/useGetHref.ts
+++ b/src/components/welcome/MyAccounts/useGetHref.ts
@@ -1,0 +1,24 @@
+import { AppRoutes } from '@/config/routes'
+import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { type NextRouter } from 'next/router'
+import { useCallback } from 'react'
+
+/**
+ * Navigate to the dashboard when selecting a safe on the welcome page,
+ * navigate to the history when selecting a safe on a single tx page,
+ * otherwise keep the current route
+ */
+export const useGetHref = (router: NextRouter) => {
+  const isWelcomePage = router.pathname === AppRoutes.welcome.accounts
+  const isSingleTxPage = router.pathname === AppRoutes.transactions.tx
+
+  return useCallback(
+    (chain: ChainInfo, address: string) => {
+      return {
+        pathname: isWelcomePage ? AppRoutes.home : isSingleTxPage ? AppRoutes.transactions.history : router.pathname,
+        query: { ...router.query, safe: `${chain.shortName}:${address}` },
+      }
+    },
+    [isSingleTxPage, isWelcomePage, router.pathname, router.query],
+  )
+}

--- a/src/components/welcome/MyAccounts/useTrackedSafesCount.ts
+++ b/src/components/welcome/MyAccounts/useTrackedSafesCount.ts
@@ -2,15 +2,17 @@ import { AppRoutes } from '@/config/routes'
 import { OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
-import type { SafeItems } from './useAllSafes'
 import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
+import { type SafeItem } from './useAllSafes'
+import { type MultiChainSafeItem } from './useAllSafesGrouped'
+import { isMultiChainSafeItem } from './utils/multiChainSafe'
 
 let isOwnedSafesTracked = false
 let isWatchlistTracked = false
 
 const useTrackSafesCount = (
-  ownedSafes: SafeItems | undefined,
-  watchlistSafes: SafeItems | undefined,
+  ownedSafes: (MultiChainSafeItem | SafeItem)[] | undefined,
+  watchlistSafes: (MultiChainSafeItem | SafeItem)[] | undefined,
   wallet: ConnectedWallet | null,
 ) => {
   const router = useRouter()
@@ -22,15 +24,23 @@ const useTrackSafesCount = (
   }, [wallet?.address])
 
   useEffect(() => {
+    const totalSafesOwned = ownedSafes?.reduce(
+      (prev, current) => prev + (isMultiChainSafeItem(current) ? current.safes.length : 1),
+      0,
+    )
     if (wallet && !isOwnedSafesTracked && ownedSafes && ownedSafes.length > 0 && isLoginPage) {
-      trackEvent({ ...OVERVIEW_EVENTS.TOTAL_SAFES_OWNED, label: ownedSafes.length })
+      trackEvent({ ...OVERVIEW_EVENTS.TOTAL_SAFES_OWNED, label: totalSafesOwned })
       isOwnedSafesTracked = true
     }
   }, [isLoginPage, ownedSafes, wallet])
 
   useEffect(() => {
+    const totalSafesWatched = watchlistSafes?.reduce(
+      (prev, current) => prev + (isMultiChainSafeItem(current) ? current.safes.length : 1),
+      0,
+    )
     if (watchlistSafes && isLoginPage && watchlistSafes.length > 0 && !isWatchlistTracked) {
-      trackEvent({ ...OVERVIEW_EVENTS.TOTAL_SAFES_WATCHLIST, label: watchlistSafes.length })
+      trackEvent({ ...OVERVIEW_EVENTS.TOTAL_SAFES_WATCHLIST, label: totalSafesWatched })
       isWatchlistTracked = true
     }
   }, [isLoginPage, watchlistSafes])

--- a/src/components/welcome/MyAccounts/utils/multiChainSafe.test.ts
+++ b/src/components/welcome/MyAccounts/utils/multiChainSafe.test.ts
@@ -1,0 +1,447 @@
+import { faker } from '@faker-js/faker/locale/af_ZA'
+import { getSharedSetup, isMultiChainSafeItem } from './multiChainSafe'
+import { PendingSafeStatus } from '@/store/slices'
+import { PayMethod } from '@/features/counterfactual/PayNowPayLater'
+
+describe('multiChainSafe', () => {
+  describe('isMultiChainSafeItem', () => {
+    it('should return true for MultiChainSafeIem', () => {
+      expect(
+        isMultiChainSafeItem({
+          address: faker.finance.ethereumAddress(),
+          safes: [
+            {
+              address: faker.finance.ethereumAddress(),
+              chainId: '1',
+              isWatchlist: false,
+            },
+          ],
+        }),
+      ).toBeTruthy()
+    })
+
+    it('should return false for SafeItem', () => {
+      expect(
+        isMultiChainSafeItem({
+          address: faker.finance.ethereumAddress(),
+          chainId: '1',
+          isWatchlist: false,
+        }),
+      ).toBeFalsy()
+    })
+  })
+
+  describe('getSharedSetup', () => {
+    it('should return undefined if no setup infos available', () => {
+      expect(
+        getSharedSetup(
+          [
+            {
+              address: faker.finance.ethereumAddress(),
+              chainId: '1',
+              isWatchlist: false,
+            },
+          ],
+          [],
+          undefined,
+        ),
+      ).toBeUndefined()
+    })
+
+    it('should return undefined if the owners do not match', () => {
+      const address = faker.finance.ethereumAddress()
+
+      // 2 Safes. One with 1 and one with 2 owners.
+      const owners1 = [
+        {
+          value: faker.finance.ethereumAddress(),
+        },
+      ]
+      const owners2 = [...owners1, { value: faker.finance.ethereumAddress() }]
+
+      expect(
+        getSharedSetup(
+          [
+            {
+              address,
+              chainId: '1',
+              isWatchlist: false,
+            },
+            {
+              address,
+              chainId: '100',
+              isWatchlist: false,
+            },
+          ],
+          [
+            {
+              address: {
+                value: address,
+              },
+              awaitingConfirmation: null,
+              chainId: '1',
+              fiatTotal: '0',
+              owners: owners1,
+              queued: 0,
+              threshold: 1,
+            },
+            {
+              address: {
+                value: address,
+              },
+              awaitingConfirmation: null,
+              chainId: '100',
+              fiatTotal: '0',
+              owners: owners2,
+              queued: 0,
+              threshold: 1,
+            },
+          ],
+          undefined,
+        ),
+      ).toBeUndefined()
+    })
+    it('should return undefined if the threshold does not match', () => {
+      const address = faker.finance.ethereumAddress()
+
+      const owners = [{ value: faker.finance.ethereumAddress() }, { value: faker.finance.ethereumAddress() }]
+
+      expect(
+        getSharedSetup(
+          [
+            {
+              address,
+              chainId: '1',
+              isWatchlist: false,
+            },
+            {
+              address,
+              chainId: '100',
+              isWatchlist: false,
+            },
+          ],
+          [
+            {
+              address: {
+                value: address,
+              },
+              awaitingConfirmation: null,
+              chainId: '1',
+              fiatTotal: '0',
+              owners,
+              queued: 0,
+              threshold: 1,
+            },
+            {
+              address: {
+                value: address,
+              },
+              awaitingConfirmation: null,
+              chainId: '100',
+              fiatTotal: '0',
+              owners,
+              queued: 0,
+              threshold: 2,
+            },
+          ],
+          undefined,
+        ),
+      ).toBeUndefined()
+    })
+
+    it('should return the shared setup if owners and threshold matches', () => {
+      const address = faker.finance.ethereumAddress()
+
+      const owners = [{ value: faker.finance.ethereumAddress() }, { value: faker.finance.ethereumAddress() }]
+
+      expect(
+        getSharedSetup(
+          [
+            {
+              address,
+              chainId: '1',
+              isWatchlist: false,
+            },
+            {
+              address,
+              chainId: '100',
+              isWatchlist: false,
+            },
+          ],
+          [
+            {
+              address: {
+                value: address,
+              },
+              awaitingConfirmation: null,
+              chainId: '1',
+              fiatTotal: '0',
+              owners,
+              queued: 0,
+              threshold: 2,
+            },
+            {
+              address: {
+                value: address,
+              },
+              awaitingConfirmation: null,
+              chainId: '100',
+              fiatTotal: '0',
+              owners,
+              queued: 0,
+              threshold: 2,
+            },
+          ],
+          undefined,
+        ),
+      ).toEqual({ owners: owners.map((owner) => owner.value), threshold: 2 })
+    })
+
+    it('should return undefined if owners do not match and some Safes are undeployed', () => {
+      const address = faker.finance.ethereumAddress()
+
+      const owners = [{ value: faker.finance.ethereumAddress() }, { value: faker.finance.ethereumAddress() }]
+
+      expect(
+        getSharedSetup(
+          [
+            {
+              address,
+              chainId: '1',
+              isWatchlist: false,
+            },
+            {
+              address,
+              chainId: '100',
+              isWatchlist: false,
+            },
+          ],
+          [
+            {
+              address: {
+                value: address,
+              },
+              awaitingConfirmation: null,
+              chainId: '1',
+              fiatTotal: '0',
+              owners,
+              queued: 0,
+              threshold: 2,
+            },
+          ],
+          {
+            ['100']: {
+              [address]: {
+                props: {
+                  safeAccountConfig: {
+                    owners: owners.map((owner) => owner.value),
+                    threshold: 1,
+                  },
+                },
+                status: {
+                  status: PendingSafeStatus.AWAITING_EXECUTION,
+                  type: PayMethod.PayLater,
+                },
+              },
+            },
+          },
+        ),
+      ).toBeUndefined()
+    })
+
+    it('should return undefined if some owner data is missing', () => {
+      const address = faker.finance.ethereumAddress()
+
+      const owners = [{ value: faker.finance.ethereumAddress() }, { value: faker.finance.ethereumAddress() }]
+
+      expect(
+        getSharedSetup(
+          [
+            {
+              address,
+              chainId: '1',
+              isWatchlist: false,
+            },
+            {
+              address,
+              chainId: '100',
+              isWatchlist: false,
+            },
+          ],
+          [
+            {
+              address: {
+                value: address,
+              },
+              awaitingConfirmation: null,
+              chainId: '1',
+              fiatTotal: '0',
+              owners,
+              queued: 0,
+              threshold: 2,
+            },
+          ],
+          {},
+        ),
+      ).toBeUndefined()
+    })
+
+    it('should return undefined if threshold does not match and some Safes are undeployed', () => {
+      const address = faker.finance.ethereumAddress()
+
+      const owners = [{ value: faker.finance.ethereumAddress() }, { value: faker.finance.ethereumAddress() }]
+
+      expect(
+        getSharedSetup(
+          [
+            {
+              address,
+              chainId: '1',
+              isWatchlist: false,
+            },
+            {
+              address,
+              chainId: '100',
+              isWatchlist: false,
+            },
+          ],
+          [
+            {
+              address: {
+                value: address,
+              },
+              awaitingConfirmation: null,
+              chainId: '1',
+              fiatTotal: '0',
+              owners: owners.slice(0, 1),
+              queued: 0,
+              threshold: 1,
+            },
+          ],
+          {
+            ['100']: {
+              [address]: {
+                props: {
+                  safeAccountConfig: {
+                    owners: owners.map((owner) => owner.value),
+                    threshold: 1,
+                  },
+                },
+                status: {
+                  status: PendingSafeStatus.AWAITING_EXECUTION,
+                  type: PayMethod.PayLater,
+                },
+              },
+            },
+          },
+        ),
+      ).toBeUndefined()
+    })
+
+    it('should return the shared setup if owners and threshold matches and some Safes are undeployed', () => {
+      const address = faker.finance.ethereumAddress()
+
+      const owners = [{ value: faker.finance.ethereumAddress() }, { value: faker.finance.ethereumAddress() }]
+
+      expect(
+        getSharedSetup(
+          [
+            {
+              address,
+              chainId: '1',
+              isWatchlist: false,
+            },
+            {
+              address,
+              chainId: '100',
+              isWatchlist: false,
+            },
+          ],
+          [
+            {
+              address: {
+                value: address,
+              },
+              awaitingConfirmation: null,
+              chainId: '1',
+              fiatTotal: '0',
+              owners,
+              queued: 0,
+              threshold: 2,
+            },
+          ],
+          {
+            ['100']: {
+              [address]: {
+                props: {
+                  safeAccountConfig: {
+                    owners: owners.map((owner) => owner.value),
+                    threshold: 2,
+                  },
+                },
+                status: {
+                  status: PendingSafeStatus.AWAITING_EXECUTION,
+                  type: PayMethod.PayLater,
+                },
+              },
+            },
+          },
+        ),
+      ).toEqual({ owners: owners.map((owner) => owner.value), threshold: 2 })
+    })
+
+    it('should return the shared setup if owners and threshold matches and all Safes are undeployed', () => {
+      const address = faker.finance.ethereumAddress()
+
+      const owners = [{ value: faker.finance.ethereumAddress() }, { value: faker.finance.ethereumAddress() }]
+
+      expect(
+        getSharedSetup(
+          [
+            {
+              address,
+              chainId: '1',
+              isWatchlist: false,
+            },
+            {
+              address,
+              chainId: '100',
+              isWatchlist: false,
+            },
+          ],
+          [],
+          {
+            ['1']: {
+              [address]: {
+                props: {
+                  safeAccountConfig: {
+                    owners: owners.map((owner) => owner.value),
+                    threshold: 2,
+                  },
+                },
+                status: {
+                  status: PendingSafeStatus.AWAITING_EXECUTION,
+                  type: PayMethod.PayLater,
+                },
+              },
+            },
+            ['100']: {
+              [address]: {
+                props: {
+                  safeAccountConfig: {
+                    owners: owners.map((owner) => owner.value),
+                    threshold: 2,
+                  },
+                },
+                status: {
+                  status: PendingSafeStatus.AWAITING_EXECUTION,
+                  type: PayMethod.PayLater,
+                },
+              },
+            },
+          },
+        ),
+      ).toEqual({ owners: owners.map((owner) => owner.value), threshold: 2 })
+    })
+  })
+})

--- a/src/components/welcome/MyAccounts/utils/multiChainSafe.ts
+++ b/src/components/welcome/MyAccounts/utils/multiChainSafe.ts
@@ -1,0 +1,65 @@
+import { type SafeOverview } from '@safe-global/safe-gateway-typescript-sdk'
+import { type SafeItem } from '../useAllSafes'
+import { type UndeployedSafe } from '@/store/slices'
+import { sameAddress } from '@/utils/addresses'
+import { type MultiChainSafeItem } from '../useAllSafesGrouped'
+
+export const isMultiChainSafeItem = (safe: SafeItem | MultiChainSafeItem): safe is MultiChainSafeItem => {
+  if ('safes' in safe && 'address' in safe) {
+    return true
+  }
+  return false
+}
+
+const areOwnersMatching = (owners1: string[], owners2: string[]) =>
+  owners1.every((owner) => owners2.some((owner2) => sameAddress(owner, owner2)))
+
+export const getSharedSetup = (
+  safes: SafeItem[],
+  safeOverviews: SafeOverview[],
+  undeployedSafe: UndeployedSafe | undefined,
+): { owners: string[]; threshold: number } | undefined => {
+  // We fetch one example setup and check that all other Safes have the same threshold and owners
+  let comparisonSetup: { threshold: number; owners: string[] } | undefined = undefined
+  if (safeOverviews && safeOverviews.length > 0) {
+    comparisonSetup = {
+      threshold: safeOverviews[0].threshold,
+      owners: safeOverviews[0].owners.map((owner) => owner.value),
+    }
+  } else if (undeployedSafe) {
+    // Use first undeployed Safe
+    comparisonSetup = {
+      threshold: undeployedSafe.props.safeAccountConfig.threshold,
+      owners: undeployedSafe.props.safeAccountConfig.owners,
+    }
+  }
+  if (!comparisonSetup) {
+    return undefined
+  }
+
+  if (
+    safes.every((safeItem) => {
+      // Find overview or undeployed Safe
+      const foundOverview = safeOverviews?.find((overview) => overview.chainId === safeItem.chainId)
+      if (foundOverview) {
+        return (
+          areOwnersMatching(
+            comparisonSetup.owners,
+            foundOverview.owners.map((owner) => owner.value),
+          ) && foundOverview.threshold === comparisonSetup.threshold
+        )
+      }
+      // Compare with counterfactual Safe instead?
+      if (!undeployedSafe) {
+        return false
+      }
+      return (
+        areOwnersMatching(undeployedSafe.props.safeAccountConfig.owners, comparisonSetup.owners) &&
+        undeployedSafe.props.safeAccountConfig.threshold === comparisonSetup.threshold
+      )
+    })
+  ) {
+    return comparisonSetup
+  }
+  return undefined
+}

--- a/src/features/counterfactual/store/undeployedSafesSlice.ts
+++ b/src/features/counterfactual/store/undeployedSafesSlice.ts
@@ -2,7 +2,7 @@ import type { PayMethod } from '@/features/counterfactual/PayNowPayLater'
 import { type RootState } from '@/store'
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import type { PredictedSafeProps } from '@safe-global/protocol-kit'
-import { selectChainIdAndSafeAddress } from '@/store/common'
+import { selectChainIdAndSafeAddress, selectSafeAddress } from '@/store/common'
 
 export enum PendingSafeStatus {
   AWAITING_EXECUTION = 'AWAITING_EXECUTION',
@@ -100,6 +100,15 @@ export const selectUndeployedSafe = createSelector(
   [selectUndeployedSafes, selectChainIdAndSafeAddress],
   (undeployedSafes, [chainId, address]): UndeployedSafe | undefined => {
     return undeployedSafes[chainId]?.[address]
+  },
+)
+
+export const selectUndeployedSafesByAddress = createSelector(
+  [selectUndeployedSafes, selectSafeAddress],
+  (undeployedSafes, [address]): UndeployedSafe[] => {
+    return Object.values(undeployedSafes)
+      .flatMap((value) => value[address])
+      .filter(Boolean)
   },
 )
 

--- a/src/services/analytics/events/overview.ts
+++ b/src/services/analytics/events/overview.ts
@@ -117,6 +117,12 @@ export const OVERVIEW_EVENTS = {
     category: OVERVIEW_CATEGORY,
     //label: OPEN_SAFE_LABELS
   },
+  // Track clicks on links to Safe Accounts
+  EXPAND_MULTI_SAFE: {
+    action: 'Expand multi Safe',
+    category: OVERVIEW_CATEGORY,
+    //label: OPEN_SAFE_LABELS
+  },
   // Track actual Safe views
   SAFE_VIEWED: {
     event: EventType.SAFE_OPENED,

--- a/src/store/common.ts
+++ b/src/store/common.ts
@@ -39,3 +39,9 @@ export const selectChainIdAndSafeAddress = createSelector(
   [(_: RootState, chainId: string) => chainId, (_: RootState, _chainId: string, safeAddress: string) => safeAddress],
   (chainId, safeAddress) => [chainId, safeAddress] as const,
 )
+
+// Memoized selector for safeAddress
+export const selectSafeAddress = createSelector(
+  [(_: RootState, safeAddress: string) => safeAddress],
+  (safeAddress) => [safeAddress] as const,
+)


### PR DESCRIPTION
## What this PR changes
Groups Safes with the same address in the sidebar.

## How to test it
- Create Safes with the same address on some networks.
- Check and observe the sidebar:
  - Multichain Safes should appear first
- The "add network" button has no function yet. It will be added in the PR that implements the action!

## Screenshots
![Screenshot 2024-08-22 at 16 13 44](https://github.com/user-attachments/assets/4a2c5315-d5c6-4523-b2bf-e0def309ebfb)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
