### PR TITLE
Feat: show warning when changing signer setup in a multichain safe [SW-150]

### DIFF
--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -166,7 +166,7 @@ export const ExecuteForm = ({
         ) : (
           (executionValidationError || gasLimitError) && (
             <ErrorMessage error={executionValidationError || gasLimitError}>
-              This transaction will most likely fail.
+              This transaction will most likely fail...
               {` To save gas costs, ${isCreation ? 'avoid creating' : 'reject'} this transaction.`}
             </ErrorMessage>
           )

--- a/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -166,7 +166,7 @@ export const ExecuteForm = ({
         ) : (
           (executionValidationError || gasLimitError) && (
             <ErrorMessage error={executionValidationError || gasLimitError}>
-              This transaction will most likely fail...
+              This transaction will most likely fail.
               {` To save gas costs, ${isCreation ? 'avoid creating' : 'reject'} this transaction.`}
             </ErrorMessage>
           )

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -41,6 +41,8 @@ import { useApprovalInfos } from '../ApprovalEditor/hooks/useApprovalInfos'
 import type { TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 import { useGetTransactionDetailsQuery, useLazyGetTransactionDetailsQuery } from '@/store/gateway'
 import { skipToken } from '@reduxjs/toolkit/query/react'
+import { isChangingSignerSetupp } from '@/features/multichain/helpers/utils'
+import { ChangeOwnerSetupWarning } from '@/features/multichain/components/ChangeOwnerSetupWarning/ChangeOwnerSetupWarning'
 
 export type SubmitCallback = (txId: string, isExecuted?: boolean) => void
 
@@ -114,6 +116,7 @@ export const SignOrExecuteForm = ({
   const isSafeOwner = useIsSafeOwner()
   const isCounterfactualSafe = !safe.deployed
   const isChangingFallbackHandler = isSettingTwapFallbackHandler(decodedData)
+  const isChangingSignerSetup = isChangingSignerSetupp(decodedData)
 
   // Check if a Zodiac Roles mod is enabled and if the user is a member of any role that allows the transaction
   const roles = useRoles(
@@ -197,6 +200,8 @@ export const SignOrExecuteForm = ({
         )}
 
         <WrongChainWarning />
+
+        {isChangingSignerSetup && <ChangeOwnerSetupWarning />}
 
         <UnknownContractError />
 

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -41,8 +41,8 @@ import { useApprovalInfos } from '../ApprovalEditor/hooks/useApprovalInfos'
 import type { TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 import { useGetTransactionDetailsQuery, useLazyGetTransactionDetailsQuery } from '@/store/gateway'
 import { skipToken } from '@reduxjs/toolkit/query/react'
-import { isChangingSignerSetupp } from '@/features/multichain/helpers/utils'
-import { ChangeOwnerSetupWarning } from '@/features/multichain/components/ChangeOwnerSetupWarning/ChangeOwnerSetupWarning'
+import { ChangeSignerSetupWarning } from '@/features/multichain/components/ChangeOwnerSetupWarning/ChangeOwnerSetupWarning'
+import { isChangingSignerSetup } from '@/features/multichain/helpers/utils'
 
 export type SubmitCallback = (txId: string, isExecuted?: boolean) => void
 
@@ -116,7 +116,7 @@ export const SignOrExecuteForm = ({
   const isSafeOwner = useIsSafeOwner()
   const isCounterfactualSafe = !safe.deployed
   const isChangingFallbackHandler = isSettingTwapFallbackHandler(decodedData)
-  const isChangingSignerSetup = isChangingSignerSetupp(decodedData)
+  const isChangingSigners = isChangingSignerSetup(decodedData)
 
   // Check if a Zodiac Roles mod is enabled and if the user is a member of any role that allows the transaction
   const roles = useRoles(
@@ -201,7 +201,7 @@ export const SignOrExecuteForm = ({
 
         <WrongChainWarning />
 
-        {isChangingSignerSetup && <ChangeOwnerSetupWarning />}
+        {isChangingSigners && <ChangeSignerSetupWarning />}
 
         <UnknownContractError />
 

--- a/src/features/multichain/components/ChangeOwnerSetupWarning/ChangeOwnerSetupWarning.tsx
+++ b/src/features/multichain/components/ChangeOwnerSetupWarning/ChangeOwnerSetupWarning.tsx
@@ -1,0 +1,18 @@
+import { Box } from '@mui/material'
+import { useIsMultichainSafe } from '../../hooks/useIsMultichainSafe'
+import ErrorMessage from '@/components/tx/ErrorMessage'
+
+export const ChangeOwnerSetupWarning = () => {
+  const isMultichainSafe = useIsMultichainSafe()
+
+  if (!isMultichainSafe) return
+
+  return (
+    <Box mt={1} mb={1}>
+      <ErrorMessage level="warning">
+        Owners are not consistent across networks on this account. Changing owners will only affect the account on the
+        selected network.
+      </ErrorMessage>
+    </Box>
+  )
+}

--- a/src/features/multichain/components/ChangeOwnerSetupWarning/ChangeOwnerSetupWarning.tsx
+++ b/src/features/multichain/components/ChangeOwnerSetupWarning/ChangeOwnerSetupWarning.tsx
@@ -2,7 +2,7 @@ import { Box } from '@mui/material'
 import { useIsMultichainSafe } from '../../hooks/useIsMultichainSafe'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 
-export const ChangeOwnerSetupWarning = () => {
+export const ChangeSignerSetupWarning = () => {
   const isMultichainSafe = useIsMultichainSafe()
 
   if (!isMultichainSafe) return
@@ -10,7 +10,7 @@ export const ChangeOwnerSetupWarning = () => {
   return (
     <Box mt={1} mb={1}>
       <ErrorMessage level="warning">
-        Owners are not consistent across networks on this account. Changing owners will only affect the account on the
+        Signers are not consistent across networks on this account. Changing signers will only affect the account on the
         selected network.
       </ErrorMessage>
     </Box>

--- a/src/features/multichain/helpers/utils.ts
+++ b/src/features/multichain/helpers/utils.ts
@@ -1,0 +1,5 @@
+import type { DecodedDataResponse } from '@safe-global/safe-gateway-typescript-sdk'
+
+export const isChangingSignerSetupp = (decodedData: DecodedDataResponse | undefined) => {
+  return decodedData?.method === 'addOwnerWithThreshold' || decodedData?.method === 'removeOwner'
+}

--- a/src/features/multichain/helpers/utils.ts
+++ b/src/features/multichain/helpers/utils.ts
@@ -1,5 +1,5 @@
 import type { DecodedDataResponse } from '@safe-global/safe-gateway-typescript-sdk'
 
-export const isChangingSignerSetupp = (decodedData: DecodedDataResponse | undefined) => {
+export const isChangingSignerSetup = (decodedData: DecodedDataResponse | undefined) => {
   return decodedData?.method === 'addOwnerWithThreshold' || decodedData?.method === 'removeOwner'
 }

--- a/src/features/multichain/hooks/useIsMultichainSafe.ts
+++ b/src/features/multichain/hooks/useIsMultichainSafe.ts
@@ -1,0 +1,18 @@
+import { useAllSafesGrouped } from '@/components/welcome/MyAccounts/useAllSafesGrouped'
+import useSafeAddress from '@/hooks/useSafeAddress'
+import { sameAddress } from '@/utils/addresses'
+import { useMemo } from 'react'
+
+export const useIsMultichainSafe = () => {
+  const safeAddress = useSafeAddress()
+  const { allMultiChainSafes } = useAllSafesGrouped()
+
+  return useMemo(
+    () =>
+      allMultiChainSafes?.some(
+        (account) => sameAddress(safeAddress, account.safes[0].address),
+        [allMultiChainSafes, safeAddress],
+      ),
+    [allMultiChainSafes, safeAddress],
+  )
+}


### PR DESCRIPTION
## What it solves
Resolves https://www.notion.so/safe-global/Multichain-Safes-V1-change-ownership-91f4347bbf764d35b7fdfa54179d7972?pvs=4

## How this PR fixes it
On the tx submit page, check if the tx is changing the signer setup and if the safe is multichain. If so, display a warning.

## How to test it
- for a multichain safe, create a new tx to add or remove a signer on one of the chains.
- see the warning on the sign or execute form.

## Screenshots
![image](https://github.com/user-attachments/assets/da103c8d-f069-4b82-ac1c-d12c8238e7cb)


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
