### PR TITLE
fix: put execute button to be full width on mobile display

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,7 +24,7 @@ jobs:
           # branch should not be protected
           branch: 'main'
           # user names of users allowed to contribute without CLA
-          allowlist: lukasschor,rmeissner,germartinez,Uxio0,dasanra,francovenica,tschubotz,luarx,DaniSomoza,iamacook,yagopv,usame-algan,schmanu,DiogoSoaress,JagoFigueroa,fmrsabino,mike10ca,jmealy,compojoom,TanyaEfremova,bot*
+          allowlist: clovisdasilvaneto,lukasschor,rmeissner,germartinez,Uxio0,dasanra,francovenica,tschubotz,luarx,DaniSomoza,iamacook,yagopv,usame-algan,schmanu,DiogoSoaress,JagoFigueroa,fmrsabino,mike10ca,jmealy,compojoom,TanyaEfremova,bot*
 
           # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
           # enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -195,7 +195,7 @@ export const ExecuteForm = ({
                 variant="contained"
                 type="submit"
                 disabled={!isOk || submitDisabled}
-                sx={{ minWidth: '112px' }}
+                sx={{ minWidth: '112px', width: ['100%', '100%', '100%', 'auto'] }}
               >
                 {!isSubmittable ? <CircularProgress size={20} /> : 'Execute'}
               </Button>


### PR DESCRIPTION
## What it solves

Resolves #
https://github.com/safe-global/safe-wallet-web/issues/4142

## How this PR fixes it
It adds correct sizes for the MUI screen variations (sm, xs, md, lg and xl)

## How to test it
1) Go to a safe you own 1/1
2) Create a tx and go to the "Confirm transaction" modal screen

## Screenshots

### Before
<img width="389" alt="Screenshot 2024-09-09 at 11 00 22" src="https://github.com/user-attachments/assets/2c546e5e-8ccc-4867-ab25-f813b5b58d97">


### After
<img width="359" alt="Screenshot 2024-09-09 at 10 56 45" src="https://github.com/user-attachments/assets/bf33a724-8636-4ef8-99a9-56098b4edcfa">


## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
