### PR TITLE
fix: Push notifications toggle

### DIFF
--- a/src/components/settings/PushNotifications/hooks/useNotificationRegistrations.ts
+++ b/src/components/settings/PushNotifications/hooks/useNotificationRegistrations.ts
@@ -1,4 +1,5 @@
 import { registerDevice, unregisterDevice, unregisterSafe } from '@safe-global/safe-gateway-typescript-sdk'
+import isEmpty from 'lodash/isEmpty'
 
 import { useAppDispatch } from '@/store'
 import { showNotification } from '@/store/notificationsSlice'
@@ -19,7 +20,7 @@ const registrationFlow = async (registrationFn: Promise<unknown>, callback: () =
 
     // Gateway will return 200 with an empty payload if the device was (un-)registered successfully
     // @see https://github.com/safe-global/safe-client-gateway-nest/blob/27b6b3846b4ecbf938cdf5d0595ca464c10e556b/src/routes/notifications/notifications.service.ts#L29
-    success = response == null
+    success = isEmpty(response)
   } catch (e) {
     logError(ErrorCodes._633, e)
   }


### PR DESCRIPTION
## What it solves

Resolves #4253 

## How this PR fixes it

- https://github.com/safe-global/safe-gateway-typescript-sdk/pull/189 changed the response from being undefined to be an empty object so we check for `isEmpty` instead of `null`. 

## How to test it

1. Open a Safe
2. Go to Notification settings
3. Turn on notifications
4. Sign the message
5. Observe the Toggle turns on

## Screenshots
<img width="637" alt="Screenshot 2024-09-26 at 11 44 21" src="https://github.com/user-attachments/assets/74483375-ab8b-4e5a-b2a3-a33f8f22e52d">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
