### PR TITLE
Chore: pull_request_target for tests action

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,9 +1,8 @@
 name: Unit tests
 on:
-  pull_request:
-
-  push:
+  pull_request_target:
     branches:
+      - dev
       - main
 
 concurrency:


### PR DESCRIPTION
## What it solves

According to the [docs](https://github.com/ArtiomTr/jest-coverage-report-action?tab=readme-ov-file#forks-with-no-write-permission), the jest action will only work on external forks with `pull_request_target`.