### PR TITLE
Fix(Multichain): Keep focus within text input when typing name in replay modal [SW-205]

### DIFF
--- a/src/components/common/NameInput/index.tsx
+++ b/src/components/common/NameInput/index.tsx
@@ -27,6 +27,7 @@ const NameInput = ({
       fullWidth
       required={required}
       className={inputCss.input}
+      onKeyDown={(e) => e.stopPropagation()}
       {...register(name, { maxLength: 50, required })}
     />
   )


### PR DESCRIPTION
## What it solves
When typing some letters in the name input within the replay safe modal, the focus is moved away from the input.
Related: https://github.com/mui/material-ui/issues/19116

## How this PR fixes it
Stops keyboard events in the text input.

## How to test it
- Open a multichain safe.
- In the network selector, open the modal to replay the safe on another chain
- In the text input for setting the name, highlight the existing text and start typing. No matter what letter you start with, it should type as expected. (problematic letters were s, e, and p)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
