### PR TITLE
[Multichain] fix: Adjust balance alignment in safe list [SW-244]

### DIFF
--- a/src/components/welcome/MyAccounts/SubAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/SubAccountItem.tsx
@@ -62,7 +62,7 @@ const SubAccountItem = ({ onLinkClick, safeItem, safeOverview }: SubAccountItem)
       className={classnames(css.listItem, { [css.currentListItem]: isCurrentSafe }, css.subItem)}
     >
       <Track {...OVERVIEW_EVENTS.OPEN_SAFE} label={trackingLabel}>
-        <Link onClick={onLinkClick} href={href} className={css.safeLink}>
+        <Link onClick={onLinkClick} href={href} className={css.safeSubLink}>
           <Box pr={2.5}>
             <SafeIcon
               address={address}

--- a/src/components/welcome/MyAccounts/styles.module.css
+++ b/src/components/welcome/MyAccounts/styles.module.css
@@ -81,7 +81,14 @@
 .safeLink {
   display: grid;
   padding: var(--space-2) var(--space-1) var(--space-2) var(--space-2);
-  grid-template-columns: 60px 3fr 3fr 2fr;
+  grid-template-columns: 60px 3fr 3fr minmax(auto, 2fr);
+  align-items: center;
+}
+
+.safeSubLink {
+  display: grid;
+  padding: var(--space-2) var(--space-1) var(--space-2) var(--space-2);
+  grid-template-columns: 60px 3fr minmax(auto, 2fr);
   align-items: center;
 }
 


### PR DESCRIPTION
## What it solves

Part of SW-244

## How this PR fixes it

- Fixes the balance alignment of sub items in the safe list

## How to test it

1. Open the sidebar or safe list
2. Expand a multichain safe
3. Observe the balances are aligned to the right

## Screenshots

Before:
<img width="647" alt="Screenshot 2024-09-30 at 16 08 38" src="https://github.com/user-attachments/assets/6a4ebc4c-ba47-4067-b403-c88b71fa71ba">

After:
<img width="661" alt="Screenshot 2024-09-30 at 16 08 19" src="https://github.com/user-attachments/assets/1fab27de-ce2c-4d13-8153-249093b8d77e">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
