### PR TITLE
fix: duplicated advanced data

### DIFF
--- a/src/components/transactions/TxDetails/Summary/index.tsx
+++ b/src/components/transactions/TxDetails/Summary/index.tsx
@@ -14,9 +14,10 @@ import DecodedData from '../TxData/DecodedData'
 interface Props {
   txDetails: TransactionDetails
   defaultExpanded?: boolean
+  hideDecodedData?: boolean
 }
 
-const Summary = ({ txDetails, defaultExpanded = false }: Props): ReactElement => {
+const Summary = ({ txDetails, defaultExpanded = false, hideDecodedData = false }: Props): ReactElement => {
   const [expanded, setExpanded] = useState<boolean>(defaultExpanded)
 
   const toggleExpanded = () => {
@@ -70,7 +71,7 @@ const Summary = ({ txDetails, defaultExpanded = false }: Props): ReactElement =>
 
           {expanded && (
             <Box mt={1}>
-              {!isCustom && (
+              {!isCustom && !hideDecodedData && (
                 <Box borderBottom="1px solid" borderColor="border.light" p={2} mt={1} mb={2} mx={-2}>
                   <DecodedData txData={txDetails.txData} toInfo={txDetails.txData?.to} />
                 </Box>

--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -45,7 +45,6 @@ const DecodedTx = ({
   const isMultisend = !!decodedData?.parameters?.[0]?.valueDecoded
   const isMethodCallInAdvanced = !showMethodCall || (isMultisend && showMultisend)
 
-  console.log('DecodedTx', tx, txId, decodedData, isMultisend, showMultisend, showMethodCall, isMethodCallInAdvanced)
   const {
     data: txDetails,
     error: txDetailsError,

--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -45,6 +45,7 @@ const DecodedTx = ({
   const isMultisend = !!decodedData?.parameters?.[0]?.valueDecoded
   const isMethodCallInAdvanced = !showMethodCall || (isMultisend && showMultisend)
 
+  console.log('DecodedTx', tx, txId, decodedData, isMultisend, showMultisend, showMethodCall, isMethodCallInAdvanced)
   const {
     data: txDetails,
     error: txDetailsError,
@@ -114,7 +115,15 @@ const DecodedTx = ({
               </>
             )}
 
-            {txDetails ? <Summary txDetails={txDetails} defaultExpanded /> : tx && <PartialSummary safeTx={tx} />}
+            {txDetails ? (
+              <Summary
+                txDetails={txDetails}
+                defaultExpanded
+                hideDecodedData={isMethodCallInAdvanced && !!decodedData?.method}
+              />
+            ) : (
+              tx && <PartialSummary safeTx={tx} />
+            )}
 
             {txDetailsLoading && <Skeleton />}
 


### PR DESCRIPTION
## What it solves
when you had a queued TX and you tried to execute it the "call method on contract" was shown twice.

![grafik](https://github.com/user-attachments/assets/07d2c7ab-fe11-4e9e-95be-84f17fcacf5a)

Resolves #

## How this PR fixes it
DecodedTx was rendering a decodedData block, which was also rendered by the Summary component.

Right now I’m hiding the decodedData block in the summary based on a prop that is passed by the parent component.

This will be refactored and tested over here:
https://github.com/safe-global/safe-wallet-web/issues/4091

## How to test it
Create a new tx, sign it. Then go in the queue and try to execute it. Now the "call x method on y contract" should be shown just once.

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
