### PR TITLE
Fix(Multichain): No network is visible in activate account flow. [SW-192]

### DIFF
--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -83,8 +83,6 @@ export const SafeSetupOverview = ({
   threshold: number
   networks: ChainInfo[]
 }) => {
-  const chain = useCurrentChain()
-
   return (
     <Grid container spacing={3}>
       <ReviewRow

--- a/src/features/counterfactual/ActivateAccountFlow.tsx
+++ b/src/features/counterfactual/ActivateAccountFlow.tsx
@@ -190,7 +190,7 @@ const ActivateAccountFlow = () => {
         <SafeSetupOverview
           owners={owners.map((owner) => ({ name: '', address: owner }))}
           threshold={threshold}
-          networks={[]}
+          networks={chain ? [chain] : []}
         />
 
         <Divider sx={{ mx: -3, mt: 2, mb: 1 }} />


### PR DESCRIPTION
## What it solves
When activating a CF safe, the network is not shown as it was before.

## How this PR fixes it
Show the network in `ActivateAccountFlow` when activating a safe

## How to test it
- Create a CF safe and then activate it.
- On the confirmation screen, the network of the safe should be shown in the `Network` section

## Screenshots
![image](https://github.com/user-attachments/assets/ae2a3aff-8137-4a13-bec6-44543ec60713)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
