### PR TITLE
Fix: "New" chip positioning

### DIFF
--- a/src/components/common/Chip/index.tsx
+++ b/src/components/common/Chip/index.tsx
@@ -13,8 +13,6 @@ export function Chip({ color = 'primary', label = 'New' }: ChipProps) {
       sx={{
         backgroundColor: `${color}.background`,
         color: `${color}.light`,
-        position: 'absolute',
-        right: 0,
         mt: '-2px',
       }}
       label={


### PR DESCRIPTION
## What it solves

A CSS regression from #4154. The New chip shouldn't be `position: absolute`.

<img width="307" alt="Screenshot 2024-09-13 at 14 51 13" src="https://github.com/user-attachments/assets/cc605e27-ef5d-4378-8fb8-b6f6296a47e2">
<img width="515" alt="Screenshot 2024-09-13 at 14 51 30" src="https://github.com/user-attachments/assets/f20c4c47-b135-435a-a146-8f236b3fc13f">