### PR TITLE
fix(Multichain): store owner and Safe name in addressBook on all chosen networks

### DIFF
--- a/src/components/new-safe/create/logic/address-book.ts
+++ b/src/components/new-safe/create/logic/address-book.ts
@@ -5,7 +5,7 @@ import { defaultSafeInfo } from '@/store/safeInfoSlice'
 import type { NamedAddress } from '@/components/new-safe/create/types'
 
 export const updateAddressBook = (
-  chainId: string,
+  chainIds: string[],
   address: string,
   name: string,
   owners: NamedAddress[],
@@ -14,7 +14,7 @@ export const updateAddressBook = (
   return (dispatch) => {
     dispatch(
       upsertAddressBookEntries({
-        chainIds: [chainId],
+        chainIds,
         address,
         name,
       }),
@@ -23,24 +23,26 @@ export const updateAddressBook = (
     owners.forEach((owner) => {
       const entryName = owner.name || owner.ens
       if (entryName) {
-        dispatch(upsertAddressBookEntries({ chainIds: [chainId], address: owner.address, name: entryName }))
+        dispatch(upsertAddressBookEntries({ chainIds, address: owner.address, name: entryName }))
       }
     })
 
-    dispatch(
-      addOrUpdateSafe({
-        safe: {
-          ...defaultSafeInfo,
-          address: { value: address, name },
-          threshold,
-          owners: owners.map((owner) => ({
-            value: owner.address,
-            name: owner.name || owner.ens,
-          })),
-          chainId,
-          nonce: 0,
-        },
-      }),
-    )
+    chainIds.forEach((chainId) => {
+      dispatch(
+        addOrUpdateSafe({
+          safe: {
+            ...defaultSafeInfo,
+            address: { value: address, name },
+            threshold,
+            owners: owners.map((owner) => ({
+              value: owner.address,
+              name: owner.name || owner.ens,
+            })),
+            chainId,
+            nonce: 0,
+          },
+        }),
+      )
+    })
   }
 }

--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -48,6 +48,7 @@ import { type ReplayedSafeProps } from '@/store/slices'
 import { predictAddressBasedOnReplayData } from '@/components/welcome/MyAccounts/utils/multiChainSafe'
 import { createWeb3 } from '@/hooks/wallets/web3'
 import { type DeploySafeProps } from '@safe-global/protocol-kit'
+import { updateAddressBook } from '../../logic/address-book'
 
 export const NetworkFee = ({
   totalFee,
@@ -214,6 +215,17 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
       for (const network of data.networks) {
         await createSafe(network, replayedSafeWithNonce, safeAddress)
       }
+
+      // Update addressbook with owners and Safe on all chosen networks
+      dispatch(
+        updateAddressBook(
+          data.networks.map((network) => network.chainId),
+          safeAddress,
+          data.name,
+          data.owners,
+          data.threshold,
+        ),
+      )
 
       gtmSetChainId(chain.chainId)
 

--- a/src/components/new-safe/create/steps/StatusStep/index.tsx
+++ b/src/components/new-safe/create/steps/StatusStep/index.tsx
@@ -2,7 +2,6 @@ import { useCounter } from '@/components/common/Notifications/useCounter'
 import type { StepRenderProps } from '@/components/new-safe/CardStepper/useCardStepper'
 import type { NewSafeFormData } from '@/components/new-safe/create'
 import { getRedirect } from '@/components/new-safe/create/logic'
-import { updateAddressBook } from '@/components/new-safe/create/logic/address-book'
 import StatusMessage from '@/components/new-safe/create/steps/StatusStep/StatusMessage'
 import useUndeployedSafe from '@/components/new-safe/create/steps/StatusStep/useUndeployedSafe'
 import lightPalette from '@/components/theme/lightPalette'
@@ -54,7 +53,6 @@ export const CreateSafeStatus = ({
     if (!chain || !safeAddress) return
 
     if (status === SafeCreationEvent.SUCCESS) {
-      dispatch(updateAddressBook(chain.chainId, safeAddress, data.name, data.owners, data.threshold))
       const redirect = getRedirect(chain.shortName, safeAddress, router.query?.safeViewRedirectURL)
       if (typeof redirect !== 'string' || redirect.startsWith('/')) {
         router.push(redirect)

--- a/src/features/counterfactual/utils.ts
+++ b/src/features/counterfactual/utils.ts
@@ -16,8 +16,6 @@ import ExternalStore from '@/services/ExternalStore'
 import { getSafeSDKWithSigner, getUncheckedSigner, tryOffChainTxSigning } from '@/services/tx/tx-sender/sdk'
 import { getRelayTxStatus, TaskState } from '@/services/tx/txMonitor'
 import type { AppDispatch } from '@/store'
-import { addOrUpdateSafe } from '@/store/addedSafesSlice'
-import { upsertAddressBookEntries } from '@/store/addressBookSlice'
 import { defaultSafeInfo } from '@/store/safeInfoSlice'
 import { didRevert, type EthersError } from '@/utils/ethers-utils'
 import { assertProvider, assertTx, assertWallet } from '@/utils/helpers'
@@ -175,21 +173,6 @@ export const replayCounterfactualSafeDeployment = (
   }
 
   dispatch(addUndeployedSafe(undeployedSafe))
-  dispatch(upsertAddressBookEntries({ chainIds: [chainId], address: safeAddress, name }))
-  dispatch(
-    addOrUpdateSafe({
-      safe: {
-        ...defaultSafeInfo,
-        address: { value: safeAddress, name },
-        threshold: setup.threshold,
-        owners: setup.owners.map((owner) => ({
-          value: owner,
-          name: undefined,
-        })),
-        chainId,
-      },
-    }),
-  )
 }
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))


### PR DESCRIPTION
## What it solves
Owner names were not added to the address book for counterfactual Safe creation.

## How this PR fixes it
- Uses the `updateAddressBook` action regardless of the Safe creation method.
- Removes dispatching Address book actions from other methods than `updateAddressBook`


## How to test it
- Create a Safe on multiple chains
- Observe the owner and SAfe name being added to all selected networks.

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
