### PR TITLE
[Multichain] fix: Use chain-specific addresses for safe creation [SW-261]

### DIFF
--- a/src/components/new-safe/create/logic/index.ts
+++ b/src/components/new-safe/create/logic/index.ts
@@ -213,13 +213,13 @@ export const createNewUndeployedSafeWithoutSalt = (
   })
   const fallbackHandlerAddress = fallbackHandlerDeployment?.defaultAddress
   const safeL2Deployment = getSafeL2SingletonDeployment({ version: safeVersion, network: chain.chainId })
-  const safeL2Address = safeL2Deployment?.defaultAddress
+  const safeL2Address = safeL2Deployment?.networkAddresses[chain.chainId]
 
   const safeL1Deployment = getSafeSingletonDeployment({ version: safeVersion, network: chain.chainId })
-  const safeL1Address = safeL1Deployment?.defaultAddress
+  const safeL1Address = safeL1Deployment?.networkAddresses[chain.chainId]
 
   const safeFactoryDeployment = getProxyFactoryDeployment({ version: safeVersion, network: chain.chainId })
-  const safeFactoryAddress = safeFactoryDeployment?.defaultAddress
+  const safeFactoryAddress = safeFactoryDeployment?.networkAddresses[chain.chainId]
 
   if (!safeL2Address || !safeL1Address || !safeFactoryAddress || !fallbackHandlerAddress) {
     throw new Error('No Safe deployment found')


### PR DESCRIPTION
## What it solves

Resolves [SW-261](https://www.notion.so/safe-global/Creating-counterfactual-safe-on-zkSync-era-fails-when-pay-later-is-selected-1138180fe5738048ba74eb19dd9eb226)

## How this PR fixes it

- Uses chain-specific addresses for safeFactory, safeL1 and safeL2

## How to test it

1. Create a safe on zkSync
2. Observe no error

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
