### PR TITLE
fix(Multichain): detect migration txs and mark them as trusted

### DIFF
--- a/src/components/transactions/TxDetails/TxData/DecodedData/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/index.tsx
@@ -12,6 +12,7 @@ import MethodCall from './MethodCall'
 import useSafeAddress from '@/hooks/useSafeAddress'
 import { sameAddress } from '@/utils/addresses'
 import { DelegateCallWarning } from '@/components/transactions/Warning'
+import { isMigrateToL2TxData } from '@/utils/transaction-guards'
 
 interface Props {
   txData: TransactionDetails['txData']
@@ -58,9 +59,11 @@ export const DecodedData = ({ txData, toInfo }: Props): ReactElement | null => {
     decodedData = <HexEncodedData title="Data (hex-encoded)" hexData={txData.hexData} />
   }
 
+  const isL2Migration = isMigrateToL2TxData(txData, chainInfo?.chainId)
+
   return (
     <Stack spacing={2}>
-      {isDelegateCall && <DelegateCallWarning showWarning={!txData.trustedDelegateCallTarget} />}
+      {isDelegateCall && <DelegateCallWarning showWarning={!txData.trustedDelegateCallTarget && !isL2Migration} />}
 
       {method ? (
         <MethodCall contractAddress={toAddress} contractName={name} contractLogo={avatar} method={method} />

--- a/src/components/transactions/TxDetails/TxData/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/index.tsx
@@ -73,7 +73,7 @@ const TxData = ({
     return <SpendingLimits txData={txDetails.txData} txInfo={txInfo} type={method} />
   }
 
-  if (isMigrateToL2TxData(txDetails.txData)) {
+  if (isMigrateToL2TxData(txDetails.txData, chainId)) {
     return <MigrationToL2TxData txDetails={txDetails} />
   }
   return <DecodedData txData={txDetails.txData} toInfo={toInfo} />

--- a/src/utils/transaction-guards.ts
+++ b/src/utils/transaction-guards.ts
@@ -57,8 +57,12 @@ import { sameAddress } from '@/utils/addresses'
 import type { NamedAddress } from '@/components/new-safe/create/types'
 import type { RecoveryQueueItem } from '@/features/recovery/services/recovery-state'
 import { ethers } from 'ethers'
-import { getSafeToL2MigrationDeployment } from '@safe-global/safe-deployments'
+import { getSafeToL2MigrationDeployment, getMultiSendDeployments } from '@safe-global/safe-deployments'
 import { Safe_to_l2_migration__factory } from '@/types/contracts'
+import { hasMatchingDeployment } from '@/services/contracts/deployments'
+import { isMultiSendCalldata } from './transaction-calldata'
+import { decodeMultiSendData } from '@safe-global/protocol-kit/dist/src/utils'
+import { OperationType } from '@safe-global/safe-core-sdk-types'
 
 export const isTxQueued = (value: TransactionStatus): boolean => {
   return [TransactionStatus.AWAITING_CONFIRMATIONS, TransactionStatus.AWAITING_EXECUTION].includes(value)
@@ -87,16 +91,48 @@ export const isModuleDetailedExecutionInfo = (value?: DetailedExecutionInfo): va
   return value?.type === DetailedExecutionInfoType.MODULE
 }
 
-export const isMigrateToL2TxData = (value: TransactionData | undefined): boolean => {
+const isMigrateToL2CallData = (value: {
+  to: string
+  data: string | undefined
+  operation?: OperationType | undefined
+}) => {
   const safeToL2MigrationDeployment = getSafeToL2MigrationDeployment()
   const safeToL2MigrationAddress = safeToL2MigrationDeployment?.defaultAddress
   const safeToL2MigrationInterface = Safe_to_l2_migration__factory.createInterface()
 
-  if (sameAddress(value?.to.value, safeToL2MigrationAddress)) {
+  if (value.operation === OperationType.DelegateCall && sameAddress(value.to, safeToL2MigrationAddress)) {
     const migrateToL2Selector = safeToL2MigrationInterface?.getFunction('migrateToL2')?.selector
-    return migrateToL2Selector && value?.hexData ? value.hexData?.startsWith(migrateToL2Selector) : false
+    return migrateToL2Selector && value.data ? value.data.startsWith(migrateToL2Selector) : false
   }
   return false
+}
+
+export const isMigrateToL2TxData = (value: TransactionData | undefined, chainId: string | undefined): boolean => {
+  if (!value) {
+    return false
+  }
+
+  if (
+    chainId &&
+    value?.hexData &&
+    isMultiSendCalldata(value?.hexData) &&
+    hasMatchingDeployment(getMultiSendDeployments, value.to.value, chainId, ['1.3.0', '1.4.1'])
+  ) {
+    // Its a multiSend to the MultiSend contract (not CallOnly)
+    const decodedMultiSend = decodeMultiSendData(value.hexData)
+    const firstTx = decodedMultiSend[0]
+
+    // We only trust the tx if the first tx is the only delegateCall
+    const hasMoreDelegateCalls = decodedMultiSend
+      .slice(1)
+      .some((value) => value.operation === OperationType.DelegateCall)
+
+    if (!hasMoreDelegateCalls && firstTx && isMigrateToL2CallData(firstTx)) {
+      return true
+    }
+  }
+
+  return isMigrateToL2CallData({ to: value.to.value, data: value.hexData, operation: value.operation as 0 | 1 })
 }
 
 // TransactionInfo type guards


### PR DESCRIPTION
## What it solves
The MultiSends of migrations are not flagged as trusted because they contain delegateCalls.

## How this PR fixes it
Adds a workaround that detects that the tx only contains a trusted migration delegateCall and nothing else.

## How to test it
Open e.g. this Safe:
`aurora:0x51b49d7812478A2eaa25fA1d5F7352600d3ABfD2`

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
