### PR TITLE
[Multichain] fix: Pass options for safe creation [SW-199]

### DIFF
--- a/src/components/new-safe/create/logic/index.ts
+++ b/src/components/new-safe/create/logic/index.ts
@@ -53,15 +53,16 @@ export const createNewSafe = async (
   undeployedSafeProps: UndeployedSafeProps,
   safeVersion: SafeVersion,
   chain: ChainInfo,
+  options: DeploySafeProps['options'],
   callback: (txHash: string) => void,
   isL1SafeSingleton?: boolean,
 ): Promise<void> => {
   const safeFactory = await getSafeFactory(provider, safeVersion, isL1SafeSingleton)
 
   if (isPredictedSafeProps(undeployedSafeProps)) {
-    await safeFactory.deploySafe({ ...undeployedSafeProps, callback })
+    await safeFactory.deploySafe({ ...undeployedSafeProps, options, callback })
   } else {
-    const txResponse = await activateReplayedSafe(chain, undeployedSafeProps, createWeb3(provider))
+    const txResponse = await activateReplayedSafe(chain, undeployedSafeProps, createWeb3(provider), options)
     callback(txResponse.hash)
   }
 }

--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -139,7 +139,6 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
   const [isCreating, setIsCreating] = useState<boolean>(false)
   const [submitError, setSubmitError] = useState<string>()
   const isCounterfactualEnabled = useHasFeature(FEATURES.COUNTERFACTUAL)
-  const isMultiChainDeploymentEnabled = useHasFeature(FEATURES.MULTI_CHAIN_SAFE_CREATION)
   const isEIP1559 = chain && hasFeature(chain, FEATURES.EIP1559)
 
   const ownerAddresses = useMemo(() => data.owners.map((owner) => owner.address), [data.owners])
@@ -281,6 +280,7 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
           props,
           data.safeVersion,
           chain,
+          options,
           (txHash) => {
             onSubmitCallback(undefined, txHash)
           },

--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -165,11 +165,17 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
     [chain, data.owners, data.safeVersion, data.threshold],
   )
 
+  const safePropsForGasEstimation = useMemo(() => {
+    return newSafeProps
+      ? {
+          ...newSafeProps,
+          saltNonce: Date.now().toString(),
+        }
+      : undefined
+  }, [newSafeProps])
+
   // We estimate with a random nonce as we'll just slightly overestimates like this
-  const { gasLimit } = useEstimateSafeCreationGas(
-    newSafeProps ? { ...newSafeProps, saltNonce: Date.now().toString() } : undefined,
-    data.safeVersion,
-  )
+  const { gasLimit } = useEstimateSafeCreationGas(safePropsForGasEstimation, data.safeVersion)
 
   const maxFeePerGas = gasPrice?.maxFeePerGas
   const maxPriorityFeePerGas = gasPrice?.maxPriorityFeePerGas

--- a/src/features/counterfactual/ActivateAccountFlow.tsx
+++ b/src/features/counterfactual/ActivateAccountFlow.tsx
@@ -94,8 +94,7 @@ const ActivateAccountFlow = () => {
 
   if (!undeployedSafe || !undeployedSafeSetup) return null
 
-  const { owners, threshold } = undeployedSafeSetup
-  const { saltNonce, safeVersion } = undeployedSafeSetup
+  const { owners, threshold, safeVersion } = undeployedSafeSetup
 
   const onSubmit = (txHash?: string) => {
     trackEvent({ ...TX_EVENTS.CREATE, label: TX_TYPES.activate_without_tx })
@@ -128,6 +127,7 @@ const ActivateAccountFlow = () => {
           undeployedSafe.props,
           safeVersion ?? getLatestSafeVersion(chain),
           chain,
+          options,
           onSubmit,
           isMultichainSafe ? true : undefined,
         )

--- a/src/features/counterfactual/utils.ts
+++ b/src/features/counterfactual/utils.ts
@@ -435,10 +435,16 @@ export const extractCounterfactualSafeSetup = (
   }
 }
 
-export const activateReplayedSafe = async (chain: ChainInfo, props: ReplayedSafeProps, provider: BrowserProvider) => {
-  const data = await encodeSafeCreationTx(props, chain)
+export const activateReplayedSafe = async (
+  chain: ChainInfo,
+  props: ReplayedSafeProps,
+  provider: BrowserProvider,
+  options: DeploySafeProps['options'],
+) => {
+  const data = encodeSafeCreationTx(props, chain)
 
   return (await provider.getSigner()).sendTransaction({
+    ...options,
     to: props.factoryAddress,
     data,
     value: '0',


### PR DESCRIPTION
## What it solves

Resolves SW-199

## How this PR fixes it

- Passes `options` to `createNewSafe`
- Adds the `saltNonce` to `newSafeProps` to avoid spreading which causes a lot of requests
- Removes unused code

## How to test it

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
