### PR TITLE
Feat: replay safe creation with same address

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -5,6 +5,7 @@
 // Learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect'
 import { TextEncoder, TextDecoder } from 'util'
+import { Headers, Request, Response } from 'node-fetch'
 
 jest.mock('@web3-onboard/coinbase', () => jest.fn())
 jest.mock('@web3-onboard/injected-wallets', () => ({ ProviderLabel: { MetaMask: 'MetaMask' } }))
@@ -12,6 +13,7 @@ jest.mock('@web3-onboard/keystone/dist/index', () => jest.fn())
 jest.mock('@web3-onboard/ledger/dist/index', () => jest.fn())
 jest.mock('@web3-onboard/trezor', () => jest.fn())
 jest.mock('@web3-onboard/walletconnect', () => jest.fn())
+jest.mock('safe-client-gateway-sdk')
 
 const mockOnboardState = {
   chains: [],
@@ -68,3 +70,8 @@ Object.defineProperty(Uint8Array, Symbol.hasInstance, {
       : Uint8Array[Symbol.hasInstance].call(this, potentialInstance)
   },
 })
+
+// These are required for safe-client-gateway-sdk
+globalThis.Request = Request
+globalThis.Response = Response
+globalThis.Headers = Headers

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "@safe-global/protocol-kit": "^4.0.4",
     "@safe-global/safe-apps-sdk": "^9.1.0",
     "@safe-global/safe-deployments": "^1.37.3",
-    "@safe-global/safe-gateway-typescript-sdk": "3.22.1",
     "@safe-global/safe-modules-deployments": "^1.2.0",
+    "@safe-global/safe-gateway-typescript-sdk": "3.22.1",
     "@sentry/react": "^7.91.0",
     "@spindl-xyz/attribution-lite": "^1.4.0",
     "@walletconnect/utils": "^2.13.1",
@@ -91,6 +91,7 @@
     "react-hook-form": "7.41.1",
     "react-papaparse": "^4.0.2",
     "react-redux": "^9.1.2",
+    "safe-client-gateway-sdk": "git+https://github.com/safe-global/safe-client-gateway-sdk.git#v1.53.0-next-7344903",
     "semver": "^7.5.2",
     "zodiac-roles-deployments": "^2.2.5"
   },

--- a/src/components/common/NetworkInput/index.tsx
+++ b/src/components/common/NetworkInput/index.tsx
@@ -1,0 +1,85 @@
+import ChainIndicator from '@/components/common/ChainIndicator'
+import { useDarkMode } from '@/hooks/useDarkMode'
+import { useTheme } from '@mui/material/styles'
+import { FormControl, InputLabel, ListSubheader, MenuItem, Select, Skeleton } from '@mui/material'
+import partition from 'lodash/partition'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import css from './styles.module.css'
+import { type ReactElement, useMemo } from 'react'
+import { useCallback } from 'react'
+import { Controller, useFormContext } from 'react-hook-form'
+import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
+
+const NetworkInput = ({
+  name,
+  required = false,
+  chainConfigs,
+}: {
+  name: string
+  required?: boolean
+  chainConfigs: ChainInfo[]
+}): ReactElement => {
+  const isDarkMode = useDarkMode()
+  const theme = useTheme()
+  const [testNets, prodNets] = useMemo(() => partition(chainConfigs, (config) => config.isTestnet), [chainConfigs])
+  const { control } = useFormContext() || {}
+
+  const renderMenuItem = useCallback(
+    (chainId: string, isSelected: boolean) => {
+      const chain = chainConfigs.find((chain) => chain.chainId === chainId)
+      if (!chain) return null
+      return (
+        <MenuItem key={chainId} value={chainId} sx={{ '&:hover': { backgroundColor: 'inherit' } }}>
+          <ChainIndicator chainId={chain.chainId} />
+        </MenuItem>
+      )
+    },
+    [chainConfigs],
+  )
+
+  return chainConfigs.length ? (
+    <Controller
+      name={name}
+      rules={{ required }}
+      control={control}
+      render={({ field: { ref, ...field }, fieldState: { error } }) => (
+        <FormControl fullWidth>
+          <InputLabel id="network-input-label">Network</InputLabel>
+          <Select
+            {...field}
+            labelId="network-input-label"
+            id="network-input"
+            fullWidth
+            label="Network"
+            IconComponent={ExpandMoreIcon}
+            renderValue={(value) => renderMenuItem(value, true)}
+            MenuProps={{
+              sx: {
+                '& .MuiPaper-root': {
+                  overflow: 'auto',
+                },
+                ...(isDarkMode
+                  ? {
+                      '& .Mui-selected, & .Mui-selected:hover': {
+                        backgroundColor: `${theme.palette.secondary.background} !important`,
+                      },
+                    }
+                  : {}),
+              },
+            }}
+          >
+            {prodNets.map((chain) => renderMenuItem(chain.chainId, false))}
+
+            <ListSubheader className={css.listSubHeader}>Testnets</ListSubheader>
+
+            {testNets.map((chain) => renderMenuItem(chain.chainId, false))}
+          </Select>
+        </FormControl>
+      )}
+    />
+  ) : (
+    <Skeleton width={94} height={31} sx={{ mx: 2 }} />
+  )
+}
+
+export default NetworkInput

--- a/src/components/common/NetworkInput/index.tsx
+++ b/src/components/common/NetworkInput/index.tsx
@@ -70,7 +70,7 @@ const NetworkInput = ({
           >
             {prodNets.map((chain) => renderMenuItem(chain.chainId, false))}
 
-            <ListSubheader className={css.listSubHeader}>Testnets</ListSubheader>
+            {testNets.length > 0 && <ListSubheader className={css.listSubHeader}>Testnets</ListSubheader>}
 
             {testNets.map((chain) => renderMenuItem(chain.chainId, false))}
           </Select>

--- a/src/components/common/NetworkInput/styles.module.css
+++ b/src/components/common/NetworkInput/styles.module.css
@@ -1,0 +1,54 @@
+.select {
+  height: 100%;
+}
+
+.select:after,
+.select:before {
+  display: none;
+}
+
+.select *:focus-visible {
+  outline: 5px auto Highlight;
+  outline: 5px auto -webkit-focus-ring-color;
+}
+
+.select :global .MuiSelect-select {
+  padding-right: 40px !important;
+  padding-left: 16px;
+  height: 100%;
+  display: flex;
+  align-items: center;
+}
+
+.select :global .MuiSelect-icon {
+  margin-right: var(--space-2);
+}
+
+.select :global .Mui-disabled {
+  pointer-events: none;
+}
+
+.select :global .MuiMenuItem-root {
+  padding: 0;
+}
+
+.listSubHeader {
+  text-transform: uppercase;
+  font-size: 11px;
+  font-weight: bold;
+  line-height: 32px;
+}
+
+.newChip {
+  font-weight: bold;
+  letter-spacing: -0.1px;
+  margin-top: -18px;
+  margin-left: -14px;
+  transform: scale(0.7);
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}

--- a/src/components/dashboard/FirstSteps/index.tsx
+++ b/src/components/dashboard/FirstSteps/index.tsx
@@ -25,6 +25,7 @@ import CheckCircleOutlineRoundedIcon from '@mui/icons-material/CheckCircleOutlin
 import LightbulbOutlinedIcon from '@mui/icons-material/LightbulbOutlined'
 import css from './styles.module.css'
 import ActivateAccountButton from '@/features/counterfactual/ActivateAccountButton'
+import { isReplayedSafeProps } from '@/features/counterfactual/utils'
 
 const calculateProgress = (items: boolean[]) => {
   const totalNumberOfItems = items.length
@@ -304,6 +305,7 @@ const FirstSteps = () => {
   const undeployedSafe = useAppSelector((state) => selectUndeployedSafe(state, safe.chainId, safeAddress))
 
   const isMultiSig = safe.threshold > 1
+  const isReplayedSafe = undeployedSafe && isReplayedSafeProps(undeployedSafe?.props)
 
   const hasNonZeroBalance = balances && (balances.items.length > 1 || BigInt(balances.items[0]?.balance || 0) > 0)
   const hasOutgoingTransactions = !!outgoingTransactions && outgoingTransactions.length > 0
@@ -383,7 +385,7 @@ const FirstSteps = () => {
           <Grid item xs={12} md={4}>
             {isActivating ? (
               <UsefulHintsWidget />
-            ) : isMultiSig ? (
+            ) : isMultiSig || isReplayedSafe ? (
               <ActivateSafeWidget />
             ) : (
               <FirstTransactionWidget completed={hasOutgoingTransactions} />

--- a/src/components/new-safe/create/index.tsx
+++ b/src/components/new-safe/create/index.tsx
@@ -160,7 +160,7 @@ const CreateSafe = () => {
     name: '',
     owners: [],
     threshold: 1,
-    saltNonce: Date.now(),
+    saltNonce: 0,
     safeVersion: getLatestSafeVersion(chain) as SafeVersion,
   }
 

--- a/src/components/new-safe/create/logic/index.ts
+++ b/src/components/new-safe/create/logic/index.ts
@@ -19,7 +19,7 @@ import { backOff } from 'exponential-backoff'
 import { EMPTY_DATA, ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 import { getLatestSafeVersion } from '@/utils/chains'
 import { ECOSYSTEM_ID_ADDRESS } from '@/config/constants'
-import { ReplayedSafeProps } from '@/store/slices'
+import { type ReplayedSafeProps } from '@/store/slices'
 
 export type SafeCreationProps = {
   owners: string[]

--- a/src/components/new-safe/create/steps/AdvancedOptionsStep/index.tsx
+++ b/src/components/new-safe/create/steps/AdvancedOptionsStep/index.tsx
@@ -54,6 +54,7 @@ const AdvancedOptionsStep = ({ onSubmit, onBack, data, setStep }: StepRenderProp
     if (!chain || !readOnlyFallbackHandlerContract || !wallet) {
       return undefined
     }
+
     return computeNewSafeAddress(
       wallet.provider,
       {

--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -173,10 +173,11 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
 
       const saltNonce = await getAvailableSaltNonce(
         wallet.provider,
-        { ...props, saltNonce: '0' },
+        { ...props, saltNonce: data.saltNonce.toString() },
         chain,
         data.safeVersion,
       )
+
       const safeAddress = await computeNewSafeAddress(wallet.provider, { ...props, saltNonce }, chain, data.safeVersion)
 
       if (isCounterfactual && payMethod === PayMethod.PayLater) {

--- a/src/components/new-safe/create/steps/StatusStep/index.tsx
+++ b/src/components/new-safe/create/steps/StatusStep/index.tsx
@@ -18,6 +18,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { getLatestSafeVersion } from '@/utils/chains'
+import { isPredictedSafeProps } from '@/features/counterfactual/utils'
 
 const SPEED_UP_THRESHOLD_IN_SECONDS = 15
 
@@ -71,7 +72,7 @@ export const CreateSafeStatus = ({
   const tryAgain = () => {
     trackEvent(CREATE_SAFE_EVENTS.RETRY_CREATE_SAFE)
 
-    if (!pendingSafe) {
+    if (!pendingSafe || !isPredictedSafeProps(pendingSafe.props)) {
       setStep(0)
       return
     }

--- a/src/components/sidebar/SafeListContextMenu/index.tsx
+++ b/src/components/sidebar/SafeListContextMenu/index.tsx
@@ -33,10 +33,12 @@ const SafeListContextMenu = ({
   name,
   address,
   chainId,
+  addNetwork,
 }: {
   name: string
   address: string
   chainId: string
+  addNetwork: boolean
 }): ReactElement => {
   const addedSafes = useAppSelector((state) => selectAddedSafes(state, chainId))
   const isAdded = !!addedSafes?.[address]
@@ -92,12 +94,14 @@ const SafeListContextMenu = ({
           </MenuItem>
         )}
 
-        <MenuItem onClick={handleOpenModal(ModalType.ADD_CHAIN, OVERVIEW_EVENTS.SIDEBAR_RENAME)}>
-          <ListItemIcon>
-            <SvgIcon component={PlusIcon} inheritViewBox fontSize="small" color="primary" />
-          </ListItemIcon>
-          <ListItemText data-testid="add-chain-btn">Add another network</ListItemText>
-        </MenuItem>
+        {addNetwork && (
+          <MenuItem onClick={handleOpenModal(ModalType.ADD_CHAIN, OVERVIEW_EVENTS.ADD_NEW_NETWORK)}>
+            <ListItemIcon>
+              <SvgIcon component={PlusIcon} inheritViewBox fontSize="small" color="primary" />
+            </ListItemIcon>
+            <ListItemText data-testid="add-chain-btn">Add another network</ListItemText>
+          </MenuItem>
+        )}
       </ContextMenu>
 
       {open[ModalType.RENAME] && (

--- a/src/components/sidebar/SafeListContextMenu/index.tsx
+++ b/src/components/sidebar/SafeListContextMenu/index.tsx
@@ -12,19 +12,22 @@ import { useAppSelector } from '@/store'
 import { selectAddedSafes } from '@/store/addedSafesSlice'
 import EditIcon from '@/public/images/common/edit.svg'
 import DeleteIcon from '@/public/images/common/delete.svg'
+import PlusIcon from '@/public/images/common/plus.svg'
 import ContextMenu from '@/components/common/ContextMenu'
 import { trackEvent, OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
 import { SvgIcon } from '@mui/material'
 import useAddressBook from '@/hooks/useAddressBook'
 import { AppRoutes } from '@/config/routes'
 import router from 'next/router'
+import { CreateSafeOnNewChain } from '@/features/multichain/components/CreateSafeOnNewChain'
 
 enum ModalType {
   RENAME = 'rename',
   REMOVE = 'remove',
+  ADD_CHAIN = 'add_chain',
 }
 
-const defaultOpen = { [ModalType.RENAME]: false, [ModalType.REMOVE]: false }
+const defaultOpen = { [ModalType.RENAME]: false, [ModalType.REMOVE]: false, [ModalType.ADD_CHAIN]: false }
 
 const SafeListContextMenu = ({
   name,
@@ -88,6 +91,13 @@ const SafeListContextMenu = ({
             <ListItemText data-testid="remove-btn">Remove</ListItemText>
           </MenuItem>
         )}
+
+        <MenuItem onClick={handleOpenModal(ModalType.ADD_CHAIN, OVERVIEW_EVENTS.SIDEBAR_RENAME)}>
+          <ListItemIcon>
+            <SvgIcon component={PlusIcon} inheritViewBox fontSize="small" color="primary" />
+          </ListItemIcon>
+          <ListItemText data-testid="add-chain-btn">Add another network</ListItemText>
+        </MenuItem>
       </ContextMenu>
 
       {open[ModalType.RENAME] && (
@@ -101,6 +111,16 @@ const SafeListContextMenu = ({
 
       {open[ModalType.REMOVE] && (
         <SafeListRemoveDialog handleClose={handleCloseModal} address={address} chainId={chainId} />
+      )}
+
+      {open[ModalType.ADD_CHAIN] && (
+        <CreateSafeOnNewChain
+          onClose={handleCloseModal}
+          currentName={name}
+          deployedChainIds={[chainId]}
+          open
+          safeAddress={address}
+        />
       )}
     </>
   )

--- a/src/components/welcome/MyAccounts/AccountItem.tsx
+++ b/src/components/welcome/MyAccounts/AccountItem.tsx
@@ -118,7 +118,7 @@ const AccountItem = ({ onLinkClick, safeItem, safeOverview }: AccountItemProps) 
         </Link>
       </Track>
 
-      <SafeListContextMenu name={name} address={address} chainId={chainId} />
+      <SafeListContextMenu name={name} address={address} chainId={chainId} addNetwork={!safeItem.isWatchlist} />
 
       <QueueActions
         queued={safeOverview?.queued || 0}

--- a/src/components/welcome/MyAccounts/AccountItem.tsx
+++ b/src/components/welcome/MyAccounts/AccountItem.tsx
@@ -25,6 +25,7 @@ import type { SafeItem } from './useAllSafes'
 import FiatValue from '@/components/common/FiatValue'
 import QueueActions from './QueueActions'
 import { useGetHref } from './useGetHref'
+import { extractCounterfactualSafeSetup } from '@/features/counterfactual/utils'
 
 type AccountItemProps = {
   safeItem: SafeItem
@@ -54,6 +55,10 @@ const AccountItem = ({ onLinkClick, safeItem, safeOverview }: AccountItemProps) 
 
   const isActivating = undeployedSafe?.status.status !== 'AWAITING_EXECUTION'
 
+  const counterfactualSetup = undeployedSafe
+    ? extractCounterfactualSafeSetup(undeployedSafe, chain?.chainId)
+    : undefined
+
   return (
     <ListItemButton
       data-testid="safe-list-item"
@@ -65,8 +70,8 @@ const AccountItem = ({ onLinkClick, safeItem, safeOverview }: AccountItemProps) 
           <Box pr={2.5}>
             <SafeIcon
               address={address}
-              owners={safeOverview?.owners.length ?? undeployedSafe?.props.safeAccountConfig.owners.length}
-              threshold={safeOverview?.threshold ?? undeployedSafe?.props.safeAccountConfig.threshold}
+              owners={safeOverview?.owners.length ?? counterfactualSetup?.owners.length}
+              threshold={safeOverview?.threshold ?? counterfactualSetup?.threshold}
               chainId={chainId}
             />
           </Box>

--- a/src/components/welcome/MyAccounts/AddNetworkButton.tsx
+++ b/src/components/welcome/MyAccounts/AddNetworkButton.tsx
@@ -1,6 +1,7 @@
 import { CreateSafeOnNewChain } from '@/features/multichain/components/CreateSafeOnNewChain'
 import { Button } from '@mui/material'
 import { useState } from 'react'
+import PlusIcon from '@/public/images/common/plus.svg'
 
 export const AddNetworkButton = ({
   safeAddress,
@@ -16,7 +17,7 @@ export const AddNetworkButton = ({
   return (
     <>
       <Button variant="text" fullWidth onClick={() => setOpen(true)}>
-        + Add another network
+        <PlusIcon /> Add another network
       </Button>
 
       {open && (

--- a/src/components/welcome/MyAccounts/AddNetworkButton.tsx
+++ b/src/components/welcome/MyAccounts/AddNetworkButton.tsx
@@ -1,0 +1,33 @@
+import { CreateSafeOnNewChain } from '@/features/multichain/components/CreateSafeOnNewChain'
+import { Button } from '@mui/material'
+import { useState } from 'react'
+
+export const AddNetworkButton = ({
+  safeAddress,
+  currentName,
+  deployedChains,
+}: {
+  safeAddress: string
+  currentName: string | undefined
+  deployedChains: string[]
+}) => {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <Button variant="text" fullWidth onClick={() => setOpen(true)}>
+        + Add another network
+      </Button>
+
+      {open && (
+        <CreateSafeOnNewChain
+          open={open}
+          onClose={() => setOpen(false)}
+          currentName={currentName}
+          safeAddress={safeAddress}
+          deployedChainIds={deployedChains}
+        />
+      )}
+    </>
+  )
+}

--- a/src/components/welcome/MyAccounts/MultiAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/MultiAccountItem.tsx
@@ -10,7 +10,6 @@ import {
   AccordionDetails,
   AccordionSummary,
   Divider,
-  Button,
 } from '@mui/material'
 import SafeIcon from '@/components/common/SafeIcon'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS, trackEvent } from '@/services/analytics'
@@ -30,6 +29,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import { type SafeItem } from './useAllSafes'
 import SubAccountItem from './SubAccountItem'
 import { getSharedSetup } from './utils/multiChainSafe'
+import { AddNetworkButton } from './AddNetworkButton'
 
 type MultiAccountItemProps = {
   multiSafeAccountItem: MultiChainSafeItem
@@ -131,10 +131,11 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, safeOverviews }: 
           </Box>
           <Divider />
           <Box display="flex" alignItems="center" justifyContent="center">
-            {/* TODO: Trigger Safe creation flow with a new network */}
-            <Button variant="text" fullWidth>
-              + Add another network
-            </Button>
+            <AddNetworkButton
+              currentName={name}
+              safeAddress={address}
+              deployedChains={safes.map((safe) => safe.chainId)}
+            />
           </Box>
         </AccordionDetails>
       </Accordion>

--- a/src/components/welcome/MyAccounts/MultiAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/MultiAccountItem.tsx
@@ -46,6 +46,11 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, safeOverviews }: 
   const isWelcomePage = router.pathname === AppRoutes.welcome.accounts
   const [expanded, setExpanded] = useState(isCurrentSafe)
 
+  const isWatchlist = useMemo(
+    () => multiSafeAccountItem.safes.every((safe) => safe.isWatchlist),
+    [multiSafeAccountItem.safes],
+  )
+
   const trackingLabel = isWelcomePage ? OVERVIEW_LABELS.login_page : OVERVIEW_LABELS.sidebar
 
   const toggleExpand = () => {
@@ -129,14 +134,18 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, safeOverviews }: 
               />
             ))}
           </Box>
-          <Divider />
-          <Box display="flex" alignItems="center" justifyContent="center">
-            <AddNetworkButton
-              currentName={name}
-              safeAddress={address}
-              deployedChains={safes.map((safe) => safe.chainId)}
-            />
-          </Box>
+          {!isWatchlist && (
+            <>
+              <Divider />
+              <Box display="flex" alignItems="center" justifyContent="center">
+                <AddNetworkButton
+                  currentName={name}
+                  safeAddress={address}
+                  deployedChains={safes.map((safe) => safe.chainId)}
+                />
+              </Box>
+            </>
+          )}
         </AccordionDetails>
       </Accordion>
     </ListItemButton>

--- a/src/components/welcome/MyAccounts/SubAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/SubAccountItem.tsx
@@ -23,6 +23,7 @@ import type { SafeItem } from './useAllSafes'
 import FiatValue from '@/components/common/FiatValue'
 import QueueActions from './QueueActions'
 import { useGetHref } from './useGetHref'
+import { extractCounterfactualSafeSetup } from '@/features/counterfactual/utils'
 
 type SubAccountItem = {
   safeItem: SafeItem
@@ -52,6 +53,8 @@ const SubAccountItem = ({ onLinkClick, safeItem, safeOverview }: SubAccountItem)
 
   const isActivating = undeployedSafe?.status.status !== 'AWAITING_EXECUTION'
 
+  const cfSafeSetup = extractCounterfactualSafeSetup(undeployedSafe, chain?.chainId)
+
   return (
     <ListItemButton
       data-testid="safe-list-item"
@@ -63,8 +66,8 @@ const SubAccountItem = ({ onLinkClick, safeItem, safeOverview }: SubAccountItem)
           <Box pr={2.5}>
             <SafeIcon
               address={address}
-              owners={safeOverview?.owners.length ?? undeployedSafe?.props.safeAccountConfig.owners.length}
-              threshold={safeOverview?.threshold ?? undeployedSafe?.props.safeAccountConfig.threshold}
+              owners={safeOverview?.owners.length ?? cfSafeSetup?.owners.length}
+              threshold={safeOverview?.threshold ?? cfSafeSetup?.threshold}
               isSubItem
               chainId={chainId}
             />

--- a/src/components/welcome/MyAccounts/SubAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/SubAccountItem.tsx
@@ -112,7 +112,7 @@ const SubAccountItem = ({ onLinkClick, safeItem, safeOverview }: SubAccountItem)
         </Link>
       </Track>
 
-      <SafeListContextMenu name={name} address={address} chainId={chainId} />
+      <SafeListContextMenu name={name} address={address} chainId={chainId} addNetwork={false} />
 
       <QueueActions
         queued={safeOverview?.queued || 0}

--- a/src/components/welcome/MyAccounts/useAllSafesGrouped.ts
+++ b/src/components/welcome/MyAccounts/useAllSafesGrouped.ts
@@ -36,7 +36,5 @@ export const useAllSafesGrouped = () => {
       allMultiChainSafes,
       allSingleSafes,
     }
-    // allSafes cause re-renderings every X seconds
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [allSafes?.length])
+  }, [allSafes])
 }

--- a/src/components/welcome/MyAccounts/useAllSafesGrouped.ts
+++ b/src/components/welcome/MyAccounts/useAllSafesGrouped.ts
@@ -36,5 +36,7 @@ export const useAllSafesGrouped = () => {
       allMultiChainSafes,
       allSingleSafes,
     }
-  }, [allSafes])
+    // allSafes cause re-renderings every X seconds
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allSafes?.length])
 }

--- a/src/features/counterfactual/__tests__/utils.test.ts
+++ b/src/features/counterfactual/__tests__/utils.test.ts
@@ -11,11 +11,13 @@ import type { PredictedSafeProps } from '@safe-global/protocol-kit'
 import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 import { TokenType } from '@safe-global/safe-gateway-typescript-sdk'
 import { type BrowserProvider, type JsonRpcProvider } from 'ethers'
+import { PendingSafeStatus } from '../store/undeployedSafesSlice'
+import { PayMethod } from '../PayNowPayLater'
 
 describe('Counterfactual utils', () => {
   describe('getUndeployedSafeInfo', () => {
     it('should return undeployed safe info', () => {
-      const undeployedSafe: PredictedSafeProps = {
+      const undeployedSafeProps: PredictedSafeProps = {
         safeAccountConfig: {
           owners: [faker.finance.ethereumAddress()],
           threshold: 1,
@@ -25,14 +27,21 @@ describe('Counterfactual utils', () => {
       const mockAddress = faker.finance.ethereumAddress()
       const mockChainId = '1'
 
-      const result = getUndeployedSafeInfo(undeployedSafe, mockAddress, chainBuilder().with({ chainId: '1' }).build())
+      const result = getUndeployedSafeInfo(
+        {
+          props: undeployedSafeProps,
+          status: { status: PendingSafeStatus.AWAITING_EXECUTION, type: PayMethod.PayLater },
+        },
+        mockAddress,
+        chainBuilder().with({ chainId: '1' }).build(),
+      )
 
       expect(result.nonce).toEqual(0)
       expect(result.deployed).toEqual(false)
       expect(result.address.value).toEqual(mockAddress)
       expect(result.chainId).toEqual(mockChainId)
-      expect(result.threshold).toEqual(undeployedSafe.safeAccountConfig.threshold)
-      expect(result.owners[0].value).toEqual(undeployedSafe.safeAccountConfig.owners[0])
+      expect(result.threshold).toEqual(undeployedSafeProps.safeAccountConfig.threshold)
+      expect(result.owners[0].value).toEqual(undeployedSafeProps.safeAccountConfig.owners[0])
     })
   })
 

--- a/src/features/counterfactual/store/undeployedSafesSlice.ts
+++ b/src/features/counterfactual/store/undeployedSafesSlice.ts
@@ -3,6 +3,7 @@ import { type RootState } from '@/store'
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import type { PredictedSafeProps } from '@safe-global/protocol-kit'
 import { selectChainIdAndSafeAddress, selectSafeAddress } from '@/store/common'
+import { type CreationTransaction } from 'safe-client-gateway-sdk'
 
 export enum PendingSafeStatus {
   AWAITING_EXECUTION = 'AWAITING_EXECUTION',
@@ -21,9 +22,15 @@ type UndeployedSafeStatus = {
   signerNonce?: number | null
 }
 
+export type ReplayedSafeProps = Pick<CreationTransaction, 'factoryAddress' | 'masterCopy' | 'setupData'> & {
+  saltNonce: string
+}
+
+export type UndeployedSafeProps = PredictedSafeProps | ReplayedSafeProps
+
 export type UndeployedSafe = {
   status: UndeployedSafeStatus
-  props: PredictedSafeProps
+  props: UndeployedSafeProps
 }
 
 type UndeployedSafesSlice = { [address: string]: UndeployedSafe }
@@ -38,7 +45,12 @@ export const undeployedSafesSlice = createSlice({
   reducers: {
     addUndeployedSafe: (
       state,
-      action: PayloadAction<{ chainId: string; address: string; type: PayMethod; safeProps: PredictedSafeProps }>,
+      action: PayloadAction<{
+        chainId: string
+        address: string
+        type: PayMethod
+        safeProps: PredictedSafeProps | ReplayedSafeProps
+      }>,
     ) => {
       const { chainId, address, type, safeProps } = action.payload
 

--- a/src/features/counterfactual/utils.ts
+++ b/src/features/counterfactual/utils.ts
@@ -23,12 +23,7 @@ import { upsertAddressBookEntry } from '@/store/addressBookSlice'
 import { defaultSafeInfo } from '@/store/safeInfoSlice'
 import { didRevert, type EthersError } from '@/utils/ethers-utils'
 import { assertProvider, assertTx, assertWallet } from '@/utils/helpers'
-import {
-  encodeCreateProxyWithNonce,
-  SafeProvider,
-  type DeploySafeProps,
-  type PredictedSafeProps,
-} from '@safe-global/protocol-kit'
+import { type DeploySafeProps, type PredictedSafeProps } from '@safe-global/protocol-kit'
 import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 import type { SafeTransaction, SafeVersion, TransactionOptions } from '@safe-global/safe-core-sdk-types'
 import {

--- a/src/features/counterfactual/utils.ts
+++ b/src/features/counterfactual/utils.ts
@@ -2,9 +2,15 @@ import type { NewSafeFormData } from '@/components/new-safe/create'
 import { getLatestSafeVersion } from '@/utils/chains'
 import { POLLING_INTERVAL } from '@/config/constants'
 import { AppRoutes } from '@/config/routes'
-import type { PayMethod } from '@/features/counterfactual/PayNowPayLater'
+import { PayMethod } from '@/features/counterfactual/PayNowPayLater'
 import { safeCreationDispatch, SafeCreationEvent } from '@/features/counterfactual/services/safeCreationEvents'
-import { addUndeployedSafe } from '@/features/counterfactual/store/undeployedSafesSlice'
+import {
+  addUndeployedSafe,
+  type UndeployedSafeProps,
+  type ReplayedSafeProps,
+  type UndeployedSafe,
+  PendingSafeStatus,
+} from '@/features/counterfactual/store/undeployedSafesSlice'
 import { type ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import { getWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { asError } from '@/services/exceptions/utils'
@@ -17,9 +23,14 @@ import { upsertAddressBookEntry } from '@/store/addressBookSlice'
 import { defaultSafeInfo } from '@/store/safeInfoSlice'
 import { didRevert, type EthersError } from '@/utils/ethers-utils'
 import { assertProvider, assertTx, assertWallet } from '@/utils/helpers'
-import type { DeploySafeProps, PredictedSafeProps } from '@safe-global/protocol-kit'
+import {
+  encodeCreateProxyWithNonce,
+  SafeProvider,
+  type DeploySafeProps,
+  type PredictedSafeProps,
+} from '@safe-global/protocol-kit'
 import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
-import type { SafeTransaction, TransactionOptions } from '@safe-global/safe-core-sdk-types'
+import type { SafeTransaction, SafeVersion, TransactionOptions } from '@safe-global/safe-core-sdk-types'
 import {
   type ChainInfo,
   ImplementationVersionState,
@@ -28,20 +39,30 @@ import {
 } from '@safe-global/safe-gateway-typescript-sdk'
 import type { BrowserProvider, ContractTransactionResponse, Eip1193Provider, Provider } from 'ethers'
 import type { NextRouter } from 'next/router'
+import { Safe__factory } from '@/types/contracts'
+import { getCompatibilityFallbackHandlerDeployments } from '@safe-global/safe-deployments'
+import { sameAddress } from '@/utils/addresses'
 
-export const getUndeployedSafeInfo = (undeployedSafe: PredictedSafeProps, address: string, chain: ChainInfo) => {
+import { getReadOnlyProxyFactoryContract } from '@/services/contracts/safeContracts'
+
+export const getUndeployedSafeInfo = (undeployedSafe: UndeployedSafe, address: string, chain: ChainInfo) => {
+  const safeSetup = extractCounterfactualSafeSetup(undeployedSafe, chain.chainId)
+
+  if (!safeSetup) {
+    throw Error('Could not determine Safe Setup.')
+  }
   const latestSafeVersion = getLatestSafeVersion(chain)
 
   return {
     ...defaultSafeInfo,
     address: { value: address },
     chainId: chain.chainId,
-    owners: undeployedSafe.safeAccountConfig.owners.map((owner) => ({ value: owner })),
+    owners: safeSetup.owners.map((owner) => ({ value: owner })),
     nonce: 0,
-    threshold: undeployedSafe.safeAccountConfig.threshold,
+    threshold: safeSetup.threshold,
     implementationVersionState: ImplementationVersionState.UP_TO_DATE,
-    fallbackHandler: { value: undeployedSafe.safeAccountConfig.fallbackHandler! },
-    version: undeployedSafe.safeDeploymentConfig?.safeVersion || latestSafeVersion,
+    fallbackHandler: { value: safeSetup.fallbackHandler! },
+    version: safeSetup?.safeVersion || latestSafeVersion,
     deployed: false,
   }
 }
@@ -179,6 +200,52 @@ export const createCounterfactualSafe = (
   })
 }
 
+export const replayCounterfactualSafeDeployment = (
+  chainId: string,
+  safeAddress: string,
+  replayedSafeProps: ReplayedSafeProps,
+  name: string,
+  dispatch: AppDispatch,
+) => {
+  const undeployedSafe = {
+    chainId,
+    address: safeAddress,
+    type: PayMethod.PayLater,
+    safeProps: replayedSafeProps,
+  }
+
+  const setup = extractCounterfactualSafeSetup(
+    {
+      props: replayedSafeProps,
+      status: {
+        status: PendingSafeStatus.AWAITING_EXECUTION,
+        type: PayMethod.PayLater,
+      },
+    },
+    chainId,
+  )
+  if (!setup) {
+    throw Error('Safe Setup could not be decoded')
+  }
+
+  dispatch(addUndeployedSafe(undeployedSafe))
+  dispatch(upsertAddressBookEntry({ chainId, address: safeAddress, name }))
+  dispatch(
+    addOrUpdateSafe({
+      safe: {
+        ...defaultSafeInfo,
+        address: { value: safeAddress, name },
+        threshold: setup.threshold,
+        owners: setup.owners.map((owner) => ({
+          value: owner,
+          name: undefined,
+        })),
+        chainId,
+      },
+    }),
+  )
+}
+
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 /**
@@ -311,4 +378,97 @@ export const checkSafeActionViaRelay = (taskId: string, safeAddress: string, typ
 
     clearInterval(intervalId)
   }, TIMEOUT_TIME)
+}
+
+export const isReplayedSafeProps = (props: UndeployedSafeProps): props is ReplayedSafeProps => {
+  if ('setupData' in props && 'masterCopy' in props && 'factoryAddress' in props && 'saltNonce' in props) {
+    return true
+  }
+  return false
+}
+
+export const isPredictedSafeProps = (props: UndeployedSafeProps): props is PredictedSafeProps => {
+  if ('safeAccountConfig' in props) {
+    return true
+  }
+  return false
+}
+
+const determineFallbackHandlerVersion = (fallbackHandler: string, chainId: string): SafeVersion | undefined => {
+  const SAFE_VERSIONS: SafeVersion[] = ['1.4.1', '1.3.0', '1.2.0', '1.1.1', '1.0.0']
+  return SAFE_VERSIONS.find((version) => {
+    const deployments = getCompatibilityFallbackHandlerDeployments({ version })?.networkAddresses[chainId]
+
+    if (Array.isArray(deployments)) {
+      return deployments.some((deployment) => sameAddress(fallbackHandler, deployment))
+    }
+    return sameAddress(fallbackHandler, deployments)
+  })
+}
+
+export const extractCounterfactualSafeSetup = (
+  undeployedSafe: UndeployedSafe | undefined,
+  chainId: string | undefined,
+):
+  | {
+      owners: string[]
+      threshold: number
+      fallbackHandler: string | undefined
+      safeVersion: SafeVersion | undefined
+      saltNonce: string | undefined
+    }
+  | undefined => {
+  if (!undeployedSafe || !chainId) {
+    return undefined
+  }
+  if (isPredictedSafeProps(undeployedSafe.props)) {
+    return {
+      owners: undeployedSafe.props.safeAccountConfig.owners,
+      threshold: undeployedSafe.props.safeAccountConfig.threshold,
+      fallbackHandler: undeployedSafe.props.safeAccountConfig.fallbackHandler,
+      safeVersion: undeployedSafe.props.safeDeploymentConfig?.safeVersion,
+      saltNonce: undeployedSafe.props.safeDeploymentConfig?.saltNonce,
+    }
+  } else {
+    if (!undeployedSafe.props.setupData) {
+      return undefined
+    }
+    const [owners, threshold, to, data, fallbackHandler, ...setupParams] =
+      Safe__factory.createInterface().decodeFunctionData('setup', undeployedSafe.props.setupData)
+
+    const safeVersion = determineFallbackHandlerVersion(fallbackHandler, chainId)
+
+    return {
+      owners,
+      threshold: Number(threshold),
+      fallbackHandler,
+      safeVersion,
+      saltNonce: undeployedSafe.props.saltNonce,
+    }
+  }
+}
+
+export const activateReplayedSafe = async (
+  safeVersion: SafeVersion,
+  chain: ChainInfo,
+  props: ReplayedSafeProps,
+  provider: BrowserProvider,
+) => {
+  const usedSafeVersion = safeVersion ?? getLatestSafeVersion(chain)
+  const readOnlyProxyContract = await getReadOnlyProxyFactoryContract(usedSafeVersion, props.factoryAddress)
+
+  if (!props.masterCopy || !props.setupData) {
+    throw Error('Cannot replay Safe without deployment info')
+  }
+  const data = readOnlyProxyContract.encode('createProxyWithNonce', [
+    props.masterCopy,
+    props.setupData,
+    BigInt(props.saltNonce),
+  ])
+
+  return (await provider.getSigner()).sendTransaction({
+    to: props.factoryAddress,
+    data,
+    value: '0',
+  })
 }

--- a/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
+++ b/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
@@ -49,7 +49,7 @@ export const CreateSafeOnNewChain = ({
   const dispatch = useAppDispatch()
 
   // Load some data
-  const [safeCreationData] = useSafeCreationData(safeAddress, chain)
+  const [safeCreationData, safeCreationDataError] = useSafeCreationData(safeAddress, chain)
 
   const onFormSubmit = handleSubmit(async (data) => {
     const selectedChain = configs.find((config) => config.chainId === data.chainId)
@@ -84,30 +84,38 @@ export const CreateSafeOnNewChain = ({
     [deployedChainIds, replayableChains],
   )
 
+  const submitDisabled = !!safeCreationDataError
+
   return (
     <Dialog open={open} onClose={onClose}>
       <form onSubmit={onFormSubmit} id="recreate-safe">
         <DialogTitle fontWeight={700}>Add another network</DialogTitle>
         <DialogContent>
-          <FormProvider {...formMethods}>
-            <Stack spacing={2}>
-              <Typography>This action re-deploys a Safe to another network with the same address.</Typography>
-              <ErrorMessage level="info">
-                The Safe will use the initial setup of the copied Safe. Any changes to owners, threshold, modules or the
-                Safe&apos;s version will not be reflected in the copy.
-              </ErrorMessage>
+          {safeCreationDataError ? (
+            <ErrorMessage error={safeCreationDataError} level="error">
+              Could not determine the Safe creation parameters.
+            </ErrorMessage>
+          ) : (
+            <FormProvider {...formMethods}>
+              <Stack spacing={2}>
+                <Typography>This action re-deploys a Safe to another network with the same address.</Typography>
+                <ErrorMessage level="info">
+                  The Safe will use the initial setup of the copied Safe. Any changes to owners, threshold, modules or
+                  the Safe&apos;s version will not be reflected in the copy.
+                </ErrorMessage>
 
-              <NameInput name="name" label="Name" />
+                <NameInput name="name" label="Name" />
 
-              <NetworkInput required name="chainId" chainConfigs={newReplayableChains} />
-            </Stack>
-          </FormProvider>
+                <NetworkInput required name="chainId" chainConfigs={newReplayableChains} />
+              </Stack>
+            </FormProvider>
+          )}
         </DialogContent>
         <DialogActions>
           <Button variant="outlined" onClick={onClose}>
             Cancel
           </Button>
-          <Button type="submit" variant="contained">
+          <Button type="submit" variant="contained" disabled={submitDisabled}>
             Submit
           </Button>
         </DialogActions>

--- a/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
+++ b/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
@@ -1,0 +1,117 @@
+import NameInput from '@/components/common/NameInput'
+import NetworkInput from '@/components/common/NetworkInput'
+import ErrorMessage from '@/components/tx/ErrorMessage'
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Stack, Typography } from '@mui/material'
+import { FormProvider, useForm } from 'react-hook-form'
+import { useSafeCreationData } from '../../hooks/useSafeCreationData'
+import { useReplayableNetworks } from '../../hooks/useReplayableNetworks'
+import { useMemo } from 'react'
+import { replayCounterfactualSafeDeployment } from '@/features/counterfactual/utils'
+
+import useChains from '@/hooks/useChains'
+import { useAppDispatch, useAppSelector } from '@/store'
+import { selectRpc } from '@/store/settingsSlice'
+import { createWeb3ReadOnly } from '@/hooks/wallets/web3'
+import { predictAddressBasedOnReplayData } from '@/components/welcome/MyAccounts/utils/multiChainSafe'
+import { sameAddress } from '@/utils/addresses'
+
+type CreateSafeOnNewChainForm = {
+  name: string
+  chainId: string
+}
+
+export const CreateSafeOnNewChain = ({
+  safeAddress,
+  deployedChainIds,
+  currentName,
+  open,
+  onClose,
+}: {
+  safeAddress: string
+  deployedChainIds: string[]
+  currentName: string | undefined
+  open: boolean
+  onClose: () => void
+}) => {
+  const formMethods = useForm<CreateSafeOnNewChainForm>({
+    mode: 'all',
+    defaultValues: {
+      name: currentName,
+    },
+  })
+
+  const { handleSubmit } = formMethods
+  const { configs } = useChains()
+
+  const chain = configs.find((config) => config.chainId === deployedChainIds[0])
+
+  const customRpc = useAppSelector(selectRpc)
+  const dispatch = useAppDispatch()
+
+  // Load some data
+  const [safeCreationData] = useSafeCreationData(safeAddress, chain)
+
+  const onFormSubmit = handleSubmit(async (data) => {
+    const selectedChain = configs.find((config) => config.chainId === data.chainId)
+    if (!safeCreationData || !safeCreationData.setupData || !selectedChain || !safeCreationData.masterCopy) {
+      return
+    }
+
+    // We need to create a readOnly provider of the deployed chain
+    const customRpcUrl = selectedChain ? customRpc?.[selectedChain.chainId] : undefined
+    const provider = createWeb3ReadOnly(selectedChain, customRpcUrl)
+    if (!provider) {
+      return
+    }
+
+    // 1. Double check that the creation Data will lead to the correct address
+    const predictedAddress = await predictAddressBasedOnReplayData(safeCreationData, provider)
+    if (!sameAddress(safeAddress, predictedAddress)) {
+      throw new Error('The replayed Safe leads to an unexpected address')
+    }
+
+    // 2. Replay Safe creation and add it to the counterfactual Safes
+    replayCounterfactualSafeDeployment(selectedChain.chainId, safeAddress, safeCreationData, data.name, dispatch)
+
+    // Close modal
+    onClose()
+  })
+
+  const replayableChains = useReplayableNetworks(safeCreationData)
+
+  const newReplayableChains = useMemo(
+    () => replayableChains.filter((chain) => !deployedChainIds.includes(chain.chainId)),
+    [deployedChainIds, replayableChains],
+  )
+
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <form onSubmit={onFormSubmit} id="recreate-safe">
+        <DialogTitle fontWeight={700}>Add another network</DialogTitle>
+        <DialogContent>
+          <FormProvider {...formMethods}>
+            <Stack spacing={2}>
+              <Typography>This action re-deploys a Safe to another network with the same address.</Typography>
+              <ErrorMessage level="info">
+                The Safe will use the initial setup of the copied Safe. Any changes to owners, threshold, modules or the
+                Safe&apos;s version will not be reflected in the copy.
+              </ErrorMessage>
+
+              <NameInput name="name" label="Name" />
+
+              <NetworkInput required name="chainId" chainConfigs={newReplayableChains} />
+            </Stack>
+          </FormProvider>
+        </DialogContent>
+        <DialogActions>
+          <Button variant="outlined" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="contained">
+            Submit
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  )
+}

--- a/src/features/multichain/hooks/__tests__/useReplayableNetworks.test.ts
+++ b/src/features/multichain/hooks/__tests__/useReplayableNetworks.test.ts
@@ -1,0 +1,302 @@
+import { renderHook } from '@/tests/test-utils'
+import { useReplayableNetworks } from '../useReplayableNetworks'
+import { type ReplayedSafeProps } from '@/store/slices'
+import { faker } from '@faker-js/faker'
+import { Safe__factory } from '@/types/contracts'
+import { EMPTY_DATA, ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
+import { ECOSYSTEM_ID_ADDRESS } from '@/config/constants'
+import { chainBuilder } from '@/tests/builders/chains'
+import {
+  getSafeSingletonDeployments,
+  getSafeL2SingletonDeployments,
+  getProxyFactoryDeployments,
+} from '@safe-global/safe-deployments'
+import * as useChains from '@/hooks/useChains'
+
+const safeInterface = Safe__factory.createInterface()
+
+const L1_111_MASTERCOPY_DEPLOYMENTS = getSafeSingletonDeployments({ version: '1.1.1' })?.deployments
+const L1_130_MASTERCOPY_DEPLOYMENTS = getSafeSingletonDeployments({ version: '1.3.0' })?.deployments
+const L1_141_MASTERCOPY_DEPLOYMENTS = getSafeSingletonDeployments({ version: '1.4.1' })?.deployments
+
+const L2_130_MASTERCOPY_DEPLOYMENTS = getSafeL2SingletonDeployments({ version: '1.3.0' })?.deployments
+const L2_141_MASTERCOPY_DEPLOYMENTS = getSafeL2SingletonDeployments({ version: '1.4.1' })?.deployments
+
+const PROXY_FACTORY_111_DEPLOYMENTS = getProxyFactoryDeployments({ version: '1.1.1' })?.deployments
+const PROXY_FACTORY_130_DEPLOYMENTS = getProxyFactoryDeployments({ version: '1.3.0' })?.deployments
+const PROXY_FACTORY_141_DEPLOYMENTS = getProxyFactoryDeployments({ version: '1.4.1' })?.deployments
+
+describe('useReplayableNetworks', () => {
+  beforeAll(() => {
+    jest.spyOn(useChains, 'default').mockReturnValue({
+      configs: [
+        chainBuilder().with({ chainId: '1' }).build(),
+        chainBuilder().with({ chainId: '10' }).build(), // This has the eip155 and then the canonical addresses
+        chainBuilder().with({ chainId: '100' }).build(), // This has the canonical and then the eip155 addresses
+        chainBuilder().with({ chainId: '324' }).build(), // ZkSync has different addresses for all versions
+        chainBuilder().with({ chainId: '480' }).build(), // Worldchain has 1.4.1 but not 1.1.1
+      ],
+    })
+  })
+  it('should return empty list without any creation data', () => {
+    const { result } = renderHook(() => useReplayableNetworks(undefined))
+    expect(result.current).toHaveLength(0)
+  })
+
+  it('should return empty list for incomplete creation data', () => {
+    const callData = {
+      owners: [faker.finance.ethereumAddress()],
+      threshold: 1,
+      to: ZERO_ADDRESS,
+      data: EMPTY_DATA,
+      fallbackHandler: faker.finance.ethereumAddress(),
+      paymentToken: ZERO_ADDRESS,
+      payment: 0,
+      paymentReceiver: ECOSYSTEM_ID_ADDRESS,
+    }
+
+    const setupData = safeInterface.encodeFunctionData('setup', [
+      callData.owners,
+      callData.threshold,
+      callData.to,
+      callData.data,
+      callData.fallbackHandler,
+      callData.paymentToken,
+      callData.payment,
+      callData.paymentReceiver,
+    ])
+
+    const creationData: ReplayedSafeProps = {
+      factoryAddress: faker.finance.ethereumAddress(),
+      masterCopy: null,
+      saltNonce: '0',
+      setupData,
+    }
+    const { result } = renderHook(() => useReplayableNetworks(creationData))
+    expect(result.current).toHaveLength(0)
+  })
+
+  it('should return empty list for unknown masterCopies', () => {
+    const callData = {
+      owners: [faker.finance.ethereumAddress()],
+      threshold: 1,
+      to: ZERO_ADDRESS,
+      data: EMPTY_DATA,
+      fallbackHandler: faker.finance.ethereumAddress(),
+      paymentToken: ZERO_ADDRESS,
+      payment: 0,
+      paymentReceiver: ECOSYSTEM_ID_ADDRESS,
+    }
+
+    const setupData = safeInterface.encodeFunctionData('setup', [
+      callData.owners,
+      callData.threshold,
+      callData.to,
+      callData.data,
+      callData.fallbackHandler,
+      callData.paymentToken,
+      callData.payment,
+      callData.paymentReceiver,
+    ])
+
+    const creationData: ReplayedSafeProps = {
+      factoryAddress: faker.finance.ethereumAddress(),
+      masterCopy: faker.finance.ethereumAddress(),
+      saltNonce: '0',
+      setupData,
+    }
+    const { result } = renderHook(() => useReplayableNetworks(creationData))
+    expect(result.current).toHaveLength(0)
+  })
+
+  it('should return empty list for unknown masterCopies', () => {
+    const callData = {
+      owners: [faker.finance.ethereumAddress()],
+      threshold: 1,
+      to: ZERO_ADDRESS,
+      data: EMPTY_DATA,
+      fallbackHandler: faker.finance.ethereumAddress(),
+      paymentToken: ZERO_ADDRESS,
+      payment: 0,
+      paymentReceiver: ECOSYSTEM_ID_ADDRESS,
+    }
+
+    const setupData = safeInterface.encodeFunctionData('setup', [
+      callData.owners,
+      callData.threshold,
+      callData.to,
+      callData.data,
+      callData.fallbackHandler,
+      callData.paymentToken,
+      callData.payment,
+      callData.paymentReceiver,
+    ])
+
+    const creationData: ReplayedSafeProps = {
+      factoryAddress: faker.finance.ethereumAddress(),
+      masterCopy: faker.finance.ethereumAddress(),
+      saltNonce: '0',
+      setupData,
+    }
+    const { result } = renderHook(() => useReplayableNetworks(creationData))
+    expect(result.current).toHaveLength(0)
+  })
+
+  it('should return everything but zkSync for 1.4.1 Safes', () => {
+    const callData = {
+      owners: [faker.finance.ethereumAddress()],
+      threshold: 1,
+      to: ZERO_ADDRESS,
+      data: EMPTY_DATA,
+      fallbackHandler: faker.finance.ethereumAddress(),
+      paymentToken: ZERO_ADDRESS,
+      payment: 0,
+      paymentReceiver: ECOSYSTEM_ID_ADDRESS,
+    }
+
+    const setupData = safeInterface.encodeFunctionData('setup', [
+      callData.owners,
+      callData.threshold,
+      callData.to,
+      callData.data,
+      callData.fallbackHandler,
+      callData.paymentToken,
+      callData.payment,
+      callData.paymentReceiver,
+    ])
+
+    {
+      const creationData: ReplayedSafeProps = {
+        factoryAddress: PROXY_FACTORY_141_DEPLOYMENTS?.canonical?.address!,
+        masterCopy: L1_141_MASTERCOPY_DEPLOYMENTS?.canonical?.address!,
+        saltNonce: '0',
+        setupData,
+      }
+      const { result } = renderHook(() => useReplayableNetworks(creationData))
+      expect(result.current).toHaveLength(4)
+      expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '480'])
+    }
+
+    {
+      const creationData: ReplayedSafeProps = {
+        factoryAddress: PROXY_FACTORY_141_DEPLOYMENTS?.canonical?.address!,
+        masterCopy: L2_141_MASTERCOPY_DEPLOYMENTS?.canonical?.address!,
+        saltNonce: '0',
+        setupData,
+      }
+      const { result } = renderHook(() => useReplayableNetworks(creationData))
+      expect(result.current).toHaveLength(4)
+      expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '480'])
+    }
+  })
+
+  it('should return correct chains for 1.3.0 Safes', () => {
+    const callData = {
+      owners: [faker.finance.ethereumAddress()],
+      threshold: 1,
+      to: ZERO_ADDRESS,
+      data: EMPTY_DATA,
+      fallbackHandler: faker.finance.ethereumAddress(),
+      paymentToken: ZERO_ADDRESS,
+      payment: 0,
+      paymentReceiver: ECOSYSTEM_ID_ADDRESS,
+    }
+
+    const setupData = safeInterface.encodeFunctionData('setup', [
+      callData.owners,
+      callData.threshold,
+      callData.to,
+      callData.data,
+      callData.fallbackHandler,
+      callData.paymentToken,
+      callData.payment,
+      callData.paymentReceiver,
+    ])
+
+    // 1.3.0, L1 and canonical
+    {
+      const creationData: ReplayedSafeProps = {
+        factoryAddress: PROXY_FACTORY_130_DEPLOYMENTS?.canonical?.address!,
+        masterCopy: L1_130_MASTERCOPY_DEPLOYMENTS?.canonical?.address!,
+        saltNonce: '0',
+        setupData,
+      }
+      const { result } = renderHook(() => useReplayableNetworks(creationData))
+      expect(result.current).toHaveLength(4)
+      expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '480'])
+    }
+
+    // 1.3.0, L2 and canonical
+    {
+      const creationData: ReplayedSafeProps = {
+        factoryAddress: PROXY_FACTORY_130_DEPLOYMENTS?.canonical?.address!,
+        masterCopy: L2_130_MASTERCOPY_DEPLOYMENTS?.canonical?.address!,
+        saltNonce: '0',
+        setupData,
+      }
+      const { result } = renderHook(() => useReplayableNetworks(creationData))
+      expect(result.current).toHaveLength(4)
+      expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '480'])
+    }
+
+    // 1.3.0, L1 and EIP155 is not available on Worldchain
+    {
+      const creationData: ReplayedSafeProps = {
+        factoryAddress: PROXY_FACTORY_130_DEPLOYMENTS?.eip155?.address!,
+        masterCopy: L1_130_MASTERCOPY_DEPLOYMENTS?.eip155?.address!,
+        saltNonce: '0',
+        setupData,
+      }
+      const { result } = renderHook(() => useReplayableNetworks(creationData))
+      expect(result.current).toHaveLength(3)
+      expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100'])
+    }
+
+    // 1.3.0, L2 and EIP155
+    {
+      const creationData: ReplayedSafeProps = {
+        factoryAddress: PROXY_FACTORY_130_DEPLOYMENTS?.eip155?.address!,
+        masterCopy: L2_130_MASTERCOPY_DEPLOYMENTS?.eip155?.address!,
+        saltNonce: '0',
+        setupData,
+      }
+      const { result } = renderHook(() => useReplayableNetworks(creationData))
+      expect(result.current).toHaveLength(3)
+      expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100'])
+    }
+  })
+
+  it('should return correct chains for 1.1.1 Safes', () => {
+    const callData = {
+      owners: [faker.finance.ethereumAddress()],
+      threshold: 1,
+      to: ZERO_ADDRESS,
+      data: EMPTY_DATA,
+      fallbackHandler: faker.finance.ethereumAddress(),
+      paymentToken: ZERO_ADDRESS,
+      payment: 0,
+      paymentReceiver: ECOSYSTEM_ID_ADDRESS,
+    }
+
+    const setupData = safeInterface.encodeFunctionData('setup', [
+      callData.owners,
+      callData.threshold,
+      callData.to,
+      callData.data,
+      callData.fallbackHandler,
+      callData.paymentToken,
+      callData.payment,
+      callData.paymentReceiver,
+    ])
+
+    const creationData: ReplayedSafeProps = {
+      factoryAddress: PROXY_FACTORY_111_DEPLOYMENTS?.canonical?.address!,
+      masterCopy: L1_111_MASTERCOPY_DEPLOYMENTS?.canonical?.address!,
+      saltNonce: '0',
+      setupData,
+    }
+    const { result } = renderHook(() => useReplayableNetworks(creationData))
+    expect(result.current).toHaveLength(2)
+    expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '100'])
+  })
+})

--- a/src/features/multichain/hooks/__tests__/useSafeCreationData.test.ts
+++ b/src/features/multichain/hooks/__tests__/useSafeCreationData.test.ts
@@ -1,0 +1,619 @@
+import { renderHook, waitFor } from '@/tests/test-utils'
+import { SAFE_CREATION_DATA_ERRORS, useSafeCreationData } from '../useSafeCreationData'
+import { faker } from '@faker-js/faker'
+import { PendingSafeStatus, type ReplayedSafeProps, type UndeployedSafe } from '@/store/slices'
+import { PayMethod } from '@/features/counterfactual/PayNowPayLater'
+import { chainBuilder } from '@/tests/builders/chains'
+import { EMPTY_DATA, ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
+import * as sdk from '@/services/tx/tx-sender/sdk'
+import * as cgwSdk from 'safe-client-gateway-sdk'
+import * as web3 from '@/hooks/wallets/web3'
+import { encodeMultiSendData, type SafeProvider } from '@safe-global/protocol-kit'
+import {
+  getCompatibilityFallbackHandlerDeployment,
+  getProxyFactoryDeployment,
+  getSafeSingletonDeployment,
+} from '@safe-global/safe-deployments'
+import { Safe__factory, Safe_proxy_factory__factory } from '@/types/contracts'
+import { type JsonRpcProvider } from 'ethers'
+import { Multi_send__factory } from '@/types/contracts/factories/@safe-global/safe-deployments/dist/assets/v1.3.0'
+
+describe('useSafeCreationData', () => {
+  beforeAll(() => {
+    jest.spyOn(sdk, 'getSafeProvider').mockReturnValue({
+      getChainId: jest.fn().mockReturnValue('1'),
+      getExternalProvider: jest.fn(),
+      getExternalSigner: jest.fn(),
+    } as unknown as SafeProvider)
+  })
+  it('should return undefined without chain info', async () => {
+    const safeAddress = faker.finance.ethereumAddress()
+    const { result } = renderHook(() => useSafeCreationData(safeAddress, undefined))
+    await waitFor(async () => {
+      await Promise.resolve()
+      expect(result.current).toEqual([undefined, undefined, false])
+    })
+  })
+
+  it('should return the replayedSafe when copying one', async () => {
+    const safeAddress = faker.finance.ethereumAddress()
+    const chainIndo = chainBuilder().with({ chainId: '1' }).build()
+    const undeployedSafe: UndeployedSafe = {
+      props: {
+        factoryAddress: faker.finance.ethereumAddress(),
+        saltNonce: '420',
+        masterCopy: faker.finance.ethereumAddress(),
+        setupData: faker.string.hexadecimal({ length: 64 }),
+      },
+      status: {
+        status: PendingSafeStatus.AWAITING_EXECUTION,
+        type: PayMethod.PayLater,
+      },
+    }
+
+    const { result } = renderHook(() => useSafeCreationData(safeAddress, chainIndo), {
+      initialReduxState: {
+        undeployedSafes: {
+          '1': {
+            [safeAddress]: undeployedSafe,
+          },
+        },
+      },
+    })
+    await waitFor(async () => {
+      await Promise.resolve()
+      expect(result.current).toEqual([undeployedSafe.props, undefined, false])
+    })
+  })
+
+  it('should extract replayedSafe data from an predictedSafe', async () => {
+    const safeAddress = faker.finance.ethereumAddress()
+    const chainInfo = chainBuilder().with({ chainId: '1', l2: false }).build()
+    const undeployedSafe = {
+      props: {
+        safeAccountConfig: {
+          owners: [faker.finance.ethereumAddress()],
+          threshold: 1,
+        },
+        safeDeploymentConfig: {
+          saltNonce: '69',
+          safeVersion: '1.3.0',
+        },
+      },
+      status: {
+        status: PendingSafeStatus.AWAITING_EXECUTION,
+        type: PayMethod.PayLater,
+      },
+    }
+
+    const { result } = renderHook(() => useSafeCreationData(safeAddress, chainInfo), {
+      initialReduxState: {
+        undeployedSafes: {
+          '1': {
+            [safeAddress]: undeployedSafe as UndeployedSafe,
+          },
+        },
+      },
+    })
+
+    const setupData = Safe__factory.createInterface().encodeFunctionData('setup', [
+      undeployedSafe.props.safeAccountConfig.owners,
+      undeployedSafe.props.safeAccountConfig.threshold,
+      ZERO_ADDRESS,
+      EMPTY_DATA,
+      getCompatibilityFallbackHandlerDeployment({ network: '1', version: '1.3.0' })?.defaultAddress!,
+      ZERO_ADDRESS,
+      0,
+      ZERO_ADDRESS,
+    ])
+
+    // Should return replayedSafeProps
+    const expectedProps: ReplayedSafeProps = {
+      factoryAddress: getProxyFactoryDeployment({ network: '1', version: '1.3.0' })?.defaultAddress!,
+      saltNonce: '69',
+      masterCopy: getSafeSingletonDeployment({ network: '1', version: '1.3.0' })?.networkAddresses['1'],
+      setupData,
+    }
+    await waitFor(async () => {
+      await Promise.resolve()
+      expect(result.current).toEqual([expectedProps, undefined, false])
+    })
+  })
+
+  it('should extract replayedSafe data from an predictedSafe which has a custom Setup', async () => {
+    const safeAddress = faker.finance.ethereumAddress()
+    const chainInfo = chainBuilder().with({ chainId: '1', l2: false }).build()
+    const undeployedSafe = {
+      props: {
+        safeAccountConfig: {
+          owners: [faker.finance.ethereumAddress(), faker.finance.ethereumAddress()],
+          threshold: 2,
+          fallbackHandler: faker.finance.ethereumAddress(),
+          data: faker.string.hexadecimal({ length: 64 }),
+          to: faker.finance.ethereumAddress(),
+          payment: 123,
+          paymentReceiver: faker.finance.ethereumAddress(),
+          paymentToken: faker.finance.ethereumAddress(),
+        },
+        safeDeploymentConfig: {
+          saltNonce: '69',
+          safeVersion: '1.3.0',
+        },
+      },
+      status: {
+        status: PendingSafeStatus.AWAITING_EXECUTION,
+        type: PayMethod.PayLater,
+      },
+    }
+
+    const setupData = Safe__factory.createInterface().encodeFunctionData('setup', [
+      undeployedSafe.props.safeAccountConfig.owners,
+      undeployedSafe.props.safeAccountConfig.threshold,
+      undeployedSafe.props.safeAccountConfig.to,
+      undeployedSafe.props.safeAccountConfig.data,
+      undeployedSafe.props.safeAccountConfig.fallbackHandler,
+      undeployedSafe.props.safeAccountConfig.paymentToken,
+      undeployedSafe.props.safeAccountConfig.payment,
+      undeployedSafe.props.safeAccountConfig.paymentReceiver,
+    ])
+
+    // Should return replayedSafeProps
+    const expectedProps: ReplayedSafeProps = {
+      factoryAddress: getProxyFactoryDeployment({ network: '1', version: '1.3.0' })?.defaultAddress!,
+      saltNonce: '69',
+      masterCopy: getSafeSingletonDeployment({ network: '1', version: '1.3.0' })?.defaultAddress,
+      setupData,
+    }
+
+    // Run hook
+    const { result } = renderHook(() => useSafeCreationData(safeAddress, chainInfo), {
+      initialReduxState: {
+        undeployedSafes: {
+          '1': {
+            [safeAddress]: undeployedSafe as UndeployedSafe,
+          },
+        },
+      },
+    })
+
+    // Expectations
+    await waitFor(async () => {
+      await Promise.resolve()
+      expect(result.current).toEqual([expectedProps, undefined, false])
+    })
+  })
+
+  it('should throw error if creation data cannot be found', async () => {
+    jest.spyOn(cgwSdk, 'getCreationTransaction').mockResolvedValue({
+      response: new Response(),
+      data: undefined,
+    } as any)
+
+    const safeAddress = faker.finance.ethereumAddress()
+    const chainInfo = chainBuilder().with({ chainId: '1', l2: false }).build()
+
+    // Run hook
+    const { result } = renderHook(() => useSafeCreationData(safeAddress, chainInfo))
+
+    await waitFor(() => {
+      expect(result.current).toEqual([undefined, new Error(SAFE_CREATION_DATA_ERRORS.NO_CREATION_DATA), false])
+    })
+  })
+
+  it('should throw error if Safe creation data is incomplete', async () => {
+    jest.spyOn(cgwSdk, 'getCreationTransaction').mockResolvedValue({
+      data: {
+        created: new Date(Date.now()).toISOString(),
+        creator: faker.finance.ethereumAddress(),
+        factoryAddress: faker.finance.ethereumAddress(),
+        transactionHash: faker.string.hexadecimal({ length: 64 }),
+        masterCopy: null,
+        setupData: null,
+      },
+      response: new Response(),
+    })
+
+    const safeAddress = faker.finance.ethereumAddress()
+    const chainInfo = chainBuilder().with({ chainId: '1', l2: false }).build()
+
+    // Run hook
+    const { result } = renderHook(() => useSafeCreationData(safeAddress, chainInfo))
+
+    await waitFor(() => {
+      expect(result.current).toEqual([undefined, new Error(SAFE_CREATION_DATA_ERRORS.NO_CREATION_DATA), false])
+    })
+  })
+
+  it('should throw error if RPC could not be created', async () => {
+    const setupData = Safe__factory.createInterface().encodeFunctionData('setup', [
+      [faker.finance.ethereumAddress(), faker.finance.ethereumAddress()],
+      1,
+      faker.finance.ethereumAddress(),
+      faker.string.hexadecimal({ length: 64 }),
+      faker.finance.ethereumAddress(),
+      faker.finance.ethereumAddress(),
+      0,
+      faker.finance.ethereumAddress(),
+    ])
+
+    jest.spyOn(cgwSdk, 'getCreationTransaction').mockResolvedValue({
+      data: {
+        created: new Date(Date.now()).toISOString(),
+        creator: faker.finance.ethereumAddress(),
+        factoryAddress: faker.finance.ethereumAddress(),
+        transactionHash: faker.string.hexadecimal({ length: 64 }),
+        masterCopy: faker.finance.ethereumAddress(),
+        setupData,
+      },
+      response: new Response(),
+    })
+
+    jest.spyOn(web3, 'createWeb3ReadOnly').mockReturnValue(undefined)
+
+    const safeAddress = faker.finance.ethereumAddress()
+    const chainInfo = chainBuilder().with({ chainId: '1', l2: false }).build()
+
+    // Run hook
+    const { result } = renderHook(() => useSafeCreationData(safeAddress, chainInfo))
+
+    await waitFor(() => {
+      expect(result.current).toEqual([undefined, new Error(SAFE_CREATION_DATA_ERRORS.NO_PROVIDER), false])
+    })
+  })
+
+  it('should throw error if RPC cannot find the tx hash', async () => {
+    const setupData = Safe__factory.createInterface().encodeFunctionData('setup', [
+      [faker.finance.ethereumAddress(), faker.finance.ethereumAddress()],
+      1,
+      faker.finance.ethereumAddress(),
+      faker.string.hexadecimal({ length: 64 }),
+      faker.finance.ethereumAddress(),
+      faker.finance.ethereumAddress(),
+      0,
+      faker.finance.ethereumAddress(),
+    ])
+
+    const mockTxHash = faker.string.hexadecimal({ length: 64 })
+    const mockFactoryAddress = faker.finance.ethereumAddress()
+    const mockMasterCopyAddress = faker.finance.ethereumAddress()
+    jest.spyOn(cgwSdk, 'getCreationTransaction').mockResolvedValue({
+      data: {
+        created: new Date(Date.now()).toISOString(),
+        creator: faker.finance.ethereumAddress(),
+        factoryAddress: mockFactoryAddress,
+        transactionHash: mockTxHash,
+        masterCopy: mockMasterCopyAddress,
+        setupData,
+      },
+      response: new Response(),
+    })
+
+    jest.spyOn(web3, 'createWeb3ReadOnly').mockReturnValue({
+      getTransaction: (txHash: string) => Promise.resolve(null),
+    } as JsonRpcProvider)
+
+    const safeAddress = faker.finance.ethereumAddress()
+    const chainInfo = chainBuilder().with({ chainId: '1', l2: false }).build()
+
+    // Run hook
+    const { result } = renderHook(() => useSafeCreationData(safeAddress, chainInfo))
+
+    await waitFor(() => {
+      expect(result.current).toEqual([undefined, new Error(SAFE_CREATION_DATA_ERRORS.TX_NOT_FOUND), false])
+    })
+  })
+
+  it('should throw an Error if an unsupported creation method is found', async () => {
+    const setupData = Safe__factory.createInterface().encodeFunctionData('setup', [
+      [faker.finance.ethereumAddress(), faker.finance.ethereumAddress()],
+      1,
+      faker.finance.ethereumAddress(),
+      faker.string.hexadecimal({ length: 64 }),
+      faker.finance.ethereumAddress(),
+      faker.finance.ethereumAddress(),
+      0,
+      faker.finance.ethereumAddress(),
+    ])
+
+    const mockTxHash = faker.string.hexadecimal({ length: 64 })
+    const mockFactoryAddress = faker.finance.ethereumAddress()
+    const mockMasterCopyAddress = faker.finance.ethereumAddress()
+    jest.spyOn(cgwSdk, 'getCreationTransaction').mockResolvedValue({
+      data: {
+        created: new Date(Date.now()).toISOString(),
+        creator: faker.finance.ethereumAddress(),
+        factoryAddress: mockFactoryAddress,
+        transactionHash: mockTxHash,
+        masterCopy: mockMasterCopyAddress,
+        setupData,
+      },
+      response: new Response(),
+    })
+
+    jest.spyOn(web3, 'createWeb3ReadOnly').mockReturnValue({
+      getTransaction: (txHash: string) => {
+        if (mockTxHash === txHash) {
+          return Promise.resolve({
+            to: mockFactoryAddress,
+            data: Safe_proxy_factory__factory.createInterface().encodeFunctionData('createProxyWithCallback', [
+              mockMasterCopyAddress,
+              setupData,
+              69,
+              faker.finance.ethereumAddress(),
+            ]),
+          })
+        }
+      },
+    } as JsonRpcProvider)
+
+    const safeAddress = faker.finance.ethereumAddress()
+    const chainInfo = chainBuilder().with({ chainId: '1', l2: false }).build()
+
+    // Run hook
+    const { result } = renderHook(() => useSafeCreationData(safeAddress, chainInfo))
+
+    await waitFor(() => {
+      expect(result.current).toEqual([undefined, new Error(SAFE_CREATION_DATA_ERRORS.UNSUPPORTED_SAFE_CREATION), false])
+    })
+  })
+
+  it('should throw error if the setup data does not match', async () => {
+    const setupData = Safe__factory.createInterface().encodeFunctionData('setup', [
+      [faker.finance.ethereumAddress(), faker.finance.ethereumAddress()],
+      1,
+      faker.finance.ethereumAddress(),
+      faker.string.hexadecimal({ length: 64 }),
+      faker.finance.ethereumAddress(),
+      faker.finance.ethereumAddress(),
+      0,
+      faker.finance.ethereumAddress(),
+    ])
+
+    const nonMatchingSetupData = Safe__factory.createInterface().encodeFunctionData('setup', [
+      [faker.finance.ethereumAddress(), faker.finance.ethereumAddress()],
+      1,
+      faker.finance.ethereumAddress(),
+      faker.string.hexadecimal({ length: 64 }),
+      faker.finance.ethereumAddress(),
+      faker.finance.ethereumAddress(),
+      0,
+      faker.finance.ethereumAddress(),
+    ])
+
+    const mockTxHash = faker.string.hexadecimal({ length: 64 })
+    const mockFactoryAddress = faker.finance.ethereumAddress()
+    const mockMasterCopyAddress = faker.finance.ethereumAddress()
+    jest.spyOn(cgwSdk, 'getCreationTransaction').mockResolvedValue({
+      data: {
+        created: new Date(Date.now()).toISOString(),
+        creator: faker.finance.ethereumAddress(),
+        factoryAddress: mockFactoryAddress,
+        transactionHash: mockTxHash,
+        masterCopy: mockMasterCopyAddress,
+        setupData,
+      },
+      response: new Response(),
+    })
+
+    jest.spyOn(web3, 'createWeb3ReadOnly').mockReturnValue({
+      getTransaction: (txHash: string) => {
+        if (mockTxHash === txHash) {
+          return Promise.resolve({
+            to: mockFactoryAddress,
+            data: Safe_proxy_factory__factory.createInterface().encodeFunctionData('createProxyWithNonce', [
+              mockMasterCopyAddress,
+              nonMatchingSetupData,
+              69,
+            ]),
+          })
+        }
+        return Promise.resolve(null)
+      },
+    } as JsonRpcProvider)
+
+    const safeAddress = faker.finance.ethereumAddress()
+    const chainInfo = chainBuilder().with({ chainId: '1', l2: false }).build()
+
+    // Run hook
+    const { result } = renderHook(() => useSafeCreationData(safeAddress, chainInfo))
+
+    await waitFor(() => {
+      expect(result.current).toEqual([undefined, new Error(SAFE_CREATION_DATA_ERRORS.UNSUPPORTED_SAFE_CREATION), false])
+    })
+  })
+
+  it('should throw error if the masterCopies do not match', async () => {
+    const setupData = Safe__factory.createInterface().encodeFunctionData('setup', [
+      [faker.finance.ethereumAddress(), faker.finance.ethereumAddress()],
+      1,
+      faker.finance.ethereumAddress(),
+      faker.string.hexadecimal({ length: 64 }),
+      faker.finance.ethereumAddress(),
+      faker.finance.ethereumAddress(),
+      0,
+      faker.finance.ethereumAddress(),
+    ])
+
+    const mockTxHash = faker.string.hexadecimal({ length: 64 })
+    const mockFactoryAddress = faker.finance.ethereumAddress()
+    const mockMasterCopyAddress = faker.finance.ethereumAddress()
+    jest.spyOn(cgwSdk, 'getCreationTransaction').mockResolvedValue({
+      data: {
+        created: new Date(Date.now()).toISOString(),
+        creator: faker.finance.ethereumAddress(),
+        factoryAddress: mockFactoryAddress,
+        transactionHash: mockTxHash,
+        masterCopy: mockMasterCopyAddress,
+        setupData,
+      },
+      response: new Response(),
+    })
+
+    jest.spyOn(web3, 'createWeb3ReadOnly').mockReturnValue({
+      getTransaction: (txHash: string) => {
+        if (mockTxHash === txHash) {
+          return Promise.resolve({
+            to: mockFactoryAddress,
+            data: Safe_proxy_factory__factory.createInterface().encodeFunctionData('createProxyWithNonce', [
+              faker.finance.ethereumAddress(),
+              setupData,
+              69,
+            ]),
+          })
+        }
+        return Promise.resolve(null)
+      },
+    } as JsonRpcProvider)
+
+    const safeAddress = faker.finance.ethereumAddress()
+    const chainInfo = chainBuilder().with({ chainId: '1', l2: false }).build()
+
+    // Run hook
+    const { result } = renderHook(() => useSafeCreationData(safeAddress, chainInfo))
+
+    await waitFor(() => {
+      expect(result.current).toEqual([undefined, new Error(SAFE_CREATION_DATA_ERRORS.UNSUPPORTED_SAFE_CREATION), false])
+    })
+  })
+
+  it('should return transaction data for direct Safe creation txs', async () => {
+    const setupData = Safe__factory.createInterface().encodeFunctionData('setup', [
+      [faker.finance.ethereumAddress(), faker.finance.ethereumAddress()],
+      1,
+      faker.finance.ethereumAddress(),
+      faker.string.hexadecimal({ length: 64 }),
+      faker.finance.ethereumAddress(),
+      faker.finance.ethereumAddress(),
+      0,
+      faker.finance.ethereumAddress(),
+    ])
+
+    const mockTxHash = faker.string.hexadecimal({ length: 64 })
+    const mockFactoryAddress = faker.finance.ethereumAddress()
+    const mockMasterCopyAddress = faker.finance.ethereumAddress()
+    jest.spyOn(cgwSdk, 'getCreationTransaction').mockResolvedValue({
+      data: {
+        created: new Date(Date.now()).toISOString(),
+        creator: faker.finance.ethereumAddress(),
+        factoryAddress: mockFactoryAddress,
+        transactionHash: mockTxHash,
+        masterCopy: mockMasterCopyAddress,
+        setupData,
+      },
+      response: new Response(),
+    })
+
+    jest.spyOn(web3, 'createWeb3ReadOnly').mockReturnValue({
+      getTransaction: (txHash: string) => {
+        if (mockTxHash === txHash) {
+          return Promise.resolve({
+            to: mockFactoryAddress,
+            data: Safe_proxy_factory__factory.createInterface().encodeFunctionData('createProxyWithNonce', [
+              mockMasterCopyAddress,
+              setupData,
+              69,
+            ]),
+          })
+        }
+        return Promise.resolve(null)
+      },
+    } as JsonRpcProvider)
+
+    const safeAddress = faker.finance.ethereumAddress()
+    const chainInfo = chainBuilder().with({ chainId: '1', l2: false }).build()
+
+    // Run hook
+    const { result } = renderHook(() => useSafeCreationData(safeAddress, chainInfo))
+
+    await waitFor(() => {
+      expect(result.current).toEqual([
+        {
+          factoryAddress: mockFactoryAddress,
+          masterCopy: mockMasterCopyAddress,
+          setupData,
+          saltNonce: '69',
+        },
+        undefined,
+        false,
+      ])
+    })
+  })
+
+  it('should return transaction data for creation bundles', async () => {
+    const setupData = Safe__factory.createInterface().encodeFunctionData('setup', [
+      [faker.finance.ethereumAddress(), faker.finance.ethereumAddress()],
+      1,
+      faker.finance.ethereumAddress(),
+      faker.string.hexadecimal({ length: 64 }),
+      faker.finance.ethereumAddress(),
+      faker.finance.ethereumAddress(),
+      0,
+      faker.finance.ethereumAddress(),
+    ])
+
+    const mockTxHash = faker.string.hexadecimal({ length: 64 })
+    const mockFactoryAddress = faker.finance.ethereumAddress()
+    const mockMasterCopyAddress = faker.finance.ethereumAddress()
+
+    jest.spyOn(cgwSdk, 'getCreationTransaction').mockResolvedValue({
+      data: {
+        created: new Date(Date.now()).toISOString(),
+        creator: faker.finance.ethereumAddress(),
+        factoryAddress: mockFactoryAddress,
+        transactionHash: mockTxHash,
+        masterCopy: mockMasterCopyAddress,
+        setupData,
+      },
+      response: new Response(),
+    })
+
+    jest.spyOn(web3, 'createWeb3ReadOnly').mockReturnValue({
+      getTransaction: (txHash: string) => {
+        if (txHash === mockTxHash) {
+          const deploymentTx = {
+            to: mockFactoryAddress,
+            data: Safe_proxy_factory__factory.createInterface().encodeFunctionData('createProxyWithNonce', [
+              mockMasterCopyAddress,
+              setupData,
+              69,
+            ]),
+            value: '0',
+            operation: 0,
+          }
+          const someOtherTx = {
+            to: faker.finance.ethereumAddress(),
+            value: '0',
+            operation: 0,
+            data: faker.string.hexadecimal({ length: 64 }),
+          }
+
+          const multiSendData = encodeMultiSendData([deploymentTx, someOtherTx])
+          return Promise.resolve({
+            to: faker.finance.ethereumAddress(),
+            data: Multi_send__factory.createInterface().encodeFunctionData('multiSend', [multiSendData]),
+          })
+        }
+        return Promise.resolve(null)
+      },
+    } as JsonRpcProvider)
+
+    const safeAddress = faker.finance.ethereumAddress()
+    const chainInfo = chainBuilder().with({ chainId: '1', l2: false }).build()
+
+    // Run hook
+    const { result } = renderHook(() => useSafeCreationData(safeAddress, chainInfo))
+
+    await waitFor(() => {
+      expect(result.current).toEqual([
+        {
+          factoryAddress: mockFactoryAddress,
+          masterCopy: mockMasterCopyAddress,
+          setupData,
+          saltNonce: '69',
+        },
+        undefined,
+        false,
+      ])
+    })
+  })
+})

--- a/src/features/multichain/hooks/useReplayableNetworks.ts
+++ b/src/features/multichain/hooks/useReplayableNetworks.ts
@@ -1,0 +1,60 @@
+import { type ReplayedSafeProps } from '@/features/counterfactual/store/undeployedSafesSlice'
+import useChains from '@/hooks/useChains'
+import { sameAddress } from '@/utils/addresses'
+import { type SafeVersion } from '@safe-global/safe-core-sdk-types'
+import {
+  type SingletonDeploymentV2,
+  getProxyFactoryDeployments,
+  getSafeL2SingletonDeployments,
+  getSafeSingletonDeployments,
+} from '@safe-global/safe-deployments'
+
+const SUPPORTED_VERSIONS: SafeVersion[] = ['1.4.1', '1.3.0', '1.1.1']
+
+const hasDeployment = (chainId: string, contractAddress: string, deployments: SingletonDeploymentV2[]) => {
+  return deployments.some((deployment) => {
+    // Check that deployment contains the contract Address on given chain
+    const networkDeployments = deployment.networkAddresses[chainId]
+    return Array.isArray(networkDeployments)
+      ? networkDeployments.some((networkDeployment) => sameAddress(networkDeployment, contractAddress))
+      : sameAddress(networkDeployments, contractAddress)
+  })
+}
+
+/**
+ * Returns all chains where the transaction can be replayed successfully.
+ * Therefore the creation's masterCopy and factory need to be deployed to that network.
+ * @param creation
+ */
+export const useReplayableNetworks = (creation: ReplayedSafeProps | undefined) => {
+  const { configs } = useChains()
+
+  if (!creation) {
+    return []
+  }
+
+  const { masterCopy, factoryAddress } = creation
+
+  if (!masterCopy) {
+    return []
+  }
+
+  const allL1SingletonDeployments = SUPPORTED_VERSIONS.map((version) =>
+    getSafeSingletonDeployments({ version }),
+  ).filter(Boolean) as SingletonDeploymentV2[]
+
+  const allL2SingletonDeployments = SUPPORTED_VERSIONS.map((version) =>
+    getSafeL2SingletonDeployments({ version }),
+  ).filter(Boolean) as SingletonDeploymentV2[]
+
+  const allProxyFactoryDeployments = SUPPORTED_VERSIONS.map((version) =>
+    getProxyFactoryDeployments({ version }),
+  ).filter(Boolean) as SingletonDeploymentV2[]
+
+  return configs.filter(
+    (config) =>
+      (hasDeployment(config.chainId, masterCopy, allL1SingletonDeployments) ||
+        hasDeployment(config.chainId, masterCopy, allL2SingletonDeployments)) &&
+      hasDeployment(config.chainId, factoryAddress, allProxyFactoryDeployments),
+  )
+}

--- a/src/features/multichain/hooks/useSafeCreationData.ts
+++ b/src/features/multichain/hooks/useSafeCreationData.ts
@@ -1,0 +1,80 @@
+import useAsync, { type AsyncResult } from '@/hooks/useAsync'
+import { createWeb3ReadOnly } from '@/hooks/wallets/web3'
+import { selectRpc, type ReplayedSafeProps } from '@/store/slices'
+import { Safe_proxy_factory__factory } from '@/types/contracts'
+import { sameAddress } from '@/utils/addresses'
+import { getCreationTransaction } from 'safe-client-gateway-sdk'
+import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { useAppSelector } from '@/store'
+
+const proxyFactoryInterface = Safe_proxy_factory__factory.createInterface()
+const createProxySelector = proxyFactoryInterface.getFunction('createProxyWithNonce').selector
+/**
+ * Fetches the data with which the given Safe was originally created.
+ * Useful to replay a Safe creation.
+ */
+export const useSafeCreationData = (
+  safeAddress: string,
+  chain: ChainInfo | undefined,
+): AsyncResult<ReplayedSafeProps> => {
+  const customRpc = useAppSelector(selectRpc)
+
+  return useAsync<ReplayedSafeProps | undefined>(async () => {
+    if (!chain) {
+      return undefined
+    }
+
+    // We need to create a readOnly provider of the deployed chain
+    const customRpcUrl = chain ? customRpc?.[chain.chainId] : undefined
+    const provider = createWeb3ReadOnly(chain, customRpcUrl)
+
+    const { data: creation } = await getCreationTransaction({
+      path: {
+        chainId: chain.chainId,
+        safeAddress,
+      },
+    })
+
+    if (!creation || !provider || !creation.masterCopy || !creation.setupData) {
+      return undefined
+    }
+
+    // TODO: Fetch saltNonce by fetching the transaction from the RPC.
+    const tx = await provider?.getTransaction(creation.transactionHash)
+
+    const txData = tx?.data
+    const startOfTx = txData?.indexOf(createProxySelector.slice(2, 10))
+    if (!txData || !startOfTx) {
+      return undefined
+    }
+
+    // decode tx
+    try {
+      const [masterCopy, initializer, saltNonce] = proxyFactoryInterface.decodeFunctionData(
+        'createProxyWithNonce',
+        `0x${txData.slice(startOfTx)}`,
+      )
+
+      const txMatches =
+        sameAddress(masterCopy, creation.masterCopy ?? undefined) &&
+        (initializer as string)?.toLowerCase().includes(creation.setupData?.toLowerCase())
+
+      if (!txMatches || typeof saltNonce !== 'bigint') {
+        // We found the wrong tx. This tx seems to deploy multiple Safes at once.
+        // TODO: Check each possible match
+        return undefined
+      }
+
+      // Check that it is the correct deployment
+      return {
+        factoryAddress: creation.factoryAddress,
+        masterCopy: creation.masterCopy,
+        setupData: creation.setupData,
+        saltNonce: saltNonce.toString(),
+      }
+    } catch (err) {
+      console.error(err)
+      throw err
+    }
+  }, [chain, customRpc, safeAddress])
+}

--- a/src/features/multichain/hooks/useSafeCreationData.ts
+++ b/src/features/multichain/hooks/useSafeCreationData.ts
@@ -7,7 +7,6 @@ import { getCreationTransaction } from 'safe-client-gateway-sdk'
 import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { useAppSelector } from '@/store'
 import { isPredictedSafeProps } from '@/features/counterfactual/utils'
-import { ECOSYSTEM_ID_ADDRESS } from '@/config/constants'
 import {
   getReadOnlyGnosisSafeContract,
   getReadOnlyProxyFactoryContract,
@@ -15,6 +14,8 @@ import {
 } from '@/services/contracts/safeContracts'
 import { getLatestSafeVersion } from '@/utils/chains'
 import { ZERO_ADDRESS, EMPTY_DATA } from '@safe-global/protocol-kit/dist/src/utils/constants'
+import { logError } from '@/services/exceptions'
+import ErrorCodes from '@/services/exceptions/ErrorCodes'
 
 const getUndeployedSafeCreationData = async (
   undeployedSafe: UndeployedSafe,
@@ -23,7 +24,8 @@ const getUndeployedSafeCreationData = async (
   if (isPredictedSafeProps(undeployedSafe.props)) {
     // Copy predicted safe
     // Encode Safe creation and determine the addresses the Safe creation would use
-    const { owners, threshold } = undeployedSafe.props.safeAccountConfig
+    const { owners, threshold, to, data, fallbackHandler, paymentToken, payment, paymentReceiver } =
+      undeployedSafe.props.safeAccountConfig
     const usedSafeVersion = undeployedSafe.props.safeDeploymentConfig?.safeVersion ?? getLatestSafeVersion(chain)
     const readOnlySafeContract = await getReadOnlyGnosisSafeContract(chain, usedSafeVersion)
     const readOnlyProxyFactoryContract = await getReadOnlyProxyFactoryContract(usedSafeVersion)
@@ -32,12 +34,12 @@ const getUndeployedSafeCreationData = async (
     const callData = {
       owners,
       threshold,
-      to: ZERO_ADDRESS,
-      data: EMPTY_DATA,
-      fallbackHandler: await readOnlyFallbackHandlerContract.getAddress(),
-      paymentToken: ZERO_ADDRESS,
-      payment: 0,
-      paymentReceiver: ECOSYSTEM_ID_ADDRESS,
+      to: to ?? ZERO_ADDRESS,
+      data: data ?? EMPTY_DATA,
+      fallbackHandler: fallbackHandler ?? (await readOnlyFallbackHandlerContract.getAddress()),
+      paymentToken: paymentToken ?? ZERO_ADDRESS,
+      payment: payment ?? 0,
+      paymentReceiver: paymentReceiver ?? ZERO_ADDRESS,
     }
 
     // @ts-ignore union type is too complex
@@ -66,6 +68,13 @@ const getUndeployedSafeCreationData = async (
 
 const proxyFactoryInterface = Safe_proxy_factory__factory.createInterface()
 const createProxySelector = proxyFactoryInterface.getFunction('createProxyWithNonce').selector
+
+export const SAFE_CREATION_DATA_ERRORS = {
+  TX_NOT_FOUND: 'The Safe creation transaction could not be found. Please retry later.',
+  NO_CREATION_DATA: 'The Safe creation information for this Safe could be found or is incomplete.',
+  UNSUPPORTED_SAFE_CREATION: 'The method this Safe was created with is not supported yet.',
+  NO_PROVIDER: 'The RPC provider for the origin network is not available.',
+}
 /**
  * Fetches the data with which the given Safe was originally created.
  * Useful to replay a Safe creation.
@@ -81,54 +90,60 @@ export const useSafeCreationData = (
   )
 
   return useAsync<ReplayedSafeProps | undefined>(async () => {
-    if (!chain) {
-      return undefined
-    }
-
-    // 1. The safe is counterfactual
-    if (undeployedSafe) {
-      return getUndeployedSafeCreationData(undeployedSafe, chain)
-    }
-
-    // We need to create a readOnly provider of the deployed chain
-    const customRpcUrl = chain ? customRpc?.[chain.chainId] : undefined
-    const provider = createWeb3ReadOnly(chain, customRpcUrl)
-
-    const { data: creation } = await getCreationTransaction({
-      path: {
-        chainId: chain.chainId,
-        safeAddress,
-      },
-    })
-
-    if (!creation || !provider || !creation.masterCopy || !creation.setupData) {
-      return undefined
-    }
-
-    // TODO: Fetch saltNonce by fetching the transaction from the RPC.
-    const tx = await provider?.getTransaction(creation.transactionHash)
-
-    const txData = tx?.data
-    const startOfTx = txData?.indexOf(createProxySelector.slice(2, 10))
-    if (!txData || !startOfTx) {
-      return undefined
-    }
-
-    // decode tx
     try {
+      if (!chain) {
+        return undefined
+      }
+
+      // 1. The safe is counterfactual
+      if (undeployedSafe) {
+        return getUndeployedSafeCreationData(undeployedSafe, chain)
+      }
+
+      const { data: creation } = await getCreationTransaction({
+        path: {
+          chainId: chain.chainId,
+          safeAddress,
+        },
+      })
+
+      if (!creation || !creation.masterCopy || !creation.setupData) {
+        throw new Error(SAFE_CREATION_DATA_ERRORS.NO_CREATION_DATA)
+      }
+
+      // We need to create a readOnly provider of the deployed chain
+      const customRpcUrl = chain ? customRpc?.[chain.chainId] : undefined
+      const provider = createWeb3ReadOnly(chain, customRpcUrl)
+
+      if (!provider) {
+        throw new Error(SAFE_CREATION_DATA_ERRORS.NO_PROVIDER)
+      }
+
+      // Fetch saltNonce by fetching the transaction from the RPC.
+      const tx = await provider.getTransaction(creation.transactionHash)
+      if (!tx) {
+        throw new Error(SAFE_CREATION_DATA_ERRORS.TX_NOT_FOUND)
+      }
+      const txData = tx.data
+      const startOfTx = txData.indexOf(createProxySelector.slice(2, 10))
+      if (startOfTx === -1) {
+        throw new Error(SAFE_CREATION_DATA_ERRORS.UNSUPPORTED_SAFE_CREATION)
+      }
+
+      // decode tx
+
       const [masterCopy, initializer, saltNonce] = proxyFactoryInterface.decodeFunctionData(
         'createProxyWithNonce',
         `0x${txData.slice(startOfTx)}`,
       )
 
       const txMatches =
-        sameAddress(masterCopy, creation.masterCopy ?? undefined) &&
+        sameAddress(masterCopy, creation.masterCopy) &&
         (initializer as string)?.toLowerCase().includes(creation.setupData?.toLowerCase())
 
-      if (!txMatches || typeof saltNonce !== 'bigint') {
-        // We found the wrong tx. This tx seems to deploy multiple Safes at once.
-        // TODO: Check each possible match
-        return undefined
+      if (!txMatches) {
+        // We found the wrong tx. This tx seems to deploy multiple Safes at once. This is not supported yet.
+        throw new Error(SAFE_CREATION_DATA_ERRORS.UNSUPPORTED_SAFE_CREATION)
       }
 
       return {
@@ -138,7 +153,7 @@ export const useSafeCreationData = (
         saltNonce: saltNonce.toString(),
       }
     } catch (err) {
-      console.error(err)
+      logError(ErrorCodes._816, err)
       throw err
     }
   }, [chain, customRpc, safeAddress, undeployedSafe])

--- a/src/features/multichain/hooks/useSafeCreationData.ts
+++ b/src/features/multichain/hooks/useSafeCreationData.ts
@@ -1,11 +1,68 @@
 import useAsync, { type AsyncResult } from '@/hooks/useAsync'
 import { createWeb3ReadOnly } from '@/hooks/wallets/web3'
-import { selectRpc, type ReplayedSafeProps } from '@/store/slices'
+import { type UndeployedSafe, selectRpc, selectUndeployedSafe, type ReplayedSafeProps } from '@/store/slices'
 import { Safe_proxy_factory__factory } from '@/types/contracts'
 import { sameAddress } from '@/utils/addresses'
 import { getCreationTransaction } from 'safe-client-gateway-sdk'
 import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { useAppSelector } from '@/store'
+import { isPredictedSafeProps } from '@/features/counterfactual/utils'
+import { ECOSYSTEM_ID_ADDRESS } from '@/config/constants'
+import {
+  getReadOnlyGnosisSafeContract,
+  getReadOnlyProxyFactoryContract,
+  getReadOnlyFallbackHandlerContract,
+} from '@/services/contracts/safeContracts'
+import { getLatestSafeVersion } from '@/utils/chains'
+import { ZERO_ADDRESS, EMPTY_DATA } from '@safe-global/protocol-kit/dist/src/utils/constants'
+
+const getUndeployedSafeCreationData = async (
+  undeployedSafe: UndeployedSafe,
+  chain: ChainInfo,
+): Promise<ReplayedSafeProps> => {
+  if (isPredictedSafeProps(undeployedSafe.props)) {
+    // Copy predicted safe
+    // Encode Safe creation and determine the addresses the Safe creation would use
+    const { owners, threshold } = undeployedSafe.props.safeAccountConfig
+    const usedSafeVersion = undeployedSafe.props.safeDeploymentConfig?.safeVersion ?? getLatestSafeVersion(chain)
+    const readOnlySafeContract = await getReadOnlyGnosisSafeContract(chain, usedSafeVersion)
+    const readOnlyProxyFactoryContract = await getReadOnlyProxyFactoryContract(usedSafeVersion)
+    const readOnlyFallbackHandlerContract = await getReadOnlyFallbackHandlerContract(usedSafeVersion)
+
+    const callData = {
+      owners,
+      threshold,
+      to: ZERO_ADDRESS,
+      data: EMPTY_DATA,
+      fallbackHandler: await readOnlyFallbackHandlerContract.getAddress(),
+      paymentToken: ZERO_ADDRESS,
+      payment: 0,
+      paymentReceiver: ECOSYSTEM_ID_ADDRESS,
+    }
+
+    // @ts-ignore union type is too complex
+    const setupData = readOnlySafeContract.encode('setup', [
+      callData.owners,
+      callData.threshold,
+      callData.to,
+      callData.data,
+      callData.fallbackHandler,
+      callData.paymentToken,
+      callData.payment,
+      callData.paymentReceiver,
+    ])
+
+    return {
+      factoryAddress: await readOnlyProxyFactoryContract.getAddress(),
+      masterCopy: await readOnlySafeContract.getAddress(),
+      saltNonce: undeployedSafe.props.safeDeploymentConfig?.saltNonce ?? '0',
+      setupData,
+    }
+  }
+
+  // We already have a replayed Safe. In this case we can return the identical data
+  return undeployedSafe.props
+}
 
 const proxyFactoryInterface = Safe_proxy_factory__factory.createInterface()
 const createProxySelector = proxyFactoryInterface.getFunction('createProxyWithNonce').selector
@@ -19,9 +76,18 @@ export const useSafeCreationData = (
 ): AsyncResult<ReplayedSafeProps> => {
   const customRpc = useAppSelector(selectRpc)
 
+  const undeployedSafe = useAppSelector((selector) =>
+    selectUndeployedSafe(selector, chain?.chainId ?? '1', safeAddress),
+  )
+
   return useAsync<ReplayedSafeProps | undefined>(async () => {
     if (!chain) {
       return undefined
+    }
+
+    // 1. The safe is counterfactual
+    if (undeployedSafe) {
+      return getUndeployedSafeCreationData(undeployedSafe, chain)
     }
 
     // We need to create a readOnly provider of the deployed chain
@@ -65,7 +131,6 @@ export const useSafeCreationData = (
         return undefined
       }
 
-      // Check that it is the correct deployment
       return {
         factoryAddress: creation.factoryAddress,
         masterCopy: creation.masterCopy,
@@ -76,5 +141,5 @@ export const useSafeCreationData = (
       console.error(err)
       throw err
     }
-  }, [chain, customRpc, safeAddress])
+  }, [chain, customRpc, safeAddress, undeployedSafe])
 }

--- a/src/hooks/coreSDK/safeCoreSDK.ts
+++ b/src/hooks/coreSDK/safeCoreSDK.ts
@@ -11,6 +11,7 @@ import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import semverSatisfies from 'semver/functions/satisfies'
 import { isValidMasterCopy } from '@/services/contracts/safeContracts'
 import { sameAddress } from '@/utils/addresses'
+import { isPredictedSafeProps } from '@/features/counterfactual/utils'
 
 export const isLegacyVersion = (safeVersion: string): boolean => {
   const LEGACY_VERSION = '<1.3.0'
@@ -81,11 +82,15 @@ export const initSafeSDK = async ({
   }
 
   if (undeployedSafe) {
-    return Safe.init({
-      provider: provider._getConnection().url,
-      isL1SafeSingleton,
-      predictedSafe: undeployedSafe.props,
-    })
+    if (isPredictedSafeProps(undeployedSafe.props)) {
+      return Safe.init({
+        provider: provider._getConnection().url,
+        isL1SafeSingleton,
+        predictedSafe: undeployedSafe.props,
+      })
+    }
+    // We cannot initialize a Core SDK for replayed Safes yet.
+    return
   }
   return Safe.init({
     provider: provider._getConnection().url,

--- a/src/hooks/loadables/useLoadSafeInfo.ts
+++ b/src/hooks/loadables/useLoadSafeInfo.ts
@@ -28,7 +28,7 @@ export const useLoadSafeInfo = (): AsyncResult<SafeInfo> => {
      * This is the one place where we can't check for `safe.deployed` as we want to update that value
      * when the local storage is cleared, so we have to check undeployedSafe
      */
-    if (undeployedSafe) return getUndeployedSafeInfo(undeployedSafe.props, address, chain)
+    if (undeployedSafe) return getUndeployedSafeInfo(undeployedSafe, address, chain)
 
     const safeInfo = await getSafeInfo(chainId, address)
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,6 +8,7 @@ import CssBaseline from '@mui/material/CssBaseline'
 import type { Theme } from '@mui/material/styles'
 import { ThemeProvider } from '@mui/material/styles'
 import { setBaseUrl as setGatewayBaseUrl } from '@safe-global/safe-gateway-typescript-sdk'
+import { setBaseUrl as setNewGatewayBaseUrl } from 'safe-client-gateway-sdk'
 import { CacheProvider, type EmotionCache } from '@emotion/react'
 import SafeThemeProvider from '@/components/theme/SafeThemeProvider'
 import '@/styles/globals.css'
@@ -51,6 +52,7 @@ const reduxStore = makeStore()
 
 const InitApp = (): null => {
   setGatewayBaseUrl(GATEWAY_URL)
+  setNewGatewayBaseUrl(GATEWAY_URL)
   useHydrateStore(reduxStore)
   useAdjustUrl()
   useGtm()

--- a/src/services/analytics/events/overview.ts
+++ b/src/services/analytics/events/overview.ts
@@ -31,6 +31,10 @@ export const OVERVIEW_EVENTS = {
     action: 'Remove from watchlist',
     category: OVERVIEW_CATEGORY,
   },
+  ADD_NEW_NETWORK: {
+    action: 'Add new network',
+    category: OVERVIEW_CATEGORY,
+  },
   DELETED_FROM_WATCHLIST: {
     action: 'Deleted from watchlist',
     category: OVERVIEW_CATEGORY,

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -105,13 +105,14 @@ export const getReadOnlyMultiSendCallOnlyContract = async (safeVersion: SafeInfo
 
 // GnosisSafeProxyFactory
 
-export const getReadOnlyProxyFactoryContract = async (safeVersion: SafeInfo['version']) => {
+export const getReadOnlyProxyFactoryContract = async (safeVersion: SafeInfo['version'], contractAddress?: string) => {
   const safeProvider = getSafeProvider()
 
   return getSafeProxyFactoryContractInstance(
     _getValidatedGetContractProps(safeVersion).safeVersion,
     safeProvider,
     safeProvider.getExternalProvider(),
+    contractAddress,
   )
 }
 

--- a/src/services/exceptions/ErrorCodes.ts
+++ b/src/services/exceptions/ErrorCodes.ts
@@ -69,6 +69,7 @@ enum ErrorCodes {
   _813 = '813: Failed to cancel recovery',
   _814 = '814: Failed to speed up transaction',
   _815 = '815: Error executing a transaction through a role',
+  _816 = '816: Error computing replay Safe creation data',
 
   _900 = '900: Error loading Safe App',
   _901 = '901: Error processing Safe Apps SDK request',

--- a/src/store/addedSafesSlice.ts
+++ b/src/store/addedSafesSlice.ts
@@ -1,7 +1,6 @@
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import type { AddressEx, SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import type { RootState } from '.'
-import { safeInfoSlice } from '@/store/safeInfoSlice'
 
 export type AddedSafesOnChain = {
   [safeAddress: string]: {
@@ -16,10 +15,6 @@ export type AddedSafesState = {
 }
 
 const initialState: AddedSafesState = {}
-
-const isAddedSafe = (state: AddedSafesState, chainId: string, safeAddress: string) => {
-  return !!state[chainId]?.[safeAddress]
-}
 
 export const addedSafesSlice = createSlice({
   name: 'addedSafes',
@@ -54,22 +49,6 @@ export const addedSafesSlice = createSlice({
         delete state[chainId]
       }
     },
-  },
-  extraReducers(builder) {
-    builder.addCase(safeInfoSlice.actions.set, (state, { payload }) => {
-      if (!payload.data) {
-        return
-      }
-
-      const { chainId, address } = payload.data
-
-      if (isAddedSafe(state, chainId, address.value)) {
-        addedSafesSlice.caseReducers.addOrUpdateSafe(state, {
-          type: addOrUpdateSafe.type,
-          payload: { safe: payload.data },
-        })
-      }
-    })
   },
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14293,6 +14293,18 @@ open@^8.0.4, open@^8.4.0:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
+openapi-fetch@^0.10.5:
+  version "0.10.6"
+  resolved "https://registry.yarnpkg.com/openapi-fetch/-/openapi-fetch-0.10.6.tgz#255017e3e609c5e7be16bc1ed7a973977c085cdc"
+  integrity sha512-6xXfvIEL/POtLGOaFPsp3O+pDe+J3DZYxbD9BrsQHXOTeNK8z/gsWHT6adUy1KcpQOhmkerMzlQrJM6DbN55dQ==
+  dependencies:
+    openapi-typescript-helpers "^0.0.11"
+
+openapi-typescript-helpers@^0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.11.tgz#d05e88216b8f3771d5df41c863ebc5c9d10e2954"
+  integrity sha512-xofUHlVFq+BMquf3nh9I8N2guHckW6mrDO/F3kaFgrL7MGbjldDnQ9TIT+rkH/+H0LiuO+RuZLnNmsJwsjwUKg==
+
 opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
@@ -15953,6 +15965,12 @@ safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, 
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+"safe-client-gateway-sdk@git+https://github.com/safe-global/safe-client-gateway-sdk.git#v1.53.0-next-7344903":
+  version "1.53.0-next-7344903"
+  resolved "git+https://github.com/safe-global/safe-client-gateway-sdk.git#b0b91319b8753b41edd117bb6425729634250e15"
+  dependencies:
+    openapi-fetch "^0.10.5"
 
 safe-regex-test@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
##  What this PR changes
- Adds logic to replay a Safe creation with its initial setup to get the same address
- Adds logic to activate replayed counterfactual Safes through the connected wallet and through relayers.
- Adds "Add new network" to Safe's context menu in the sidebar

## How to test it
- Click "Add new network"
- Select a available network

## TODO
- [x] Better error handling
- [x] Replaying Counterfactual Safes

## Screenshots

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
