### PR TITLE
[Multichain] fix: Update address book for replayed safe [SW-270]

### DIFF
--- a/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
+++ b/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
@@ -1,5 +1,6 @@
 import ModalDialog from '@/components/common/ModalDialog'
 import NetworkInput from '@/components/common/NetworkInput'
+import { updateAddressBook } from '@/components/new-safe/create/logic/address-book'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import { CREATE_SAFE_CATEGORY, CREATE_SAFE_EVENTS, OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
 import { gtmSetChainId } from '@/services/analytics/gtm'
@@ -120,6 +121,16 @@ const ReplaySafeDialog = ({
       })
 
       trackEvent({ ...OVERVIEW_EVENTS.SWITCH_NETWORK, label: selectedChain.chainId })
+
+      dispatch(
+        updateAddressBook(
+          [selectedChain.chainId],
+          safeAddress,
+          currentName || '',
+          safeCreationData.safeAccountConfig.owners.map((owner) => ({ address: owner, name: '' })),
+          safeCreationData.safeAccountConfig.threshold,
+        ),
+      )
 
       dispatch(
         showNotification({


### PR DESCRIPTION
## What it solves

Resolves [SW-270](https://www.notion.so/safe-global/Adding-new-network-does-not-update-address-book-1198180fe5738025b835d3aeb84d5162)

## How this PR fixes it

- Calls `updateAddressBook` when replaying a safe from the sidebar or network selector

## How to test it

1. Create a safe
2. Open the sidebar and replay the safe on another network
3. Go to the address book
4. Observe an entry for this safe

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
