### PR TITLE
Fix(Multichain): zk sync creation

### DIFF
--- a/src/components/new-safe/create/logic/index.test.ts
+++ b/src/components/new-safe/create/logic/index.test.ts
@@ -320,5 +320,35 @@ describe('create/logic', () => {
         factoryAddress: getProxyFactoryDeployment({ version: '1.4.1', network: '137' })?.defaultAddress,
       })
     })
+
+    it('should use l2 masterCopy and no migration on zkSync', () => {
+      const safeSetup = {
+        owners: [faker.finance.ethereumAddress()],
+        threshold: 1,
+      }
+      expect(
+        createNewUndeployedSafeWithoutSalt(
+          '1.3.0',
+          safeSetup,
+          chainBuilder()
+            .with({ chainId: '324' })
+            // Multichain and 1.4.1 creation is toggled off
+            .with({ features: [FEATURES.COUNTERFACTUAL] as any })
+            .with({ l2: true })
+            .build(),
+        ),
+      ).toEqual({
+        safeAccountConfig: {
+          ...safeSetup,
+          fallbackHandler: getFallbackHandlerDeployment({ version: '1.3.0', network: '324' })?.networkAddresses['324'],
+          to: ZERO_ADDRESS,
+          data: EMPTY_DATA,
+          paymentReceiver: ECOSYSTEM_ID_ADDRESS,
+        },
+        safeVersion: '1.3.0',
+        masterCopy: getSafeL2SingletonDeployment({ version: '1.3.0', network: '324' })?.networkAddresses['324'],
+        factoryAddress: getProxyFactoryDeployment({ version: '1.3.0', network: '324' })?.networkAddresses['324'],
+      })
+    })
   })
 })

--- a/src/components/new-safe/create/logic/index.ts
+++ b/src/components/new-safe/create/logic/index.ts
@@ -87,7 +87,6 @@ export const computeNewSafeAddress = async (
       saltNonce: props.saltNonce,
       safeVersion: safeVersion ?? getLatestSafeVersion(chain),
     },
-    isL1SafeSingleton: true,
   })
 }
 
@@ -211,7 +210,7 @@ export const createNewUndeployedSafeWithoutSalt = (
     version: safeVersion,
     network: chain.chainId,
   })
-  const fallbackHandlerAddress = fallbackHandlerDeployment?.defaultAddress
+  const fallbackHandlerAddress = fallbackHandlerDeployment?.networkAddresses[chain.chainId]
   const safeL2Deployment = getSafeL2SingletonDeployment({ version: safeVersion, network: chain.chainId })
   const safeL2Address = safeL2Deployment?.networkAddresses[chain.chainId]
 


### PR DESCRIPTION
## What it solves
Fixes address prediction on zkSync and therefore safe creation

## How this PR fixes it
- Reverts to using the core sdk for address prediction on zk sync.

## How to test it
- Create a CF Safe on zkSync
- Activate it and observe that the predicted address matches again

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
