### PR TITLE
fix: Poll safe creation info even when switching networks

### DIFF
--- a/src/features/counterfactual/CounterfactualSuccessScreen.tsx
+++ b/src/features/counterfactual/CounterfactualSuccessScreen.tsx
@@ -1,7 +1,7 @@
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { safeCreationPendingStatuses } from '@/features/counterfactual/hooks/usePendingSafeStatuses'
 import { SafeCreationEvent, safeCreationSubscribe } from '@/features/counterfactual/services/safeCreationEvents'
-import { useCurrentChain } from '@/hooks/useChains'
+import { useChain, useCurrentChain } from '@/hooks/useChains'
 import { useEffect, useState } from 'react'
 import { Box, Button, Dialog, DialogContent, Typography } from '@mui/material'
 import CheckRoundedIcon from '@mui/icons-material/CheckRounded'
@@ -9,12 +9,18 @@ import CheckRoundedIcon from '@mui/icons-material/CheckRounded'
 const CounterfactualSuccessScreen = () => {
   const [open, setOpen] = useState<boolean>(false)
   const [safeAddress, setSafeAddress] = useState<string>()
-  const chain = useCurrentChain()
+  const [chainId, setChainId] = useState<string>()
+  const currentChain = useCurrentChain()
+  const chain = useChain(chainId || currentChain?.chainId || '')
 
   useEffect(() => {
     const unsubFns = Object.entries(safeCreationPendingStatuses).map(([event]) =>
       safeCreationSubscribe(event as SafeCreationEvent, async (detail) => {
         if (event === SafeCreationEvent.INDEXED) {
+          if ('chainId' in detail) {
+            setChainId(detail.chainId)
+          }
+
           setSafeAddress(detail.safeAddress)
           setOpen(true)
         }
@@ -60,7 +66,7 @@ const CounterfactualSuccessScreen = () => {
 
         {safeAddress && (
           <Box p={2} bgcolor="background.main" borderRadius={1} fontSize={14}>
-            <EthHashInfo address={safeAddress} shortAddress={false} showCopyButton avatarSize={32} />
+            <EthHashInfo address={safeAddress} chainId={chainId} shortAddress={false} showCopyButton avatarSize={32} />
           </Box>
         )}
 

--- a/src/features/counterfactual/services/safeCreationEvents.ts
+++ b/src/features/counterfactual/services/safeCreationEvents.ts
@@ -25,10 +25,12 @@ export interface SafeCreationEvents {
     groupKey: string
     safeAddress: string
     type: PayMethod
+    chainId: string
   }
   [SafeCreationEvent.INDEXED]: {
     groupKey: string
     safeAddress: string
+    chainId: string
   }
   [SafeCreationEvent.FAILED]: {
     groupKey: string

--- a/src/features/counterfactual/utils.ts
+++ b/src/features/counterfactual/utils.ts
@@ -189,7 +189,7 @@ const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
  * @param txHash
  * @param maxAttempts
  */
-async function retryGetTransaction(provider: Provider, txHash: string, maxAttempts = 6) {
+async function retryGetTransaction(provider: Provider, txHash: string, maxAttempts = 8) {
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const txResponse = await provider.getTransaction(txHash)
     if (txResponse !== null) {
@@ -208,6 +208,7 @@ export const checkSafeActivation = async (
   txHash: string,
   safeAddress: string,
   type: PayMethod,
+  chainId: string,
   startBlock?: number,
 ) => {
   try {
@@ -233,6 +234,7 @@ export const checkSafeActivation = async (
       groupKey: CF_TX_GROUP_KEY,
       safeAddress,
       type,
+      chainId,
     })
   } catch (err) {
     const _err = err as EthersError
@@ -242,6 +244,7 @@ export const checkSafeActivation = async (
         groupKey: CF_TX_GROUP_KEY,
         safeAddress,
         type,
+        chainId,
       })
       return
     }
@@ -263,7 +266,7 @@ export const checkSafeActivation = async (
   }
 }
 
-export const checkSafeActionViaRelay = (taskId: string, safeAddress: string, type: PayMethod) => {
+export const checkSafeActionViaRelay = (taskId: string, safeAddress: string, type: PayMethod, chainId: string) => {
   const TIMEOUT_TIME = 2 * 60 * 1000 // 2 minutes
 
   let intervalId: NodeJS.Timeout
@@ -281,6 +284,7 @@ export const checkSafeActionViaRelay = (taskId: string, safeAddress: string, typ
           groupKey: CF_TX_GROUP_KEY,
           safeAddress,
           type,
+          chainId,
         })
         break
       case TaskState.ExecReverted:


### PR DESCRIPTION
## What it solves

Resolves #4293

## How this PR fixes it

- Emits the `chainId` with the SUCCESS and INDEXED safe creation event
- Uses that chainId inside the success modal instead of the current chain id

## How to test it

1. Create a safe on network A
2. Switch to a safe on network B
3. Observe the success screen showing network A info correctly once the safe has been deployed

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
