### PR TITLE
fix: Cleanup pending txs if nonce already executed

### DIFF
--- a/src/features/speedup/components/SpeedUpModal.tsx
+++ b/src/features/speedup/components/SpeedUpModal.tsx
@@ -101,6 +101,7 @@ export const SpeedUpModal = ({
           chainInfo.chainId,
           wallet.address,
           safeAddress,
+          safeTx.data.nonce,
         )
         const { data: details } = await trigger({ chainId: chainInfo.chainId, txId })
         const txType = getTransactionTrackingType(details)
@@ -114,6 +115,7 @@ export const SpeedUpModal = ({
           wallet.provider,
           wallet.address,
           safeAddress,
+          pendingTx.nonce,
         )
         // Currently all custom txs are batch executes
         trackEvent({ ...TX_EVENTS.SPEED_UP, label: 'batch' })

--- a/src/features/speedup/utils/__tests__/IsSpeedableTx.test.ts
+++ b/src/features/speedup/utils/__tests__/IsSpeedableTx.test.ts
@@ -5,6 +5,7 @@ import { faker } from '@faker-js/faker'
 describe('isSpeedableTx', () => {
   it('returns true when all conditions are met', () => {
     const pendingTx: PendingTx = {
+      nonce: 1,
       status: PendingStatus.PROCESSING,
       txHash: '0x123',
       signerAddress: '0xabc',
@@ -26,6 +27,7 @@ describe('isSpeedableTx', () => {
 
   it('returns false when one of the conditions is not met', () => {
     const pendingTx: PendingTx = {
+      nonce: 1,
       status: PendingStatus.PROCESSING,
       txHash: '0x123',
       signerAddress: '0xabc',

--- a/src/features/speedup/utils/__tests__/IsSpeedableTx.test.ts
+++ b/src/features/speedup/utils/__tests__/IsSpeedableTx.test.ts
@@ -1,20 +1,14 @@
-import { isSpeedableTx } from '../IsSpeedableTx'
 import { PendingStatus, type PendingTx, PendingTxType } from '@/store/pendingTxsSlice'
-import { faker } from '@faker-js/faker'
+import { pendingTxBuilder } from '@/tests/builders/pendingTx'
+import { isSpeedableTx } from '../IsSpeedableTx'
 
 describe('isSpeedableTx', () => {
   it('returns true when all conditions are met', () => {
     const pendingTx: PendingTx = {
-      nonce: 1,
-      status: PendingStatus.PROCESSING,
+      ...pendingTxBuilder().with({ status: PendingStatus.PROCESSING }).build(),
       txHash: '0x123',
       signerAddress: '0xabc',
-      chainId: '1',
-      safeAddress: '0xdef',
       txType: PendingTxType.SAFE_TX,
-      signerNonce: 0,
-      submittedAt: Date.now(),
-      gasLimit: 45_000,
     }
 
     const isSmartContract = false
@@ -27,17 +21,10 @@ describe('isSpeedableTx', () => {
 
   it('returns false when one of the conditions is not met', () => {
     const pendingTx: PendingTx = {
-      nonce: 1,
-      status: PendingStatus.PROCESSING,
+      ...pendingTxBuilder().with({ status: PendingStatus.PROCESSING }).build(),
       txHash: '0x123',
       signerAddress: '0xabc',
-      chainId: '1',
-      safeAddress: '0xdef',
-      txType: PendingTxType.CUSTOM_TX,
-      signerNonce: 0,
-      submittedAt: Date.now(),
-      data: '0x1234',
-      to: faker.finance.ethereumAddress(),
+      txType: PendingTxType.SAFE_TX,
     }
 
     const isSmartContract = true

--- a/src/hooks/__tests__/useTxPendingStatus.test.ts
+++ b/src/hooks/__tests__/useTxPendingStatus.test.ts
@@ -54,6 +54,7 @@ describe('useTxMonitor', () => {
 
     const pendingTx: PendingTxsState = {
       '123': {
+        nonce: 1,
         chainId: '11155111',
         safeAddress: faker.finance.ethereumAddress(),
         status: PendingStatus.PROCESSING,
@@ -77,6 +78,7 @@ describe('useTxMonitor', () => {
 
     const pendingTx: PendingTxsState = {
       '123': {
+        nonce: 1,
         chainId: '11155111',
         safeAddress: faker.finance.ethereumAddress(),
         status: PendingStatus.RELAYING,
@@ -95,6 +97,7 @@ describe('useTxMonitor', () => {
 
     const pendingTxs: PendingTxsState = {
       '123': {
+        nonce: 1,
         chainId: '11155111',
         safeAddress: faker.finance.ethereumAddress(),
         status: PendingStatus.PROCESSING,
@@ -146,11 +149,13 @@ describe('useTxPendingStatuses', () => {
     const mockSignerAddress = faker.finance.ethereumAddress()
 
     txDispatch(TxEvent.SIGNATURE_PROPOSED, {
+      nonce: 1,
       txId: mockTxId,
       signerAddress: mockSignerAddress,
     })
 
     expect(setPendingTx).toHaveBeenCalledWith({
+      nonce: 1,
       chainId: expect.anything(),
       safeAddress: expect.anything(),
       signerAddress: mockSignerAddress,
@@ -170,6 +175,7 @@ describe('useTxPendingStatuses', () => {
     const mockTo = faker.finance.ethereumAddress()
 
     txDispatch(TxEvent.PROCESSING, {
+      nonce: 1,
       txId: mockTxId,
       txHash: mockTxHash,
       signerNonce: mockNonce,
@@ -180,6 +186,7 @@ describe('useTxPendingStatuses', () => {
     })
 
     expect(setPendingTx).toHaveBeenCalledWith({
+      nonce: 1,
       chainId: expect.anything(),
       safeAddress: expect.anything(),
       submittedAt: expect.anything(),
@@ -204,6 +211,7 @@ describe('useTxPendingStatuses', () => {
     const mockSignerAddress = faker.finance.ethereumAddress()
 
     txDispatch(TxEvent.PROCESSING, {
+      nonce: 1,
       txId: mockTxId,
       txHash: mockTxHash,
       signerNonce: mockNonce,
@@ -213,6 +221,7 @@ describe('useTxPendingStatuses', () => {
     })
 
     expect(setPendingTx).toHaveBeenCalledWith({
+      nonce: 1,
       chainId: expect.anything(),
       safeAddress: expect.anything(),
       submittedAt: expect.anything(),
@@ -232,10 +241,12 @@ describe('useTxPendingStatuses', () => {
     const mockTxId = '123'
 
     txDispatch(TxEvent.EXECUTING, {
+      nonce: 1,
       txId: mockTxId,
     })
 
     expect(setPendingTx).toHaveBeenCalledWith({
+      nonce: 1,
       chainId: expect.anything(),
       safeAddress: expect.anything(),
       status: PendingStatus.SUBMITTING,
@@ -249,11 +260,13 @@ describe('useTxPendingStatuses', () => {
     const mockTxId = '123'
 
     txDispatch(TxEvent.PROCESSED, {
+      nonce: 1,
       txId: mockTxId,
       safeAddress: faker.finance.ethereumAddress(),
     })
 
     expect(setPendingTx).toHaveBeenCalledWith({
+      nonce: 1,
       chainId: expect.anything(),
       safeAddress: expect.anything(),
       status: PendingStatus.INDEXING,
@@ -268,11 +281,13 @@ describe('useTxPendingStatuses', () => {
     const mockTaskId = '0x123'
 
     txDispatch(TxEvent.RELAYING, {
+      nonce: 1,
       txId: mockTxId,
       taskId: mockTaskId,
     })
 
     expect(setPendingTx).toHaveBeenCalledWith({
+      nonce: 1,
       chainId: expect.anything(),
       safeAddress: expect.anything(),
       status: PendingStatus.RELAYING,
@@ -287,6 +302,7 @@ describe('useTxPendingStatuses', () => {
     const mockTxId = '123'
 
     txDispatch(TxEvent.SUCCESS, {
+      nonce: 1,
       txId: mockTxId,
     })
 
@@ -313,6 +329,7 @@ describe('useTxPendingStatuses', () => {
     const mockTxId = '123'
 
     txDispatch(TxEvent.REVERTED, {
+      nonce: 1,
       txId: mockTxId,
       error: new Error('Transaction reverted'),
     })
@@ -327,6 +344,7 @@ describe('useTxPendingStatuses', () => {
     const mockTxId = '123'
 
     txDispatch(TxEvent.FAILED, {
+      nonce: 1,
       txId: mockTxId,
       error: new Error('Transaction failed'),
     })

--- a/src/hooks/__tests__/useTxPendingStatus.test.ts
+++ b/src/hooks/__tests__/useTxPendingStatus.test.ts
@@ -1,11 +1,8 @@
-import { txDispatch, TxEvent } from '@/services/tx/txEvents'
-import { extendedSafeInfoBuilder } from '@/tests/builders/safe'
-import { faker } from '@faker-js/faker'
-import type { JsonRpcProvider } from 'ethers'
 import * as useChainIdHook from '@/hooks/useChainId'
 import * as useSafeInfoHook from '@/hooks/useSafeInfo'
 import useTxPendingStatuses, { useTxMonitor } from '@/hooks/useTxPendingStatuses'
 import * as web3 from '@/hooks/wallets/web3'
+import { txDispatch, TxEvent } from '@/services/tx/txEvents'
 import * as txMonitor from '@/services/tx/txMonitor'
 import {
   clearPendingTx,
@@ -14,7 +11,11 @@ import {
   PendingTxType,
   setPendingTx,
 } from '@/store/pendingTxsSlice'
+import { pendingTxBuilder } from '@/tests/builders/pendingTx'
+import { extendedSafeInfoBuilder } from '@/tests/builders/safe'
 import { renderHook } from '@/tests/test-utils'
+import { faker } from '@faker-js/faker'
+import type { JsonRpcProvider } from 'ethers'
 
 describe('useTxMonitor', () => {
   let mockProvider
@@ -53,17 +54,7 @@ describe('useTxMonitor', () => {
     const mockWaitForRelayedTx = jest.spyOn(txMonitor, 'waitForRelayedTx')
 
     const pendingTx: PendingTxsState = {
-      '123': {
-        nonce: 1,
-        chainId: '11155111',
-        safeAddress: faker.finance.ethereumAddress(),
-        status: PendingStatus.PROCESSING,
-        txHash: '0x456',
-        submittedAt: Date.now(),
-        signerNonce: 1,
-        signerAddress: faker.finance.ethereumAddress(),
-        txType: PendingTxType.SAFE_TX,
-      },
+      '123': pendingTxBuilder().with({ chainId: '11155111', status: PendingStatus.PROCESSING }).build(),
     }
 
     renderHook(() => useTxMonitor(), { initialReduxState: { pendingTxs: pendingTx } })
@@ -77,13 +68,7 @@ describe('useTxMonitor', () => {
     const mockWaitForRelayedTx = jest.spyOn(txMonitor, 'waitForRelayedTx')
 
     const pendingTx: PendingTxsState = {
-      '123': {
-        nonce: 1,
-        chainId: '11155111',
-        safeAddress: faker.finance.ethereumAddress(),
-        status: PendingStatus.RELAYING,
-        taskId: '0x456',
-      },
+      '123': pendingTxBuilder().with({ chainId: '11155111', status: PendingStatus.RELAYING }).build(),
     }
 
     renderHook(() => useTxMonitor(), { initialReduxState: { pendingTxs: pendingTx } })
@@ -96,17 +81,7 @@ describe('useTxMonitor', () => {
     const mockWaitForTx = jest.spyOn(txMonitor, 'waitForTx')
 
     const pendingTxs: PendingTxsState = {
-      '123': {
-        nonce: 1,
-        chainId: '11155111',
-        safeAddress: faker.finance.ethereumAddress(),
-        status: PendingStatus.PROCESSING,
-        txHash: '0x456',
-        submittedAt: Date.now(),
-        signerNonce: 1,
-        signerAddress: faker.finance.ethereumAddress(),
-        txType: PendingTxType.SAFE_TX,
-      },
+      '123': pendingTxBuilder().with({ chainId: '11155111', status: PendingStatus.PROCESSING }).build(),
     }
 
     const { rerender } = renderHook(() => useTxMonitor(), { initialReduxState: { pendingTxs } })

--- a/src/hooks/__tests__/useTxTracking.test.ts
+++ b/src/hooks/__tests__/useTxTracking.test.ts
@@ -25,6 +25,7 @@ describe('useTxTracking', () => {
     renderHook(() => useTxTracking())
 
     txDispatch(TxEvent.PROCESSING, {
+      nonce: 1,
       txId: '123',
       txHash: '0x123',
       signerAddress: faker.finance.ethereumAddress(),
@@ -66,6 +67,7 @@ describe('useTxTracking', () => {
     renderHook(() => useTxTracking())
 
     txDispatch(TxEvent.PROCESSING, {
+      nonce: 1,
       txId: '0x123',
       txHash: '0x234',
       signerAddress: faker.finance.ethereumAddress(),

--- a/src/hooks/useDraftBatch.ts
+++ b/src/hooks/useDraftBatch.ts
@@ -1,3 +1,4 @@
+import { isMultisigExecutionInfo } from '@/utils/transaction-guards'
 import { useCallback } from 'react'
 import { useAppDispatch, useAppSelector } from '@/store'
 import useChainId from './useChainId'
@@ -24,7 +25,9 @@ export const useUpdateBatch = () => {
         }),
       )
 
-      txDispatch(TxEvent.BATCH_ADD, { txId: txDetails.txId })
+      if (isMultisigExecutionInfo(txDetails.detailedExecutionInfo)) {
+        txDispatch(TxEvent.BATCH_ADD, { txId: txDetails.txId, nonce: txDetails.detailedExecutionInfo.nonce })
+      }
 
       trackEvent({ ...BATCH_EVENTS.BATCH_TX_APPENDED, label: txDetails.txInfo.type })
     },

--- a/src/hooks/useTxPendingStatuses.ts
+++ b/src/hooks/useTxPendingStatuses.ts
@@ -53,13 +53,14 @@ export const useTxMonitor = (): void => {
           pendingTx.safeAddress,
           pendingTx.signerAddress,
           pendingTx.signerNonce,
+          pendingTx.nonce,
           chainId,
         )
         continue
       }
 
       if (isRelaying) {
-        waitForRelayedTx(pendingTx.taskId, [txId], pendingTx.safeAddress)
+        waitForRelayedTx(pendingTx.taskId, [txId], pendingTx.safeAddress, pendingTx.nonce)
       }
     }
     // `provider` is updated when switching chains, re-running this effect
@@ -83,7 +84,9 @@ const useTxPendingStatuses = (): void => {
     const unsubSignatureProposing = txSubscribe(TxEvent.SIGNATURE_PROPOSED, (detail) => {
       // All pending txns should have a txId
       const txId = 'txId' in detail && detail.txId
-      if (!txId) return
+      const nonce = 'nonce' in detail ? detail.nonce : undefined
+
+      if (!txId || nonce === undefined) return
 
       // If we have future issues with statuses, we should refactor `useTxPendingStatuses`
       // @see https://github.com/safe-global/safe-wallet-web/issues/1754
@@ -95,6 +98,7 @@ const useTxPendingStatuses = (): void => {
       // Update pendingTx
       dispatch(
         setPendingTx({
+          nonce,
           chainId,
           safeAddress,
           txId,
@@ -107,7 +111,9 @@ const useTxPendingStatuses = (): void => {
     const unsubProcessing = txSubscribe(TxEvent.PROCESSING, (detail) => {
       // All pending txns should have a txId
       const txId = 'txId' in detail && detail.txId
-      if (!txId) return
+      const nonce = 'nonce' in detail ? detail.nonce : undefined
+
+      if (!txId || nonce === undefined) return
 
       // If we have future issues with statuses, we should refactor `useTxPendingStatuses`
       // @see https://github.com/safe-global/safe-wallet-web/issues/1754
@@ -119,6 +125,7 @@ const useTxPendingStatuses = (): void => {
       const pendingTx: PendingProcessingTx & { txId: string } =
         detail.txType === 'Custom'
           ? {
+              nonce,
               chainId,
               safeAddress,
               txId,
@@ -132,6 +139,7 @@ const useTxPendingStatuses = (): void => {
               to: detail.to,
             }
           : {
+              nonce,
               chainId,
               safeAddress,
               txId,
@@ -149,7 +157,9 @@ const useTxPendingStatuses = (): void => {
     const unsubExecuting = txSubscribe(TxEvent.EXECUTING, (detail) => {
       // All pending txns should have a txId
       const txId = 'txId' in detail && detail.txId
-      if (!txId) return
+      const nonce = 'nonce' in detail ? detail.nonce : undefined
+
+      if (!txId || nonce === undefined) return
 
       // If we have future issues with statuses, we should refactor `useTxPendingStatuses`
       // @see https://github.com/safe-global/safe-wallet-web/issues/1754
@@ -161,6 +171,7 @@ const useTxPendingStatuses = (): void => {
       // Update pendingTx
       dispatch(
         setPendingTx({
+          nonce,
           chainId,
           safeAddress,
           txId,
@@ -172,7 +183,9 @@ const useTxPendingStatuses = (): void => {
     const unsubProcessed = txSubscribe(TxEvent.PROCESSED, (detail) => {
       // All pending txns should have a txId
       const txId = 'txId' in detail && detail.txId
-      if (!txId) return
+      const nonce = 'nonce' in detail ? detail.nonce : undefined
+
+      if (!txId || nonce === undefined) return
 
       // If we have future issues with statuses, we should refactor `useTxPendingStatuses`
       // @see https://github.com/safe-global/safe-wallet-web/issues/1754
@@ -184,6 +197,7 @@ const useTxPendingStatuses = (): void => {
       // Update pendingTx
       dispatch(
         setPendingTx({
+          nonce,
           chainId,
           safeAddress,
           txId,
@@ -195,7 +209,9 @@ const useTxPendingStatuses = (): void => {
     const unsubRelaying = txSubscribe(TxEvent.RELAYING, (detail) => {
       // All pending txns should have a txId
       const txId = 'txId' in detail && detail.txId
-      if (!txId) return
+      const nonce = 'nonce' in detail ? detail.nonce : undefined
+
+      if (!txId || nonce === undefined) return
 
       // If we have future issues with statuses, we should refactor `useTxPendingStatuses`
       // @see https://github.com/safe-global/safe-wallet-web/issues/1754
@@ -207,6 +223,7 @@ const useTxPendingStatuses = (): void => {
       // Update pendingTx
       dispatch(
         setPendingTx({
+          nonce,
           chainId,
           safeAddress,
           txId,

--- a/src/services/tx/__tests__/txEvents.test.ts
+++ b/src/services/tx/__tests__/txEvents.test.ts
@@ -11,6 +11,7 @@ describe('txEvents', () => {
     const event = TxEvent.PROCESSING
 
     const detail = {
+      nonce: 1,
       txId: '123',
       txHash: '0x123',
       signerAddress: faker.finance.ethereumAddress(),
@@ -28,6 +29,7 @@ describe('txEvents', () => {
     expect(callback).toHaveBeenCalledWith(detail)
 
     const detail2 = {
+      nonce: 1,
       txId: '123',
       txHash: '0x456',
       signerAddress: faker.finance.ethereumAddress(),
@@ -52,6 +54,7 @@ describe('txEvents', () => {
     const event = TxEvent.FAILED
 
     const detail = {
+      nonce: 1,
       txId: '0x123',
       tx,
       error: new Error('Tx failed'),

--- a/src/services/tx/__tests__/txMonitor.test.ts
+++ b/src/services/tx/__tests__/txMonitor.test.ts
@@ -47,9 +47,9 @@ describe('txMonitor', () => {
       // https://docs.ethers.io/v5/single-page/#/v5/api/providers/provider/-%23-Provider-waitForTransaction
       const receipt = null as unknown as TransactionReceipt
       watchTxHashSpy.mockImplementation(() => Promise.resolve(receipt))
-      await waitForTx(provider, ['0x0'], '0x0', safeAddress, faker.finance.ethereumAddress(), 1, '11155111')
+      await waitForTx(provider, ['0x0'], '0x0', safeAddress, faker.finance.ethereumAddress(), 1, 1, '11155111')
 
-      expect(txDispatchSpy).toHaveBeenCalledWith('FAILED', { txId: '0x0', error: expect.any(Error) })
+      expect(txDispatchSpy).toHaveBeenCalledWith('FAILED', { txId: '0x0', error: expect.any(Error), nonce: 1 })
     })
 
     it('emits a REVERTED event if the tx reverted', async () => {
@@ -58,9 +58,10 @@ describe('txMonitor', () => {
       } as TransactionReceipt
 
       watchTxHashSpy.mockImplementation(() => Promise.resolve(receipt))
-      await waitForTx(provider, ['0x0'], '0x0', safeAddress, faker.finance.ethereumAddress(), 1, '11155111')
+      await waitForTx(provider, ['0x0'], '0x0', safeAddress, faker.finance.ethereumAddress(), 1, 1, '11155111')
 
       expect(txDispatchSpy).toHaveBeenCalledWith('REVERTED', {
+        nonce: 1,
         txId: '0x0',
         error: new Error('Transaction reverted by EVM.'),
       })
@@ -68,9 +69,9 @@ describe('txMonitor', () => {
 
     it('emits a FAILED event if waitForTransaction throws', async () => {
       watchTxHashSpy.mockImplementation(() => Promise.reject(new Error('Test error.')))
-      await waitForTx(provider, ['0x0'], '0x0', safeAddress, faker.finance.ethereumAddress(), 1, '11155111')
+      await waitForTx(provider, ['0x0'], '0x0', safeAddress, faker.finance.ethereumAddress(), 1, 1, '11155111')
 
-      expect(txDispatchSpy).toHaveBeenCalledWith('FAILED', { txId: '0x0', error: new Error('Test error.') })
+      expect(txDispatchSpy).toHaveBeenCalledWith('FAILED', { txId: '0x0', error: new Error('Test error.'), nonce: 1 })
     })
   })
 
@@ -85,14 +86,14 @@ describe('txMonitor', () => {
 
       const mockFetch = jest.spyOn(global, 'fetch')
 
-      waitForRelayedTx('0x1', ['0x2'], safeAddress)
+      waitForRelayedTx('0x1', ['0x2'], safeAddress, 1)
 
       await act(() => {
         jest.advanceTimersByTime(15_000 + 1)
       })
 
       expect(mockFetch).toHaveBeenCalledTimes(1)
-      expect(txDispatchSpy).toHaveBeenCalledWith('PROCESSED', { txId: '0x2', safeAddress })
+      expect(txDispatchSpy).toHaveBeenCalledWith('PROCESSED', { txId: '0x2', safeAddress, nonce: 1 })
 
       // The relay timeout should have been cancelled
       txDispatchSpy.mockClear()
@@ -112,7 +113,7 @@ describe('txMonitor', () => {
 
       const mockFetch = jest.spyOn(global, 'fetch')
 
-      waitForRelayedTx('0x1', ['0x2'], safeAddress)
+      waitForRelayedTx('0x1', ['0x2'], safeAddress, 1)
 
       await act(() => {
         jest.advanceTimersByTime(15_000 + 1)
@@ -120,6 +121,7 @@ describe('txMonitor', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(1)
       expect(txDispatchSpy).toHaveBeenCalledWith('REVERTED', {
+        nonce: 1,
         txId: '0x2',
         error: new Error(`Relayed transaction reverted by EVM.`),
       })
@@ -142,7 +144,7 @@ describe('txMonitor', () => {
 
       const mockFetch = jest.spyOn(global, 'fetch')
 
-      waitForRelayedTx('0x1', ['0x2'], safeAddress)
+      waitForRelayedTx('0x1', ['0x2'], safeAddress, 1)
 
       await act(() => {
         jest.advanceTimersByTime(15_000 + 1)
@@ -150,6 +152,7 @@ describe('txMonitor', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(1)
       expect(txDispatchSpy).toHaveBeenCalledWith('FAILED', {
+        nonce: 1,
         txId: '0x2',
         error: new Error(`Relayed transaction was blacklisted by relay provider.`),
       })
@@ -172,7 +175,7 @@ describe('txMonitor', () => {
 
       const mockFetch = jest.spyOn(global, 'fetch')
 
-      waitForRelayedTx('0x1', ['0x2'], safeAddress)
+      waitForRelayedTx('0x1', ['0x2'], safeAddress, 1)
 
       await act(() => {
         jest.advanceTimersByTime(15_000 + 1)
@@ -180,6 +183,7 @@ describe('txMonitor', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(1)
       expect(txDispatchSpy).toHaveBeenCalledWith('FAILED', {
+        nonce: 1,
         txId: '0x2',
         error: new Error(`Relayed transaction was cancelled by relay provider.`),
       })
@@ -202,7 +206,7 @@ describe('txMonitor', () => {
 
       const mockFetch = jest.spyOn(global, 'fetch')
 
-      waitForRelayedTx('0x1', ['0x2'], safeAddress)
+      waitForRelayedTx('0x1', ['0x2'], safeAddress, 1)
 
       await act(() => {
         jest.advanceTimersByTime(15_000 + 1)
@@ -210,6 +214,7 @@ describe('txMonitor', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(1)
       expect(txDispatchSpy).toHaveBeenCalledWith('FAILED', {
+        nonce: 1,
         txId: '0x2',
         error: new Error(`Relayed transaction was not found.`),
       })
@@ -230,13 +235,14 @@ describe('txMonitor', () => {
       }
       global.fetch = jest.fn().mockImplementation(setupFetchStub(mockData))
 
-      waitForRelayedTx('0x1', ['0x2'], safeAddress)
+      waitForRelayedTx('0x1', ['0x2'], safeAddress, 1)
 
       await act(() => {
         jest.advanceTimersByTime(3 * 60_000 + 1)
       })
 
       expect(txDispatchSpy).toHaveBeenCalledWith('FAILED', {
+        nonce: 1,
         txId: '0x2',
         error: new Error('Transaction not relayed in 3 minutes. Be aware that it might still be relayed.'),
       })

--- a/src/services/tx/tx-sender/__tests__/ts-sender.test.ts
+++ b/src/services/tx/tx-sender/__tests__/ts-sender.test.ts
@@ -72,7 +72,7 @@ const mockSafeSDK = {
     signatures: new Map(),
     addSignature: jest.fn(),
     data: {
-      nonce: '1',
+      nonce: 1,
     },
   })),
   createRejectionTransaction: jest.fn(() => ({
@@ -210,7 +210,7 @@ describe('txSender', () => {
       expect(proposeTx).toHaveBeenCalledWith('4', '0x123', '0x456', tx, '0x1234567890', undefined)
       expect(proposedTx).toEqual({ txId: '123' })
 
-      expect(txEvents.txDispatch).toHaveBeenCalledWith('PROPOSED', { txId: '123' })
+      expect(txEvents.txDispatch).toHaveBeenCalledWith('PROPOSED', { txId: '123', nonce: 0 })
     })
 
     it('should dispatch a SIGNATURE_PROPOSED event if tx has signatures and an id', async () => {
@@ -231,7 +231,11 @@ describe('txSender', () => {
       expect(proposeTx).toHaveBeenCalledWith('4', '0x123', '0x456', tx, '0x1234567890', undefined)
       expect(proposedTx).toEqual({ txId: '123' })
 
-      expect(txEvents.txDispatch).toHaveBeenCalledWith('SIGNATURE_PROPOSED', { txId: '123', signerAddress: '0x456' })
+      expect(txEvents.txDispatch).toHaveBeenCalledWith('SIGNATURE_PROPOSED', {
+        txId: '123',
+        signerAddress: '0x456',
+        nonce: 0,
+      })
     })
 
     it('should fail to propose a signature', async () => {
@@ -445,8 +449,9 @@ describe('txSender', () => {
       await dispatchTxExecution(safeTx, { nonce: 1 }, txId, MockEip1193Provider, SIGNER_ADDRESS, safeAddress, false)
 
       expect(mockSafeSDK.executeTransaction).toHaveBeenCalled()
-      expect(txEvents.txDispatch).toHaveBeenCalledWith('EXECUTING', { txId })
+      expect(txEvents.txDispatch).toHaveBeenCalledWith('EXECUTING', { txId, nonce: 1 })
       expect(txEvents.txDispatch).toHaveBeenCalledWith('PROCESSING', {
+        nonce: 1,
         txId,
         signerAddress: SIGNER_ADDRESS,
         signerNonce: 1,
@@ -474,7 +479,7 @@ describe('txSender', () => {
       )
 
       expect(mockSafeSDK.executeTransaction).toHaveBeenCalled()
-      expect(txEvents.txDispatch).toHaveBeenCalledWith('FAILED', { txId, error: new Error('error') })
+      expect(txEvents.txDispatch).toHaveBeenCalledWith('FAILED', { txId, error: new Error('error'), nonce: 1 })
     })
 
     it('should revert a tx', async () => {
@@ -493,8 +498,9 @@ describe('txSender', () => {
       await dispatchTxExecution(safeTx, { nonce: 1 }, txId, MockEip1193Provider, SIGNER_ADDRESS, '0x123', false)
 
       expect(mockSafeSDK.executeTransaction).toHaveBeenCalled()
-      expect(txEvents.txDispatch).toHaveBeenCalledWith('EXECUTING', { txId })
+      expect(txEvents.txDispatch).toHaveBeenCalledWith('EXECUTING', { txId, nonce: 1 })
       expect(txEvents.txDispatch).toHaveBeenCalledWith('PROCESSING', {
+        nonce: 1,
         txId,
         signerAddress: SIGNER_ADDRESS,
         signerNonce: 1,
@@ -512,10 +518,16 @@ describe('txSender', () => {
 
       const txDetails1 = {
         txId: 'multisig_0x01',
+        detailedExecutionInfo: {
+          type: 'MULTISIG',
+        },
       } as TransactionDetails
 
       const txDetails2 = {
         txId: 'multisig_0x02',
+        detailedExecutionInfo: {
+          type: 'MULTISIG',
+        },
       } as TransactionDetails
 
       const txs = [txDetails1, txDetails2]

--- a/src/services/tx/tx-sender/dispatch.ts
+++ b/src/services/tx/tx-sender/dispatch.ts
@@ -1,4 +1,5 @@
 import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
+import { isMultisigExecutionInfo } from '@/utils/transaction-guards'
 import { isHardwareWallet, isSmartContractWallet } from '@/utils/wallets'
 import type { MultiSendCallOnlyContractImplementationType } from '@safe-global/protocol-kit'
 import {
@@ -77,6 +78,7 @@ export const dispatchTxProposal = async ({
     txDispatch(txId ? TxEvent.SIGNATURE_PROPOSED : TxEvent.PROPOSED, {
       txId: proposedTx.txId,
       signerAddress: txId ? sender : undefined,
+      nonce: safeTx.data.nonce,
     })
   }
 
@@ -142,7 +144,7 @@ export const dispatchOnChainSigning = async (
 ) => {
   const sdk = await getSafeSDKWithSigner(provider)
   const safeTxHash = await sdk.getTransactionHash(safeTx)
-  const eventParams = { txId }
+  const eventParams = { txId, nonce: safeTx.data.nonce }
 
   const options = chainId === chains.zksync ? { gasLimit: ZK_SYNC_ON_CHAIN_SIGNATURE_GAS_LIMIT } : undefined
 
@@ -174,9 +176,10 @@ export const dispatchSafeTxSpeedUp = async (
   chainId: SafeInfo['chainId'],
   signerAddress: string,
   safeAddress: string,
+  nonce: number,
 ) => {
   const sdk = await getSafeSDKWithSigner(provider)
-  const eventParams = { txId }
+  const eventParams = { txId, nonce }
   const signerNonce = txOptions.nonce
   const isSmartAccount = await isSmartContractWallet(chainId, signerAddress)
 
@@ -226,8 +229,9 @@ export const dispatchCustomTxSpeedUp = async (
   provider: Eip1193Provider,
   signerAddress: string,
   safeAddress: string,
+  nonce: number,
 ) => {
-  const eventParams = { txId }
+  const eventParams = { txId, nonce }
   const signerNonce = txOptions.nonce
 
   // Execute the tx
@@ -267,7 +271,7 @@ export const dispatchTxExecution = async (
   isSmartAccount: boolean,
 ): Promise<string> => {
   const sdk = await getSafeSDKWithSigner(provider)
-  const eventParams = { txId }
+  const eventParams = { txId, nonce: safeTx.data.nonce }
 
   const signerNonce = txOptions.nonce ?? (await getUserNonce(signerAddress))
 
@@ -289,7 +293,7 @@ export const dispatchTxExecution = async (
     } else {
       result = await sdk.executeTransaction(safeTx, txOptions)
     }
-    txDispatch(TxEvent.EXECUTING, eventParams)
+    txDispatch(TxEvent.EXECUTING, { ...eventParams })
   } catch (error) {
     txDispatch(TxEvent.FAILED, { ...eventParams, error: asError(error) })
     throw error
@@ -297,6 +301,7 @@ export const dispatchTxExecution = async (
 
   txDispatch(TxEvent.PROCESSING, {
     ...eventParams,
+    nonce: safeTx.data.nonce,
     txHash: result.hash,
     signerAddress,
     signerNonce,
@@ -511,12 +516,12 @@ export const dispatchTxRelay = async (
       throw new Error('Transaction could not be relayed')
     }
 
-    txDispatch(TxEvent.RELAYING, { taskId, txId })
+    txDispatch(TxEvent.RELAYING, { taskId, txId, nonce: safeTx.data.nonce })
 
     // Monitor relay tx
-    waitForRelayedTx(taskId, [txId], safe.address.value)
+    waitForRelayedTx(taskId, [txId], safe.address.value, safeTx.data.nonce)
   } catch (error) {
-    txDispatch(TxEvent.FAILED, { txId, error: asError(error) })
+    txDispatch(TxEvent.FAILED, { txId, error: asError(error), nonce: safeTx.data.nonce })
     throw error
   }
 }
@@ -552,8 +557,10 @@ export const dispatchBatchExecutionRelay = async (
   }
 
   const taskId = relayResponse.taskId
-  txs.forEach(({ txId }) => {
-    txDispatch(TxEvent.RELAYING, { taskId, txId, groupKey })
+  txs.forEach(({ txId, detailedExecutionInfo }) => {
+    if (isMultisigExecutionInfo(detailedExecutionInfo)) {
+      txDispatch(TxEvent.RELAYING, { taskId, txId, groupKey, nonce: detailedExecutionInfo.nonce })
+    }
   })
 
   // Monitor relay tx
@@ -561,6 +568,7 @@ export const dispatchBatchExecutionRelay = async (
     taskId,
     txs.map((tx) => tx.txId),
     safeAddress,
+    isMultisigExecutionInfo(txs[0].detailedExecutionInfo) ? txs[0].detailedExecutionInfo.nonce : 0,
     groupKey,
   )
 }

--- a/src/services/tx/txEvents.ts
+++ b/src/services/tx/txEvents.ts
@@ -25,16 +25,16 @@ export enum TxEvent {
   SPEEDUP_FAILED = 'SPEEDUP_FAILED',
 }
 
-type Id = { txId: string; groupKey?: string } | { txId?: string; groupKey: string }
+type Id = { txId: string; nonce: number; groupKey?: string } | { txId?: string; nonce?: number; groupKey: string }
 
 interface TxEvents {
   [TxEvent.SIGNED]: { txId?: string }
   [TxEvent.SIGN_FAILED]: { txId?: string; error: Error }
   [TxEvent.PROPOSE_FAILED]: { error: Error }
-  [TxEvent.PROPOSED]: { txId: string }
+  [TxEvent.PROPOSED]: { txId: string; nonce: number }
   [TxEvent.DELETED]: { safeTxHash: string }
   [TxEvent.SIGNATURE_PROPOSE_FAILED]: { txId: string; error: Error }
-  [TxEvent.SIGNATURE_PROPOSED]: { txId: string; signerAddress: string }
+  [TxEvent.SIGNATURE_PROPOSED]: { txId: string; nonce: number; signerAddress: string }
   [TxEvent.SIGNATURE_INDEXED]: { txId: string }
   [TxEvent.ONCHAIN_SIGNATURE_REQUESTED]: Id
   [TxEvent.ONCHAIN_SIGNATURE_SUCCESS]: Id

--- a/src/store/__tests__/pendingTxsSlice.test.ts
+++ b/src/store/__tests__/pendingTxsSlice.test.ts
@@ -4,11 +4,13 @@ import { selectPendingTxIdsBySafe } from '../pendingTxsSlice'
 
 const pendingTxs: PendingTxsState = {
   '123': {
+    nonce: 1,
     chainId: '5',
     safeAddress: '0x123',
     status: PendingStatus.INDEXING,
   },
   '456': {
+    nonce: 1,
     chainId: '5',
     safeAddress: '0x456',
     status: PendingStatus.INDEXING,
@@ -30,6 +32,7 @@ describe('pendingTxsSlice', () => {
 
   it('should select a pending tx by id', () => {
     expect(selectPendingTxById({ pendingTxs } as unknown as RootState, '456')).toEqual({
+      nonce: 1,
       chainId: '5',
       safeAddress: '0x456',
       status: PendingStatus.INDEXING,

--- a/src/store/__tests__/txHistorySlice.test.ts
+++ b/src/store/__tests__/txHistorySlice.test.ts
@@ -1,12 +1,12 @@
-import { createListenerMiddleware } from '@reduxjs/toolkit'
-import { LabelValue, TransactionListItemType } from '@safe-global/safe-gateway-typescript-sdk'
-import type { TransactionListItem, Label, ConflictHeader, DateLabel } from '@safe-global/safe-gateway-typescript-sdk'
-
 import * as txEvents from '@/services/tx/txEvents'
-import { txHistoryListener, txHistorySlice } from '../txHistorySlice'
+import { pendingTxBuilder } from '@/tests/builders/pendingTx'
+import { createListenerMiddleware } from '@reduxjs/toolkit'
+import type { ConflictHeader, DateLabel, Label, TransactionListItem } from '@safe-global/safe-gateway-typescript-sdk'
+import { LabelValue, TransactionListItemType } from '@safe-global/safe-gateway-typescript-sdk'
+import type { RootState } from '..'
 import type { PendingTxsState } from '../pendingTxsSlice'
 import { PendingStatus } from '../pendingTxsSlice'
-import type { RootState } from '..'
+import { txHistoryListener, txHistorySlice } from '../txHistorySlice'
 
 describe('txHistorySlice', () => {
   describe('txHistoryListener', () => {
@@ -24,13 +24,7 @@ describe('txHistorySlice', () => {
     it('should dispatch SUCCESS event if tx is pending', () => {
       const state = {
         pendingTxs: {
-          '0x123': {
-            nonce: 1,
-            chainId: '5',
-            safeAddress: '0x0000000000000000000000000000000000000000',
-            status: PendingStatus.INDEXING,
-            groupKey: 'groupKey',
-          },
+          '0x123': pendingTxBuilder().with({ nonce: 1, status: PendingStatus.INDEXING }).build(),
         } as PendingTxsState,
       } as RootState
 
@@ -62,20 +56,14 @@ describe('txHistorySlice', () => {
       expect(txDispatchSpy).toHaveBeenCalledWith(txEvents.TxEvent.SUCCESS, {
         nonce: 1,
         txId: '0x123',
-        groupKey: 'groupKey',
+        groupKey: expect.anything(),
       })
     })
 
     it('should not dispatch an event if the history slice is cleared', () => {
       const state = {
         pendingTxs: {
-          '0x123': {
-            nonce: 1,
-            chainId: '5',
-            safeAddress: '0x0000000000000000000000000000000000000000',
-            status: PendingStatus.INDEXING,
-            groupKey: 'groupKey',
-          },
+          '0x123': pendingTxBuilder().build(),
         } as PendingTxsState,
       } as RootState
 
@@ -97,13 +85,7 @@ describe('txHistorySlice', () => {
     it('should not dispatch an event for date labels, labels or conflict headers', () => {
       const state = {
         pendingTxs: {
-          '0x123': {
-            nonce: 1,
-            chainId: '5',
-            safeAddress: '0x0000000000000000000000000000000000000000',
-            status: PendingStatus.INDEXING,
-            groupKey: '',
-          },
+          '0x123': pendingTxBuilder().build(),
         } as PendingTxsState,
       } as RootState
 
@@ -142,13 +124,7 @@ describe('txHistorySlice', () => {
     it('should not dispatch an event if tx is not pending', () => {
       const state = {
         pendingTxs: {
-          '0x123': {
-            nonce: 1,
-            chainId: '5',
-            safeAddress: '0x0000000000000000000000000000000000000000',
-            status: PendingStatus.INDEXING,
-            groupKey: '',
-          },
+          '0x123': pendingTxBuilder().build(),
         } as PendingTxsState,
       } as RootState
 
@@ -179,13 +155,7 @@ describe('txHistorySlice', () => {
     it('should clear a replaced pending transaction', () => {
       const state = {
         pendingTxs: {
-          '0x123': {
-            nonce: 1,
-            chainId: '5',
-            safeAddress: '0x0000000000000000000000000000000000000000',
-            status: PendingStatus.INDEXING,
-            groupKey: '',
-          },
+          '0x123': pendingTxBuilder().with({ nonce: 1, status: PendingStatus.INDEXING }).build(),
         } as PendingTxsState,
       } as RootState
 

--- a/src/store/__tests__/txHistorySlice.test.ts
+++ b/src/store/__tests__/txHistorySlice.test.ts
@@ -25,6 +25,7 @@ describe('txHistorySlice', () => {
       const state = {
         pendingTxs: {
           '0x123': {
+            nonce: 1,
             chainId: '5',
             safeAddress: '0x0000000000000000000000000000000000000000',
             status: PendingStatus.INDEXING,
@@ -42,6 +43,10 @@ describe('txHistorySlice', () => {
         type: TransactionListItemType.TRANSACTION,
         transaction: {
           id: '0x123',
+          executionInfo: {
+            type: 'MULTISIG',
+            nonce: 1,
+          },
         },
       } as TransactionListItem
 
@@ -55,6 +60,7 @@ describe('txHistorySlice', () => {
       listenerMiddlewareInstance.middleware(listenerApi)(jest.fn())(action)
 
       expect(txDispatchSpy).toHaveBeenCalledWith(txEvents.TxEvent.SUCCESS, {
+        nonce: 1,
         txId: '0x123',
         groupKey: 'groupKey',
       })
@@ -64,6 +70,7 @@ describe('txHistorySlice', () => {
       const state = {
         pendingTxs: {
           '0x123': {
+            nonce: 1,
             chainId: '5',
             safeAddress: '0x0000000000000000000000000000000000000000',
             status: PendingStatus.INDEXING,
@@ -98,6 +105,7 @@ describe('txHistorySlice', () => {
       const state = {
         pendingTxs: {
           '0x123': {
+            nonce: 1,
             chainId: '5',
             safeAddress: '0x0000000000000000000000000000000000000000',
             status: PendingStatus.INDEXING,
@@ -142,6 +150,7 @@ describe('txHistorySlice', () => {
       const state = {
         pendingTxs: {
           '0x123': {
+            nonce: 1,
             chainId: '5',
             safeAddress: '0x0000000000000000000000000000000000000000',
             status: PendingStatus.INDEXING,

--- a/src/store/__tests__/txQueueSlice.test.ts
+++ b/src/store/__tests__/txQueueSlice.test.ts
@@ -34,6 +34,7 @@ describe('txQueueSlice', () => {
     const state = {
       pendingTxs: {
         '0x123': {
+          nonce: 1,
           chainId: '5',
           safeAddress: '0x0000000000000000000000000000000000000000',
           status: PendingStatus.SIGNING,
@@ -74,6 +75,7 @@ describe('txQueueSlice', () => {
     const state = {
       pendingTxs: {
         '0x123': {
+          nonce: 1,
           chainId: '5',
           safeAddress: '0x0000000000000000000000000000000000000000',
           status: PendingStatus.SIGNING,
@@ -101,6 +103,7 @@ describe('txQueueSlice', () => {
     const state = {
       pendingTxs: {
         '0x123': {
+          nonce: 1,
           chainId: '5',
           safeAddress: '0x0000000000000000000000000000000000000000',
           status: PendingStatus.SIGNING,
@@ -145,6 +148,7 @@ describe('txQueueSlice', () => {
     const state = {
       pendingTxs: {
         '0x123': {
+          nonce: 1,
           chainId: '5',
           safeAddress: '0x0000000000000000000000000000000000000000',
           status: PendingStatus.SIGNING,

--- a/src/store/pendingTxsSlice.ts
+++ b/src/store/pendingTxsSlice.ts
@@ -22,6 +22,7 @@ const ActivePendingStates = [PendingStatus.RELAYING, PendingStatus.INDEXING, Pen
 export type PendingTxCommonProps = {
   chainId: string
   safeAddress: string
+  nonce: number
   groupKey?: string
 }
 

--- a/src/store/txHistorySlice.ts
+++ b/src/store/txHistorySlice.ts
@@ -1,9 +1,14 @@
 import type { listenerMiddlewareInstance } from '@/store'
 import { createSelector } from '@reduxjs/toolkit'
 import type { TransactionListPage } from '@safe-global/safe-gateway-typescript-sdk'
-import { isCreationTxInfo, isIncomingTransfer, isTransactionListItem } from '@/utils/transaction-guards'
+import {
+  isCreationTxInfo,
+  isIncomingTransfer,
+  isMultisigExecutionInfo,
+  isTransactionListItem,
+} from '@/utils/transaction-guards'
 import { txDispatch, TxEvent } from '@/services/tx/txEvents'
-import { selectPendingTxs } from './pendingTxsSlice'
+import { clearPendingTx, selectPendingTxs } from './pendingTxsSlice'
 import { makeLoadableSlice } from './common'
 
 const { slice, selector } = makeLoadableSlice('txHistory', undefined as TransactionListPage | undefined)
@@ -32,17 +37,29 @@ export const txHistoryListener = (listenerMiddleware: typeof listenerMiddlewareI
           continue
         }
 
+        const pendingTxByNonce = Object.entries(pendingTxs).find(([txId, pendingTx]) =>
+          isMultisigExecutionInfo(result.transaction.executionInfo)
+            ? pendingTx.nonce === result.transaction.executionInfo.nonce
+            : false,
+        )
+
         const txId = result.transaction.id
 
-        const pendingTx = pendingTxs[txId]
+        if (!pendingTxByNonce) continue
 
-        if (pendingTx) {
+        const [pendingTxId, pendingTx] = pendingTxByNonce
+
+        if (pendingTxId === txId) {
           const txHash = 'txHash' in pendingTx ? pendingTx.txHash : undefined
           txDispatch(TxEvent.SUCCESS, {
+            nonce: pendingTx.nonce,
             txId,
             groupKey: pendingTxs[txId].groupKey,
             txHash,
           })
+        } else {
+          // There is a pending tx with the same nonce as a history tx but their txIds don't match
+          listenerApi.dispatch(clearPendingTx({ txId: pendingTxId }))
         }
       }
     },

--- a/src/store/txHistorySlice.ts
+++ b/src/store/txHistorySlice.ts
@@ -43,9 +43,9 @@ export const txHistoryListener = (listenerMiddleware: typeof listenerMiddlewareI
             : false,
         )
 
-        const txId = result.transaction.id
-
         if (!pendingTxByNonce) continue
+
+        const txId = result.transaction.id
 
         const [pendingTxId, pendingTx] = pendingTxByNonce
 

--- a/src/tests/builders/pendingTx.ts
+++ b/src/tests/builders/pendingTx.ts
@@ -1,0 +1,14 @@
+import { PendingStatus } from '@/store/pendingTxsSlice'
+import type { PendingTx } from '@/store/pendingTxsSlice'
+import { Builder, type IBuilder } from '@/tests/Builder'
+import { faker } from '@faker-js/faker'
+
+export function pendingTxBuilder(): IBuilder<PendingTx> {
+  return Builder.new<PendingTx>().with({
+    chainId: faker.string.numeric(),
+    safeAddress: faker.finance.ethereumAddress(),
+    nonce: faker.number.int(),
+    groupKey: faker.string.hexadecimal(),
+    status: faker.helpers.enumValue(PendingStatus),
+  })
+}

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -192,11 +192,15 @@ export function isRecoveryQueueItem(value: TransactionListItem | RecoveryQueueIt
 }
 
 // Narrows `Transaction`
-export const isMultisigExecutionInfo = (value?: ExecutionInfo): value is MultisigExecutionInfo =>
-  value?.type === DetailedExecutionInfoType.MULTISIG
+// TODO: Consolidate these types with the new sdk
+export const isMultisigExecutionInfo = (
+  value?: ExecutionInfo | DetailedExecutionInfo,
+): value is MultisigExecutionInfo => {
+  return value?.type === 'MULTISIG'
+}
 
-export const isModuleExecutionInfo = (value?: ExecutionInfo): value is ModuleExecutionInfo =>
-  value?.type === DetailedExecutionInfoType.MODULE
+export const isModuleExecutionInfo = (value?: ExecutionInfo | DetailedExecutionInfo): value is ModuleExecutionInfo =>
+  value?.type === 'MODULE'
 
 export const isSignableBy = (txSummary: TransactionSummary, walletAddress: string): boolean => {
   const executionInfo = isMultisigExecutionInfo(txSummary.executionInfo) ? txSummary.executionInfo : undefined


### PR DESCRIPTION
## What it solves

Follow up to #4025

This is needed in order for #4069 to work since migration transactions are always replaced and their pending state is stuck indefinitely which bricks the safe.

## How this PR fixes it

- Stores the `nonce` for each pending transaction
- Extends the pending tx cleanup logic in the tx history middleware by not just checking if there is a matchin txId but also if there is a matching nonce and in case there is and txIds don't match it means the pending transaction got replaced so it is safe to clear it

## ToDo

- [x] Extend tests for `txHistorySlice`
- [x] (optional) Simplify test mocks by using a builder

## How to test it

1. Open the same safe in two different browsers
2. Execute a transaction with the same nonce at the same time from each browser
3. Observe both pending states to be cleared as soon as one of the transactions is executed

## Screenshots

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
