### PR TITLE
Fix: icon spacing in EthHashInfo

### DIFF
--- a/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
@@ -82,7 +82,7 @@ const SrcEthHashInfo = ({
         </div>
       )}
 
-      <Box overflow="hidden" className={onlyName ? css.inline : undefined}>
+      <Box overflow="hidden" className={onlyName ? css.inline : undefined} gap={0.5}>
         {name && (
           <Box title={name} display="flex" alignItems="center" gap={0.5}>
             <Box overflow="hidden" textOverflow="ellipsis">

--- a/src/components/common/EthHashInfo/SrcEthHashInfo/styles.module.css
+++ b/src/components/common/EthHashInfo/SrcEthHashInfo/styles.module.css
@@ -19,7 +19,6 @@
 .addressContainer {
   display: flex;
   align-items: center;
-  gap: 0.25em;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## What it solves

The spacing inside EthHashInfo was inconsistent.

Before:
<img width="520" alt="Screenshot 2024-09-27 at 15 56 30" src="https://github.com/user-attachments/assets/5132b334-573b-49a8-98bc-fccf18b31140">

After:
<img width="504" alt="Screenshot 2024-09-27 at 15 58 11" src="https://github.com/user-attachments/assets/c0b8d71d-cfd4-4562-a90c-65add4c64fec">