### PR TITLE
[Multichain] fix: allow activating Safes as non-owner

### DIFF
--- a/src/features/counterfactual/ActivateAccountFlow.tsx
+++ b/src/features/counterfactual/ActivateAccountFlow.tsx
@@ -245,7 +245,7 @@ const ActivateAccountFlow = () => {
         <Divider sx={{ mx: -3, mt: 2, mb: 1 }} />
 
         <Box display="flex" flexDirection="row" justifyContent="flex-end" gap={3}>
-          <CheckWallet checkNetwork={!submitDisabled}>
+          <CheckWallet checkNetwork={!submitDisabled} allowNonOwner>
             {(isOk) => (
               <Button
                 data-testid="activate-account-btn"


### PR DESCRIPTION
## What it solves
Allows activating Safe accounts as non owner and for multisig counterfactual Safes.

## How this PR fixes it
Adds `allowNonOwner` to `CheckWallet` within the `ActivateAccountFlow`

## How to test it
- Create a m/n counterfactual Safe
- Activate it

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
