### PR TITLE
Fix(Multichain): do not migrate to L2 if no lib contract is available

### DIFF
--- a/src/hooks/__tests__/useSafeNotifications.test.ts
+++ b/src/hooks/__tests__/useSafeNotifications.test.ts
@@ -134,7 +134,7 @@ describe('useSafeNotifications', () => {
           address: {
             value: '0x1',
           },
-          chainId: '5',
+          chainId: '10',
         },
       })
 
@@ -165,7 +165,7 @@ describe('useSafeNotifications', () => {
           address: {
             value: '0x1',
           },
-          chainId: '5',
+          chainId: '10',
         },
       })
 
@@ -191,7 +191,7 @@ describe('useSafeNotifications', () => {
           address: {
             value: '0x1',
           },
-          chainId: '5',
+          chainId: '10',
         },
       })
 

--- a/src/services/contracts/__tests__/safeContracts.test.ts
+++ b/src/services/contracts/__tests__/safeContracts.test.ts
@@ -1,5 +1,11 @@
 import { ImplementationVersionState } from '@safe-global/safe-gateway-typescript-sdk'
-import { _getValidatedGetContractProps, isValidMasterCopy, _getMinimumMultiSendCallOnlyVersion } from '../safeContracts'
+import {
+  _getValidatedGetContractProps,
+  isValidMasterCopy,
+  _getMinimumMultiSendCallOnlyVersion,
+  isMigrationToL2Possible,
+} from '../safeContracts'
+import { safeInfoBuilder } from '@/tests/builders/safe'
 
 describe('safeContracts', () => {
   describe('isValidMasterCopy', () => {
@@ -61,6 +67,20 @@ describe('safeContracts', () => {
 
     it('should return the Safe version if the Safe version is higher than the initial version', () => {
       expect(_getMinimumMultiSendCallOnlyVersion('1.4.1')).toBe('1.4.1')
+    })
+  })
+
+  describe('isMigrationToL2Possible', () => {
+    it('should not be possible to migrate Safes on chains without migration lib', () => {
+      expect(isMigrationToL2Possible(safeInfoBuilder().with({ nonce: 0, chainId: '69420' }).build())).toBeFalsy()
+    })
+
+    it('should not be possible to migrate Safes with nonce > 0', () => {
+      expect(isMigrationToL2Possible(safeInfoBuilder().with({ nonce: 2, chainId: '10' }).build())).toBeFalsy()
+    })
+
+    it('should be possible to migrate Safes with nonce 0 on chains with migration lib', () => {
+      expect(isMigrationToL2Possible(safeInfoBuilder().with({ nonce: 0, chainId: '10' }).build())).toBeTruthy()
     })
   })
 })

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -15,6 +15,7 @@ import type { SafeVersion } from '@safe-global/safe-core-sdk-types'
 import { assertValidSafeVersion, getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 import semver from 'semver'
 import { getLatestSafeVersion } from '@/utils/chains'
+import { getSafeToL2MigrationDeployment } from '@safe-global/safe-deployments'
 
 // `UNKNOWN` is returned if the mastercopy does not match supported ones
 // @see https://github.com/safe-global/safe-client-gateway/blob/main/src/routes/safes/handlers/safes.rs#L28-L31
@@ -24,7 +25,10 @@ export const isValidMasterCopy = (implementationVersionState: SafeInfo['implemen
 }
 
 export const isMigrationToL2Possible = (safe: SafeInfo): boolean => {
-  return safe.nonce === 0
+  return (
+    safe.nonce === 0 &&
+    Boolean(getSafeToL2MigrationDeployment({ network: safe.chainId })?.networkAddresses[safe.chainId])
+  )
 }
 
 export const _getValidatedGetContractProps = (

--- a/src/utils/__tests__/transactions.test.ts
+++ b/src/utils/__tests__/transactions.test.ts
@@ -322,6 +322,20 @@ describe('transactions', () => {
       )
     })
 
+    it('should not modify tx if the chain has no migration lib deployed', () => {
+      const safeTx = safeTxBuilder()
+        .with({ data: safeTxDataBuilder().with({ nonce: 0 }).build() })
+        .build()
+
+      const safeInfo = extendedSafeInfoBuilder()
+        .with({ implementationVersionState: ImplementationVersionState.UNKNOWN })
+        .build()
+
+      expect(
+        prependSafeToL2Migration(safeTx, safeInfo, chainBuilder().with({ l2: true, chainId: '69420' }).build()),
+      ).resolves.toEqual(safeTx)
+    })
+
     it('should not modify tx if the tx already migrates', () => {
       const safeL2SingletonDeployment = getSafeL2SingletonDeployment()?.defaultAddress
 


### PR DESCRIPTION
## What it solves
On e.g. Gnosis Chiado no migration libs are deployed. We still tried to migrate from L1 to L2 though.

## How this PR fixes it
- Does not prepend a migration call if the chain does not have the migration contracts deployed.

## How to test it
- Create a L1 1.3.0 Mainnet Safe
- Add Gnosis Chiado to it
- Activate and do any tx
- It should not try to migrate

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
