### PR TITLE
[Multichain] fix: Adjust multichain analytics events [SW-165]

### DIFF
--- a/src/components/common/NetworkSelector/index.tsx
+++ b/src/components/common/NetworkSelector/index.tsx
@@ -233,9 +233,14 @@ const UndeployedNetworks = ({
     closeNetworkSelect()
   }
 
+  const onShowAllNetworks = () => {
+    !open && trackEvent(OVERVIEW_EVENTS.SHOW_ALL_NETWORKS)
+    setOpen((prev) => !prev)
+  }
+
   return (
     <>
-      <ButtonBase className={css.listSubHeader} onClick={() => setOpen((prev) => !prev)} tabIndex={-1}>
+      <ButtonBase className={css.listSubHeader} onClick={onShowAllNetworks} tabIndex={-1}>
         <Stack direction="row" spacing={1} alignItems="center">
           <div>Show all networks</div>
           <ExpandMoreIcon

--- a/src/components/welcome/MyAccounts/MultiAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/MultiAccountItem.tsx
@@ -86,7 +86,7 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountIte
   const trackingLabel = isWelcomePage ? OVERVIEW_LABELS.login_page : OVERVIEW_LABELS.sidebar
 
   const toggleExpand = () => {
-    trackEvent({ ...OVERVIEW_EVENTS.EXPAND_MULTI_SAFE, label: trackingLabel })
+    !expanded && trackEvent({ ...OVERVIEW_EVENTS.EXPAND_MULTI_SAFE, label: trackingLabel })
     setExpanded((prev) => !prev)
   }
 

--- a/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
+++ b/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
@@ -2,6 +2,7 @@ import ModalDialog from '@/components/common/ModalDialog'
 import NetworkInput from '@/components/common/NetworkInput'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import { CREATE_SAFE_CATEGORY, CREATE_SAFE_EVENTS, OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
+import { gtmSetChainId } from '@/services/analytics/gtm'
 import { showNotification } from '@/store/notificationsSlice'
 import { Box, Button, CircularProgress, DialogActions, DialogContent, Stack, Typography } from '@mui/material'
 import { FormProvider, useForm } from 'react-hook-form'
@@ -94,6 +95,8 @@ const ReplaySafeDialog = ({
         setCreationError(new Error('The replayed Safe leads to an unexpected address'))
         return
       }
+
+      gtmSetChainId(selectedChain.chainId)
 
       trackEvent({ ...OVERVIEW_EVENTS.SUBMIT_ADD_NEW_NETWORK, label: selectedChain.chainId })
 

--- a/src/services/analytics/events/overview.ts
+++ b/src/services/analytics/events/overview.ts
@@ -135,6 +135,10 @@ export const OVERVIEW_EVENTS = {
     category: OVERVIEW_CATEGORY,
     //label: OPEN_SAFE_LABELS
   },
+  SHOW_ALL_NETWORKS: {
+    action: 'Show all networks',
+    category: OVERVIEW_CATEGORY,
+  },
   // Track actual Safe views
   SAFE_VIEWED: {
     event: EventType.SAFE_OPENED,


### PR DESCRIPTION
## What it solves

Follow-up on [SW-165](https://www.notion.so/safe-global/Check-analytics-7f1cdc962c6f45e1a1a79dc79055e948)

## How this PR fixes it

- Only emits expand event if expanded not collapsed
- Adds an event for expanding "Show all networks"
- Sets the chainId when creating a new safe

## How to test it

1. Open the sidebar and expand a multichain safe
2. Observe an expand event
3. Collapse the multichain safe
4. Observe no expand event
5. Click on on "Show all networks" in the header
6. Observe an event when expanding but not collapsing
7. Add a safe on another network
8. Observe the GA events contain the chainId of the new safe

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
