### PR TITLE
Feat(Multichain): use contract addresses from safe-deployments [SW-169]

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@safe-global/api-kit": "^2.4.4",
     "@safe-global/protocol-kit": "^4.1.0",
     "@safe-global/safe-apps-sdk": "^9.1.0",
-    "@safe-global/safe-deployments": "^1.37.8",
+    "@safe-global/safe-deployments": "^1.37.10",
     "@safe-global/safe-gateway-typescript-sdk": "3.22.3-beta.13",
     "@safe-global/safe-modules-deployments": "^2.2.1",
     "@sentry/react": "^7.91.0",

--- a/src/components/new-safe/create/logic/index.test.ts
+++ b/src/components/new-safe/create/logic/index.test.ts
@@ -1,4 +1,4 @@
-import { JsonRpcProvider } from 'ethers'
+import { Interface, JsonRpcProvider } from 'ethers'
 import * as contracts from '@/services/contracts/safeContracts'
 import type { SafeProvider } from '@safe-global/protocol-kit'
 import type { CompatibilityFallbackHandlerContractImplementationType } from '@safe-global/protocol-kit/dist/src/types'
@@ -9,7 +9,6 @@ import {
   relaySafeCreation,
   getRedirect,
   createNewUndeployedSafeWithoutSalt,
-  SAFE_TO_L2_SETUP_INTERFACE,
 } from '@/components/new-safe/create/logic/index'
 import { relayTransaction } from '@safe-global/safe-gateway-typescript-sdk'
 import { toBeHex } from 'ethers'
@@ -28,7 +27,7 @@ import { type FEATURES as GatewayFeatures } from '@safe-global/safe-gateway-type
 import { chainBuilder } from '@/tests/builders/chains'
 import { type ReplayedSafeProps } from '@/store/slices'
 import { faker } from '@faker-js/faker'
-import { ECOSYSTEM_ID_ADDRESS, SAFE_TO_L2_SETUP_ADDRESS } from '@/config/constants'
+import { ECOSYSTEM_ID_ADDRESS } from '@/config/constants'
 import {
   getFallbackHandlerDeployment,
   getProxyFactoryDeployment,
@@ -43,6 +42,9 @@ const latestSafeVersion = getLatestSafeVersion(
     .with({ chainId: '1', features: [FEATURES.SAFE_141 as unknown as GatewayFeatures] })
     .build(),
 )
+
+const SAFE_TO_L2_SETUP_ADDRESS = '0xBD89A1CE4DDe368FFAB0eC35506eEcE0b1fFdc54'
+const SAFE_TO_L2_SETUP_INTERFACE = new Interface(['function setupToL2(address l2Singleton)'])
 
 describe('create/logic', () => {
   describe('createNewSafeViaRelayer', () => {

--- a/src/components/new-safe/create/logic/index.ts
+++ b/src/components/new-safe/create/logic/index.ts
@@ -242,10 +242,7 @@ export const createNewUndeployedSafeWithoutSalt = (
       owners: safeAccountConfig.owners,
       fallbackHandler: fallbackHandlerAddress,
       to: includeMigration && safeToL2SetupAddress ? safeToL2SetupAddress : ZERO_ADDRESS,
-      data:
-        includeMigration && safeToL2SetupInterface
-          ? safeToL2SetupInterface.encodeFunctionData('setupToL2', [safeL2Address])
-          : EMPTY_DATA,
+      data: includeMigration ? safeToL2SetupInterface.encodeFunctionData('setupToL2', [safeL2Address]) : EMPTY_DATA,
       paymentReceiver: ECOSYSTEM_ID_ADDRESS,
     },
     safeVersion,

--- a/src/components/new-safe/create/logic/index.ts
+++ b/src/components/new-safe/create/logic/index.ts
@@ -1,5 +1,5 @@
 import type { SafeVersion } from '@safe-global/safe-core-sdk-types'
-import { Interface, type Eip1193Provider, type Provider } from 'ethers'
+import { type Eip1193Provider, type Provider } from 'ethers'
 import semverSatisfies from 'semver/functions/satisfies'
 
 import { getSafeInfo, type SafeInfo, type ChainInfo, relayTransaction } from '@safe-global/safe-gateway-typescript-sdk'
@@ -25,7 +25,7 @@ import { ECOSYSTEM_ID_ADDRESS } from '@/config/constants'
 import type { ReplayedSafeProps, UndeployedSafeProps } from '@/store/slices'
 import { activateReplayedSafe, isPredictedSafeProps } from '@/features/counterfactual/utils'
 import { getSafeContractDeployment } from '@/services/contracts/deployments'
-import { Safe__factory, Safe_proxy_factory__factory } from '@/types/contracts'
+import { Safe__factory, Safe_proxy_factory__factory, Safe_to_l2_setup__factory } from '@/types/contracts'
 import { createWeb3 } from '@/hooks/wallets/web3'
 import { hasMultiChainCreationFeatures } from '@/components/welcome/MyAccounts/utils/multiChainSafe'
 
@@ -225,9 +225,9 @@ export const createNewUndeployedSafeWithoutSalt = (
     throw new Error('No Safe deployment found')
   }
 
-  const safeToL2SetupDeployment = getSafeToL2SetupDeployment({ version: safeVersion, network: chain.chainId })
-  const safeToL2SetupAddress = safeToL2SetupDeployment?.defaultAddress
-  const safeToL2SetupInterface = safeToL2SetupDeployment && new Interface(safeToL2SetupDeployment?.abi)
+  const safeToL2SetupDeployment = getSafeToL2SetupDeployment({ version: '1.4.1', network: chain.chainId })
+  const safeToL2SetupAddress = safeToL2SetupDeployment?.networkAddresses[chain.chainId]
+  const safeToL2SetupInterface = Safe_to_l2_setup__factory.createInterface()
 
   // Only do migration if the chain supports multiChain deployments.
   const includeMigration = hasMultiChainCreationFeatures(chain) && semverSatisfies(safeVersion, '>=1.4.1')

--- a/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
@@ -8,7 +8,7 @@ import accordionCss from '@/styles/accordion.module.css'
 import CodeIcon from '@mui/icons-material/Code'
 import DecodedData from '@/components/transactions/TxDetails/TxData/DecodedData'
 import { sameAddress } from '@/utils/addresses'
-import { SAFE_TO_L2_MIGRATION_ADDRESS } from '@/config/constants'
+import { getSafeToL2MigrationDeployment } from '@safe-global/safe-deployments'
 
 type SingleTxDecodedProps = {
   tx: InternalTransaction
@@ -26,6 +26,9 @@ export const SingleTxDecoded = ({ tx, txData, actionTitle, variant, expanded, on
   const addressInfo = txData.addressInfoIndex?.[tx.to]
   const name = addressInfo?.name
 
+  const safeToL2MigrationDeployment = getSafeToL2MigrationDeployment()
+  const safeToL2MigrationAddress = safeToL2MigrationDeployment?.defaultAddress
+
   const singleTxData = {
     to: { value: tx.to },
     value: tx.value,
@@ -33,7 +36,7 @@ export const SingleTxDecoded = ({ tx, txData, actionTitle, variant, expanded, on
     dataDecoded: tx.dataDecoded,
     hexData: tx.data ?? undefined,
     addressInfoIndex: txData.addressInfoIndex,
-    trustedDelegateCallTarget: sameAddress(tx.to, SAFE_TO_L2_MIGRATION_ADDRESS), // We only trusted a nested Migration
+    trustedDelegateCallTarget: sameAddress(tx.to, safeToL2MigrationAddress), // We only trusted a nested Migration
   }
 
   return (

--- a/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
@@ -9,6 +9,7 @@ import CodeIcon from '@mui/icons-material/Code'
 import DecodedData from '@/components/transactions/TxDetails/TxData/DecodedData'
 import { sameAddress } from '@/utils/addresses'
 import { getSafeToL2MigrationDeployment } from '@safe-global/safe-deployments'
+import { useCurrentChain } from '@/hooks/useChains'
 
 type SingleTxDecodedProps = {
   tx: InternalTransaction
@@ -20,6 +21,7 @@ type SingleTxDecodedProps = {
 }
 
 export const SingleTxDecoded = ({ tx, txData, actionTitle, variant, expanded, onChange }: SingleTxDecodedProps) => {
+  const chain = useCurrentChain()
   const isNativeTransfer = tx.value !== '0' && (!tx.data || isEmptyHexData(tx.data))
   const method = tx.dataDecoded?.method || (isNativeTransfer ? 'native transfer' : 'contract interaction')
 
@@ -27,7 +29,7 @@ export const SingleTxDecoded = ({ tx, txData, actionTitle, variant, expanded, on
   const name = addressInfo?.name
 
   const safeToL2MigrationDeployment = getSafeToL2MigrationDeployment()
-  const safeToL2MigrationAddress = safeToL2MigrationDeployment?.defaultAddress
+  const safeToL2MigrationAddress = chain && safeToL2MigrationDeployment?.networkAddresses[chain.chainId]
 
   const singleTxData = {
     to: { value: tx.to },

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,4 +1,3 @@
-import { Interface } from 'ethers'
 import chains from './chains'
 
 export const IS_PRODUCTION = process.env.NEXT_PUBLIC_IS_PRODUCTION === 'true'
@@ -110,11 +109,5 @@ export const REDEFINE_ARTICLE = 'https://safe.mirror.xyz/rInLWZwD_sf7enjoFerj6FI
 
 export const CHAINALYSIS_OFAC_CONTRACT = '0x40c57923924b5c5c5455c48d93317139addac8fb'
 
-// TODO: Get from safe-deployments once available
-export const SAFE_TO_L2_MIGRATION_ADDRESS = '0x7Baec386CAF8e02B0BB4AFc98b4F9381EEeE283C'
-export const SAFE_TO_L2_INTERFACE = new Interface(['function migrateToL2(address l2Singleton)'])
-
 export const ECOSYSTEM_ID_ADDRESS =
   process.env.NEXT_PUBLIC_ECOSYSTEM_ID_ADDRESS || '0x0000000000000000000000000000000000000000'
-
-export const SAFE_TO_L2_SETUP_ADDRESS = '0x80E0d1577aD3d982BF2F49aAB00BfA161AA763c4'

--- a/src/features/counterfactual/ActivateAccountFlow.tsx
+++ b/src/features/counterfactual/ActivateAccountFlow.tsx
@@ -96,7 +96,7 @@ const ActivateAccountFlow = () => {
 
   const { owners, threshold, safeVersion } = undeployedSafeSetup
 
-  const safeToL2SetupDeployment = getSafeToL2SetupDeployment({ version: safeVersion, network: chain?.chainId })
+  const safeToL2SetupDeployment = getSafeToL2SetupDeployment({ version: '1.4.1', network: chain?.chainId })
   const safeToL2SetupAddress = safeToL2SetupDeployment?.defaultAddress
   const isMultichainSafe = sameAddress(safeAccountConfig?.to, safeToL2SetupAddress)
 

--- a/src/features/counterfactual/ActivateAccountFlow.tsx
+++ b/src/features/counterfactual/ActivateAccountFlow.tsx
@@ -31,8 +31,8 @@ import { sameAddress } from '@/utils/addresses'
 import { useEstimateSafeCreationGas } from '@/components/new-safe/create/useEstimateSafeCreationGas'
 import useIsWrongChain from '@/hooks/useIsWrongChain'
 import NetworkWarning from '@/components/new-safe/create/NetworkWarning'
-import { SAFE_TO_L2_SETUP_ADDRESS } from '@/config/constants'
 import CheckWallet from '@/components/common/CheckWallet'
+import { getSafeToL2SetupDeployment } from '@safe-global/safe-deployments'
 
 const useActivateAccount = (undeployedSafe: UndeployedSafe | undefined) => {
   const chain = useCurrentChain()
@@ -84,7 +84,7 @@ const ActivateAccountFlow = () => {
 
   const safeAccountConfig =
     undeployedSafe && isPredictedSafeProps(undeployedSafe?.props) ? undeployedSafe?.props.safeAccountConfig : undefined
-  const isMultichainSafe = sameAddress(safeAccountConfig?.to, SAFE_TO_L2_SETUP_ADDRESS)
+
   const ownerAddresses = undeployedSafeSetup?.owners || []
   const [minRelays] = useLeastRemainingRelays(ownerAddresses)
 
@@ -95,6 +95,10 @@ const ActivateAccountFlow = () => {
   if (!undeployedSafe || !undeployedSafeSetup) return null
 
   const { owners, threshold, safeVersion } = undeployedSafeSetup
+
+  const safeToL2SetupDeployment = getSafeToL2SetupDeployment({ version: safeVersion, network: chain?.chainId })
+  const safeToL2SetupAddress = safeToL2SetupDeployment?.defaultAddress
+  const isMultichainSafe = sameAddress(safeAccountConfig?.to, safeToL2SetupAddress)
 
   const onSubmit = (txHash?: string) => {
     trackEvent({ ...TX_EVENTS.CREATE, label: TX_TYPES.activate_without_tx })

--- a/src/utils/__tests__/transactions.test.ts
+++ b/src/utils/__tests__/transactions.test.ts
@@ -22,11 +22,14 @@ import { encodeMultiSendData } from '@safe-global/protocol-kit'
 import { Multi_send__factory } from '@/types/contracts'
 import { faker } from '@faker-js/faker'
 import { getAndValidateSafeSDK } from '@/services/tx/tx-sender/sdk'
+import { Interface } from 'ethers'
 import { decodeMultiSendData } from '@safe-global/protocol-kit/dist/src/utils'
 import { checksumAddress } from '../addresses'
-import { SAFE_TO_L2_MIGRATION_ADDRESS, SAFE_TO_L2_INTERFACE } from '@/config/constants'
 
 jest.mock('@/services/tx/tx-sender/sdk')
+
+export const SAFE_TO_L2_MIGRATION_ADDRESS = '0xfF83F6335d8930cBad1c0D439A841f01888D9f69'
+export const SAFE_TO_L2_INTERFACE = new Interface(['function migrateToL2(address l2Singleton)'])
 
 describe('transactions', () => {
   const mockGetAndValidateSdk = getAndValidateSafeSDK as jest.MockedFunction<typeof getAndValidateSafeSDK>
@@ -325,7 +328,6 @@ describe('transactions', () => {
             .build(),
         })
         .build()
-
       const safeInfo = extendedSafeInfoBuilder()
         .with({
           implementationVersionState: ImplementationVersionState.UNKNOWN,
@@ -335,11 +337,9 @@ describe('transactions', () => {
           },
         })
         .build()
-
       expect(
         prependSafeToL2Migration(safeTx, safeInfo, chainBuilder().with({ l2: true, chainId: '10' }).build()),
       ).resolves.toEqual(safeTx)
-
       const multiSendSafeTx = safeTxBuilder()
         .with({
           data: safeTxDataBuilder()
@@ -362,7 +362,6 @@ describe('transactions', () => {
             .build(),
         })
         .build()
-
       expect(
         prependSafeToL2Migration(multiSendSafeTx, safeInfo, chainBuilder().with({ l2: true, chainId: '10' }).build()),
       ).resolves.toEqual(multiSendSafeTx)

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -57,8 +57,9 @@ import { getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimi
 import { sameAddress } from '@/utils/addresses'
 import type { NamedAddress } from '@/components/new-safe/create/types'
 import type { RecoveryQueueItem } from '@/features/recovery/services/recovery-state'
-import { ethers, Interface } from 'ethers'
+import { ethers } from 'ethers'
 import { getSafeToL2MigrationDeployment } from '@safe-global/safe-deployments'
+import { Safe_to_l2_migration__factory } from '@/types/contracts'
 
 export const isTxQueued = (value: TransactionStatus): boolean => {
   return [TransactionStatus.AWAITING_CONFIRMATIONS, TransactionStatus.AWAITING_EXECUTION].includes(value)
@@ -90,12 +91,10 @@ export const isModuleDetailedExecutionInfo = (value?: DetailedExecutionInfo): va
 export const isMigrateToL2TxData = (value: TransactionData | undefined): boolean => {
   const safeToL2MigrationDeployment = getSafeToL2MigrationDeployment()
   const safeToL2MigrationAddress = safeToL2MigrationDeployment?.defaultAddress
-  const safeToL2SetupInterface = safeToL2MigrationDeployment
-    ? new Interface(safeToL2MigrationDeployment?.abi)
-    : undefined
+  const safeToL2MigrationInterface = Safe_to_l2_migration__factory.createInterface()
 
   if (sameAddress(value?.to.value, safeToL2MigrationAddress)) {
-    const migrateToL2Selector = safeToL2SetupInterface?.getFunction('migrateToL2')?.selector
+    const migrateToL2Selector = safeToL2MigrationInterface?.getFunction('migrateToL2')?.selector
     return migrateToL2Selector && value?.hexData ? value.hexData?.startsWith(migrateToL2Selector) : false
   }
   return false

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -57,8 +57,8 @@ import { getSpendingLimitModuleAddress } from '@/services/contracts/spendingLimi
 import { sameAddress } from '@/utils/addresses'
 import type { NamedAddress } from '@/components/new-safe/create/types'
 import type { RecoveryQueueItem } from '@/features/recovery/services/recovery-state'
-import { ethers } from 'ethers'
-import { SAFE_TO_L2_MIGRATION_ADDRESS, SAFE_TO_L2_INTERFACE } from '@/config/constants'
+import { ethers, Interface } from 'ethers'
+import { getSafeToL2MigrationDeployment } from '@safe-global/safe-deployments'
 
 export const isTxQueued = (value: TransactionStatus): boolean => {
   return [TransactionStatus.AWAITING_CONFIRMATIONS, TransactionStatus.AWAITING_EXECUTION].includes(value)
@@ -88,8 +88,14 @@ export const isModuleDetailedExecutionInfo = (value?: DetailedExecutionInfo): va
 }
 
 export const isMigrateToL2TxData = (value: TransactionData | undefined): boolean => {
-  if (sameAddress(value?.to.value, SAFE_TO_L2_MIGRATION_ADDRESS)) {
-    const migrateToL2Selector = SAFE_TO_L2_INTERFACE.getFunction('migrateToL2')?.selector
+  const safeToL2MigrationDeployment = getSafeToL2MigrationDeployment()
+  const safeToL2MigrationAddress = safeToL2MigrationDeployment?.defaultAddress
+  const safeToL2SetupInterface = safeToL2MigrationDeployment
+    ? new Interface(safeToL2MigrationDeployment?.abi)
+    : undefined
+
+  if (sameAddress(value?.to.value, safeToL2MigrationAddress)) {
+    const migrateToL2Selector = safeToL2SetupInterface?.getFunction('migrateToL2')?.selector
     return migrateToL2Selector && value?.hexData ? value.hexData?.startsWith(migrateToL2Selector) : false
   }
   return false
@@ -100,12 +106,15 @@ export const isMigrateToL2MultiSend = (decodedData: DecodedDataResponse | undefi
     const innerTxs = decodedData.parameters[0].valueDecoded
     const firstInnerTx = innerTxs[0]
     if (firstInnerTx) {
+      const safeToL2MigrationDeployment = getSafeToL2MigrationDeployment()
+      const safeToL2MigrationAddress = safeToL2MigrationDeployment?.defaultAddress
+
       return (
         firstInnerTx.dataDecoded?.method === 'migrateToL2' &&
         firstInnerTx.dataDecoded.parameters.length === 1 &&
         firstInnerTx.dataDecoded?.parameters?.[0]?.type === 'address' &&
         typeof firstInnerTx.dataDecoded?.parameters[0].value === 'string' &&
-        sameAddress(firstInnerTx.to, SAFE_TO_L2_MIGRATION_ADDRESS)
+        sameAddress(firstInnerTx.to, safeToL2MigrationAddress)
       )
     }
   }
@@ -149,7 +158,10 @@ export const isOrderTxInfo = (value: TransactionInfo): value is Order => {
 }
 
 export const isMigrateToL2TxInfo = (value: TransactionInfo): value is Custom => {
-  return isCustomTxInfo(value) && sameAddress(value.to.value, SAFE_TO_L2_MIGRATION_ADDRESS)
+  const safeToL2MigrationDeployment = getSafeToL2MigrationDeployment()
+  const safeToL2MigrationAddress = safeToL2MigrationDeployment?.defaultAddress
+
+  return isCustomTxInfo(value) && sameAddress(value.to.value, safeToL2MigrationAddress)
 }
 
 export const isSwapOrderTxInfo = (value: TransactionInfo): value is SwapOrder => {

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -29,8 +29,8 @@ import type { SafeTransaction, TransactionOptions } from '@safe-global/safe-core
 import { FEATURES, hasFeature } from '@/utils/chains'
 import uniqBy from 'lodash/uniqBy'
 import { Errors, logError } from '@/services/exceptions'
-import { Multi_send__factory } from '@/types/contracts'
-import { toBeHex, AbiCoder, Interface } from 'ethers'
+import { Multi_send__factory, Safe_to_l2_migration__factory } from '@/types/contracts'
+import { toBeHex, AbiCoder } from 'ethers'
 import { type BaseTransaction } from '@safe-global/safe-apps-sdk'
 import { id } from 'ethers'
 import { isEmptyHexData } from '@/utils/hex'
@@ -353,7 +353,7 @@ export const prependSafeToL2Migration = (
   }
 
   const safeToL2MigrationAddress = safeToL2MigrationDeployment.defaultAddress
-  const safeToL2SetupInterface = new Interface(safeToL2MigrationDeployment.abi)
+  const safeToL2MigrationInterface = Safe_to_l2_migration__factory.createInterface()
 
   if (sameAddress(safe.implementation.value, safeL2DeploymentAddress)) {
     // Safe already has the correct L2 masterCopy
@@ -381,7 +381,7 @@ export const prependSafeToL2Migration = (
   const newTxs: MetaTransactionData[] = [
     {
       operation: 1, // DELEGATE CALL REQUIRED
-      data: safeToL2SetupInterface.encodeFunctionData('migrateToL2', [safeL2DeploymentAddress]),
+      data: safeToL2MigrationInterface.encodeFunctionData('migrateToL2', [safeL2DeploymentAddress]),
       to: safeToL2MigrationAddress,
       value: '0',
     },

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -30,7 +30,7 @@ import { FEATURES, hasFeature } from '@/utils/chains'
 import uniqBy from 'lodash/uniqBy'
 import { Errors, logError } from '@/services/exceptions'
 import { Multi_send__factory } from '@/types/contracts'
-import { toBeHex, AbiCoder } from 'ethers'
+import { toBeHex, AbiCoder, Interface } from 'ethers'
 import { type BaseTransaction } from '@safe-global/safe-apps-sdk'
 import { id } from 'ethers'
 import { isEmptyHexData } from '@/utils/hex'
@@ -40,8 +40,8 @@ import { sameAddress } from './addresses'
 import { isMultiSendCalldata } from './transaction-calldata'
 import { decodeMultiSendData } from '@safe-global/protocol-kit/dist/src/utils'
 import { __unsafe_createMultiSendTx } from '@/services/tx/tx-sender'
-import { SAFE_TO_L2_MIGRATION_ADDRESS, SAFE_TO_L2_INTERFACE } from '@/config/constants'
 import { getOriginPath } from './url'
+import { getSafeToL2MigrationDeployment } from '@safe-global/safe-deployments'
 
 export const makeTxFromDetails = (txDetails: TransactionDetails): Transaction => {
   const getMissingSigners = ({
@@ -342,10 +342,18 @@ export const prependSafeToL2Migration = (
 
   const safeL2Deployment = getSafeContractDeployment(chain, safe.version)
   const safeL2DeploymentAddress = safeL2Deployment?.networkAddresses[chain.chainId]
+  const safeToL2MigrationDeployment = getSafeToL2MigrationDeployment({ network: chain?.chainId })
 
   if (!safeL2DeploymentAddress) {
     throw new Error('No L2 MasterCopy found')
   }
+
+  if (!safeToL2MigrationDeployment) {
+    throw new Error('No safe to L2 migration contract found')
+  }
+
+  const safeToL2MigrationAddress = safeToL2MigrationDeployment.defaultAddress
+  const safeToL2SetupInterface = new Interface(safeToL2MigrationDeployment.abi)
 
   if (sameAddress(safe.implementation.value, safeL2DeploymentAddress)) {
     // Safe already has the correct L2 masterCopy
@@ -364,7 +372,7 @@ export const prependSafeToL2Migration = (
     internalTxs = [{ to: safeTx.data.to, operation: safeTx.data.operation, value: safeTx.data.value, data: txData }]
   }
 
-  if (sameAddress(internalTxs[0]?.to, SAFE_TO_L2_MIGRATION_ADDRESS)) {
+  if (sameAddress(internalTxs[0]?.to, safeToL2MigrationAddress)) {
     // We already migrate. Nothing to do.
     return Promise.resolve(safeTx)
   }
@@ -373,8 +381,8 @@ export const prependSafeToL2Migration = (
   const newTxs: MetaTransactionData[] = [
     {
       operation: 1, // DELEGATE CALL REQUIRED
-      data: SAFE_TO_L2_INTERFACE.encodeFunctionData('migrateToL2', [safeL2DeploymentAddress]),
-      to: SAFE_TO_L2_MIGRATION_ADDRESS,
+      data: safeToL2SetupInterface.encodeFunctionData('migrateToL2', [safeL2DeploymentAddress]),
+      to: safeToL2MigrationAddress,
       value: '0',
     },
     ...internalTxs,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4279,7 +4279,14 @@
   dependencies:
     abitype "^1.0.2"
 
-"@safe-global/safe-deployments@^1.37.3", "@safe-global/safe-deployments@^1.37.8":
+"@safe-global/safe-deployments@^1.37.10":
+  version "1.37.10"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.10.tgz#2f61a25bd479332821ba2e91a575237d77406ec3"
+  integrity sha512-lcxX9CV+xdcLs4dF6Cx18zDww5JyqaX6RdcvU0o/34IgJ4Wjo3J/RNzJAoMhurCAfTGr+0vyJ9V13Qo50AR6JA==
+  dependencies:
+    semver "^7.6.2"
+
+"@safe-global/safe-deployments@^1.37.3":
   version "1.37.8"
   resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.8.tgz#5d51a57e4c3a9274ce09d8fe7fbe1265a1aaf4c4"
   integrity sha512-BT34eqSJ1K+4xJgJVY3/Yxg8TRTEvFppkt4wcirIPGCgR4/j06HptHPyDdmmqTuvih8wi8OpFHi0ncP+cGlXWA==


### PR DESCRIPTION
## What it solves

Resolves: https://www.notion.so/safe-global/Use-officially-deployed-lib-contracts-ee4ff0091ae946799c37dde88531a070

## How this PR fixes it
- Replaces hardcoded temporary contract addresses with the proper addresses from `safe-deployments`

## How to test it
- Ensure safe creation works as before.
- Ensure migration of invalid mastercopy safes works as before.
- It should work on all the chains where the new contracts are deployed.
- Creation and migration transactions should not be flagged by blockaid.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
