### PR TITLE
[Multichain] fix: Add loading spinner to add new network form when submitting [SW-173]

### DIFF
--- a/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
+++ b/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
@@ -3,7 +3,7 @@ import NameInput from '@/components/common/NameInput'
 import NetworkInput from '@/components/common/NetworkInput'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import { OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
-import { Box, Button, CircularProgress, DialogActions, DialogContent, Divider, Stack, Typography } from '@mui/material'
+import { Box, Button, CircularProgress, DialogActions, DialogContent, Stack, Typography } from '@mui/material'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useSafeCreationData } from '../../hooks/useSafeCreationData'
 import { replayCounterfactualSafeDeployment } from '@/features/counterfactual/utils'
@@ -170,8 +170,7 @@ const ReplaySafeDialog = ({
             </Stack>
           </FormProvider>
         </DialogContent>
-        <Divider />
-        <DialogActions sx={{ m: 2 }}>
+        <DialogActions>
           {isUnsupportedSafeCreationVersion ? (
             <Box display="flex" width="100%" alignItems="center" justifyContent="space-between">
               <ExternalLink sx={{ flexGrow: 1 }} href="https://safe.global">
@@ -187,7 +186,7 @@ const ReplaySafeDialog = ({
                 Cancel
               </Button>
               <Button type="submit" variant="contained" disabled={submitDisabled}>
-                Add network
+                {isSubmitting ? <CircularProgress size={20} /> : 'Add network'}
               </Button>
             </>
           )}


### PR DESCRIPTION
## What it solves

Resolves [SW-173](https://www.notion.so/safe-global/Close-networks-selector-in-the-header-after-choosing-network-8300245b7058465ea6de4a9e9171f094)

## How this PR fixes it

- Adds a loading spinner to the new network form
- Removes double divider

## How to test it

1. Open a safe
2. Press add another network and choose a network
3. Press submit and observe the button being disabled and a loading spinner appearing

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
