### PR TITLE
Fix: don't show "verified by WalletConnect"

### DIFF
--- a/src/features/walletconnect/components/WcProposalForm/ProposalVerification.tsx
+++ b/src/features/walletconnect/components/WcProposalForm/ProposalVerification.tsx
@@ -1,72 +1,42 @@
 import type { Web3WalletTypes } from '@walletconnect/web3wallet'
 import { Alert, SvgIcon } from '@mui/material'
-import type { AlertColor } from '@mui/material'
 import AlertIcon from '@/public/images/notifications/alert.svg'
-import type { Verify } from '@walletconnect/types'
-import type { ComponentType, ReactElement } from 'react'
-import CloseIcon from '@/public/images/common/close.svg'
-import InfoIcon from '@/public/images/notifications/info.svg'
-import CheckIcon from '@/public/images/common/check.svg'
+import type { ReactElement } from 'react'
 import { getPeerName } from '@/features/walletconnect/services/utils'
 import css from './styles.module.css'
 
-const Validation: {
-  [key in Verify.Context['verified']['validation']]: {
-    color: AlertColor
-    desc: string
-    Icon: ComponentType
-  }
-} = {
-  VALID: {
-    color: 'success',
-    desc: 'has been verified by WalletConnect.',
-    Icon: CheckIcon,
-  },
-  UNKNOWN: {
-    color: 'warning',
-    desc: 'has not been verified by WalletConnect.',
-    Icon: InfoIcon,
-  },
-  INVALID: {
-    color: 'error',
-    desc: 'has a domain that does not match the sender of this request. Approving it may result in a loss of funds.',
-    Icon: CloseIcon,
-  },
-}
-
 const ProposalVerification = ({ proposal }: { proposal: Web3WalletTypes.SessionProposal }): ReactElement | null => {
-  const { proposer } = proposal.params
   const { isScam, validation } = proposal.verifyContext.verified
 
-  if (validation === 'UNKNOWN') {
+  if (validation === 'UNKNOWN' || validation === 'VALID') {
     return null
   }
 
-  const _validation = Validation[validation]
-  const color = isScam ? 'error' : _validation.color
-  const Icon = isScam ? AlertIcon : _validation.Icon
+  const appName = getPeerName(proposal.params.proposer)
 
   return (
     <Alert
-      severity={color}
-      sx={{ bgcolor: ({ palette }) => palette[color].background }}
+      severity="error"
+      sx={{ bgcolor: 'error.background' }}
       className={css.alert}
       icon={
         <SvgIcon
-          component={Icon}
+          component={AlertIcon}
           inheritViewBox
-          color={color}
+          color="error"
           sx={{
             '& path': {
-              fill: ({ palette }) => palette[color].main,
+              fill: 'error.main',
             },
           }}
         />
       }
     >
       {isScam
-        ? `We prevent connecting to ${getPeerName(proposer) || 'this dApp'} as they are a known scam.`
-        : `${getPeerName(proposer) || 'This dApp'} ${_validation.desc}`}
+        ? `We prevent connecting to ${appName || 'this dApp'} as they are a known scam.`
+        : `${
+            appName || 'This dApp'
+          } has a domain that does not match the sender of this request. Approving it may result in a loss of funds.`}
     </Alert>
   )
 }


### PR DESCRIPTION
## What it solves

As requested by WalletConnect, we should not show `has been verified by WalletConnect` as it's not 100% bullet-proof. See https://docs.walletconnect.com/walletkit/web/verify#disclaimer

So from now on, we'll be showing only if a dApp is a known scam or there's a domain mismatch.

<img width="438" alt="Screenshot 2024-08-26 at 10 14 15" src="https://github.com/user-attachments/assets/333246a1-1e63-43b5-a12a-7c8fe6d43609">
