### PR TITLE
feat(tx-builder-mode): share dark mode information with safe apps

### DIFF
--- a/src/components/safe-apps/AppFrame/useAppCommunicator.ts
+++ b/src/components/safe-apps/AppFrame/useAppCommunicator.ts
@@ -33,6 +33,7 @@ import { SAFE_APPS_EVENTS, trackSafeAppEvent } from '@/services/analytics'
 import { useAppSelector } from '@/store'
 import { selectRpc } from '@/store/settingsSlice'
 import { createSafeAppsWeb3Provider } from '@/hooks/wallets/web3'
+import { useDarkMode } from '@/hooks/useDarkMode'
 
 export enum CommunicatorMessages {
   REJECT_TRANSACTION_MESSAGE = 'Transaction was rejected',
@@ -73,6 +74,7 @@ const useAppCommunicator = (
 ): AppCommunicator | undefined => {
   const [communicator, setCommunicator] = useState<AppCommunicator | undefined>(undefined)
   const customRpc = useAppSelector(selectRpc)
+  const isDarkMode = useDarkMode()
 
   const safeAppWeb3Provider = useMemo(() => {
     if (!chain) {
@@ -118,6 +120,15 @@ const useAppCommunicator = (
       communicatorInstance?.clear()
     }
   }, [app, iframeRef])
+
+  useEffect(() => {
+    communicator?.send(
+      {
+        darkMode: isDarkMode,
+      },
+      'tx-builder',
+    )
+  }, [communicator, isDarkMode])
 
   // Adding communicator logic for the required SDK Methods
   // We don't need to unsubscribe from the events because there can be just one subscription
@@ -205,7 +216,17 @@ const useAppCommunicator = (
     communicator?.on(Methods.requestAddressBook, (msg) => {
       return handlers.onRequestAddressBook(msg.origin)
     })
-  }, [safeAppWeb3Provider, handlers, chain, communicator])
+
+    // TODO: it will be moved to safe-apps-sdk soon
+    communicator?.on('getCurrentTheme' as Methods, (msg) => {
+      communicator.send(
+        {
+          darkMode: isDarkMode,
+        },
+        msg.data.id,
+      )
+    })
+  }, [safeAppWeb3Provider, handlers, chain, communicator, isDarkMode])
 
   return communicator
 }

--- a/src/components/safe-apps/AppFrame/useAppCommunicator.ts
+++ b/src/components/safe-apps/AppFrame/useAppCommunicator.ts
@@ -122,11 +122,13 @@ const useAppCommunicator = (
   }, [app, iframeRef])
 
   useEffect(() => {
+    const id = Math.random().toString(36).slice(2)
+
     communicator?.send(
       {
         darkMode: isDarkMode,
       },
-      'tx-builder',
+      id,
     )
   }, [communicator, isDarkMode])
 

--- a/src/services/safe-apps/AppCommunicator.ts
+++ b/src/services/safe-apps/AppCommunicator.ts
@@ -37,11 +37,15 @@ class AppCommunicator {
     const sentFromIframe = this.iframeRef.current?.contentWindow === msg.source
     const knownMethod = Object.values(Methods).includes(msg.data.method)
 
-    return sentFromIframe && knownMethod
+    // TODO: move it to safe-app Methods types
+    const isThemeInfoMethod = (msg.data.method as string) === 'getCurrentTheme'
+
+    return sentFromIframe && (knownMethod || isThemeInfoMethod)
   }
 
   private canHandleMessage = (msg: SDKMessageEvent): boolean => {
     if (!msg.data) return false
+
     return Boolean(this.handlers.get(msg.data.method))
   }
 


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/safe-react-apps/issues/824

## How this PR fixes it
It adds the getCurrentTheme method into the app communicator in order to share the darkMode information with the transaction builder or any other safe app.

## How to test it
- Take the transaction builder dark mode deployed PR link and add it on your safe
- Open the custom tx-builder app which you just added
- change the dark mode toggle on the sidebar
- **the transaction builder theme should change according to safe wallet theme** 

## Screenshots
[txbuilder.webm](https://github.com/user-attachments/assets/94ef42c4-815d-4717-9dfc-f62ae71adba7)


## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
