### PR TITLE
Chore: contents read permission for unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   test:
     permissions:
-      contents: write
+      contents: read
       checks: write
       pull-requests: write
 


### PR DESCRIPTION
## What it solves

Checking if we can downgrade the contents permission.
