### PR TITLE
fix(Multichain): add more unsupported Safe cases

### DIFF
--- a/src/features/multichain/hooks/__tests__/useCompatibleNetworks.test.ts
+++ b/src/features/multichain/hooks/__tests__/useCompatibleNetworks.test.ts
@@ -2,7 +2,6 @@ import { renderHook } from '@/tests/test-utils'
 import { useCompatibleNetworks } from '../useCompatibleNetworks'
 import { type ReplayedSafeProps } from '@/store/slices'
 import { faker } from '@faker-js/faker'
-import { Safe__factory } from '@/types/contracts'
 import { EMPTY_DATA, ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 import { ECOSYSTEM_ID_ADDRESS } from '@/config/constants'
 import { chainBuilder } from '@/tests/builders/chains'
@@ -10,10 +9,9 @@ import {
   getSafeSingletonDeployments,
   getSafeL2SingletonDeployments,
   getProxyFactoryDeployments,
+  getCompatibilityFallbackHandlerDeployments,
 } from '@safe-global/safe-deployments'
 import * as useChains from '@/hooks/useChains'
-
-const safeInterface = Safe__factory.createInterface()
 
 const L1_111_MASTERCOPY_DEPLOYMENTS = getSafeSingletonDeployments({ version: '1.1.1' })?.deployments
 const L1_130_MASTERCOPY_DEPLOYMENTS = getSafeSingletonDeployments({ version: '1.3.0' })?.deployments
@@ -25,6 +23,9 @@ const L2_141_MASTERCOPY_DEPLOYMENTS = getSafeL2SingletonDeployments({ version: '
 const PROXY_FACTORY_111_DEPLOYMENTS = getProxyFactoryDeployments({ version: '1.1.1' })?.deployments
 const PROXY_FACTORY_130_DEPLOYMENTS = getProxyFactoryDeployments({ version: '1.3.0' })?.deployments
 const PROXY_FACTORY_141_DEPLOYMENTS = getProxyFactoryDeployments({ version: '1.4.1' })?.deployments
+
+const FALLBACK_HANDLER_130_DEPLOYMENTS = getCompatibilityFallbackHandlerDeployments({ version: '1.3.0' })?.deployments
+const FALLBACK_HANDLER_141_DEPLOYMENTS = getCompatibilityFallbackHandlerDeployments({ version: '1.4.1' })?.deployments
 
 describe('useCompatibleNetworks', () => {
   beforeAll(() => {
@@ -44,7 +45,7 @@ describe('useCompatibleNetworks', () => {
     expect(result.current).toHaveLength(0)
   })
 
-  it('should set available to false for unknown masterCopies', () => {
+  it('should set available to false for unknown contracts', () => {
     const callData = {
       owners: [faker.finance.ethereumAddress()],
       threshold: 1,
@@ -73,7 +74,7 @@ describe('useCompatibleNetworks', () => {
       threshold: 1,
       to: ZERO_ADDRESS,
       data: EMPTY_DATA,
-      fallbackHandler: faker.finance.ethereumAddress(),
+      fallbackHandler: FALLBACK_HANDLER_141_DEPLOYMENTS?.canonical?.address!,
       paymentToken: ZERO_ADDRESS,
       payment: 0,
       paymentReceiver: ECOSYSTEM_ID_ADDRESS,
@@ -107,13 +108,13 @@ describe('useCompatibleNetworks', () => {
     }
   })
 
-  it('should mark already deployed chains as not available', () => {
+  it('should mark compatible chains as available', () => {
     const callData = {
       owners: [faker.finance.ethereumAddress()],
       threshold: 1,
       to: ZERO_ADDRESS,
       data: EMPTY_DATA,
-      fallbackHandler: faker.finance.ethereumAddress(),
+      fallbackHandler: ZERO_ADDRESS,
       paymentToken: ZERO_ADDRESS,
       payment: 0,
       paymentReceiver: ECOSYSTEM_ID_ADDRESS,
@@ -125,7 +126,7 @@ describe('useCompatibleNetworks', () => {
         factoryAddress: PROXY_FACTORY_130_DEPLOYMENTS?.canonical?.address!,
         masterCopy: L1_130_MASTERCOPY_DEPLOYMENTS?.canonical?.address!,
         saltNonce: '0',
-        safeAccountConfig: callData,
+        safeAccountConfig: { ...callData, fallbackHandler: FALLBACK_HANDLER_130_DEPLOYMENTS?.canonical?.address! },
         safeVersion: '1.3.0',
       }
       const { result } = renderHook(() => useCompatibleNetworks(creationData))
@@ -140,7 +141,7 @@ describe('useCompatibleNetworks', () => {
         factoryAddress: PROXY_FACTORY_130_DEPLOYMENTS?.canonical?.address!,
         masterCopy: L2_130_MASTERCOPY_DEPLOYMENTS?.canonical?.address!,
         saltNonce: '0',
-        safeAccountConfig: callData,
+        safeAccountConfig: { ...callData, fallbackHandler: FALLBACK_HANDLER_130_DEPLOYMENTS?.canonical?.address! },
         safeVersion: '1.3.0',
       }
       const { result } = renderHook(() => useCompatibleNetworks(creationData))
@@ -155,7 +156,7 @@ describe('useCompatibleNetworks', () => {
         factoryAddress: PROXY_FACTORY_130_DEPLOYMENTS?.eip155?.address!,
         masterCopy: L1_130_MASTERCOPY_DEPLOYMENTS?.eip155?.address!,
         saltNonce: '0',
-        safeAccountConfig: callData,
+        safeAccountConfig: { ...callData, fallbackHandler: FALLBACK_HANDLER_130_DEPLOYMENTS?.eip155?.address! },
         safeVersion: '1.3.0',
       }
       const { result } = renderHook(() => useCompatibleNetworks(creationData))
@@ -170,7 +171,7 @@ describe('useCompatibleNetworks', () => {
         factoryAddress: PROXY_FACTORY_130_DEPLOYMENTS?.eip155?.address!,
         masterCopy: L2_130_MASTERCOPY_DEPLOYMENTS?.eip155?.address!,
         saltNonce: '0',
-        safeAccountConfig: callData,
+        safeAccountConfig: { ...callData, fallbackHandler: FALLBACK_HANDLER_130_DEPLOYMENTS?.eip155?.address! },
         safeVersion: '1.3.0',
       }
       const { result } = renderHook(() => useCompatibleNetworks(creationData))

--- a/src/features/multichain/hooks/useCompatibleNetworks.ts
+++ b/src/features/multichain/hooks/useCompatibleNetworks.ts
@@ -1,9 +1,9 @@
 import { type ReplayedSafeProps } from '@/features/counterfactual/store/undeployedSafesSlice'
 import useChains from '@/hooks/useChains'
-import { sameAddress } from '@/utils/addresses'
+import { hasMatchingDeployment } from '@/services/contracts/deployments'
 import { type SafeVersion } from '@safe-global/safe-core-sdk-types'
 import {
-  type SingletonDeploymentV2,
+  getCompatibilityFallbackHandlerDeployments,
   getProxyFactoryDeployments,
   getSafeL2SingletonDeployments,
   getSafeSingletonDeployments,
@@ -11,16 +11,6 @@ import {
 import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 
 const SUPPORTED_VERSIONS: SafeVersion[] = ['1.4.1', '1.3.0']
-
-const hasDeployment = (chainId: string, contractAddress: string, deployments: SingletonDeploymentV2[]) => {
-  return deployments.some((deployment) => {
-    // Check that deployment contains the contract Address on given chain
-    const networkDeployments = deployment.networkAddresses[chainId]
-    return Array.isArray(networkDeployments)
-      ? networkDeployments.some((networkDeployment) => sameAddress(networkDeployment, contractAddress))
-      : sameAddress(networkDeployments, contractAddress)
-  })
-}
 
 /**
  * Returns all chains where the creations's masterCopy and factory are deployed.
@@ -35,27 +25,25 @@ export const useCompatibleNetworks = (
     return []
   }
 
-  const { masterCopy, factoryAddress } = creation
+  const { masterCopy, factoryAddress, safeAccountConfig } = creation
 
-  const allL1SingletonDeployments = SUPPORTED_VERSIONS.map((version) =>
-    getSafeSingletonDeployments({ version }),
-  ).filter(Boolean) as SingletonDeploymentV2[]
+  const { fallbackHandler } = safeAccountConfig
 
-  const allL2SingletonDeployments = SUPPORTED_VERSIONS.map((version) =>
-    getSafeL2SingletonDeployments({ version }),
-  ).filter(Boolean) as SingletonDeploymentV2[]
-
-  const allProxyFactoryDeployments = SUPPORTED_VERSIONS.map((version) =>
-    getProxyFactoryDeployments({ version }),
-  ).filter(Boolean) as SingletonDeploymentV2[]
+  console.log('Fallbackhandler', fallbackHandler)
 
   return configs.map((config) => {
     return {
       ...config,
       available:
-        (hasDeployment(config.chainId, masterCopy, allL1SingletonDeployments) ||
-          hasDeployment(config.chainId, masterCopy, allL2SingletonDeployments)) &&
-        hasDeployment(config.chainId, factoryAddress, allProxyFactoryDeployments),
+        (hasMatchingDeployment(getSafeSingletonDeployments, masterCopy, config.chainId, SUPPORTED_VERSIONS) ||
+          hasMatchingDeployment(getSafeL2SingletonDeployments, masterCopy, config.chainId, SUPPORTED_VERSIONS)) &&
+        hasMatchingDeployment(getProxyFactoryDeployments, factoryAddress, config.chainId, SUPPORTED_VERSIONS) &&
+        hasMatchingDeployment(
+          getCompatibilityFallbackHandlerDeployments,
+          fallbackHandler,
+          config.chainId,
+          SUPPORTED_VERSIONS,
+        ),
     }
   })
 }

--- a/src/features/multichain/hooks/useCompatibleNetworks.ts
+++ b/src/features/multichain/hooks/useCompatibleNetworks.ts
@@ -29,8 +29,6 @@ export const useCompatibleNetworks = (
 
   const { fallbackHandler } = safeAccountConfig
 
-  console.log('Fallbackhandler', fallbackHandler)
-
   return configs.map((config) => {
     return {
       ...config,

--- a/src/features/multichain/hooks/useSafeCreationData.ts
+++ b/src/features/multichain/hooks/useSafeCreationData.ts
@@ -10,6 +10,8 @@ import { determineMasterCopyVersion, isPredictedSafeProps } from '@/features/cou
 import { logError } from '@/services/exceptions'
 import ErrorCodes from '@/services/exceptions/ErrorCodes'
 import { asError } from '@/services/exceptions/utils'
+import semverSatisfies from 'semver/functions/satisfies'
+import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 
 export const SAFE_CREATION_DATA_ERRORS = {
   TX_NOT_FOUND: 'The Safe creation transaction could not be found. Please retry later.',
@@ -17,6 +19,9 @@ export const SAFE_CREATION_DATA_ERRORS = {
   UNSUPPORTED_SAFE_CREATION: 'The method this Safe was created with is not supported.',
   NO_PROVIDER: 'The RPC provider for the origin network is not available.',
   LEGACY_COUNTERFATUAL: 'This undeployed Safe cannot be replayed. Please activate the Safe first.',
+  PAYMENT_SAFE: 'The Safe creation used reimbursement. Adding networks to such Safes is not supported.',
+  UNSUPPORTED_IMPLEMENTATION:
+    'The Safe was created using an unsupported or outdated implementation. Adding networks to this Safe is not possible.',
 }
 
 export const decodeSetupData = (setupData: string): ReplayedSafeProps['safeAccountConfig'] => {
@@ -47,6 +52,12 @@ const getUndeployedSafeCreationData = async (undeployedSafe: UndeployedSafe): Pr
 const proxyFactoryInterface = Safe_proxy_factory__factory.createInterface()
 const createProxySelector = proxyFactoryInterface.getFunction('createProxyWithNonce').selector
 
+/**
+ * Loads the creation data from the CGW or infers it from an undeployed Safe.
+ *
+ * Throws errors for the reasons in {@link SAFE_CREATION_DATA_ERRORS}.
+ * Checking the cheap cases not requiring RPC calls first.
+ */
 const getCreationDataForChain = async (
   chain: ChainInfo,
   undeployedSafe: UndeployedSafe,
@@ -67,6 +78,19 @@ const getCreationDataForChain = async (
 
   if (!creation || !creation.masterCopy || !creation.setupData) {
     throw new Error(SAFE_CREATION_DATA_ERRORS.NO_CREATION_DATA)
+  }
+
+  // Safes that were deployed with an unknown mastercopy or < 1.3.0 are not supported.
+  const safeVersion = determineMasterCopyVersion(creation.masterCopy, chain.chainId)
+  if (!safeVersion || semverSatisfies(safeVersion, '<1.3.0')) {
+    throw new Error(SAFE_CREATION_DATA_ERRORS.UNSUPPORTED_IMPLEMENTATION)
+  }
+
+  const safeAccountConfig = decodeSetupData(creation.setupData)
+
+  // Safes that used the reimbursement logic are not supported
+  if ((safeAccountConfig.payment && safeAccountConfig.payment > 0) || safeAccountConfig.paymentToken !== ZERO_ADDRESS) {
+    throw new Error(SAFE_CREATION_DATA_ERRORS.PAYMENT_SAFE)
   }
 
   // We need to create a readOnly provider of the deployed chain
@@ -101,12 +125,6 @@ const getCreationDataForChain = async (
   if (!txMatches) {
     // We found the wrong tx. This tx seems to deploy multiple Safes at once. This is not supported yet.
     throw new Error(SAFE_CREATION_DATA_ERRORS.UNSUPPORTED_SAFE_CREATION)
-  }
-  const safeAccountConfig = decodeSetupData(creation.setupData)
-  const safeVersion = determineMasterCopyVersion(creation.masterCopy, chain.chainId)
-
-  if (!safeVersion) {
-    throw new Error('Could not determine Safe version of used master copy')
   }
 
   return {


### PR DESCRIPTION
## What it solves
Disables adding networks for:
- Safes using reimbursement on creation
- Safes with unknown fallback handler

## How this PR fixes it

## How to test it
- Try to add a network to a Safe that used reimbursements (`payment > 0`)
- Try to add a network to a Safe with a custom fallback handler

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
