### PR TITLE
fix: click in sidebar was not triggering GTM event

### DIFF
--- a/src/components/sidebar/SidebarNavigation/index.tsx
+++ b/src/components/sidebar/SidebarNavigation/index.tsx
@@ -19,12 +19,18 @@ import { isRouteEnabled } from '@/utils/chains'
 import { trackEvent } from '@/services/analytics'
 import { SWAP_EVENTS, SWAP_LABELS } from '@/services/analytics/events/swaps'
 import { GeoblockingContext } from '@/components/common/GeoblockingProvider'
+import { STAKE_EVENTS, STAKE_LABELS } from '@/services/analytics/events/stake'
 
 const getSubdirectory = (pathname: string): string => {
   return pathname.split('/')[1]
 }
 
 const geoBlockedRoutes = [AppRoutes.swap, AppRoutes.stake]
+
+const customSidebarEvents: { [key: string]: { event: any; label: string } } = {
+  [AppRoutes.swap]: { event: SWAP_EVENTS.OPEN_SWAPS, label: SWAP_LABELS.sidebar },
+  [AppRoutes.stake]: { event: STAKE_EVENTS.OPEN_STAKE, label: STAKE_LABELS.sidebar },
+}
 
 const Navigation = (): ReactElement => {
   const chain = useCurrentChain()
@@ -60,8 +66,9 @@ const Navigation = (): ReactElement => {
   }
 
   const handleNavigationClick = (href: string) => {
-    if (href === AppRoutes.swap) {
-      trackEvent({ ...SWAP_EVENTS.OPEN_SWAPS, label: SWAP_LABELS.sidebar })
+    const eventInfo = customSidebarEvents[href]
+    if (eventInfo) {
+      trackEvent({ ...eventInfo.event, label: eventInfo.label })
     }
   }
 


### PR DESCRIPTION
## What it solves
Tracks a click on the stake route.

## How this PR fixes it
I had to refactor the code a bit to make it easier to add those custom track events.

- Defined a new object customSidebarEvents to handle events and labels for both swap and stake routes.
- Refactored the handleNavigationClick function to dynamically track events for both swap and stake routes by using the new customSidebarEvents mapping.

## How to test it
1. Navigate to the sidebar and click on the swap and stake routes.
2. Verify that the correct events (OPEN_SWAPS for swap, OPEN_STAKE for stake) are tracked and logged with appropriate labels.


## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
