### PR TITLE
fix(staking): fee displayed in wrong format [SW-242]

### DIFF
--- a/src/features/stake/components/StakingConfirmationTx/Deposit.tsx
+++ b/src/features/stake/components/StakingConfirmationTx/Deposit.tsx
@@ -20,6 +20,8 @@ const CURRENCY = 'USD'
 const StakingConfirmationTxDeposit = ({ order }: StakingOrderConfirmationViewProps) => {
   const isOrder = order.type === ConfirmationViewTypes.KILN_NATIVE_STAKING_DEPOSIT
 
+  // the fee is returned in decimal format, so we multiply by 100 to get the percentage
+  const fee = (order.fee * 100).toFixed(2)
   return (
     <Stack gap={isOrder ? 2 : 1}>
       {isOrder && (
@@ -58,7 +60,7 @@ const StakingConfirmationTxDeposit = ({ order }: StakingOrderConfirmationViewPro
           </>
         }
       >
-        {order.fee}%
+        {fee} %
       </FieldsGrid>
 
       <Stack


### PR DESCRIPTION
## What it solves
The displayed fee was wrong.


## How this PR fixes it
the fee is returned by the API in decimal format, so we have to multiply by 100 to get the percentage

## How to test it
Make a deposit and check that the values in the widget match the values in the deocding

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
