### PR TITLE
[Multichain] Fix: multichain disable cf creation

### DIFF
--- a/src/components/common/CheckWallet/index.test.tsx
+++ b/src/components/common/CheckWallet/index.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@/tests/test-utils'
+import { getByLabelText, render } from '@/tests/test-utils'
 import CheckWallet from '.'
 import useIsOnlySpendingLimitBeneficiary from '@/hooks/useIsOnlySpendingLimitBeneficiary'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
@@ -85,7 +85,7 @@ describe('CheckWallet', () => {
     expect(container.querySelector('button')).toBeDisabled()
 
     // Check the tooltip text
-    expect(container.querySelector('span[aria-label]')).toHaveAttribute('aria-label', 'Please connect your wallet')
+    getByLabelText(container, 'Please connect your wallet')
   })
 
   it('should disable the button when the wallet is connected to the right chain but is not an owner', () => {
@@ -121,10 +121,7 @@ describe('CheckWallet', () => {
     const { container } = renderButton()
 
     expect(container.querySelector('button')).toBeDisabled()
-    expect(container.querySelector('span[aria-label]')).toHaveAttribute(
-      'aria-label',
-      'Your connected wallet is not a signer of this Safe Account',
-    )
+    getByLabelText(container, 'Your connected wallet is not a signer of this Safe Account')
 
     const { container: allowContainer } = render(
       <CheckWallet allowSpendingLimit>{(isOk) => <button disabled={!isOk}>Continue</button>}</CheckWallet>,
@@ -161,10 +158,7 @@ describe('CheckWallet', () => {
     const { container } = renderButton()
 
     expect(container.querySelector('button')).toBeDisabled()
-    expect(container.querySelector('span[aria-label]')).toHaveAttribute(
-      'aria-label',
-      'You need to activate the Safe before transacting',
-    )
+    getByLabelText(container, 'You need to activate the Safe before transacting')
   })
 
   it('should enable the button for counterfactual Safes if allowed', () => {

--- a/src/components/common/CheckWallet/index.tsx
+++ b/src/components/common/CheckWallet/index.tsx
@@ -1,5 +1,5 @@
 import { useIsWalletDelegate } from '@/hooks/useDelegates'
-import { type ReactElement } from 'react'
+import { useMemo, type ReactElement } from 'react'
 import useIsOnlySpendingLimitBeneficiary from '@/hooks/useIsOnlySpendingLimitBeneficiary'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import useWallet from '@/hooks/wallets/useWallet'
@@ -14,12 +14,13 @@ type CheckWalletProps = {
   allowNonOwner?: boolean
   noTooltip?: boolean
   checkNetwork?: boolean
+  allowUndeployedSafe?: boolean
 }
 
 enum Message {
   WalletNotConnected = 'Please connect your wallet',
   NotSafeOwner = 'Your connected wallet is not a signer of this Safe Account',
-  CounterfactualMultisig = 'You need to activate the Safe before transacting',
+  SafeNotActivated = 'You need to activate the Safe before transacting',
 }
 
 const CheckWallet = ({
@@ -28,28 +29,39 @@ const CheckWallet = ({
   allowNonOwner,
   noTooltip,
   checkNetwork = false,
+  allowUndeployedSafe = false,
 }: CheckWalletProps): ReactElement => {
   const wallet = useWallet()
   const isSafeOwner = useIsSafeOwner()
-  const isSpendingLimit = useIsOnlySpendingLimitBeneficiary()
+  const isOnlySpendingLimit = useIsOnlySpendingLimitBeneficiary()
   const connectWallet = useConnectWallet()
   const isWrongChain = useIsWrongChain()
   const isDelegate = useIsWalletDelegate()
 
   const { safe } = useSafeInfo()
 
-  const isCounterfactualMultiSig = !allowNonOwner && !safe.deployed && safe.threshold > 1
+  const isUndeployedSafe = !safe.deployed
 
-  const message =
-    wallet &&
-    (isSafeOwner || allowNonOwner || (isSpendingLimit && allowSpendingLimit) || isDelegate) &&
-    !isCounterfactualMultiSig
-      ? ''
-      : !wallet
-      ? Message.WalletNotConnected
-      : isCounterfactualMultiSig
-      ? Message.CounterfactualMultisig
-      : Message.NotSafeOwner
+  const message = useMemo(() => {
+    if (!wallet) {
+      return Message.WalletNotConnected
+    }
+    if ((!allowNonOwner && !isSafeOwner && !isDelegate) || (isOnlySpendingLimit && !allowSpendingLimit)) {
+      return Message.NotSafeOwner
+    }
+    if (isUndeployedSafe && !allowUndeployedSafe) {
+      return Message.SafeNotActivated
+    }
+  }, [
+    allowNonOwner,
+    allowSpendingLimit,
+    allowUndeployedSafe,
+    isDelegate,
+    isOnlySpendingLimit,
+    isSafeOwner,
+    isUndeployedSafe,
+    wallet,
+  ])
 
   if (checkNetwork && isWrongChain) return children(false)
   if (!message) return children(true)

--- a/src/components/common/CheckWallet/index.tsx
+++ b/src/components/common/CheckWallet/index.tsx
@@ -46,11 +46,11 @@ const CheckWallet = ({
     if (!wallet) {
       return Message.WalletNotConnected
     }
-    if ((!allowNonOwner && !isSafeOwner && !isDelegate) || (isOnlySpendingLimit && !allowSpendingLimit)) {
-      return Message.NotSafeOwner
-    }
     if (isUndeployedSafe && !allowUndeployedSafe) {
       return Message.SafeNotActivated
+    }
+    if ((!allowNonOwner && !isSafeOwner && !isDelegate) || (isOnlySpendingLimit && !allowSpendingLimit)) {
+      return Message.NotSafeOwner
     }
   }, [
     allowNonOwner,

--- a/src/features/counterfactual/ActivateAccountButton.tsx
+++ b/src/features/counterfactual/ActivateAccountButton.tsx
@@ -25,7 +25,7 @@ const ActivateAccountButton = () => {
   return (
     <Tooltip title={isProcessing ? 'The safe activation is already in process' : undefined}>
       <span>
-        <CheckWallet allowNonOwner>
+        <CheckWallet allowNonOwner allowUndeployedSafe>
           {(isOk) => (
             <Button
               data-testid="activate-account-btn-cf"

--- a/src/features/counterfactual/ActivateAccountFlow.tsx
+++ b/src/features/counterfactual/ActivateAccountFlow.tsx
@@ -210,7 +210,7 @@ const ActivateAccountFlow = () => {
         <Divider sx={{ mx: -3, mt: 2, mb: 1 }} />
 
         <Box display="flex" flexDirection="row" justifyContent="flex-end" gap={3}>
-          <CheckWallet checkNetwork={!submitDisabled} allowNonOwner>
+          <CheckWallet checkNetwork={!submitDisabled} allowNonOwner allowUndeployedSafe>
             {(isOk) => (
               <Button
                 data-testid="activate-account-btn"


### PR DESCRIPTION
## What this PR changes
- new `allowUndeployedSafe` prop in `CheckWallet`
- If false the buttons get disabled for undeployed Safes
- Unit tests

## How to test it
- Create a new CF multichain Safe
- Go to e.g. Settings and observe the "Add owner" button to be disabled

## Screenshots
![Screenshot 2024-09-19 at 12 45 29](https://github.com/user-attachments/assets/30b5612b-7973-47fd-8f35-2218d5baca36)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
