### PR TITLE
fix: increase relay limit window to daily

### DIFF
--- a/cypress/e2e/happypath/sendfunds_relay.cy.js
+++ b/cypress/e2e/happypath/sendfunds_relay.cy.js
@@ -45,7 +45,7 @@ function visit(url) {
   cy.visit(url)
 }
 
-// TODO: Relay only allows 5 txs per hour.
+// TODO: Relay only allows 5 txs per day.
 describe('Send funds with relay happy path tests', { defaultCommandTimeout: 300000 }, () => {
   before(async () => {
     cy.clearLocalStorage().then(() => {

--- a/cypress/e2e/pages/create_tx.pages.js
+++ b/cypress/e2e/pages/create_tx.pages.js
@@ -47,7 +47,7 @@ const viewTransactionBtn = 'View transaction'
 const transactionDetailsTitle = 'Transaction details'
 const QueueLabel = 'needs to be executed first'
 const TransactionSummary = 'Send '
-const transactionsPerHrStr = 'free transactions left this hour'
+const transactionsPerHrStr = 'free transactions left today'
 
 const maxAmountBtnStr = 'Max'
 const nextBtnStr = 'Next'

--- a/src/components/tx/RemainingRelays/index.tsx
+++ b/src/components/tx/RemainingRelays/index.tsx
@@ -1,18 +1,18 @@
 import { SvgIcon, Tooltip, Typography } from '@mui/material'
 import InfoIcon from '@/public/images/notifications/info.svg'
-import { MAX_HOUR_RELAYS } from '@/hooks/useRemainingRelays'
+import { MAX_DAY_RELAYS } from '@/hooks/useRemainingRelays'
 import css from '../BalanceInfo/styles.module.css'
 import type { RelayCountResponse } from '@safe-global/safe-gateway-typescript-sdk'
 
 const RemainingRelays = ({ relays, tooltip }: { relays?: RelayCountResponse; tooltip?: string }) => {
   if (!tooltip) {
-    tooltip = `${relays?.limit ?? MAX_HOUR_RELAYS} transactions per hour for free`
+    tooltip = `${relays?.limit ?? MAX_DAY_RELAYS} transactions per day for free`
   }
 
   return (
     <div className={css.container}>
       <Typography variant="body2" color="primary.light" display="flex" alignItems="center" gap={0.5}>
-        <b>{relays?.remaining ?? MAX_HOUR_RELAYS}</b> free transactions left this hour
+        <b>{relays?.remaining ?? MAX_DAY_RELAYS}</b> free transactions left today
         <Tooltip title={tooltip} placement="top" arrow>
           <span style={{ lineHeight: 0 }}>
             <SvgIcon component={InfoIcon} inheritViewBox color="info" fontSize="small" sx={{ color: '#B2B5B2' }} />

--- a/src/hooks/useRemainingRelays.ts
+++ b/src/hooks/useRemainingRelays.ts
@@ -4,7 +4,7 @@ import { FEATURES, hasFeature } from '@/utils/chains'
 import { useCurrentChain } from '@/hooks/useChains'
 import { getRelayCount } from '@safe-global/safe-gateway-typescript-sdk'
 
-export const MAX_HOUR_RELAYS = 5
+export const MAX_DAY_RELAYS = 5
 
 export const useRelaysBySafe = (txOrigin?: string) => {
   const chain = useCurrentChain()
@@ -35,7 +35,7 @@ export const useLeastRemainingRelays = (ownerAddresses: string[]) => {
         return result.find((r) => r.remaining === min)
       })
       .catch(() => {
-        return { remaining: 0, limit: MAX_HOUR_RELAYS }
+        return { remaining: 0, limit: MAX_DAY_RELAYS }
       })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chain, ownerAddresses, safe.txHistoryTag])

--- a/src/services/exceptions/ErrorCodes.ts
+++ b/src/services/exceptions/ErrorCodes.ts
@@ -38,7 +38,7 @@ enum ErrorCodes {
   _616 = '616: Failed to retrieve recommended nonce',
   _619 = '619: Error fetching data from master-copies',
   _620 = '620: Error loading chains',
-  _630 = '630: Error fetching remaining hourly relays',
+  _630 = '630: Error fetching remaining daily relays',
   _631 = '631: Transaction failed to be relayed',
   _632 = '632: Error fetching relay task status',
   _633 = '633: Notification (un-)registration failed',


### PR DESCRIPTION
## What it solves

Reflect increased relay window in UI.

## How this PR fixes it

All references to "per hour" for the relay limit window have been changed to daily to reflect the forthcoming increase.

## How to test it

Relay a transaction and observe all limit references be daily.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
