### PR TITLE
Refactor: unify confirmBatch screen

### DIFF
--- a/src/components/tx-flow/flows/ConfirmBatch/index.tsx
+++ b/src/components/tx-flow/flows/ConfirmBatch/index.tsx
@@ -8,7 +8,6 @@ import { OperationType } from '@safe-global/safe-core-sdk-types'
 import TxLayout from '../../common/TxLayout'
 import BatchIcon from '@/public/images/common/batch.svg'
 import { useDraftBatch } from '@/hooks/useDraftBatch'
-import BatchTxList from '@/components/batch/BatchSidebar/BatchTxList'
 
 type ConfirmBatchProps = {
   onSubmit: () => void
@@ -32,11 +31,7 @@ const ConfirmBatch = ({ onSubmit }: ConfirmBatchProps): ReactElement => {
     createMultiSendCallOnlyTx(calls).then(setSafeTx).catch(setSafeTxError)
   }, [batchTxs, setSafeTx, setSafeTxError])
 
-  return (
-    <SignOrExecuteForm onSubmit={onSubmit} isBatch>
-      <BatchTxList txItems={batchTxs} />
-    </SignOrExecuteForm>
-  )
+  return <SignOrExecuteForm onSubmit={onSubmit} isBatch />
 }
 
 const ConfirmBatchFlow = (props: ConfirmBatchProps) => {

--- a/src/components/tx/confirmation-views/BatchTransactions/BatchTransactions.stories.tsx
+++ b/src/components/tx/confirmation-views/BatchTransactions/BatchTransactions.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Paper, ThemeProvider } from '@mui/material'
+import { StoreDecorator } from '@/stories/storeDecorator'
+import BatchTransactions from './index'
+import { mockedDarftBatch } from './mockData'
+import createSafeTheme from '@/components/theme/safeTheme'
+
+const meta = {
+  component: BatchTransactions,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => {
+      return (
+        <StoreDecorator
+          initialState={{
+            chains: { data: [{ chainId: '11155111' }] },
+            batch: {
+              '11155111': {
+                '': [mockedDarftBatch[0], mockedDarftBatch[0]],
+              },
+            },
+          }}
+        >
+          <ThemeProvider theme={createSafeTheme('dark')}>
+            <Paper sx={{ padding: 2 }}>
+              <Story />
+            </Paper>
+          </ThemeProvider>
+        </StoreDecorator>
+      )
+    },
+  ],
+
+  tags: ['autodocs'],
+} satisfies Meta<typeof BatchTransactions>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/src/components/tx/confirmation-views/BatchTransactions/BatchTransactions.test.tsx
+++ b/src/components/tx/confirmation-views/BatchTransactions/BatchTransactions.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@/tests/test-utils'
+import BatchTransactions from '.'
+import * as useDraftBatch from '@/hooks/useDraftBatch'
+import { mockedDarftBatch } from './mockData'
+
+jest.spyOn(useDraftBatch, 'useDraftBatch').mockImplementation(() => mockedDarftBatch)
+
+describe('BatchTransactions', () => {
+  it('should render a list of batch transactions', () => {
+    const { container, getByText } = render(<BatchTransactions />)
+
+    expect(container).toMatchSnapshot()
+    expect(getByText('GnosisSafeProxy')).toBeDefined()
+  })
+})

--- a/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
+++ b/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
@@ -1,0 +1,268 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BatchTransactions should render a list of batch transactions 1`] = `
+<div>
+  <ul
+    class="MuiList-root MuiList-padding css-lcvy9m-MuiList-root"
+  >
+    <li
+      class="MuiListItem-root MuiListItem-gutters css-1ukg6v4-MuiListItem-root"
+    >
+      <div
+        class="number"
+      >
+        1
+      </div>
+      <div
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-1qub31g-MuiPaper-root-MuiAccordion-root"
+      >
+        <div
+          aria-expanded="false"
+          class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-gutters accordion css-1gi6o5u-MuiButtonBase-root-MuiAccordionSummary-root"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiAccordionSummary-content MuiAccordionSummary-contentGutters css-c1i83b-MuiAccordionSummary-content"
+          >
+            <div
+              class="MuiBox-root css-mvjamn"
+            >
+              <div
+                class="txType MuiBox-root css-0"
+              >
+                <img
+                  alt="Send"
+                  height="16"
+                  src="/images/transactions/outgoing.svg"
+                  width="16"
+                />
+                <span
+                  class="txTypeText"
+                >
+                  Send
+                </span>
+              </div>
+              <div
+                class="MuiBox-root css-1rr4qq7"
+              >
+                <span
+                  aria-label="1000000000000"
+                  class="container"
+                  data-mui-internal-clone-element="true"
+                >
+                  <b>
+                    -
+                    1000000000000
+                     
+                  </b>
+                </span>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiAccordionSummary-expandIconWrapper css-yw020d-MuiAccordionSummary-expandIconWrapper"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-17ceore-MuiSvgIcon-root"
+              data-testid="ExpandMoreIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
+          style="min-height: 0px;"
+        >
+          <div
+            class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+          >
+            <div
+              class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+            >
+              <div
+                class="MuiAccordion-region"
+                role="region"
+              >
+                <div
+                  class="MuiAccordionDetails-root css-7wcoc8-MuiAccordionDetails-root"
+                >
+                  <div
+                    class="details"
+                  >
+                    <div
+                      class="MuiBox-root css-1821gv5"
+                    >
+                      <div
+                        class="MuiBox-root css-8v90jo"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1pqjor9-MuiTypography-root"
+                        >
+                          Send
+                           
+                          <b>
+                            <span
+                              aria-label="1000000000000"
+                              class="container"
+                              data-mui-internal-clone-element="true"
+                            >
+                              <b>
+                                1000000000000
+                                 
+                              </b>
+                            </span>
+                          </b>
+                           to:
+                        </p>
+                      </div>
+                      <div
+                        class="MuiBox-root css-7pf6at"
+                      >
+                        <div
+                          class="container"
+                        >
+                          <div
+                            class="avatarContainer"
+                            style="width: 40px; height: 40px;"
+                          >
+                            <div
+                              class="icon"
+                              style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjI2IDc1JSA0NCUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCg3MCA1NyUgNTYlKSIgZD0iTTAsMGgxdjFoLTF6TTcsMGgxdjFoLTF6TTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTEsMmgxdjFoLTF6TTYsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTEsM2gxdjFoLTF6TTYsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTEsNmgxdjFoLTF6TTYsNmgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDMzMSA4NiUgNDglKSIgZD0iTTAsM2gxdjFoLTF6TTcsM2gxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTIsN2gxdjFoLTF6TTUsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 40px; height: 40px;"
+                            />
+                          </div>
+                          <div
+                            class="MuiBox-root css-i6bazn"
+                          >
+                            <div
+                              class="MuiBox-root css-171onha"
+                              title="GnosisSafeProxy"
+                            >
+                              <div
+                                class="MuiBox-root css-1o4wo1x"
+                              >
+                                GnosisSafeProxy
+                              </div>
+                            </div>
+                            <div
+                              class="addressContainer"
+                            >
+                              <div
+                                class="MuiBox-root css-b5p5gz"
+                              >
+                                <span
+                                  aria-label="Copy to clipboard"
+                                  class=""
+                                  data-mui-internal-clone-element="true"
+                                  style="cursor: pointer;"
+                                >
+                                  <span>
+                                    0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6
+                                  </span>
+                                </span>
+                              </div>
+                              <span
+                                aria-label="Copy to clipboard"
+                                class=""
+                                data-mui-internal-clone-element="true"
+                                style="cursor: pointer;"
+                              >
+                                <button
+                                  aria-label="Copy to clipboard"
+                                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-nmr6e8-MuiButtonBase-root-MuiIconButton-root"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  <mock-icon
+                                    aria-hidden="true"
+                                    classname="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-j1da6x-MuiSvgIcon-root"
+                                    data-testid="copy-btn-icon"
+                                    focusable="false"
+                                  />
+                                  <span
+                                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                                  />
+                                </button>
+                              </span>
+                              <div
+                                class="MuiBox-root css-yjghm1"
+                              >
+                                <button
+                                  aria-label=""
+                                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1o2vr87-MuiButtonBase-root-MuiIconButton-root"
+                                  data-mui-internal-clone-element="true"
+                                  data-testid="explorer-btn"
+                                  href=""
+                                  rel="noreferrer"
+                                  tabindex="0"
+                                  target="_blank"
+                                  type="button"
+                                >
+                                  <mock-icon
+                                    aria-hidden="true"
+                                    classname="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-11dtfly-MuiSvgIcon-root"
+                                    focusable="false"
+                                  />
+                                  <span
+                                    class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                                  />
+                                </button>
+                              </div>
+                              <button
+                                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeSmall css-sl0yvu-MuiButtonBase-root-MuiIconButton-root"
+                                tabindex="0"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-1pay1n0-MuiSvgIcon-root"
+                                  data-testid="MoreHorizIcon"
+                                  focusable="false"
+                                  viewBox="0 0 24 24"
+                                >
+                                  <path
+                                    d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                                  />
+                                </svg>
+                                <span
+                                  class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                                />
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="gridRow"
+                    >
+                      <div
+                        class="title"
+                        data-testid="tx-row-title"
+                      >
+                        Created:
+                      </div>
+                      <div
+                        class="MuiTypography-root MuiTypography-body1 css-1pqjor9-MuiTypography-root"
+                        data-testid="tx-data-row"
+                      >
+                        9/20/2024, 10:20:15 AM
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+  </ul>
+</div>
+`;

--- a/src/components/tx/confirmation-views/BatchTransactions/index.tsx
+++ b/src/components/tx/confirmation-views/BatchTransactions/index.tsx
@@ -1,0 +1,10 @@
+import BatchTxList from '@/components/batch/BatchSidebar/BatchTxList'
+import { useDraftBatch } from '@/hooks/useDraftBatch'
+
+function BatchTransactions() {
+  const batchTxs = useDraftBatch()
+
+  return <BatchTxList txItems={batchTxs} />
+}
+
+export default BatchTransactions

--- a/src/components/tx/confirmation-views/BatchTransactions/mockData.ts
+++ b/src/components/tx/confirmation-views/BatchTransactions/mockData.ts
@@ -1,0 +1,121 @@
+import type { DraftBatchItem } from '@/store/batchSlice'
+
+export const mockedDarftBatch = [
+  {
+    id: '6283sw7pzyk',
+    timestamp: 1726820415651,
+    txDetails: {
+      safeAddress: '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6',
+      txId: 'multisig_0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6_0x876e728deafcc9ba46461cc63078a521f520b620b0a3c2e4b40a5f1f69358f6c',
+      executedAt: null,
+      txStatus: 'AWAITING_CONFIRMATIONS',
+      txInfo: {
+        type: 'Transfer',
+        humanDescription: null,
+        sender: {
+          value: '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6',
+          name: null,
+          logoUri: null,
+        },
+        recipient: {
+          value: '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6',
+          name: 'GnosisSafeProxy',
+          logoUri: null,
+        },
+        direction: 'OUTGOING',
+        transferInfo: {
+          type: 'NATIVE_COIN',
+          value: '1000000000000',
+        },
+      },
+      txData: {
+        hexData: null,
+        dataDecoded: null,
+        to: {
+          value: '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6',
+          name: 'GnosisSafeProxy',
+          logoUri: null,
+        },
+        value: '1000000000000',
+        operation: 0,
+        trustedDelegateCallTarget: null,
+        addressInfoIndex: null,
+      },
+      txHash: null,
+      detailedExecutionInfo: {
+        type: 'MULTISIG',
+        submittedAt: 1726820406700,
+        nonce: 45,
+        safeTxGas: '0',
+        baseGas: '0',
+        gasPrice: '0',
+        gasToken: '0x0000000000000000000000000000000000000000',
+        refundReceiver: {
+          value: '0x0000000000000000000000000000000000000000',
+          name: null,
+          logoUri: null,
+        },
+        safeTxHash: '0x876e728deafcc9ba46461cc63078a521f520b620b0a3c2e4b40a5f1f69358f6c',
+        executor: null,
+        signers: [
+          {
+            value: '0xDa5e9FA404881Ff36DDa97b41Da402dF6430EE6b',
+            name: null,
+            logoUri: null,
+          },
+          {
+            value: '0xEe91F585eA6ABc2822FaD082a095B46939059a31',
+            name: null,
+            logoUri: null,
+          },
+          {
+            value: '0x3819b800c67Be64029C1393c8b2e0d0d627dADE2',
+            name: null,
+            logoUri: null,
+          },
+          {
+            value: '0xd8BBcB76BC9AeA78972ED4773A5EB67B413f26A5',
+            name: null,
+            logoUri: null,
+          },
+          {
+            value: '0x21D62C6894741DE97944D7844ED44D7782C66ABC',
+            name: null,
+            logoUri: null,
+          },
+          {
+            value: '0xD33dD066fC8a0BC70269AC06B0ED98B00BFA3A0a',
+            name: null,
+            logoUri: null,
+          },
+          {
+            value: '0xC2e333cb4aFfD6067D1d46ff80A6e631EC7B5A17',
+            name: null,
+            logoUri: null,
+          },
+          {
+            value: '0xbc2BB26a6d821e69A38016f3858561a1D80d4182',
+            name: null,
+            logoUri: null,
+          },
+          {
+            value: '0x474e5Ded6b5D078163BFB8F6dBa355C3aA5478C8',
+            name: null,
+            logoUri: null,
+          },
+        ],
+        confirmationsRequired: 2,
+        confirmations: [],
+        rejectors: [],
+        gasTokenInfo: null,
+        trusted: false,
+        proposer: {
+          value: '0xDa5e9FA404881Ff36DDa97b41Da402dF6430EE6b',
+          name: null,
+          logoUri: null,
+        },
+      },
+      safeAppInfo: null,
+    },
+  },
+] as unknown as DraftBatchItem[]

--- a/src/components/tx/confirmation-views/utils.ts
+++ b/src/components/tx/confirmation-views/utils.ts
@@ -1,0 +1,10 @@
+import type { TransactionInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { SettingsInfoType, TransactionInfoType } from '@safe-global/safe-gateway-typescript-sdk'
+import { ConfirmBatchFlow } from '@/components/tx-flow/flows'
+
+export const isSettingsChangeView = (txInfo: TransactionInfo) => txInfo.type === TransactionInfoType.SETTINGS_CHANGE
+
+export const isConfirmBatchView = (txFlow?: JSX.Element) => txFlow?.type === ConfirmBatchFlow
+
+export const isChangeThresholdView = (txInfo: TransactionInfo) =>
+  txInfo.type === TransactionInfoType.SETTINGS_CHANGE && txInfo.settingsInfo?.type === SettingsInfoType.CHANGE_THRESHOLD


### PR DESCRIPTION
## What it solves

This PR is part of the unify confirmations screen refactor in the transactions flow (https://github.com/safe-global/safe-wallet-web/pull/4177). 

## How this PR fixes it
In this PR we're moving the `BatchList`  from `ConfirmBatch` component to be inside the `tx/confirmation-view/BatchTransactions` component. Please noticed we still have logic inside the `ConfirmBatch` component because the `SignOrExecuteForm/index` depends on the SafeTx in order to get the transactionDetails, and the place where we create the SafeTx for the Batch screen is inside the `ConfirmBatch` component.

## How to test it
1) Go to the top bar of the application and try to send a batch transaction
2) The confirm batch transaction screen should look the same as production app.

## Screenshots

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
