### PR TITLE
fix: swap & stake decoding was displayed twice

### DIFF
--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -27,7 +27,7 @@ import { trackEvent } from '@/services/analytics'
 import useChainId from '@/hooks/useChainId'
 import ExecuteThroughRoleForm from './ExecuteThroughRoleForm'
 import { findAllowingRole, findMostLikelyRole, useRoles } from './ExecuteThroughRoleForm/hooks'
-import { isCustomTxInfo, isGenericConfirmation } from '@/utils/transaction-guards'
+import { isAnyStakingTxInfo, isCustomTxInfo, isGenericConfirmation, isOrderTxInfo } from '@/utils/transaction-guards'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import { BlockaidBalanceChanges } from '../security/blockaid/BlockaidBalanceChange'
 import { Blockaid } from '../security/blockaid'
@@ -104,7 +104,12 @@ export const SignOrExecuteForm = ({
         }
       : skipToken,
   )
-  const showTxDetails = props.txId && txDetails && !isCustomTxInfo(txDetails.txInfo)
+  const showTxDetails =
+    props.txId &&
+    txDetails &&
+    !isCustomTxInfo(txDetails.txInfo) &&
+    !isAnyStakingTxInfo(txDetails.txInfo) &&
+    !isOrderTxInfo(txDetails.txInfo)
   const isDelegate = useIsWalletDelegate()
   const [trigger] = useLazyGetTransactionDetailsQuery()
   const [readableApprovals] = useApprovalInfos({ safeTransaction: safeTx })

--- a/src/features/stake/components/StakingConfirmationTx/Withdraw.tsx
+++ b/src/features/stake/components/StakingConfirmationTx/Withdraw.tsx
@@ -1,8 +1,8 @@
 import { Stack } from '@mui/material'
 import FieldsGrid from '@/components/tx/FieldsGrid'
-import type {
-  NativeStakingWithdrawConfirmationView,
-  StakingTxWithdrawInfo,
+import {
+  type NativeStakingWithdrawConfirmationView,
+  type StakingTxWithdrawInfo,
 } from '@safe-global/safe-gateway-typescript-sdk'
 import TokenAmount from '@/components/common/TokenAmount'
 


### PR DESCRIPTION
## What it solves
I was originally fixing a bug with staking decoding being displayed twice:
![grafik](https://github.com/user-attachments/assets/868d2781-4c87-4182-ac01-6357c0dc1d40)

But actually it turned out to be also the same for swaps:
![grafik](https://github.com/user-attachments/assets/798418bd-4262-4bec-a286-4780164d2624)

Resolves #
We introduced this bug with the redesign of the tx-details: https://github.com/safe-global/safe-wallet-web/commit/fced30195d512e991afa29f9c77008b8654ddefc . We moved the TxData block higher up in the tree, but failed to account that we display the same info with the ConfirmationOrder view. So this block should be hidden if we are dealing with a stake or swap txs.

## How this PR fixes it
If we have any kind of StakingTxInfo or OrderTxInfo tx we hide the TxData block.

## How to test it
Create a swap or stake tx. Sign it. Now in the tx queue hit execute. In production right now we display nearly the same data twice, with this fix only the appropriate confirmation view data is displayed. 

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
