### PR TITLE
feat: start the stake widget on the overview screen SW-233

### DIFF
--- a/src/features/stake/constants.ts
+++ b/src/features/stake/constants.ts
@@ -1,7 +1,7 @@
 export const STAKE_TITLE = 'Stake'
 
-export const WIDGET_PRODUCTION_URL = 'https://safe.widget.kiln.fi/earn'
-export const WIDGET_TESTNET_URL = 'https://safe.widget.testnet.kiln.fi/earn'
+export const WIDGET_PRODUCTION_URL = 'https://safe.widget.kiln.fi/overview'
+export const WIDGET_TESTNET_URL = 'https://safe.widget.testnet.kiln.fi/overview'
 
 export const widgetAppData = {
   url: WIDGET_PRODUCTION_URL,


### PR DESCRIPTION
## What it solves
When navigating to the earn page the user was directly sent to the earn tab. With this change the user will be one the overview page.

## How this PR fixes it
Changes the default url for the widget

## How to test it
Go to staking and observe that the user is on the overview tab.

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
