### PR TITLE
[Multichain] fix: Display Activate now button in sidebar for counterfactual safes [SW-259]

### DIFF
--- a/src/components/sidebar/NewTxButton/index.tsx
+++ b/src/components/sidebar/NewTxButton/index.tsx
@@ -1,3 +1,5 @@
+import ActivateAccountButton from '@/features/counterfactual/ActivateAccountButton'
+import useIsCounterfactualSafe from '@/features/counterfactual/hooks/useIsCounterfactualSafe'
 import { type ReactElement, useContext } from 'react'
 import Button from '@mui/material/Button'
 import { OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
@@ -8,10 +10,15 @@ import WatchlistAddButton from '../WatchlistAddButton'
 
 const NewTxButton = (): ReactElement => {
   const { setTxFlow } = useContext(TxModalContext)
+  const isCounterfactualSafe = useIsCounterfactualSafe()
 
   const onClick = () => {
     setTxFlow(<NewTxFlow />, undefined, false)
     trackEvent({ ...OVERVIEW_EVENTS.NEW_TRANSACTION, label: 'sidebar' })
+  }
+
+  if (isCounterfactualSafe) {
+    return <ActivateAccountButton />
   }
 
   return (

--- a/src/features/counterfactual/ActivateAccountButton.tsx
+++ b/src/features/counterfactual/ActivateAccountButton.tsx
@@ -31,6 +31,7 @@ const ActivateAccountButton = () => {
               data-testid="activate-account-btn-cf"
               variant="contained"
               size="small"
+              fullWidth
               onClick={activateAccount}
               disabled={isProcessing || !isOk}
               sx={{ minHeight: '40px' }}


### PR DESCRIPTION
## What it solves

Resolves [SW-259](https://www.notion.so/safe-global/Show-Activate-Safe-button-in-sidebar-1138180fe57380968e26c6b987d7c090)

## How this PR fixes it

- Displays the `Activate now` button in the sidebar in case it is a counterfactual safe

## How to test it

1. Create a counterfactual safe
2. Observe there is an Activate now button in the sidebar

## Screenshots
<img width="1511" alt="Screenshot 2024-10-02 at 14 50 43" src="https://github.com/user-attachments/assets/0b664607-ef79-4df4-a26a-81277ba33506">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
