### PR TITLE
Fix: multichain decode migration

### DIFF
--- a/src/components/transactions/TxDetails/TxData/MigrationToL2TxData/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/MigrationToL2TxData/index.tsx
@@ -49,19 +49,19 @@ export const MigrationToL2TxData = ({ txDetails }: { txDetails: TransactionDetai
       }
       return createTx({
         to: execTxArgs[0],
-        value: execTxArgs[1],
+        value: execTxArgs[1].toString(),
         data: execTxArgs[2],
-        operation: execTxArgs[3],
-        safeTxGas: execTxArgs[4],
-        baseGas: execTxArgs[5],
-        gasPrice: execTxArgs[6],
-        gasToken: execTxArgs[7],
+        operation: Number(execTxArgs[3]),
+        safeTxGas: execTxArgs[4].toString(),
+        baseGas: execTxArgs[5].toString(),
+        gasPrice: execTxArgs[6].toString(),
+        gasToken: execTxArgs[7].toString(),
         refundReceiver: execTxArgs[8],
       })
     }
   }, [readOnlyProvider, txDetails.txHash, chain, safe.version, sdk])
 
-  const [decodedRealTx] = useDecodeTx(realSafeTx)
+  const [decodedRealTx, decodedRealTxError] = useDecodeTx(realSafeTx)
 
   const decodedDataUnavailable = !realSafeTx && !realSafeTxLoading
 
@@ -70,6 +70,8 @@ export const MigrationToL2TxData = ({ txDetails }: { txDetails: TransactionDetai
       <MigrateToL2Information variant="history" />
       {realSafeTxError ? (
         <ErrorMessage>{realSafeTxError.message}</ErrorMessage>
+      ) : decodedRealTxError ? (
+        <ErrorMessage>{decodedRealTxError.message}</ErrorMessage>
       ) : decodedDataUnavailable ? (
         <DecodedData txData={txDetails.txData} />
       ) : (


### PR DESCRIPTION
## What it solves
Fixes the decoding of transactions that migrate from L1 to L2.

## How to test it
- Open the tx history of a Safe that was migrated from L1 to L2 and check the tx details of the migration tx.

## Screenshots
![Screenshot 2024-10-01 at 10 17 40](https://github.com/user-attachments/assets/6caf1eb1-167d-4b44-ba9f-14193e66ad85)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
