### PR TITLE
fix: Show block explorer link for transaction guards

### DIFF
--- a/src/components/settings/TransactionGuards/index.tsx
+++ b/src/components/settings/TransactionGuards/index.tsx
@@ -26,7 +26,7 @@ const GuardDisplay = ({ guardAddress, chainId }: { guardAddress: string; chainId
 
   return (
     <Box className={css.guardDisplay}>
-      <EthHashInfo shortAddress={false} address={guardAddress} showCopyButton chainId={chainId} />
+      <EthHashInfo shortAddress={false} address={guardAddress} showCopyButton hasExplorer chainId={chainId} />
       <CheckWallet>
         {(isOk) => (
           <IconButton


### PR DESCRIPTION
## What it solves

Resolves #4256 

## How this PR fixes it

- Adds the `hasExplorer` flag to transaction guards

## How to test it

1. Open a safe with a transaction guard
2. Navigate to the settings page
3. Observe a block explorer button

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
