### PR TITLE
Fix: (css) center-align delegate warning

### DIFF
--- a/src/components/transactions/Warning/index.tsx
+++ b/src/components/transactions/Warning/index.tsx
@@ -22,7 +22,7 @@ const Warning = ({
     <Tooltip data-testid={datatestid} title={title} placement="top-start" arrow>
       <Alert
         className={css.alert}
-        sx={{ borderLeft: ({ palette }) => `3px solid ${palette[severity].main} !important` }}
+        sx={{ borderLeft: ({ palette }) => `3px solid ${palette[severity].main} !important`, alignItems: 'center' }}
         severity={severity}
         icon={<SvgIcon component={InfoOutlinedIcon} inheritViewBox color={severity} />}
       >


### PR DESCRIPTION
## What it solves
The contents of the delegate call warning weren't center-aligned which drove me crazy.

<img width="585" alt="Screenshot 2024-09-04 at 08 09 19" src="https://github.com/user-attachments/assets/e6fdb59e-78c3-4f47-a144-dbcead9dc965">
