### PR TITLE
Fix: back button breakpoint in tx flow

### DIFF
--- a/src/components/tx-flow/common/TxLayout/index.tsx
+++ b/src/components/tx-flow/common/TxLayout/index.tsx
@@ -83,7 +83,7 @@ const TxLayout = ({
 
   const theme = useTheme()
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'))
-  const isDesktop = useMediaQuery(theme.breakpoints.down(1399.95))
+  const isDesktop = useMediaQuery(theme.breakpoints.down('lg'))
 
   const steps = Array.isArray(children) ? children : [children]
   const progress = Math.round(((step + 1) / steps.length) * 100)

--- a/src/components/tx-flow/common/TxLayout/styles.module.css
+++ b/src/components/tx-flow/common/TxLayout/styles.module.css
@@ -108,7 +108,7 @@
   /* Height of transaction type title */
   margin-top: 46px;
 }
-@media (max-width: 1399.95px) {
+@media (max-width: 1199px) {
   .backButton {
     left: 50%;
     transform: translateX(-50%);


### PR DESCRIPTION
## What it solves

Resolves 
release blocker: https://github.com/safe-global/safe-wallet-web/pull/4162#issuecomment-2349136056

## How this PR fixes it
It decreases the breakpoint of the backButton css and removes a magic number from the txLayout component. Now the `isDesktop` variable is getting it value based on the `lg` measure.

## How to test it
1) Go to any transaction screen where the back button appears
2) Resize the screen 
3) The back button should break only in the 1199 resolution

## Screenshots

Video: https://www.awesomescreenshot.com/video/31567985?key=75c8d42a80cec6163ca9679d129950cf

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
