### PR TITLE
fix: Handle special characters for prefix in address input

### DIFF
--- a/src/utils/__tests__/addresses.test.ts
+++ b/src/utils/__tests__/addresses.test.ts
@@ -1,4 +1,4 @@
-import { checksumAddress, isChecksummedAddress, parsePrefixedAddress, sameAddress } from '../addresses'
+import { checksumAddress, cleanInputValue, isChecksummedAddress, parsePrefixedAddress, sameAddress } from '../addresses'
 
 describe('Addresses', () => {
   describe('checksumAddress', () => {
@@ -97,6 +97,99 @@ describe('Addresses', () => {
       const { prefix, address } = parsePrefixedAddress('sdfgsdfg')
       expect(prefix).toBeUndefined()
       expect(address).toBe('sdfgsdfg')
+    })
+  })
+
+  describe('cleanInputValue', () => {
+    it('should return the address when input is a valid address without prefix', () => {
+      const input = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+      const output = cleanInputValue(input)
+
+      expect(output).toBe('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd')
+    })
+
+    it('should return the address with prefix when input has a valid prefix', () => {
+      const input = 'prefix:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+      const output = cleanInputValue(input)
+
+      expect(output).toBe('prefix:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd')
+    })
+
+    it('should return the matched address when input contains text before the match', () => {
+      const input = 'some text prefix:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+      const output = cleanInputValue(input)
+
+      expect(output).toBe('prefix:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd')
+    })
+
+    it('should return the matched address when input contains text after the match', () => {
+      const input = 'prefix:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd some text'
+      const output = cleanInputValue(input)
+
+      expect(output).toBe('prefix:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd')
+    })
+
+    it('should return the original value when input does not match the regex', () => {
+      const input = 'invalid input'
+      const output = cleanInputValue(input)
+
+      expect(output).toBe('invalid input')
+    })
+
+    it('should handle prefixes with hyphens', () => {
+      const input = 'uh-huh:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+      const output = cleanInputValue(input)
+
+      expect(output).toBe('uh-huh:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd')
+    })
+
+    it('should return the address when input has uppercase letters', () => {
+      const input = '0xABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD'
+      const output = cleanInputValue(input)
+
+      expect(output).toBe('0xABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD')
+    })
+
+    it('should return the original value when Ethereum address is invalid (too short)', () => {
+      const input = '0x123'
+      const output = cleanInputValue(input)
+
+      expect(output).toBe('0x123')
+    })
+
+    it('should trim spaces and return the address when input has leading and trailing spaces', () => {
+      const input = '  0xabcdefabcdefabcdefabcdefabcdefabcdefabcd  '
+      const output = cleanInputValue(input)
+
+      expect(output).toBe('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd')
+    })
+
+    it('should return the first matched address when input contains multiple addresses', () => {
+      const input = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd 0x1234567890abcdef1234567890abcdef12345678'
+      const output = cleanInputValue(input)
+
+      expect(output).toBe('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd')
+    })
+
+    it('should return the address with numeric prefix', () => {
+      const input = '12345:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+      const output = cleanInputValue(input)
+
+      expect(output).toBe('12345:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd')
+    })
+
+    it('should return the address when prefix is missing colon', () => {
+      const input = 'prefix0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+      const output = cleanInputValue(input)
+
+      expect(output).toBe('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd')
+    })
+
+    it('should return the original value when prefix contains invalid characters', () => {
+      const input = 'invalid!prefix:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+      const output = cleanInputValue(input)
+
+      expect(output).toBe(input)
     })
   })
 })

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -58,7 +58,7 @@ export const formatPrefixedAddress = (address: string, prefix?: string): string 
 }
 
 export const cleanInputValue = (value: string): string => {
-  const regex = /(?:([a-z0-9]+):)?(0x[a-f0-9]{40})\b/i
+  const regex = /(?:([^\s:]+):)?(0x[a-f0-9]{40})\b/i
   const match = value.match(regex)
   // if match, return the address with optional prefix
   if (match) return match[0]


### PR DESCRIPTION
## What it solves

Noticed that the `AddressInput` unit test randomly fails sometimes. This happens when faker generates a shortName with a hyphen or other special characters in it so I adjusted our cleanup function to handle such characters.

## How this PR fixes it

- Updates `cleanInputValue` to not only handle `a-z0-9` characters in the prefix but any character that is not a `:`
- Adds unit tests for `cleanInputValue`

## How to test it

1. Create a send transaction
2. Input `test-prefix:<some address>` into the recipient field
3. Observe that the value is not changed
4. Input a real chain prefix like `eth:<some address>`
5. Observe that it is the same behaviour as previously

## Screenshots

On prod when typing `test-hyphen:<some address>`
<img width="705" alt="Screenshot 2024-09-30 at 16 44 36" src="https://github.com/user-attachments/assets/2ac9cf27-e2da-401b-9ab0-b6db08619e4c">

With the change when typing `test-hyphen:<some address>`
<img width="712" alt="Screenshot 2024-09-30 at 16 44 23" src="https://github.com/user-attachments/assets/20003641-6f0a-4bf0-a016-72755507bee0">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
