### PR TITLE
Highlight raw data transactions

### DIFF
--- a/src/components/transactions/HexEncodedData/HexEncodedData.test.tsx
+++ b/src/components/transactions/HexEncodedData/HexEncodedData.test.tsx
@@ -1,0 +1,39 @@
+import { render } from '@/tests/test-utils'
+import { HexEncodedData } from '.'
+
+const hexData = '0xed2ad31ed00088fc64d00c49774b2fe3fb7fd7db1c2a714700892607b9f77dc1'
+
+describe('HexEncodedData', () => {
+  it('should render the default component markup', () => {
+    const result = render(<HexEncodedData hexData={hexData} title="Data (hex-encoded)" />)
+    const showMoreButton = result.getByTestId('show-more')
+    const tooltipComponent = result.getByLabelText(
+      'The first 4 bytes determine the contract method that is being called',
+    )
+    const copyButton = result.getByTestId('copy-btn-icon')
+
+    expect(showMoreButton).toBeInTheDocument()
+    expect(showMoreButton).toHaveTextContent('Show more')
+    expect(tooltipComponent).toBeInTheDocument()
+    expect(copyButton).toBeInTheDocument()
+
+    expect(result.container).toMatchSnapshot()
+  })
+
+  it('should not highlight the data if highlight option is false', () => {
+    const result = render(
+      <HexEncodedData hexData="0x102384763718984309876" highlightFirstBytes={false} title="Some arbitrary data" />,
+    )
+
+    expect(result.container.querySelector('b')).not.toBeInTheDocument()
+    expect(result.container).toMatchSnapshot()
+  })
+
+  it('should not cut the text in case the limit option is higher than the provided hexData', () => {
+    const result = render(<HexEncodedData hexData={hexData} limit={1000} title="Data (hex-encoded)" />)
+
+    expect(result.container.querySelector("button[data-testid='show-more']")).not.toBeInTheDocument()
+
+    expect(result.container).toMatchSnapshot()
+  })
+})

--- a/src/components/transactions/HexEncodedData/__snapshots__/HexEncodedData.test.tsx.snap
+++ b/src/components/transactions/HexEncodedData/__snapshots__/HexEncodedData.test.tsx.snap
@@ -1,0 +1,187 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HexEncodedData should not cut the text in case the limit option is higher than the provided hexData 1`] = `
+<div>
+  <div
+    class="MuiGrid-root MuiGrid-container css-1d1otxt-MuiGrid-root"
+  >
+    <div
+      class="MuiGrid-root MuiGrid-item css-f2z333-MuiGrid-root"
+    >
+      <p
+        class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-s5yue5-MuiTypography-root"
+      >
+        Data (hex-encoded)
+      </p>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
+    >
+      <div
+        class="encodedData MuiBox-root css-0"
+        data-testid="tx-hexData"
+      >
+        <span
+          aria-label="Copy to clipboard"
+          class=""
+          data-mui-internal-clone-element="true"
+          style="cursor: pointer;"
+        >
+          <button
+            aria-label="Copy to clipboard"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-nmr6e8-MuiButtonBase-root-MuiIconButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <mock-icon
+              aria-hidden="true"
+              classname="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-j1da6x-MuiSvgIcon-root"
+              data-testid="copy-btn-icon"
+              focusable="false"
+            />
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+        </span>
+        <b
+          aria-label="The first 4 bytes determine the contract method that is being called"
+          class=""
+          data-mui-internal-clone-element="true"
+        >
+          0xed2ad31e
+        </b>
+        d00088fc64d00c49774b2fe3fb7fd7db1c2a714700892607b9f77dc1
+         
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`HexEncodedData should not highlight the data if highlight option is false 1`] = `
+<div>
+  <div
+    class="MuiGrid-root MuiGrid-container css-1d1otxt-MuiGrid-root"
+  >
+    <div
+      class="MuiGrid-root MuiGrid-item css-f2z333-MuiGrid-root"
+    >
+      <p
+        class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-s5yue5-MuiTypography-root"
+      >
+        Some arbitrary data
+      </p>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
+    >
+      <div
+        class="encodedData MuiBox-root css-0"
+        data-testid="tx-hexData"
+      >
+        <span
+          aria-label="Copy to clipboard"
+          class=""
+          data-mui-internal-clone-element="true"
+          style="cursor: pointer;"
+        >
+          <button
+            aria-label="Copy to clipboard"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-nmr6e8-MuiButtonBase-root-MuiIconButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <mock-icon
+              aria-hidden="true"
+              classname="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-j1da6x-MuiSvgIcon-root"
+              data-testid="copy-btn-icon"
+              focusable="false"
+            />
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+        </span>
+        0x10238476...
+         
+        <button
+          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button css-fl9gtn-MuiTypography-root-MuiLink-root"
+          data-testid="show-more"
+          type="button"
+        >
+          Show 
+          more
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`HexEncodedData should render the default component markup 1`] = `
+<div>
+  <div
+    class="MuiGrid-root MuiGrid-container css-1d1otxt-MuiGrid-root"
+  >
+    <div
+      class="MuiGrid-root MuiGrid-item css-f2z333-MuiGrid-root"
+    >
+      <p
+        class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-s5yue5-MuiTypography-root"
+      >
+        Data (hex-encoded)
+      </p>
+    </div>
+    <div
+      class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
+    >
+      <div
+        class="encodedData MuiBox-root css-0"
+        data-testid="tx-hexData"
+      >
+        <span
+          aria-label="Copy to clipboard"
+          class=""
+          data-mui-internal-clone-element="true"
+          style="cursor: pointer;"
+        >
+          <button
+            aria-label="Copy to clipboard"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-nmr6e8-MuiButtonBase-root-MuiIconButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <mock-icon
+              aria-hidden="true"
+              classname="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-j1da6x-MuiSvgIcon-root"
+              data-testid="copy-btn-icon"
+              focusable="false"
+            />
+            <span
+              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+            />
+          </button>
+        </span>
+        <b
+          aria-label="The first 4 bytes determine the contract method that is being called"
+          class=""
+          data-mui-internal-clone-element="true"
+        >
+          0xed2ad31e
+        </b>
+        d00088fc64...
+         
+        <button
+          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button css-fl9gtn-MuiTypography-root-MuiLink-root"
+          data-testid="show-more"
+          type="button"
+        >
+          Show 
+          more
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/transactions/HexEncodedData/index.tsx
+++ b/src/components/transactions/HexEncodedData/index.tsx
@@ -8,13 +8,14 @@ import FieldsGrid from '@/components/tx/FieldsGrid'
 
 interface Props {
   hexData: string
+  highlightFirstBytes?: boolean;
   title?: string
   limit?: number
 }
 
 const FIRST_BYTES = 10
 
-export const HexEncodedData = ({ hexData, title, limit = 20 }: Props): ReactElement => {
+export const HexEncodedData = ({ hexData, title, highlightFirstBytes = true, limit = 20 }: Props): ReactElement => {
   const [showTxData, setShowTxData] = useState(false)
   const showExpandBtn = hexData.length > limit
 
@@ -22,12 +23,12 @@ export const HexEncodedData = ({ hexData, title, limit = 20 }: Props): ReactElem
     setShowTxData((val) => !val)
   }
 
-  const firstBytes = (
+  const firstBytes = highlightFirstBytes ? (
     <Tooltip title="The first 4 bytes determine the contract method that is being called" arrow>
       <b>{hexData.slice(0, FIRST_BYTES)}</b>
     </Tooltip>
-  )
-  const restBytes = hexData.slice(FIRST_BYTES)
+  ) : null
+  const restBytes = highlightFirstBytes ? hexData.slice(FIRST_BYTES) : hexData
 
   const content = (
     <Box data-testid="tx-hexData" className={css.encodedData}>
@@ -37,7 +38,7 @@ export const HexEncodedData = ({ hexData, title, limit = 20 }: Props): ReactElem
         {firstBytes}
         {showTxData || !showExpandBtn ? restBytes : shortenText(restBytes, limit - FIRST_BYTES)}{' '}
         {showExpandBtn && (
-          <Link component="button" onClick={toggleExpanded} type="button" sx={{ verticalAlign: 'text-top' }}>
+          <Link component="button" data-testid="show-more" onClick={toggleExpanded} type="button" sx={{ verticalAlign: 'text-top' }}>
             Show {showTxData ? 'less' : 'more'}
           </Link>
         )}

--- a/src/components/transactions/HexEncodedData/index.tsx
+++ b/src/components/transactions/HexEncodedData/index.tsx
@@ -8,7 +8,7 @@ import FieldsGrid from '@/components/tx/FieldsGrid'
 
 interface Props {
   hexData: string
-  highlightFirstBytes?: boolean;
+  highlightFirstBytes?: boolean
   title?: string
   limit?: number
 }
@@ -38,7 +38,13 @@ export const HexEncodedData = ({ hexData, title, highlightFirstBytes = true, lim
         {firstBytes}
         {showTxData || !showExpandBtn ? restBytes : shortenText(restBytes, limit - FIRST_BYTES)}{' '}
         {showExpandBtn && (
-          <Link component="button" data-testid="show-more" onClick={toggleExpanded} type="button" sx={{ verticalAlign: 'text-top' }}>
+          <Link
+            component="button"
+            data-testid="show-more"
+            onClick={toggleExpanded}
+            type="button"
+            sx={{ verticalAlign: 'text-top' }}
+          >
             Show {showTxData ? 'less' : 'more'}
           </Link>
         )}

--- a/src/components/transactions/TxDetails/Summary/TxDataRow/index.tsx
+++ b/src/components/transactions/TxDetails/Summary/TxDataRow/index.tsx
@@ -40,7 +40,7 @@ export const generateDataRowValue = (
         </Box>
       )
     case 'bytes':
-      return <HexEncodedData limit={60} hexData={value} />
+      return <HexEncodedData highlightFirstBytes={false} limit={60} hexData={value} />
     default:
       return <Typography sx={{ wordBreak: 'break-all' }}>{value}</Typography>
   }

--- a/src/components/transactions/TxDetails/TxData/DecodedData/ValueArray/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/ValueArray/index.tsx
@@ -62,7 +62,7 @@ export const Value = ({ type, value, ...props }: ValueArrayProps): ReactElement 
 }
 
 const getTextValue = (value: string, key?: string) => {
-  return <HexEncodedData limit={60} hexData={value} key={key} />
+  return <HexEncodedData highlightFirstBytes={false} limit={60} hexData={value} key={key} />
 }
 
 const getArrayValue = (parentId: string, value: string[], separator?: boolean) => (


### PR DESCRIPTION
## What it solves

Resolves #4136

## How this PR fixes it
A new property called `highlightFirstBytes` was added in to the `<HexEncodedData />`component, where we can explicitly say where we wish to have the highlight or not. I've added it as default `true` because the default behaviour of this component was supposed to be highlighted and also we do not need to go across the entire application and set the highlight as true. 

## How to test it
Create any raw undecoded data transaction, and you'll see the highlight still exists, and for any type of hex-bytes it is not highlighted.

## Screenshots

### Before
<img width="672" alt="Screenshot 2024-09-09 at 14 46 59" src="https://github.com/user-attachments/assets/2b8719a8-c687-4d93-b253-94dd26c03bd3">


### After
<img width="675" alt="Screenshot 2024-09-09 at 14 43 06" src="https://github.com/user-attachments/assets/e81e7615-64e1-421c-ae89-74676d8077b5">
<img width="521" alt="Screenshot 2024-09-09 at 14 42 56" src="https://github.com/user-attachments/assets/06d37a65-0688-4ec4-b283-ff07f58348d9">

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
