### PR TITLE
Feat: add sdai, usdc.e, EURE to the list of stables

### DIFF
--- a/src/features/swap/helpers/data/stablecoins.ts
+++ b/src/features/swap/helpers/data/stablecoins.ts
@@ -506,4 +506,34 @@ export const stableCoinAddresses: {
     symbol: 'USDT',
     chains: ['sepolia'],
   },
+  '0xaf204776c7245bf4147c2612bf6e5972ee483701': {
+    name: 'Savings xDai',
+    symbol: 'SDAI',
+    chains: ['gnosis'],
+  },
+  '0x83f20f44975d03b1b09e64809b757c47f942beea': {
+    name: 'Savings xDai',
+    symbol: 'SDAI',
+    chains: ['ethereum'],
+  },
+  '0x4c612e3b15b96ff9a6faed838f8d07d479a8dd4c': {
+    name: 'Aave v3 sDai',
+    symbol: 'ASDAI',
+    chains: ['ethereum'],
+  },
+  '0x7a5c3860a77a8dc1b225bd46d0fb2ac1c6d191bc': {
+    name: 'Aave v3 sDai',
+    symbol: 'ASDAI',
+    chains: ['gnosis'],
+  },
+  '0x2a22f9c3b484c3629090feed35f17ff8f88f76f0': {
+    name: 'Gnosis xDAI Bridged USDC',
+    symbol: 'USDC.e',
+    chains: ['gnosis'],
+  },
+  '0xcb444e90d8198415266c6a2724b7900fb12fc56e': {
+    name: 'Monerium EUR emoney',
+    symbol: 'EURE',
+    chains: ['gnosis'],
+  },
 }


### PR DESCRIPTION
## What it solves
Some user were complaining that our swaps was applying a too high fee on stables. It turned out that we didn't have sdai, eure and usdc.e tokens in the list of stables.

Resolves #

## How this PR fixes it

## How to test it
Try to swap 100 between the tokens and your swap should have a 0.1% fee applied instead of 0.35%

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
