### PR TITLE
Fix: (Swaps) sell token reactivity

### DIFF
--- a/src/features/swap/index.tsx
+++ b/src/features/swap/index.tsx
@@ -274,6 +274,14 @@ const SwapWidget = ({ sell }: Params) => {
     }))
   }, [palette, darkMode, chainId])
 
+  useEffect(() => {
+    if (!sell) return
+    setParams((params) => ({
+      ...params,
+      sell,
+    }))
+  }, [sell])
+
   const chain = useCurrentChain()
 
   const iframeRef: MutableRefObject<HTMLIFrameElement | null> = useRef<HTMLIFrameElement | null>(null)

--- a/src/pages/swap.tsx
+++ b/src/pages/swap.tsx
@@ -6,6 +6,15 @@ import { useContext } from 'react'
 import { AppRoutes } from '@/config/routes'
 import dynamic from 'next/dynamic'
 
+// Cow Swap expects native token addresses to be in the format '0xeeee...eeee'
+const adjustEthAddress = (address: string) => {
+  if (address && Number(address) === 0) {
+    const ETH_ADDRESS = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+    return ETH_ADDRESS
+  }
+  return address
+}
+
 const SwapWidgetNoSSR = dynamic(() => import('@/features/swap'), { ssr: false })
 const Swap: NextPage = () => {
   const router = useRouter()
@@ -19,8 +28,8 @@ const Swap: NextPage = () => {
   let sell = undefined
   if (token && amount) {
     sell = {
-      asset: String(token),
-      amount: String(amount),
+      asset: adjustEthAddress(String(token ?? '')),
+      amount: adjustEthAddress(String(amount ?? '')),
     }
   }
 


### PR DESCRIPTION
## What it solves

Resolves #4144

## How this PR fixes it

The sell token query parameter wasn't properly pass to the Swaps widget. It will now update the widget params when the URL query becomes available.