### PR TITLE
[Multichain] fix: Network selector links and visual style [SW-184]

### DIFF
--- a/src/components/common/NetworkSelector/NetworkMultiSelector.tsx
+++ b/src/components/common/NetworkSelector/NetworkMultiSelector.tsx
@@ -1,4 +1,5 @@
 import useChains from '@/hooks/useChains'
+import useSafeAddress from '@/hooks/useSafeAddress'
 import { useCallback, type ReactElement } from 'react'
 import { Checkbox, Autocomplete, TextField, Chip } from '@mui/material'
 import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
@@ -22,6 +23,7 @@ const NetworkMultiSelector = ({
   const { configs } = useChains()
   const router = useRouter()
   const isWalletConnected = !!useWallet()
+  const safeAddress = useSafeAddress()
 
   const {
     formState: { errors },
@@ -36,7 +38,7 @@ const NetworkMultiSelector = ({
     (chains: ChainInfo[]) => {
       if (chains.length !== 1) return
       const shortName = chains[0].shortName
-      const networkLink = getNetworkLink(router, shortName, isWalletConnected)
+      const networkLink = getNetworkLink(router, safeAddress, shortName)
       router.replace(networkLink)
     },
     [isWalletConnected, router],

--- a/src/components/common/NetworkSelector/NetworkMultiSelector.tsx
+++ b/src/components/common/NetworkSelector/NetworkMultiSelector.tsx
@@ -8,7 +8,6 @@ import css from './styles.module.css'
 import { Controller, useFormContext, useWatch } from 'react-hook-form'
 import { useRouter } from 'next/router'
 import { getNetworkLink } from '.'
-import useWallet from '@/hooks/wallets/useWallet'
 import { SetNameStepFields } from '@/components/new-safe/create/steps/SetNameStep'
 import { getSafeSingletonDeployment } from '@safe-global/safe-deployments'
 import { getLatestSafeVersion } from '@/utils/chains'
@@ -22,7 +21,6 @@ const NetworkMultiSelector = ({
 }): ReactElement => {
   const { configs } = useChains()
   const router = useRouter()
-  const isWalletConnected = !!useWallet()
   const safeAddress = useSafeAddress()
 
   const {
@@ -41,7 +39,7 @@ const NetworkMultiSelector = ({
       const networkLink = getNetworkLink(router, safeAddress, shortName)
       router.replace(networkLink)
     },
-    [isWalletConnected, router],
+    [router, safeAddress],
   )
 
   const handleDelete = useCallback(

--- a/src/components/common/NetworkSelector/index.tsx
+++ b/src/components/common/NetworkSelector/index.tsx
@@ -38,7 +38,6 @@ import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import PlusIcon from '@/public/images/common/plus.svg'
 import useAddressBook from '@/hooks/useAddressBook'
 import { CreateSafeOnSpecificChain } from '@/features/multichain/components/CreateSafeOnNewChain'
-import useWallet from '@/hooks/wallets/useWallet'
 
 export const getNetworkLink = (router: NextRouter, safeAddress: string, networkShortName: string) => {
   const isSafeOpened = safeAddress !== ''
@@ -223,7 +222,6 @@ const NetworkSelector = ({
   const router = useRouter()
   const safeAddress = useSafeAddress()
   const chains = useAppSelector(selectChains)
-  const isWalletConnected = !!useWallet()
 
   const isSafeOpened = safeAddress !== ''
 
@@ -293,7 +291,7 @@ const NetworkSelector = ({
         </MenuItem>
       )
     },
-    [chains.data, isWalletConnected, onChainSelect, router, safeOverviews],
+    [chains.data, onChainSelect, router, safeAddress, safeOverviews],
   )
 
   return configs.length ? (

--- a/src/components/common/NetworkSelector/index.tsx
+++ b/src/components/common/NetworkSelector/index.tsx
@@ -38,24 +38,26 @@ import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import PlusIcon from '@/public/images/common/plus.svg'
 import useAddressBook from '@/hooks/useAddressBook'
 import { CreateSafeOnSpecificChain } from '@/features/multichain/components/CreateSafeOnNewChain'
-import { AppRoutes } from '@/config/routes'
 import useWallet from '@/hooks/wallets/useWallet'
 
-export const getNetworkLink = (router: NextRouter, networkShortName: string, isWalletConnected: boolean) => {
-  const shouldKeepPath = !router.query.safe
+export const getNetworkLink = (router: NextRouter, safeAddress: string, networkShortName: string) => {
+  const isSafeOpened = safeAddress !== ''
+
+  const query = (
+    isSafeOpened
+      ? {
+          safe: `${networkShortName}:${safeAddress}`,
+        }
+      : { chain: networkShortName }
+  ) as {
+    safe?: string
+    chain?: string
+    safeViewRedirectURL?: string
+  }
 
   const route = {
-    pathname: shouldKeepPath
-      ? router.pathname
-      : isWalletConnected
-      ? AppRoutes.welcome.accounts
-      : AppRoutes.welcome.index,
-    query: {
-      chain: networkShortName,
-    } as {
-      chain: string
-      safeViewRedirectURL?: string
-    },
+    pathname: router.pathname,
+    query,
   }
 
   if (router.query?.safeViewRedirectURL) {
@@ -262,7 +264,7 @@ const NetworkSelector = ({
 
     if (shortName) {
       trackEvent({ ...OVERVIEW_EVENTS.SWITCH_NETWORK, label: newChainId })
-      const networkLink = getNetworkLink(router, shortName, isWalletConnected)
+      const networkLink = getNetworkLink(router, safeAddress, shortName)
       router.push(networkLink)
     }
   }
@@ -277,7 +279,7 @@ const NetworkSelector = ({
       return (
         <MenuItem key={chainId} value={chainId} sx={{ '&:hover': { backgroundColor: 'inherit' } }}>
           <Link
-            href={getNetworkLink(router, chain.shortName, isWalletConnected)}
+            href={getNetworkLink(router, safeAddress, chain.shortName)}
             onClick={onChainSelect}
             className={css.item}
           >

--- a/src/components/common/NetworkSelector/styles.module.css
+++ b/src/components/common/NetworkSelector/styles.module.css
@@ -37,9 +37,9 @@
   font-size: 11px;
   font-weight: bold;
   line-height: 32px;
-  background-color: var(--color-background-main);
   text-align: center;
   letter-spacing: 1px;
+  width: 100%;
 }
 
 [data-theme='dark'] .undeployedNetworksHeader {
@@ -50,6 +50,8 @@
   background-color: var(--color-background-main);
   text-align: center;
   line-height: 32px;
+  padding: 0;
+  margin-top: var(--space-1);
 }
 
 .plusIcon {


### PR DESCRIPTION
## What it solves

Resolves SW-184 and fixes a regression introduced in #4075 for `getNetworkLink`

## How this PR fixes it

- Checks for `safeAddress` inside `getNetworkLink` and simplifies the pathname

## How to test it

1. Open a Safe that is deployed on multiple networks
2. Switch to a different network
3. Observe the same route is still open for the new network
4. Observe no visual issue in dark mode when pressing "Show all networks"

## Screenshots
<img width="282" alt="Screenshot 2024-09-16 at 11 37 17" src="https://github.com/user-attachments/assets/5c391d21-9178-46f3-be31-d0e2416f665f">
<img width="283" alt="Screenshot 2024-09-16 at 11 37 26" src="https://github.com/user-attachments/assets/c77f3c97-aa99-4103-900a-4461e5f205b3">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
