### PR TITLE
fix: Consider app category in the searchbar query filter

### DIFF
--- a/src/hooks/safe-apps/useAppsSearch.ts
+++ b/src/hooks/safe-apps/useAppsSearch.ts
@@ -15,6 +15,10 @@ const useAppsSearch = (apps: SafeAppData[], query: string): SafeAppData[] => {
             name: 'description',
             weight: 0.5,
           },
+          {
+            name: 'tags',
+            weight: 0.99,
+          },
         ],
         // https://fusejs.io/api/options.html#threshold
         // Very naive explanation: threshold represents how accurate the search results should be. The default is 0.6


### PR DESCRIPTION
## What it solves

Resolves #4088

## How this PR fixes it
It adds the tags property from the apps array into the fusion constructor parameters.

## How to test it
Type the category you want to search in the safe apps search bar and you'll have the apps filtered not only by the name or description but also category.

## Screenshots
<img width="1317" alt="Screenshot 2024-09-09 at 16 35 44" src="https://github.com/user-attachments/assets/0bb769ae-f91c-47a3-b19a-8bca686ccaa4">


## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
