### PR TITLE
fix: Change color of New chip in sidebar

### DIFF
--- a/src/components/common/Chip/index.tsx
+++ b/src/components/common/Chip/index.tsx
@@ -1,18 +1,17 @@
-import { Typography, Chip as MuiChip } from '@mui/material'
+import { Typography, Chip as MuiChip, type ChipProps } from '@mui/material'
 
-type ChipProps = {
+type Props = {
   label?: string
-  color?: 'primary' | 'secondary' | 'info' | 'warning' | 'success' | 'error'
+  sx?: ChipProps['sx']
 }
 
-export function Chip({ color = 'primary', label = 'New' }: ChipProps) {
+export function Chip({ sx, label = 'New' }: Props) {
   return (
     <MuiChip
       size="small"
       component="span"
       sx={{
-        backgroundColor: `${color}.background`,
-        color: `${color}.light`,
+        ...sx,
         mt: '-2px',
       }}
       label={

--- a/src/components/sidebar/SidebarNavigation/config.tsx
+++ b/src/components/sidebar/SidebarNavigation/config.tsx
@@ -40,7 +40,7 @@ export const navItems: NavItem[] = [
     label: 'Stake',
     icon: <SvgIcon component={StakeIcon} inheritViewBox />,
     href: AppRoutes.stake,
-    tag: <Chip label="New" sx={{ backgroundColor: 'secondary.light', color: 'text.primary' }} />,
+    tag: <Chip label="New" sx={{ backgroundColor: 'secondary.light', color: 'static.main' }} />,
   },
   {
     label: 'Transactions',

--- a/src/components/sidebar/SidebarNavigation/config.tsx
+++ b/src/components/sidebar/SidebarNavigation/config.tsx
@@ -40,7 +40,7 @@ export const navItems: NavItem[] = [
     label: 'Stake',
     icon: <SvgIcon component={StakeIcon} inheritViewBox />,
     href: AppRoutes.stake,
-    tag: <Chip label="New" />,
+    tag: <Chip label="New" sx={{ backgroundColor: 'secondary.light', color: 'text.primary' }} />,
   },
   {
     label: 'Transactions',


### PR DESCRIPTION
## What it solves

Resolves #4259 

## How this PR fixes it

- Adjusts the `Chip` component to receive an `sx` prop to have more granular control over colors

## How to test it

1. Open a Safe
2. Observe the New chip in the sidebar is green
3. Observe the Chip for the SAP on the dashboard still looks the same

## Screenshots
<img width="261" alt="Screenshot 2024-10-08 at 14 46 28" src="https://github.com/user-attachments/assets/71f771f5-ffae-4922-8d81-f6498c0913e7">
<img width="474" alt="Screenshot 2024-10-08 at 14 46 35" src="https://github.com/user-attachments/assets/7e477030-e9d4-4bba-b4a7-f743aa61fd05">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
