### PR TITLE
fix(Multichain): memoize data for InconsistentSignerSetupWarning

### DIFF
--- a/src/features/multichain/components/SignerSetupWarning/InconsistentSignerSetupWarning.tsx
+++ b/src/features/multichain/components/SignerSetupWarning/InconsistentSignerSetupWarning.tsx
@@ -47,7 +47,7 @@ export const InconsistentSignerSetupWarning = () => {
   const [safeOverviews] = useSafeOverviews(multiChainGroupSafes)
 
   const safeSetups = useMemo(
-    () => getSafeSetups(multiChainGroupSafes ?? [], safeOverviews ?? [], undeployedSafes),
+    () => getSafeSetups(multiChainGroupSafes, safeOverviews ?? [], undeployedSafes),
     [multiChainGroupSafes, safeOverviews, undeployedSafes],
   )
   const deviatingSetups = getDeviatingSetups(safeSetups, currentChain?.chainId)

--- a/src/features/multichain/components/SignerSetupWarning/InconsistentSignerSetupWarning.tsx
+++ b/src/features/multichain/components/SignerSetupWarning/InconsistentSignerSetupWarning.tsx
@@ -40,12 +40,15 @@ export const InconsistentSignerSetupWarning = () => {
   const undeployedSafes = useAppSelector(selectUndeployedSafes)
   const { allMultiChainSafes } = useAllSafesGrouped()
 
-  const multiChainGroup = allMultiChainSafes?.find((account) => sameAddress(safeAddress, account.safes[0].address))
-  const [safeOverviews] = useSafeOverviews(multiChainGroup?.safes ?? [])
+  const multiChainGroupSafes = useMemo(
+    () => allMultiChainSafes?.find((account) => sameAddress(safeAddress, account.safes[0].address))?.safes ?? [],
+    [allMultiChainSafes, safeAddress],
+  )
+  const [safeOverviews] = useSafeOverviews(multiChainGroupSafes)
 
   const safeSetups = useMemo(
-    () => getSafeSetups(multiChainGroup?.safes ?? [], safeOverviews ?? [], undeployedSafes),
-    [multiChainGroup?.safes, safeOverviews, undeployedSafes],
+    () => getSafeSetups(multiChainGroupSafes ?? [], safeOverviews ?? [], undeployedSafes),
+    [multiChainGroupSafes, safeOverviews, undeployedSafes],
   )
   const deviatingSetups = getDeviatingSetups(safeSetups, currentChain?.chainId)
   const deviatingChainIds = deviatingSetups.map((setup) => setup?.chainId)


### PR DESCRIPTION
## What it solves
Fixes issue that caused the Safe overviews to be fetched on every render on the dashboard.

## How to test it
- Open a multichain Safe and go to the dashboard
- Observe only one request to the safe overview endpoint

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
