### PR TITLE
Feat(Multichain): update text on safe creation review step [SW-225]

### DIFF
--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -439,7 +439,7 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
             size="stretched"
             disabled={isDisabled}
           >
-            {isCreating ? <CircularProgress size={18} /> : 'Create'}
+            {isCreating ? <CircularProgress size={18} /> : 'Create Account'}
           </Button>
         </Box>
       </Box>

--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -118,7 +118,7 @@ export const SafeSetupOverview = ({
         name="Threshold"
         value={
           <Typography>
-            {threshold} out of {owners.length} signer(s)
+            {threshold} out of {owners.length} {owners.length > 1 ? 'signers' : 'signer'}
           </Typography>
         }
       />

--- a/src/features/counterfactual/PayNowPayLater.tsx
+++ b/src/features/counterfactual/PayNowPayLater.tsx
@@ -43,23 +43,30 @@ const PayNowPayLater = ({
   return (
     <>
       <Typography variant="h4" fontWeight="bold">
-        Before you continue
+        Before we continue...
       </Typography>
       {isMultiChain && (
         <ErrorMessage level="info">
-          You will need to <b>activate your account</b> separately, on each network.
+          You will need to <b>activate your account</b> separately on each network. Make sure you have funds on your
+          wallet to pay the network fee.
         </ErrorMessage>
       )}
       <List>
+        {isMultiChain && (
+          <ListItem disableGutters>
+            <ListItemIcon className={css.listItem}>
+              <CheckRoundedIcon fontSize="small" color="inherit" />
+            </ListItemIcon>
+            <Typography variant="body2">
+              Start exploring the accounts now, and activate them later to start making transactions
+            </Typography>
+          </ListItem>
+        )}
         <ListItem disableGutters>
           <ListItemIcon className={css.listItem}>
             <CheckRoundedIcon fontSize="small" color="inherit" />
           </ListItemIcon>
-          <Typography variant="body2">
-            {`There will be a one-time network fee to activate your smart account wallet ${
-              isMultiChain ? 'on each network' : ''
-            }.`}
-          </Typography>
+          <Typography variant="body2">There will be a one-time activation fee</Typography>
         </ListItem>
         {!isMultiChain && (
           <ListItem disableGutters>


### PR DESCRIPTION
## What it solves

Resolves [SW-225](https://www.notion.so/safe-global/Safe-creation-Update-review-safe-creation-screen-according-to-the-design-10b8180fe5738051b666d3385e418d7c)

## How this PR fixes it
- Changes the title for the info block to `Before we continue...`
- Changes the info  bullet points for multichain safe creation
- Adds text to the blue info alert.
- Updates create button text

## Screenshots
![image](https://github.com/user-attachments/assets/3405f242-2fcf-48db-b0ec-7e2cace21286)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
