### PR TITLE
Feat(swaps): add usds stable coin

### DIFF
--- a/src/features/swap/helpers/data/stablecoins.ts
+++ b/src/features/swap/helpers/data/stablecoins.ts
@@ -536,4 +536,9 @@ export const stableCoinAddresses: {
     symbol: 'EURE',
     chains: ['gnosis'],
   },
+  '0xdc035d45d973e3ec169d2276ddab16f1e407384f': {
+    name: 'Sky dollar',
+    symbol: 'USDS',
+    chains: ['ethereum'],
+  },
 }


### PR DESCRIPTION
https://www.coingecko.com/en/coins/sky-dollar

## What it solves
DAI has rebranded to SKY and that new token is most probably going to be used quite a lot in the future. We need to have the token address in the stablecoints array otherwise the swap widget will apply the wrong fee.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
