### PR TITLE
Feat(Multichain): explain impossible network addition

### DIFF
--- a/src/components/common/NetworkSelector/index.tsx
+++ b/src/components/common/NetworkSelector/index.tsx
@@ -196,7 +196,7 @@ const UndeployedNetworks = ({
       <Stack direction="row" spacing={1} alignItems="center">
         {safeCreationDataError?.message && (
           <Tooltip title={safeCreationDataError?.message}>
-            <InfoOutlined color="info" fontSize="small" />
+            <InfoOutlined color="info" fontSize="medium" />
           </Tooltip>
         )}
         <Typography>Adding another network is not possible for this Safe. </Typography>

--- a/src/components/common/NetworkSelector/index.tsx
+++ b/src/components/common/NetworkSelector/index.tsx
@@ -15,6 +15,7 @@ import {
   Select,
   Skeleton,
   Stack,
+  Tooltip,
   Typography,
 } from '@mui/material'
 import partition from 'lodash/partition'
@@ -38,6 +39,7 @@ import PlusIcon from '@/public/images/common/plus.svg'
 import useAddressBook from '@/hooks/useAddressBook'
 import { CreateSafeOnSpecificChain } from '@/features/multichain/components/CreateSafeOnNewChain'
 import { useGetSafeOverviewQuery } from '@/store/api/gateway'
+import { InfoOutlined } from '@mui/icons-material'
 
 const ChainIndicatorWithFiatBalance = ({
   isSelected,
@@ -190,11 +192,20 @@ const UndeployedNetworks = ({
   }
 
   const errorMessage =
-    safeCreationDataError || (safeCreationData && noAvailableNetworks)
-      ? 'Adding another network is not possible for this Safe.'
-      : isUnsupportedSafeCreationVersion
-      ? 'This account was created from an outdated mastercopy. Adding another network is not possible.'
-      : ''
+    safeCreationDataError || (safeCreationData && noAvailableNetworks) ? (
+      <Stack direction="row" spacing={1} alignItems="center">
+        {safeCreationDataError?.message && (
+          <Tooltip title={safeCreationDataError?.message}>
+            <InfoOutlined color="info" fontSize="small" />
+          </Tooltip>
+        )}
+        <Typography>Adding another network is not possible for this Safe. </Typography>
+      </Stack>
+    ) : isUnsupportedSafeCreationVersion ? (
+      'This account was created from an outdated mastercopy. Adding another network is not possible.'
+    ) : (
+      ''
+    )
 
   if (errorMessage) {
     return (


### PR DESCRIPTION
## What it solves
Explains why no network can be added to a Safe when trying to add a new network from the Network selector.

## How to test it
- Open a Safe that can not add another network (e.g. 1.1.1 Safe)
- Open the network selector
- Check the tooltip of the info icon

## Screenshots
![Screenshot 2024-09-30 at 14 24 05](https://github.com/user-attachments/assets/b32a5c93-2af6-4935-bf04-d0215011b354)



## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
