### PR TITLE
[Multichain] fix: Add condensed network list to safe creation review [SW-264]

### DIFF
--- a/src/components/new-safe/create/OverviewWidget/styles.module.css
+++ b/src/components/new-safe/create/OverviewWidget/styles.module.css
@@ -19,4 +19,5 @@
   justify-content: space-between;
   align-items: center;
   border-top: 1px solid var(--color-border-light);
+  gap: var(--space-1);
 }

--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -1,6 +1,7 @@
 import type { NamedAddress } from '@/components/new-safe/create/types'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { safeCreationDispatch, SafeCreationEvent } from '@/features/counterfactual/services/safeCreationEvents'
+import NetworkLogosList from '@/features/multichain/components/NetworkLogosList'
 import { getTotalFeeFormatted } from '@/hooks/useGasPrice'
 import type { StepRenderProps } from '@/components/new-safe/CardStepper/useCardStepper'
 import type { NewSafeFormData } from '@/components/new-safe/create'
@@ -33,7 +34,7 @@ import { FEATURES, hasFeature } from '@/utils/chains'
 import { hasRemainingRelays } from '@/utils/relaying'
 import { isWalletRejection } from '@/utils/wallets'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
-import { Box, Button, CircularProgress, Divider, Grid, Typography } from '@mui/material'
+import { Box, Button, CircularProgress, Divider, Grid, Tooltip, Typography } from '@mui/material'
 import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import classnames from 'classnames'
 import { useRouter } from 'next/router'
@@ -87,11 +88,22 @@ export const SafeSetupOverview = ({
       <ReviewRow
         name={networks.length > 1 ? 'Networks' : 'Network'}
         value={
-          <Box display="flex" flexWrap="wrap" gap={1}>
-            {networks.map((network) => (
-              <ChainIndicator inline key={network.chainId} chainId={network.chainId} showUnknown={false} />
-            ))}
-          </Box>
+          <Tooltip
+            title={
+              <Box>
+                {networks.map((safeItem) => (
+                  <Box p="4px 0px" key={safeItem.chainId}>
+                    <ChainIndicator chainId={safeItem.chainId} />
+                  </Box>
+                ))}
+              </Box>
+            }
+            arrow
+          >
+            <Box display="inline-block">
+              <NetworkLogosList networks={networks} />
+            </Box>
+          </Tooltip>
         }
       />
       {name && <ReviewRow name="Name" value={<Typography>{name}</Typography>} />}

--- a/src/features/multichain/components/NetworkLogosList/styles.module.css
+++ b/src/features/multichain/components/NetworkLogosList/styles.module.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-wrap: wrap;
   margin-left: 6px;
+  row-gap: 4px;
 }
 
 .networks img {


### PR DESCRIPTION
## What it solves

Resolves [SW-264](https://www.notion.so/safe-global/Show-condensed-view-of-networks-on-creation-review-1158180fe573804099ecf5463ab2531b)

## How this PR fixes it

- Uses `NetworkLogosList` with a Tooltip in Review step
- Adds a slight gap to the overview widget network list

## How to test it

1. Create a Safe with multiple networks selected
2. Go to the review step
3. Observe the condensed network view

## Screenshots
<img width="794" alt="Screenshot 2024-10-07 at 10 48 35" src="https://github.com/user-attachments/assets/a66cbe95-e19c-4a41-9a93-5457f902fd87">
<img width="805" alt="Screenshot 2024-10-07 at 10 48 42" src="https://github.com/user-attachments/assets/3d7cbbd1-aa64-49c1-8c54-1e9a46122c13">
<img width="418" alt="Screenshot 2024-10-07 at 10 49 50" src="https://github.com/user-attachments/assets/3d347156-0f77-4c4a-891d-b776b0531221">



## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
