### PR TITLE
fix(Multichain): do not disable currently selected network in the network selector

### DIFF
--- a/src/components/common/NetworkSelector/NetworkMultiSelector.tsx
+++ b/src/components/common/NetworkSelector/NetworkMultiSelector.tsx
@@ -67,8 +67,9 @@ const NetworkMultiSelector = ({
       if (isAdvancedFlow) return optionNetwork.chainId != firstSelectedNetwork.chainId
 
       // Check required feature toggles
+      const optionIsSelectedNetwork = firstSelectedNetwork.chainId === optionNetwork.chainId
       if (!hasMultiChainCreationFeatures(optionNetwork) || !hasMultiChainCreationFeatures(firstSelectedNetwork)) {
-        return true
+        return !optionIsSelectedNetwork
       }
 
       // Check if required deployments are available
@@ -88,7 +89,7 @@ const NetworkMultiSelector = ({
       )
 
       // Only 1.4.1 safes with canonical deployment addresses can be deployed as part of a multichain group
-      if (!selectedHasCanonicalSingletonDeployment) return firstSelectedNetwork.chainId !== optionNetwork.chainId
+      if (!selectedHasCanonicalSingletonDeployment) return !optionIsSelectedNetwork
       return !optionHasCanonicalSingletonDeployment
     },
     [isAdvancedFlow, selectedNetworks],


### PR DESCRIPTION
## What it solves
In the network multi select for safe creation, if the selected network does not have the multichain feature enabled, then the network is disabled after selection, so you cannot deselect it.

## How this PR fixes it
If the feature is not enabled on the currently selected network, all other networks are disabled, but the currently selected one is not.

## How to test it
- In the safe creation flow, use the network selector to select a chain without multichain enabled (eg. Mantle, Holesky on dev)
- The selected option should not become disabled.

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/7b7d82fd-7615-491c-a0d9-84ae68ce0359)

After:
![image](https://github.com/user-attachments/assets/82625ef1-69f9-4a88-b077-8fce2ac17219)


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
