### PR TITLE
Fix(Multichain): no setupTol2 for legacy versions

### DIFF
--- a/src/components/new-safe/create/logic/index.test.ts
+++ b/src/components/new-safe/create/logic/index.test.ts
@@ -250,6 +250,36 @@ describe('create/logic', () => {
       })
     })
 
+    it('should use l2 masterCopy and no migration on l2s with multichain feature but on old version', () => {
+      const safeSetup = {
+        owners: [faker.finance.ethereumAddress()],
+        threshold: 1,
+      }
+      expect(
+        createNewUndeployedSafeWithoutSalt(
+          '1.3.0',
+          safeSetup,
+          chainBuilder()
+            .with({ chainId: '137' })
+            // Multichain creation is toggled off
+            .with({ features: [FEATURES.SAFE_141, FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
+            .with({ l2: true })
+            .build(),
+        ),
+      ).toEqual({
+        safeAccountConfig: {
+          ...safeSetup,
+          fallbackHandler: getFallbackHandlerDeployment({ version: '1.3.0', network: '137' })?.defaultAddress,
+          to: ZERO_ADDRESS,
+          data: EMPTY_DATA,
+          paymentReceiver: ECOSYSTEM_ID_ADDRESS,
+        },
+        safeVersion: '1.3.0',
+        masterCopy: getSafeL2SingletonDeployment({ version: '1.3.0', network: '137' })?.defaultAddress,
+        factoryAddress: getProxyFactoryDeployment({ version: '1.3.0', network: '137' })?.defaultAddress,
+      })
+    })
+
     it('should use l1 masterCopy and migration on l2s with multichain feature', () => {
       const safeSetup = {
         owners: [faker.finance.ethereumAddress()],

--- a/src/components/new-safe/create/logic/index.ts
+++ b/src/components/new-safe/create/logic/index.ts
@@ -1,5 +1,6 @@
 import type { SafeVersion } from '@safe-global/safe-core-sdk-types'
 import { Interface, type Eip1193Provider, type Provider } from 'ethers'
+import semverSatisfies from 'semver/functions/satisfies'
 
 import { getSafeInfo, type SafeInfo, type ChainInfo, relayTransaction } from '@safe-global/safe-gateway-typescript-sdk'
 import { getReadOnlyProxyFactoryContract } from '@/services/contracts/safeContracts'
@@ -225,7 +226,7 @@ export const createNewUndeployedSafeWithoutSalt = (
   }
 
   // Only do migration if the chain supports multiChain deployments.
-  const includeMigration = hasMultiChainCreationFeatures(chain)
+  const includeMigration = hasMultiChainCreationFeatures(chain) && semverSatisfies(safeVersion, '>=1.4.1')
 
   const masterCopy = includeMigration ? safeL1Address : chain.l2 ? safeL2Address : safeL1Address
 


### PR DESCRIPTION
## What it solves

For Safe versions `< 1.4.1` no `setupToL2` call is used when creating the Safe.

## How this PR fixes it
- Checks the safe version and only migrates if the safe version is >= 1.4.1

## How to test it
- Create a Safe on a  network that does not support 1.4.1.

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
