### PR TITLE
fix(Multichain): overview of non multichain Safe

### DIFF
--- a/src/components/welcome/MyAccounts/useSafeOverviews.ts
+++ b/src/components/welcome/MyAccounts/useSafeOverviews.ts
@@ -26,6 +26,9 @@ function useSafeOverviews(safes: Array<SafeParams>): AsyncResult<SafeOverview[]>
   const safesIds = useMemo(() => safes.filter(validateSafeParams).map(makeSafeId), [safes])
 
   const [data, error, isLoading] = useAsync(async () => {
+    if (safesIds.length === 0) {
+      return []
+    }
     return await getSafeOverviews(safesIds, {
       trusted: true,
       exclude_spam: excludeSpam,


### PR DESCRIPTION
## What it solves
Does not fetch safe overview for empty list of Safes.

## How to test it
Open a non-multichain Safe's dashboard. There should be no attempt to load the Safe overview

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
