### PR TITLE
Fix: too wide label

### DIFF
--- a/src/components/transactions/HexEncodedData/__snapshots__/HexEncodedData.test.tsx.snap
+++ b/src/components/transactions/HexEncodedData/__snapshots__/HexEncodedData.test.tsx.snap
@@ -6,11 +6,12 @@ exports[`HexEncodedData should not cut the text in case the limit option is high
     class="MuiGrid-root MuiGrid-container css-1d1otxt-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item css-658w1k-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item css-1wehkfy-MuiGrid-root"
       data-testid="tx-row-title"
+      style="word-break: break-word;"
     >
       <p
-        class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-s5yue5-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-body1 css-fzss1y-MuiTypography-root"
       >
         Data (hex-encoded)
       </p>
@@ -67,11 +68,12 @@ exports[`HexEncodedData should not highlight the data if highlight option is fal
     class="MuiGrid-root MuiGrid-container css-1d1otxt-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item css-658w1k-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item css-1wehkfy-MuiGrid-root"
       data-testid="tx-row-title"
+      style="word-break: break-word;"
     >
       <p
-        class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-s5yue5-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-body1 css-fzss1y-MuiTypography-root"
       >
         Some arbitrary data
       </p>
@@ -129,11 +131,12 @@ exports[`HexEncodedData should render the default component markup 1`] = `
     class="MuiGrid-root MuiGrid-container css-1d1otxt-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item css-658w1k-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item css-1wehkfy-MuiGrid-root"
       data-testid="tx-row-title"
+      style="word-break: break-word;"
     >
       <p
-        class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-s5yue5-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-body1 css-fzss1y-MuiTypography-root"
       >
         Data (hex-encoded)
       </p>

--- a/src/components/transactions/TxDetails/Summary/index.tsx
+++ b/src/components/transactions/TxDetails/Summary/index.tsx
@@ -14,9 +14,10 @@ import DecodedData from '../TxData/DecodedData'
 interface Props {
   txDetails: TransactionDetails
   defaultExpanded?: boolean
+  hideDecodedData?: boolean
 }
 
-const Summary = ({ txDetails, defaultExpanded = false }: Props): ReactElement => {
+const Summary = ({ txDetails, defaultExpanded = false, hideDecodedData = false }: Props): ReactElement => {
   const [expanded, setExpanded] = useState<boolean>(defaultExpanded)
 
   const toggleExpanded = () => {
@@ -70,7 +71,7 @@ const Summary = ({ txDetails, defaultExpanded = false }: Props): ReactElement =>
 
           {expanded && (
             <Box mt={1}>
-              {!isCustom && (
+              {!isCustom && !hideDecodedData && (
                 <Box borderBottom="1px solid" borderColor="border.light" p={2} mt={1} mb={2} mx={-2}>
                   <DecodedData txData={txDetails.txData} toInfo={txDetails.txData?.to} />
                 </Box>

--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -45,7 +45,6 @@ const DecodedTx = ({
   const isMultisend = !!decodedData?.parameters?.[0]?.valueDecoded
   const isMethodCallInAdvanced = !showMethodCall || (isMultisend && showMultisend)
 
-  console.log('DecodedTx', tx, txId, decodedData, isMultisend, showMultisend, showMethodCall, isMethodCallInAdvanced)
   const {
     data: txDetails,
     error: txDetailsError,

--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -45,6 +45,7 @@ const DecodedTx = ({
   const isMultisend = !!decodedData?.parameters?.[0]?.valueDecoded
   const isMethodCallInAdvanced = !showMethodCall || (isMultisend && showMultisend)
 
+  console.log('DecodedTx', tx, txId, decodedData, isMultisend, showMultisend, showMethodCall, isMethodCallInAdvanced)
   const {
     data: txDetails,
     error: txDetailsError,
@@ -114,7 +115,15 @@ const DecodedTx = ({
               </>
             )}
 
-            {txDetails ? <Summary txDetails={txDetails} defaultExpanded /> : tx && <PartialSummary safeTx={tx} />}
+            {txDetails ? (
+              <Summary
+                txDetails={txDetails}
+                defaultExpanded
+                hideDecodedData={isMethodCallInAdvanced && !!decodedData?.method}
+              />
+            ) : (
+              tx && <PartialSummary safeTx={tx} />
+            )}
 
             {txDetailsLoading && <Skeleton />}
 

--- a/src/components/tx/FieldsGrid/index.tsx
+++ b/src/components/tx/FieldsGrid/index.tsx
@@ -1,16 +1,15 @@
 import { type ReactNode } from 'react'
 import { Grid, Typography } from '@mui/material'
 
+const width = { xl: '25%', lg: '200px', xs: 'auto' }
 const minWidth = { xl: '25%', lg: '200px' }
 const wrap = { flexWrap: { xl: 'nowrap' } }
 
 const FieldsGrid = ({ title, children }: { title: string | ReactNode; children: ReactNode }) => {
   return (
     <Grid container alignItems="center" gap={1} sx={wrap}>
-      <Grid item minWidth={minWidth} data-testid="tx-row-title">
-        <Typography color="primary.light" noWrap>
-          {title}
-        </Typography>
+      <Grid item data-testid="tx-row-title" width={width} minWidth={minWidth} style={{ wordBreak: 'break-word' }}>
+        <Typography color="primary.light">{title}</Typography>
       </Grid>
 
       <Grid item xs data-testid="tx-data-row">


### PR DESCRIPTION
## What it solves

Resolves #
https://safe-wallet-web.dev.5afe.dev/transactions/tx?safe=eth:0x2F41E38fcACF402d2abcf567D924e138BE963bDF&id=multisig_0x2F41E38fcACF402d2abcf567D924e138BE963bDF_0x0390584d687540241abe1529e8e50c44f6ec0efe8b897dac8d0cdebfbe669d4b
![grafik](https://github.com/user-attachments/assets/c42cd4b2-371b-49b4-acba-98a51d42efb2)

## How this PR fixes it
The content inside of the label was continuous and since we were only forcing min-width it was spanning as much as possible. I opted for "width" instead. On smaller devices we do just min-width this way the column can stretch to the max available space

## How to test it
before
https://safe-wallet-web.dev.5afe.dev/transactions/tx?safe=eth:0x2F41E38fcACF402d2abcf567D924e138BE963bDF&id=multisig_0x2F41E38fcACF402d2abcf567D924e138BE963bDF_0x0390584d687540241abe1529e8e50c44f6ec0efe8b897dac8d0cdebfbe669d4b

after:
https://fix_too_wide_label--walletweb.review.5afe.dev/transactions/tx?safe=eth:0x2F41E38fcACF402d2abcf567D924e138BE963bDF&id=multisig_0x2F41E38fcACF402d2abcf567D924e138BE963bDF_0x0390584d687540241abe1529e8e50c44f6ec0efe8b897dac8d0cdebfbe669d4b

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
