### PR TITLE
fix: avoid blinking screen in the confirmation modal view

### DIFF
--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -94,6 +94,7 @@ export const SignOrExecuteForm = ({
   const isNewExecutableTx = useImmediatelyExecutable() && isCreation
   const isCorrectNonce = useValidateNonce(safeTx)
   const [decodedData] = useDecodeTx(safeTx)
+
   const isBatchable = props.isBatchable !== false && safeTx && !isDelegateCall(safeTx)
   const isSwapOrder = isConfirmationViewOrder(decodedData)
   const { data: txDetails } = useGetTransactionDetailsQuery(
@@ -159,7 +160,7 @@ export const SignOrExecuteForm = ({
           </ErrorBoundary>
         )}
 
-        {!props.isRejection && (
+        {!props.isRejection && decodedData && (
           <ErrorBoundary fallback={<div>Error parsing data</div>}>
             {isApproval && <ApprovalEditor safeTransaction={safeTx} />}
 

--- a/src/hooks/useDecodeTx.ts
+++ b/src/hooks/useDecodeTx.ts
@@ -23,13 +23,17 @@ const useDecodeTx = (
 
   const [data, error, loading] = useAsync<
     DecodedDataResponse | BaselineConfirmationView | OrderConfirmationView | undefined
-  >(() => {
-    if (!encodedData || isEmptyData) {
-      const nativeTransfer = isEmptyData && !isRejection ? getNativeTransferData(tx?.data) : undefined
-      return Promise.resolve(nativeTransfer)
-    }
-    return getConfirmationView(chainId, safeAddress, encodedData, tx.data.to)
-  }, [chainId, encodedData, isEmptyData, tx?.data, isRejection, safeAddress])
+  >(
+    () => {
+      if (!encodedData || isEmptyData) {
+        const nativeTransfer = isEmptyData && !isRejection ? getNativeTransferData(tx?.data) : undefined
+        return Promise.resolve(nativeTransfer)
+      }
+      return getConfirmationView(chainId, safeAddress, encodedData, tx.data.to)
+    },
+    [chainId, encodedData, isEmptyData, tx?.data, isRejection, safeAddress],
+    false,
+  )
 
   return [data, error, loading]
 }


### PR DESCRIPTION
## What it solves

Resolves #4119

## How this PR fixes it
This problem was happening because the call to get the `decodedData` is an asynchronous call which uses the `useAsync` hook. This `useAsync` hook was clearing the data everytime the component re-renders, what was making the component who presents the decoded transaction details (`<DecodedTx />`) to be unmounted. Diving in the three of this component and its dependencies, I found we have a parameter in the `useAsync` hook, which was added specially to avoiding cleaning the data after the consumer is re-rendered, and the default behaviour of it is to clear the data. 

The solution was to simply provide this parameter in the execution of `useAsync` hook inside the `useDecodeTx` hook, and also just show the `<DecodedTx />` component once the `decodedData` exists.

## How to test it
1) Go to the drain app ( any tx with many actions - starting from 2)
2) select a few tokens
3) enter recipient
4) Click Create tx

## Screenshots
Bellow is a video of the solution working:
[screen-recorder-tue-sep-10-2024-11-56-27.webm](https://github.com/user-attachments/assets/46b291db-6ec6-4281-8010-1182050d9b68)


## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
