### PR TITLE
Refactor: replace deprecated timezone_offset parameter with timezone

### DIFF
--- a/cypress/e2e/prodhealthcheck/tx_history.cy.js
+++ b/cypress/e2e/prodhealthcheck/tx_history.cy.js
@@ -27,7 +27,7 @@ describe('Tx history tests 1', () => {
         constants.stagingCGWSafes
       }${staticSafes.SEP_STATIC_SAFE_7.substring(4)}/transactions/history**`,
       (req) => {
-        req.url = `https://safe-client.safe.global/v1/chains/11155111/safes/0x5912f6616c84024cD1aff0D5b55bb36F5180fFdb/transactions/history?timezone_offset=7200000&trusted=false&cursor=limit=100&offset=1`
+        req.url = `https://safe-client.safe.global/v1/chains/11155111/safes/0x5912f6616c84024cD1aff0D5b55bb36F5180fFdb/transactions/history?timezone=Europe/Berlin&trusted=false&cursor=limit=100&offset=1`
         req.continue()
       },
     ).as('allTransactions')

--- a/cypress/e2e/prodhealthcheck/tx_history_2.cy.js
+++ b/cypress/e2e/prodhealthcheck/tx_history_2.cy.js
@@ -30,7 +30,7 @@ describe('Tx history tests 2', () => {
         constants.stagingCGWSafes
       }${staticSafes.SEP_STATIC_SAFE_7.substring(4)}/transactions/history**`,
       (req) => {
-        req.url = `https://safe-client.safe.global/v1/chains/11155111/safes/0x5912f6616c84024cD1aff0D5b55bb36F5180fFdb/transactions/history?timezone_offset=7200000&trusted=false&cursor=limit=100&offset=1`
+        req.url = `https://safe-client.safe.global/v1/chains/11155111/safes/0x5912f6616c84024cD1aff0D5b55bb36F5180fFdb/transactions/history?timezone=Europe/Berlin&trusted=false&cursor=limit=100&offset=1`
         req.continue()
       },
     ).as('allTransactions')

--- a/cypress/e2e/regression/tx_history.cy.js
+++ b/cypress/e2e/regression/tx_history.cy.js
@@ -27,7 +27,7 @@ describe('Tx history tests 1', () => {
         constants.stagingCGWSafes
       }${staticSafes.SEP_STATIC_SAFE_7.substring(4)}/transactions/history**`,
       (req) => {
-        req.url = `https://safe-client.staging.5afe.dev/v1/chains/11155111/safes/0x5912f6616c84024cD1aff0D5b55bb36F5180fFdb/transactions/history?timezone_offset=7200000&trusted=false&cursor=limit=100&offset=1`
+        req.url = `https://safe-client.staging.5afe.dev/v1/chains/11155111/safes/0x5912f6616c84024cD1aff0D5b55bb36F5180fFdb/transactions/history?timezone=Europe/Berlin&trusted=false&cursor=limit=100&offset=1`
         req.continue()
       },
     ).as('allTransactions')

--- a/cypress/e2e/regression/tx_history_2.cy.js
+++ b/cypress/e2e/regression/tx_history_2.cy.js
@@ -30,7 +30,7 @@ describe('Tx history tests 2', () => {
         constants.stagingCGWSafes
       }${staticSafes.SEP_STATIC_SAFE_7.substring(4)}/transactions/history**`,
       (req) => {
-        req.url = `https://safe-client.staging.5afe.dev/v1/chains/11155111/safes/0x5912f6616c84024cD1aff0D5b55bb36F5180fFdb/transactions/history?timezone_offset=7200000&trusted=false&cursor=limit=100&offset=1`
+        req.url = `https://safe-client.staging.5afe.dev/v1/chains/11155111/safes/0x5912f6616c84024cD1aff0D5b55bb36F5180fFdb/transactions/history?timezone=Europe/Berlin&trusted=false&cursor=limit=100&offset=1`
         req.continue()
       },
     ).as('allTransactions')

--- a/cypress/support/utils/txquery.js
+++ b/cypress/support/utils/txquery.js
@@ -9,7 +9,7 @@ function buildQueryUrl({ chainId, safeAddress, transactionType, ...params }) {
 
   const defaultParams = {
     safe: `sep:${safeAddress}`,
-    timezone_offset: '7200000',
+    timezone: 'Europe/Berlin',
     trusted: 'false',
   }
 

--- a/package.json
+++ b/package.json
@@ -158,6 +158,5 @@
     "budgetPercentIncreaseRed": 20,
     "minimumChangeThreshold": 0,
     "showDetails": true
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@safe-global/protocol-kit": "^4.1.0",
     "@safe-global/safe-apps-sdk": "^9.1.0",
     "@safe-global/safe-deployments": "^1.37.3",
-    "@safe-global/safe-gateway-typescript-sdk": "3.22.2",
+    "@safe-global/safe-gateway-typescript-sdk": "3.22.4-beta.1",
     "@safe-global/safe-modules-deployments": "^1.2.0",
     "@sentry/react": "^7.91.0",
     "@spindl-xyz/attribution-lite": "^1.4.0",
@@ -158,5 +158,6 @@
     "budgetPercentIncreaseRed": 20,
     "minimumChangeThreshold": 0,
     "showDetails": true
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/services/transactions/index.tests.ts
+++ b/src/services/transactions/index.tests.ts
@@ -1,8 +1,9 @@
-import { getTimezoneOffset } from '.'
+import { getTimezone } from '.'
 
-describe('getTimezoneOffset', () => {
-  it('should return timezone offset in milliseconds', () => {
-    const CET = 60 * 60 * 1000 // tests are run in CET
-    expect(getTimezoneOffset()).toBe(-CET)
+describe('getTimezone', () => {
+  it('should return timezone', () => {
+    const result = getTimezone()
+
+    expect(result).toBeDefined()
   })
 })

--- a/src/services/transactions/index.ts
+++ b/src/services/transactions/index.ts
@@ -1,6 +1,6 @@
 import { getModuleTransactions, getTransactionHistory } from '@safe-global/safe-gateway-typescript-sdk'
 
-export const getTimezoneOffset = () => new Date().getTimezoneOffset() * 60 * -1000
+export const getTimezone = () => Intl.DateTimeFormat().resolvedOptions().timeZone
 
 export const getTxHistory = (
   chainId: string,
@@ -13,7 +13,7 @@ export const getTxHistory = (
     chainId,
     safeAddress,
     {
-      timezone_offset: getTimezoneOffset(), // used for grouping txs by date
+      timezone: getTimezone(), // used for grouping txs by date
       // Untrusted and imitation txs are filtered together in the UI
       trusted: hideUntrustedTxs, // if false, include transactions marked untrusted in the UI
       imitation: !hideImitationTxs, // If true, include transactions marked imitation in the UI

--- a/src/utils/__tests__/tx-history-filter.test.ts
+++ b/src/utils/__tests__/tx-history-filter.test.ts
@@ -19,6 +19,7 @@ import {
 import { renderHook } from '@/tests/test-utils'
 import type { NextRouter } from 'next/router'
 import { type TxFilterFormState } from '@/components/transactions/TxFilterForm'
+import { getTimezone } from '@/services/transactions'
 
 MockDate.set('2021-01-01T00:00:00.000Z')
 
@@ -395,7 +396,7 @@ describe('tx-history-filter', () => {
       expect(getIncomingTransfers).toHaveBeenCalledWith(
         '4',
         '0x123',
-        { value: '123', executed: undefined, timezone_offset: 3600000, trusted: false, imitation: true },
+        { value: '123', executed: undefined, timezone: getTimezone(), trusted: false, imitation: true },
         'pageUrl1',
       )
 
@@ -422,7 +423,7 @@ describe('tx-history-filter', () => {
         {
           execution_date__gte: '1970-01-01T00:00:00.000Z',
           executed: 'true',
-          timezone_offset: 3600000,
+          timezone: getTimezone(),
           trusted: false,
           imitation: true,
         },
@@ -446,7 +447,7 @@ describe('tx-history-filter', () => {
       expect(getModuleTransactions).toHaveBeenCalledWith(
         '1',
         '0x789',
-        { to: '0x123', executed: undefined, timezone_offset: 3600000, trusted: false, imitation: true },
+        { to: '0x123', executed: undefined, timezone: getTimezone(), trusted: false, imitation: true },
         'pageUrl3',
       )
 

--- a/src/utils/tx-history-filter.ts
+++ b/src/utils/tx-history-filter.ts
@@ -12,7 +12,7 @@ import { startOfDay, endOfDay } from 'date-fns'
 
 import type { TxFilterFormState } from '@/components/transactions/TxFilterForm'
 import { safeFormatUnits, safeParseUnits } from '@/utils/formatters'
-import { getTimezoneOffset } from '@/services/transactions'
+import { getTimezone } from '@/services/transactions'
 
 type IncomingTxFilter = NonNullable<operations['incoming_transfers']['parameters']['query']>
 type MultisigTxFilter = NonNullable<operations['multisig_transactions']['parameters']['query']>
@@ -126,7 +126,7 @@ export const fetchFilteredTxHistory = async (
   const fetchPage = () => {
     const query = {
       ...filterData.filter,
-      timezone_offset: getTimezoneOffset(),
+      timezone: getTimezone(),
       trusted: hideUntrustedTxs,
       imitation: !hideImitationTxs,
       executed: filterData.type === TxFilterType.MULTISIG ? 'true' : undefined,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4183,10 +4183,10 @@
   dependencies:
     semver "^7.6.2"
 
-"@safe-global/safe-gateway-typescript-sdk@3.22.2":
-  version "3.22.2"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.22.2.tgz#d4ff9972e58f9344fc95f8d41b2ec6517baa8e79"
-  integrity sha512-Y0yAxRaB98LFp2Dm+ACZqBSdAmI3FlpH/LjxOZ94g/ouuDJecSq0iR26XZ5QDuEL8Rf+L4jBJaoDC08CD0KkJw==
+"@safe-global/safe-gateway-typescript-sdk@3.22.4-beta.1":
+  version "3.22.4-beta.1"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.22.4-beta.1.tgz#ef8d0506d8c747124fae721a9baf99dda71af189"
+  integrity sha512-adxHiSeUc47MqkW7BM50U5xy6144rDEf0jyftzGXrBkG+nv/oL55SZQ/DdAsxyI1Mns02gzawa3Up+MfA8SKCQ==
 
 "@safe-global/safe-gateway-typescript-sdk@^3.5.3":
   version "3.21.2"


### PR DESCRIPTION
Removes deprecated timezone_offset, Adds `timezone` as a replacement.

## What it solves

Resolves
https://github.com/safe-global/safe-client-gateway/issues/1024

## How this PR fixes it
A new query parameter, timezone, has been introduced. This parameter accepts only valid timezone strings (e.g., Europe/Berlin) and supersedes the deprecated timezone_offset, which previously accepted a numeric timezone difference.

## How to test it

- Review the transaction history list.
- Make sure the transactions are listed with the correct time and date, and verify that they are grouped by day properly.
- Ensure that transactions occurring around midnight are not mistakenly assigned to the following day.
For more info please visit https://github.com/safe-global/safe-client-gateway/issues/1024

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
