### PR TITLE
fix: Set pending state for batched transactions

### DIFF
--- a/src/components/tx-flow/flows/ExecuteBatch/ReviewBatch.tsx
+++ b/src/components/tx-flow/flows/ExecuteBatch/ReviewBatch.tsx
@@ -117,6 +117,7 @@ export const ReviewBatch = ({ params }: { params: ExecuteBatchFlowProps }) => {
       wallet.address,
       safe.address.value,
       overrides as Overrides & { nonce: number },
+      safe.nonce,
     )
   }
 

--- a/src/services/tx/tx-sender/dispatch.ts
+++ b/src/services/tx/tx-sender/dispatch.ts
@@ -253,6 +253,7 @@ export const dispatchCustomTxSpeedUp = async (
     to,
     groupKey: result?.hash,
     txType: 'Custom',
+    nonce,
   })
 
   return result.hash
@@ -320,6 +321,7 @@ export const dispatchBatchExecution = async (
   signerAddress: string,
   safeAddress: string,
   overrides: Omit<Overrides, 'nonce'> & { nonce: number },
+  nonce: number,
 ) => {
   const groupKey = multiSendTxData
 
@@ -337,11 +339,11 @@ export const dispatchBatchExecution = async (
     result = await multiSendContract.contract.connect(signer).multiSend(multiSendTxData, overrides)
 
     txIds.forEach((txId) => {
-      txDispatch(TxEvent.EXECUTING, { txId, groupKey })
+      txDispatch(TxEvent.EXECUTING, { txId, groupKey, nonce })
     })
   } catch (err) {
     txIds.forEach((txId) => {
-      txDispatch(TxEvent.FAILED, { txId, error: asError(err), groupKey })
+      txDispatch(TxEvent.FAILED, { txId, error: asError(err), groupKey, nonce })
     })
     throw err
   }
@@ -357,6 +359,7 @@ export const dispatchBatchExecution = async (
       txType: 'Custom',
       data: txData,
       to: txTo,
+      nonce,
     })
   })
 


### PR DESCRIPTION
## What it solves

Resolves [RC issue](https://github.com/safe-global/safe-wallet-web/pull/4290#issuecomment-2387667536)

Fixes a regression introduced in #4158 

## How this PR fixes it

- Sets `nonce` when emitting tx events from the batch execution

## How to test it

1. Queue and sign at least 2 transactions
2. Bulk execute them
3. Observe the Execute button changing to a processing state

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
