### PR TITLE
[Multichain] fix: Redirect user to dashboard after safe creation [SW-227]

### DIFF
--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -246,7 +246,7 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
         gtmSetSafeAddress(safeAddress)
 
         trackEvent({ ...OVERVIEW_EVENTS.PROCEED_WITH_TX, label: 'counterfactual', category: CREATE_SAFE_CATEGORY })
-        replayCounterfactualSafeDeployment(chain.chainId, safeAddress, props, data.name, dispatch)
+        replayCounterfactualSafeDeployment(chain.chainId, safeAddress, props, data.name, dispatch, payMethod)
         trackEvent({ ...CREATE_SAFE_EVENTS.CREATED_SAFE, label: 'counterfactual' })
         return
       }
@@ -261,7 +261,7 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
 
       const onSubmitCallback = async (taskId?: string, txHash?: string) => {
         // Create a counterfactual Safe
-        replayCounterfactualSafeDeployment(chain.chainId, safeAddress, props, data.name, dispatch)
+        replayCounterfactualSafeDeployment(chain.chainId, safeAddress, props, data.name, dispatch, payMethod)
 
         if (taskId) {
           safeCreationDispatch(SafeCreationEvent.RELAYING, { groupKey: CF_TX_GROUP_KEY, taskId, safeAddress })

--- a/src/features/counterfactual/utils.ts
+++ b/src/features/counterfactual/utils.ts
@@ -1,6 +1,6 @@
 import { getLatestSafeVersion } from '@/utils/chains'
 import { POLLING_INTERVAL } from '@/config/constants'
-import { PayMethod } from '@/features/counterfactual/PayNowPayLater'
+import type { PayMethod } from '@/features/counterfactual/PayNowPayLater'
 import { safeCreationDispatch, SafeCreationEvent } from '@/features/counterfactual/services/safeCreationEvents'
 import {
   addUndeployedSafe,
@@ -151,11 +151,12 @@ export const replayCounterfactualSafeDeployment = (
   replayedSafeProps: ReplayedSafeProps,
   name: string,
   dispatch: AppDispatch,
+  payMethod: PayMethod,
 ) => {
   const undeployedSafe = {
     chainId,
     address: safeAddress,
-    type: PayMethod.PayLater,
+    type: payMethod,
     safeProps: replayedSafeProps,
   }
 
@@ -164,7 +165,7 @@ export const replayCounterfactualSafeDeployment = (
       props: replayedSafeProps,
       status: {
         status: PendingSafeStatus.AWAITING_EXECUTION,
-        type: PayMethod.PayLater,
+        type: payMethod,
       },
     },
     chainId,

--- a/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
+++ b/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
@@ -19,6 +19,7 @@ import ChainIndicator from '@/components/common/ChainIndicator'
 import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { useMemo, useState } from 'react'
 import { useCompatibleNetworks } from '../../hooks/useCompatibleNetworks'
+import { PayMethod } from '@/features/counterfactual/PayNowPayLater'
 
 type CreateSafeOnNewChainForm = {
   chainId: string
@@ -99,6 +100,7 @@ const ReplaySafeDialog = ({
         safeCreationData,
         currentName || '',
         dispatch,
+        PayMethod.PayLater,
       )
 
       router.push({


### PR DESCRIPTION
## What it solves

Resolves [SW-227](https://www.notion.so/safe-global/Sometimes-the-user-is-not-navigated-to-the-dashboard-after-safe-creation-10c8180fe57380f1afd7c3bdd6e7b930)

## How this PR fixes it

- Sets `payMethod` instead of hard-coding it to `PayLater` so that the `useUndeployedSafe` works again

## How to test it

1. Create a safe and pay now
2. Observe being navigated to the dashboard after success

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
