### PR TITLE
Feat stake OFAC

### DIFF
--- a/src/components/common/BlockedAddress/index.tsx
+++ b/src/components/common/BlockedAddress/index.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router'
 import Disclaimer from '@/components/common/Disclaimer'
 import { AppRoutes } from '@/config/routes'
 
-export const BlockedAddress = ({ address }: { address?: string }): ReactElement => {
+export const BlockedAddress = ({ address, featureTitle }: { address: string; featureTitle: string }): ReactElement => {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
   const displayAddress = address && isMobile ? shortenAddress(address) : address
@@ -19,7 +19,7 @@ export const BlockedAddress = ({ address }: { address?: string }): ReactElement 
     <Disclaimer
       title="Blocked address"
       subtitle={displayAddress}
-      content="The above address is part of the OFAC SDN list and the embedded swaps feature with CoW Swap is unavailable for sanctioned addresses."
+      content={`The above address is part of the OFAC SDN list and the ${featureTitle} is unavailable for sanctioned addresses.`}
       onAccept={handleAccept}
     />
   )

--- a/src/features/stake/components/StakePage/index.tsx
+++ b/src/features/stake/components/StakePage/index.tsx
@@ -4,11 +4,37 @@ import WidgetDisclaimer from '@/components/common/WidgetDisclaimer'
 import useStakeConsent from '@/features/stake/useStakeConsent'
 import StakingWidget from '../StakingWidget'
 import { useRouter } from 'next/router'
+import { useGetIsSanctionedQuery } from '@/store/ofac'
+import { skipToken } from '@reduxjs/toolkit/query/react'
+import useWallet from '@/hooks/wallets/useWallet'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import { getKeyWithTrueValue } from '@/utils/helpers'
+import BlockedAddress from '@/components/common/BlockedAddress'
 
 const StakePage = () => {
   const { isConsentAccepted, onAccept } = useStakeConsent()
   const router = useRouter()
   const { asset } = router.query
+
+  const { safeAddress } = useSafeInfo()
+  const wallet = useWallet()
+
+  const { data: isSafeAddressBlocked } = useGetIsSanctionedQuery(safeAddress || skipToken)
+  const { data: isWalletAddressBlocked } = useGetIsSanctionedQuery(wallet?.address || skipToken)
+  const blockedAddresses = {
+    [safeAddress]: !!isSafeAddressBlocked,
+    [wallet?.address || '']: !!isWalletAddressBlocked,
+  }
+
+  const blockedAddress = getKeyWithTrueValue(blockedAddresses)
+
+  if (blockedAddress) {
+    return (
+      <Stack direction="column" alignItems="center" justifyContent="center" flex={1}>
+        <BlockedAddress address={blockedAddress} featureTitle="stake feature with Kiln" />
+      </Stack>
+    )
+  }
 
   return (
     <>

--- a/src/features/swap/index.tsx
+++ b/src/features/swap/index.tsx
@@ -294,7 +294,7 @@ const SwapWidget = ({ sell }: Params) => {
   useCustomAppCommunicator(iframeRef, appData, chain)
 
   if (blockedAddress) {
-    return <BlockedAddress address={blockedAddress} />
+    return <BlockedAddress address={blockedAddress} featureTitle="embedded swaps feature with CoW Swap" />
   }
 
   if (!isConsentAccepted) {

--- a/src/store/ofac.ts
+++ b/src/store/ofac.ts
@@ -62,6 +62,7 @@ export const ofacApi = createApi({
           return { error: { status: 'CUSTOM_ERROR', data: (error as Error).message } }
         }
       },
+      keepUnusedDataFor: 24 * 60 * 60, // 24 hours
     }),
   }),
 })


### PR DESCRIPTION
## What it solves
Checks whether the currently connected wallet or safe is on the OFAC list and blocks access to the stake feature.

## How to test it
You can use impersonator.xyz with any of the addresses on the https://github.com/ultrasoundmoney/ofac-ethereum-addresses/blob/main/data.csv list and it should display a block letting you know that the address is blocked.

## Screenshots
![grafik](https://github.com/user-attachments/assets/17c195fe-d943-4925-bcc7-dc66665b8ba1)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
