### PR TITLE
Analytics(stake): add tx type tracking

### DIFF
--- a/src/services/analytics/tx-tracking.ts
+++ b/src/services/analytics/tx-tracking.ts
@@ -8,6 +8,7 @@ import {
   isCustomTxInfo,
   isCancellationTxInfo,
   isSwapOrderTxInfo,
+  isAnyStakingTxInfo,
 } from '@/utils/transaction-guards'
 
 export const getTransactionTrackingType = (details: TransactionDetails | undefined): string => {
@@ -26,6 +27,10 @@ export const getTransactionTrackingType = (details: TransactionDetails | undefin
 
   if (isSwapOrderTxInfo(txInfo)) {
     return TX_TYPES.native_swap
+  }
+
+  if (isAnyStakingTxInfo(txInfo)) {
+    return txInfo.type
   }
 
   if (isSettingsChangeTxInfo(txInfo)) {

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -38,6 +38,8 @@ import type {
   StakingTxDepositInfo,
   StakingTxWithdrawInfo,
   NativeStakingWithdrawConfirmationView,
+  NativeStakingValidatorsExitConfirmationView,
+  StakingTxInfo,
 } from '@safe-global/safe-gateway-typescript-sdk'
 import {
   ConfirmationViewTypes,
@@ -54,7 +56,6 @@ import { sameAddress } from '@/utils/addresses'
 import type { NamedAddress } from '@/components/new-safe/create/types'
 import type { RecoveryQueueItem } from '@/features/recovery/services/recovery-state'
 import { ethers } from 'ethers'
-import type { NativeStakingValidatorsExitConfirmationView } from '@safe-global/safe-gateway-typescript-sdk/dist/types/decoded-data'
 
 export const isTxQueued = (value: TransactionStatus): boolean => {
   return [TransactionStatus.AWAITING_CONFIRMATIONS, TransactionStatus.AWAITING_EXECUTION].includes(value)
@@ -136,6 +137,10 @@ export const isStakingTxExitInfo = (value: TransactionInfo): value is StakingTxE
 
 export const isStakingTxWithdrawInfo = (value: TransactionInfo): value is StakingTxWithdrawInfo => {
   return value.type === TransactionInfoType.NATIVE_STAKING_WITHDRAW
+}
+
+export const isAnyStakingTxInfo = (value: TransactionInfo): value is StakingTxInfo => {
+  return isStakingTxDepositInfo(value) || isStakingTxExitInfo(value) || isStakingTxWithdrawInfo(value)
 }
 
 export const isTwapConfirmationViewOrder = (


### PR DESCRIPTION
## What it solves
With the changes in this pr we will be able to distinguish between deposit, exit and withdraw tx initiated through the stake widget.

## How this PR fixes it
This PR introduces logic to differentiate between various staking transaction types, such as deposit, exit, and withdraw, by adding the isAnyStakingTxInfo utility. The getTransactionTrackingType function is updated to recognize these transaction types, ensuring that the correct transaction type is logged when a staking-related transaction is processed.

## How to test it
Submit deposit, exit and withdraw txs. In the browser terminal you should see the GTM tag sent.

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
