### PR TITLE
[Multichain] Fix: Disable legacy safe replaying

### DIFF
--- a/src/components/common/NetworkInput/index.tsx
+++ b/src/components/common/NetworkInput/index.tsx
@@ -16,7 +16,7 @@ const NetworkInput = ({
 }: {
   name: string
   required?: boolean
-  chainConfigs: ChainInfo[]
+  chainConfigs: (ChainInfo & { available: boolean })[]
 }): ReactElement => {
   const isDarkMode = useDarkMode()
   const theme = useTheme()
@@ -24,11 +24,16 @@ const NetworkInput = ({
   const { control } = useFormContext() || {}
 
   const renderMenuItem = useCallback(
-    (chainId: string, isSelected: boolean) => {
+    (chainId: string, isDisabled: boolean) => {
       const chain = chainConfigs.find((chain) => chain.chainId === chainId)
       if (!chain) return null
       return (
-        <MenuItem key={chainId} value={chainId} sx={{ '&:hover': { backgroundColor: 'inherit' } }}>
+        <MenuItem
+          disabled={isDisabled}
+          key={chainId}
+          value={chainId}
+          sx={{ '&:hover': { backgroundColor: 'inherit' } }}
+        >
           <ChainIndicator chainId={chain.chainId} />
         </MenuItem>
       )
@@ -51,7 +56,7 @@ const NetworkInput = ({
             fullWidth
             label="Network"
             IconComponent={ExpandMoreIcon}
-            renderValue={(value) => renderMenuItem(value, true)}
+            renderValue={(value) => renderMenuItem(value, false)}
             MenuProps={{
               sx: {
                 '& .MuiPaper-root': {
@@ -67,11 +72,11 @@ const NetworkInput = ({
               },
             }}
           >
-            {prodNets.map((chain) => renderMenuItem(chain.chainId, false))}
+            {prodNets.map((chain) => renderMenuItem(chain.chainId, !chain.available))}
 
             {testNets.length > 0 && <ListSubheader className={css.listSubHeader}>Testnets</ListSubheader>}
 
-            {testNets.map((chain) => renderMenuItem(chain.chainId, false))}
+            {testNets.map((chain) => renderMenuItem(chain.chainId, !chain.available))}
           </Select>
         </FormControl>
       )}

--- a/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
+++ b/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
@@ -109,7 +109,8 @@ const ReplaySafeDialog = ({
   const submitDisabled =
     isUnsupportedSafeCreationVersion || !!safeCreationDataError || safeCreationDataLoading || !formState.isValid
 
-  const noChainsAvailable = !chain && safeCreationData && replayableChains && replayableChains.length === 0
+  const noChainsAvailable =
+    !chain && safeCreationData && replayableChains && replayableChains.filter((chain) => chain.available).length === 0
 
   return (
     <Dialog open={open} onClose={onClose} onClick={(e) => e.stopPropagation()}>


### PR DESCRIPTION
## What it solves
Legacy Safes could be replayed through the sidebar context menu.

## How this PR fixes it
Marks unavailable chains as disabled

## How to test it
- Try to add a network to a 1.1.1 Safe

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
