### PR TITLE
Chore: pull-requests: read permisison

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
       checks: write
-      pull-requests: write
+      pull-requests: read
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What it solves

A follow-up on #4236.

Replacing `pull-requests: write` with a safer read permission.