### PR TITLE
[Multichain] fix: Invert condition to disable correct nav items [SW-266]

### DIFF
--- a/src/components/sidebar/SidebarNavigation/index.tsx
+++ b/src/components/sidebar/SidebarNavigation/index.tsx
@@ -56,7 +56,7 @@ const Navigation = (): ReactElement => {
   const enabledNavItems = useMemo(() => {
     return safe.deployed
       ? visibleNavItems
-      : visibleNavItems.filter((item) => undeployedSafeBlockedRoutes.includes(item.href))
+      : visibleNavItems.filter((item) => !undeployedSafeBlockedRoutes.includes(item.href))
   }, [safe.deployed, visibleNavItems])
 
   const getBadge = (item: NavItem) => {


### PR DESCRIPTION
## What it solves

Resolves [SW-266](https://www.notion.so/safe-global/Wrong-categories-are-blocked-for-the-CF-safe-1188180fe57380b8aed4e878ae8ebaeb)

## How this PR fixes it

- Inverts the condition so that the correct nav items are disabled

## How to test it

1. Open a counterfactual safe
2. Observe Swaps, Apps and Staking are disabled in the sidebar

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
