### PR TITLE
fix(Staking): display correct value for withdrawal

### DIFF
--- a/src/features/stake/components/StakingConfirmationTx/Withdraw.tsx
+++ b/src/features/stake/components/StakingConfirmationTx/Withdraw.tsx
@@ -16,7 +16,7 @@ const StakingConfirmationTxWithdraw = ({ order }: StakingOrderConfirmationViewPr
       <FieldsGrid title="Receive">
         {' '}
         <TokenAmount
-          value={order.rewards}
+          value={order.value}
           tokenSymbol={order.tokenInfo.symbol}
           decimals={order.tokenInfo.decimals}
           logoUri={order.tokenInfo.logoUri}


### PR DESCRIPTION
## What it solves
Display correct value to withdraw. The Kiln API was not returning the correct value for the amount the user was going to withdraw. They've correct this and the fix was implemented on CGW, so had to update our UI as well.

Resolves #

## How this PR fixes it
The rewards prop was removed from the cgw endpoint. `value` now returns the correct net(minus any fees) reward

## How to test it
Withdraw a reward(claim) -> you should see the same value as displayed in the kiln widget.

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
