### PR TITLE
Fix(Multichain): ignore empty safe address when loading safeOverviews

### DIFF
--- a/src/components/common/NetworkSelector/index.tsx
+++ b/src/components/common/NetworkSelector/index.tsx
@@ -38,6 +38,8 @@ import PlusIcon from '@/public/images/common/plus.svg'
 import useAddressBook from '@/hooks/useAddressBook'
 import { CreateSafeOnSpecificChain } from '@/features/multichain/components/CreateSafeOnNewChain'
 import { useGetSafeOverviewQuery } from '@/store/api/gateway'
+import { selectUndeployedSafe } from '@/store/slices'
+import { skipToken } from '@reduxjs/toolkit/query'
 
 const ChainIndicatorWithFiatBalance = ({
   isSelected,
@@ -48,7 +50,10 @@ const ChainIndicatorWithFiatBalance = ({
   chain: ChainInfo
   safeAddress: string
 }) => {
-  const { data: safeOverview } = useGetSafeOverviewQuery({ safeAddress, chainId: chain.chainId })
+  const undeployedSafe = useAppSelector((state) => selectUndeployedSafe(state, chain.chainId, safeAddress))
+  const { data: safeOverview } = useGetSafeOverviewQuery(
+    undeployedSafe ? skipToken : { safeAddress, chainId: chain.chainId },
+  )
 
   return (
     <ChainIndicator

--- a/src/store/__tests__/safeOverviews.test.ts
+++ b/src/store/__tests__/safeOverviews.test.ts
@@ -45,6 +45,25 @@ describe('safeOverviews', () => {
       })
     })
 
+    it('should return null if safeOverview is not found for a given Safe', async () => {
+      const request = { chainId: '1', safeAddress: faker.finance.ethereumAddress() }
+      mockedGetSafeOverviews.mockResolvedValueOnce([])
+
+      const { result } = renderHook(() => useGetSafeOverviewQuery(request))
+
+      // Request should get queued and remain loading for the queue seconds
+      expect(result.current.isLoading).toBeTruthy()
+
+      await Promise.resolve()
+
+      await waitFor(() => {
+        expect(mockedGetSafeOverviews).toHaveBeenCalled()
+        expect(result.current.isLoading).toBeFalsy()
+        expect(result.current.error).toBeUndefined()
+        expect(result.current.data).toEqual(null)
+      })
+    })
+
     it('should return the Safe overview if fetching is successful', async () => {
       const request = { chainId: '1', safeAddress: faker.finance.ethereumAddress() }
 

--- a/src/store/__tests__/safeOverviews.test.ts
+++ b/src/store/__tests__/safeOverviews.test.ts
@@ -13,6 +13,22 @@ describe('safeOverviews', () => {
   })
 
   describe('useGetSafeOverviewQuery', () => {
+    it('should return null for empty safe Address', async () => {
+      const request = { chainId: '1', safeAddress: '' }
+      const { result } = renderHook(() => useGetSafeOverviewQuery(request))
+
+      // Request should get queued and remain loading for the queue seconds
+      expect(result.current.isLoading).toBeTruthy()
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBeFalsy()
+        expect(result.current.error).toBeUndefined()
+        expect(result.current.data).toBeNull()
+      })
+
+      expect(mockedGetSafeOverviews).not.toHaveBeenCalled()
+    })
+
     it('should return an error if fetching fails', async () => {
       const request = { chainId: '1', safeAddress: faker.finance.ethereumAddress() }
       mockedGetSafeOverviews.mockRejectedValueOnce('Service unavailable')

--- a/src/store/api/gateway/safeOverviews.ts
+++ b/src/store/api/gateway/safeOverviews.ts
@@ -5,6 +5,7 @@ import { sameAddress } from '@/utils/addresses'
 import type { RootState } from '../..'
 import { selectCurrency } from '../../settingsSlice'
 import { type SafeItem } from '@/components/welcome/MyAccounts/useAllSafes'
+import { asError } from '@/services/exceptions/utils'
 
 type SafeOverviewQueueItem = {
   safeAddress: string
@@ -128,8 +129,8 @@ export const safeOverviewEndpoints = (
   getSafeOverview: builder.query<SafeOverview | null, { safeAddress: string; walletAddress?: string; chainId: string }>(
     {
       async queryFn({ safeAddress, walletAddress, chainId }, { getState }) {
-        const state = getState()
-        const currency = selectCurrency(state as RootState)
+        const state = getState() as RootState
+        const currency = selectCurrency(state)
 
         if (!safeAddress) {
           return { data: null }
@@ -139,7 +140,7 @@ export const safeOverviewEndpoints = (
           const safeOverview = await batchedFetcher.getOverview({ chainId, currency, walletAddress, safeAddress })
           return { data: safeOverview ?? null }
         } catch (error) {
-          return { error: { status: 'CUSTOM_ERROR', error: (error as Error).message } }
+          return { error: { status: 'CUSTOM_ERROR', error: asError(error).message } }
         }
       },
     },

--- a/src/store/api/gateway/safeOverviews.ts
+++ b/src/store/api/gateway/safeOverviews.ts
@@ -125,22 +125,25 @@ export const safeOverviewEndpoints = (
     'gatewayApi'
   >,
 ) => ({
-  getSafeOverview: builder.query<
-    SafeOverview | undefined,
-    { safeAddress: string; walletAddress?: string; chainId: string }
-  >({
-    async queryFn({ safeAddress, walletAddress, chainId }, { getState }) {
-      const state = getState()
-      const currency = selectCurrency(state as RootState)
+  getSafeOverview: builder.query<SafeOverview | null, { safeAddress: string; walletAddress?: string; chainId: string }>(
+    {
+      async queryFn({ safeAddress, walletAddress, chainId }, { getState }) {
+        const state = getState()
+        const currency = selectCurrency(state as RootState)
 
-      try {
-        const safeOverview = await batchedFetcher.getOverview({ chainId, currency, walletAddress, safeAddress })
-        return { data: safeOverview }
-      } catch (error) {
-        return { error: { status: 'CUSTOM_ERROR', error: (error as Error).message } }
-      }
+        if (!safeAddress) {
+          return { data: null }
+        }
+
+        try {
+          const safeOverview = await batchedFetcher.getOverview({ chainId, currency, walletAddress, safeAddress })
+          return { data: safeOverview ?? null }
+        } catch (error) {
+          return { error: { status: 'CUSTOM_ERROR', error: (error as Error).message } }
+        }
+      },
     },
-  }),
+  ),
   getMultipleSafeOverviews: builder.query<SafeOverview[], MultiOverviewQueryParams>({
     async queryFn(params) {
       const { safes, walletAddress, currency } = params


### PR DESCRIPTION
## What it solves
We use `""` as fallback value for `useSafeAddress`. This caused empty requests to be triggered for the safe overview endpoint.

This fixes it by checking the safeAddress parameter before loading the safe overviews.

## How to test it
- Observe no more empty requests while the safe information is loading

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
