### PR TITLE
Bug chain prefix toggle

### DIFF
--- a/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
+++ b/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
@@ -62,7 +62,7 @@ const SrcEthHashInfo = ({
 
   const addressElement = (
     <>
-      {showPrefix && shouldPrefix && prefix && <b>{prefix}:</b>}
+      {showPrefix && shouldPrefix && prefix && <b>{prefix}</b>}
       <span>{shortAddress || isMobile ? shortenAddress(address) : address}</span>
     </>
   )

--- a/src/components/sidebar/QrCodeButton/QrModal.tsx
+++ b/src/components/sidebar/QrCodeButton/QrModal.tsx
@@ -17,7 +17,7 @@ const QrModal = ({ onClose }: { onClose: () => void }): ReactElement => {
   const qrCode = `${qrPrefix}${safeAddress}`
   const chainName = chain?.chainName || ''
   const nativeToken = chain?.nativeCurrency.symbol || ''
-  
+
   return (
     <ModalDialog open dialogTitle="Receive assets" onClose={onClose} hideChainIndicator>
       <DialogContent>

--- a/src/components/sidebar/QrCodeButton/QrModal.tsx
+++ b/src/components/sidebar/QrCodeButton/QrModal.tsx
@@ -17,7 +17,7 @@ const QrModal = ({ onClose }: { onClose: () => void }): ReactElement => {
   const qrCode = `${qrPrefix}${safeAddress}`
   const chainName = chain?.chainName || ''
   const nativeToken = chain?.nativeCurrency.symbol || ''
-
+  
   return (
     <ModalDialog open dialogTitle="Receive assets" onClose={onClose} hideChainIndicator>
       <DialogContent>
@@ -47,7 +47,7 @@ const QrModal = ({ onClose }: { onClose: () => void }): ReactElement => {
           />
 
           <Box mt={2}>
-            <EthHashInfo address={safeAddress} shortAddress={false} hasExplorer showCopyButton />
+            <EthHashInfo address={safeAddress} shortAddress={false} prefix={qrPrefix} hasExplorer showCopyButton />
           </Box>
         </Box>
       </DialogContent>


### PR DESCRIPTION
## What it solves
This PR has been raised to resolve the issue [#4261](https://github.com/safe-global/safe-wallet-web/issues/4261). The 
Resolves the issue of the chain prefix before the address

## How this PR fixes it
This pr fixes it by passing the prefix as a prop to the component

## How to test it
Click on the QR code and try to switch the toggle, you can see the difference in the address displayed below

## Screenshots
While toggle on-
![image](https://github.com/user-attachments/assets/3fa347c6-fd4a-4b85-af83-035efcd3954e)
While toggle off-
![image](https://github.com/user-attachments/assets/54b44c40-d95d-4233-a27e-855678735c2a)



## Checklist
* [* ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
