### PR TITLE
[Multichain] fix: Display current chain network logo in success screen as a fallback [SW-224]

### DIFF
--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -212,7 +212,7 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
       const safeAddress = await predictAddressBasedOnReplayData(replayedSafeWithNonce, createWeb3(wallet.provider))
 
       for (const network of data.networks) {
-        createSafe(network, replayedSafeWithNonce, safeAddress)
+        await createSafe(network, replayedSafeWithNonce, safeAddress)
       }
 
       gtmSetChainId(chain.chainId)

--- a/src/features/counterfactual/CounterfactualSuccessScreen.tsx
+++ b/src/features/counterfactual/CounterfactualSuccessScreen.tsx
@@ -12,8 +12,8 @@ import useAllAddressBooks from '@/hooks/useAllAddressBooks'
 const CounterfactualSuccessScreen = () => {
   const [open, setOpen] = useState<boolean>(false)
   const [safeAddress, setSafeAddress] = useState<string>()
-  const [networks, setNetworks] = useState<ChainInfo[]>([])
   const chain = useCurrentChain()
+  const [networks, setNetworks] = useState<ChainInfo[]>([])
   const addressBooks = useAllAddressBooks()
   const safeName = safeAddress && chain ? addressBooks?.[chain.chainId]?.[safeAddress] : ''
   const isCFCreation = !!networks.length
@@ -84,7 +84,7 @@ const CounterfactualSuccessScreen = () => {
 
         {safeAddress && (
           <Box p={2} bgcolor="background.main" borderRadius={1} fontSize={14}>
-            <NetworkLogosList networks={networks} />
+            <NetworkLogosList networks={networks.length > 0 ? networks : chain ? [chain] : []} />
             <Typography variant="h5" mt={2}>
               {safeName}
             </Typography>


### PR DESCRIPTION
## What it solves

Resolves [SW-224](https://www.notion.so/safe-global/Network-logo-is-missing-after-safe-activation-10b8180fe57380daa4a9efb8c81f39da)

## How this PR fixes it

- Falls back to the current chain for the safe creation success screen in case there are none available through the dispatched event
- Awaits safe creation before showing the success screen

## How to test it

1. Go to safe creation and submit a new counterfactual safe
2. Observe the success screen appears only after navigating to the dashboard
3. Reload the page and activate the safe
4. Observe the current network logo is visible in the success screen

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
