### PR TITLE
Fix: update unverified token warning

### DIFF
--- a/src/components/transactions/MaliciousTxWarning/index.tsx
+++ b/src/components/transactions/MaliciousTxWarning/index.tsx
@@ -3,7 +3,7 @@ import WarningIcon from '@/public/images/notifications/warning.svg'
 
 const MaliciousTxWarning = ({ withTooltip = true }: { withTooltip?: boolean }) => {
   return withTooltip ? (
-    <Tooltip title="This token is unfamiliar and may pose risks when interacting with it or involved addresses">
+    <Tooltip title="This token isn’t verified on major token lists and may pose risks when interacting with it or involved addresses">
       <Box lineHeight="16px">
         <SvgIcon component={WarningIcon} fontSize="small" inheritViewBox color="warning" />
       </Box>

--- a/src/components/transactions/TxDetails/TxData/Transfer/index.test.tsx
+++ b/src/components/transactions/TxDetails/TxData/Transfer/index.test.tsx
@@ -56,7 +56,7 @@ describe('TransferTxInfo', () => {
       expect(result.getByText('1 TST')).toBeInTheDocument()
       expect(result.getByText(recipient)).toBeInTheDocument()
       expect(result.queryByText('malicious', { exact: false })).toBeNull()
-      expect(result.queryByLabelText('This token is unfamiliar', { exact: false })).toBeNull()
+      expect(result.queryByLabelText('This token isn’t verified on major token lists', { exact: false })).toBeNull()
     })
 
     it('incoming tx', () => {
@@ -91,7 +91,7 @@ describe('TransferTxInfo', () => {
       expect(result.getByText('12.34 TST')).toBeInTheDocument()
       expect(result.getByText(sender)).toBeInTheDocument()
       expect(result.queryByText('malicious', { exact: false })).toBeNull()
-      expect(result.queryByLabelText('This token is unfamiliar', { exact: false })).toBeNull()
+      expect(result.queryByLabelText('This token isn’t verified on major token lists', { exact: false })).toBeNull()
     })
   })
 
@@ -128,7 +128,9 @@ describe('TransferTxInfo', () => {
       expect(result.getByText('1 TST')).toBeInTheDocument()
       expect(result.getByText(recipient)).toBeInTheDocument()
       expect(result.queryByText('malicious', { exact: false })).toBeNull()
-      expect(result.getByLabelText('This token is unfamiliar', { exact: false })).toBeInTheDocument()
+      expect(
+        result.getByLabelText('This token isn’t verified on major token lists', { exact: false }),
+      ).toBeInTheDocument()
     })
 
     it('incoming tx', () => {
@@ -163,7 +165,9 @@ describe('TransferTxInfo', () => {
       expect(result.getByText('12.34 TST')).toBeInTheDocument()
       expect(result.getByText(sender)).toBeInTheDocument()
       expect(result.queryByText('malicious', { exact: false })).toBeNull()
-      expect(result.queryByLabelText('This token is unfamiliar', { exact: false })).toBeInTheDocument()
+      expect(
+        result.queryByLabelText('This token isn’t verified on major token lists', { exact: false }),
+      ).toBeInTheDocument()
     })
   })
 
@@ -200,7 +204,7 @@ describe('TransferTxInfo', () => {
       expect(result.getByText('1 TST')).toBeInTheDocument()
       expect(result.getByText(recipient)).toBeInTheDocument()
       expect(result.getByText('malicious', { exact: false })).toBeInTheDocument()
-      expect(result.queryByLabelText('This token is unfamiliar', { exact: false })).toBeNull()
+      expect(result.queryByLabelText('This token isn’t verified on major token lists', { exact: false })).toBeNull()
     })
 
     it('incoming tx', () => {
@@ -235,7 +239,7 @@ describe('TransferTxInfo', () => {
       expect(result.getByText('12.34 TST')).toBeInTheDocument()
       expect(result.getByText(sender)).toBeInTheDocument()
       expect(result.getByText('malicious', { exact: false })).toBeInTheDocument()
-      expect(result.queryByLabelText('This token is unfamiliar', { exact: false })).toBeNull()
+      expect(result.queryByLabelText('This token isn’t verified on major token lists', { exact: false })).toBeNull()
     })
 
     it('untrusted and imitation tx', () => {
@@ -270,7 +274,7 @@ describe('TransferTxInfo', () => {
       expect(result.getByText('12.34 TST')).toBeInTheDocument()
       expect(result.getByText(sender)).toBeInTheDocument()
       expect(result.getByText('malicious', { exact: false })).toBeInTheDocument()
-      expect(result.queryByLabelText('This token is unfamiliar', { exact: false })).toBeNull()
+      expect(result.queryByLabelText('This token isn’t verified on major token lists', { exact: false })).toBeNull()
     })
   })
 })


### PR DESCRIPTION
## What it solves

Make the unverified token tooltip a little bit clear that it's based on 3rd-party token lists.

<img width="952" alt="Screenshot 2024-09-11 at 12 15 51" src="https://github.com/user-attachments/assets/e1f108b0-72db-4d21-8331-1764c8f459cc">
