### PR TITLE
[Multichain] fix: check for canonical deployments

### DIFF
--- a/src/components/common/NetworkSelector/NetworkMultiSelector.tsx
+++ b/src/components/common/NetworkSelector/NetworkMultiSelector.tsx
@@ -9,8 +9,9 @@ import { useRouter } from 'next/router'
 import { getNetworkLink } from '.'
 import useWallet from '@/hooks/wallets/useWallet'
 import { SetNameStepFields } from '@/components/new-safe/create/steps/SetNameStep'
-import { getSafeSingletonDeployment } from '@safe-global/safe-deployments'
+import { getSafeSingletonDeployments } from '@safe-global/safe-deployments'
 import { getLatestSafeVersion } from '@/utils/chains'
+import { hasCanonicalDeployment } from '@/services/contracts/deployments'
 
 const NetworkMultiSelector = ({
   name,
@@ -60,17 +61,19 @@ const NetworkMultiSelector = ({
       // do not allow multi chain safes for advanced setup flow.
       if (isAdvancedFlow) return optionNetwork.chainId != firstSelectedNetwork.chainId
 
-      const optionHasCanonicalSingletonDeployment = Boolean(
-        getSafeSingletonDeployment({
+      const optionHasCanonicalSingletonDeployment = hasCanonicalDeployment(
+        getSafeSingletonDeployments({
           network: optionNetwork.chainId,
           version: getLatestSafeVersion(firstSelectedNetwork),
-        })?.deployments.canonical,
+        }),
+        optionNetwork.chainId,
       )
-      const selectedHasCanonicalSingletonDeployment = Boolean(
-        getSafeSingletonDeployment({
+      const selectedHasCanonicalSingletonDeployment = hasCanonicalDeployment(
+        getSafeSingletonDeployments({
           network: firstSelectedNetwork.chainId,
           version: getLatestSafeVersion(firstSelectedNetwork),
-        })?.deployments.canonical,
+        }),
+        firstSelectedNetwork.chainId,
       )
 
       // Only 1.4.1 safes with canonical deployment addresses can be deployed as part of a multichain group

--- a/src/services/contracts/deployments.ts
+++ b/src/services/contracts/deployments.ts
@@ -9,9 +9,24 @@ import {
   getSignMessageLibDeployment,
   getCreateCallDeployment,
 } from '@safe-global/safe-deployments'
-import type { SingletonDeployment, DeploymentFilter } from '@safe-global/safe-deployments'
+import type { SingletonDeployment, DeploymentFilter, SingletonDeploymentV2 } from '@safe-global/safe-deployments'
 import type { ChainInfo, SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { getLatestSafeVersion } from '@/utils/chains'
+import { sameAddress } from '@/utils/addresses'
+
+const toNetworkAddressList = (addresses: string | string[]) => (Array.isArray(addresses) ? addresses : [addresses])
+
+export const hasCanonicalDeployment = (deployment: SingletonDeploymentV2 | undefined, chainId: string) => {
+  const canonicalAddress = deployment?.deployments.canonical?.address
+
+  if (!canonicalAddress) {
+    return false
+  }
+
+  const networkAddresses = toNetworkAddressList(deployment.networkAddresses[chainId])
+
+  return networkAddresses.some((networkAddress) => sameAddress(canonicalAddress, networkAddress))
+}
 
 export const _tryDeploymentVersions = (
   getDeployment: (filter?: DeploymentFilter) => SingletonDeployment | undefined,


### PR DESCRIPTION
## What it solves
Fixes the check for canonical deployments in the `NetworkMultiSelector` 

## How to test it
- Create a new Safe and start with any chain except zkSync.
- Observe that now zkSync is not offered (greyed out)

## Screenshots
![Screenshot 2024-09-17 at 18 27 53](https://github.com/user-attachments/assets/6f19708d-bc0c-47b2-b3d2-3ba48c6fc5b3)


## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
