### PR TITLE
fix: useLoadChains should follow the next url

### DIFF
--- a/src/hooks/__tests__/useLoadChains.test.ts
+++ b/src/hooks/__tests__/useLoadChains.test.ts
@@ -1,20 +1,18 @@
-import { getChainsConfig } from '@safe-global/safe-gateway-typescript-sdk'
 import useLoadChains from '@/hooks/loadables/useLoadChains'
 import { act, renderHook } from '@/tests/test-utils'
+import { getConfigs } from '@/hooks/loadables/helpers/config'
 
 // Mock getChainsConfig
-jest.mock('@safe-global/safe-gateway-typescript-sdk', () => {
+jest.mock('@/hooks/loadables/helpers/config.ts', () => {
   return {
-    getChainsConfig: jest.fn(() => {
+    getConfigs: jest.fn(() => {
       return new Promise((resolve) => {
         setTimeout(() => {
-          resolve({
-            results: [
-              {
-                chainId: '4',
-              },
-            ],
-          })
+          resolve([
+            {
+              chainId: '4',
+            },
+          ])
         }, 100)
       })
     }),
@@ -61,7 +59,7 @@ describe('useLoadChains hook', () => {
 
   it('should set the error state when the promise rejects', async () => {
     // Change the getChainsConfig mock to reject
-    ;(getChainsConfig as jest.Mock).mockImplementation(() => Promise.reject(new Error('Something went wrong')))
+    ;(getConfigs as jest.Mock).mockImplementation(() => Promise.reject(new Error('Something went wrong')))
 
     const { result } = renderHook(() => useLoadChains())
 

--- a/src/hooks/loadables/__tests__/useLoadChains.test.ts
+++ b/src/hooks/loadables/__tests__/useLoadChains.test.ts
@@ -1,0 +1,156 @@
+// getConfigs.test.ts
+
+import { getConfigs } from '@/hooks/loadables/useLoadChains'
+
+// Mock data for testing
+const mockDataPage1 = {
+  results: [
+    { id: 1, name: 'Chain 1' },
+    { id: 2, name: 'Chain 2' },
+  ],
+  next: 'https://safe-client.safe.global/v1/chains?cursor=limit%3D2%26offset%3D20',
+}
+
+const mockDataPage2 = {
+  results: [
+    { id: 3, name: 'Chain 3' },
+    { id: 4, name: 'Chain 4' },
+  ],
+  next: null,
+}
+
+describe('getConfigs', () => {
+  beforeEach(() => {
+    // Clear all instances and calls to fetch
+    jest.clearAllMocks()
+  })
+
+  it('should fetch data from the API and concatenate results', async () => {
+    // Mock fetch responses for each call
+    global.fetch = jest
+      .fn()
+      // First call returns mockDataPage1
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockDataPage1,
+      })
+      // Second call returns mockDataPage2
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockDataPage2,
+      })
+
+    const results = await getConfigs()
+
+    expect(results).toEqual([
+      { id: 1, name: 'Chain 1' },
+      { id: 2, name: 'Chain 2' },
+      { id: 3, name: 'Chain 3' },
+      { id: 4, name: 'Chain 4' },
+    ])
+
+    // Ensure fetch was called twice
+    expect(fetch).toHaveBeenCalledTimes(2)
+
+    // Check that fetch was called with the correct URLs
+    expect(fetch).toHaveBeenCalledWith('https://safe-client.staging.5afe.dev/v1/chains')
+    expect(fetch).toHaveBeenCalledWith('https://safe-client.safe.global/v1/chains?cursor=limit%3D2%26offset%3D20')
+  })
+
+  it('should handle a single page of results', async () => {
+    // Mock fetch response
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [{ id: 1, name: 'Chain 1' }],
+        next: null,
+      }),
+    })
+
+    const results = await getConfigs()
+
+    expect(results).toEqual([{ id: 1, name: 'Chain 1' }])
+
+    // Ensure fetch was called once
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    // Check that fetch was called with the correct URL
+    expect(fetch).toHaveBeenCalledWith('https://safe-client.staging.5afe.dev/v1/chains')
+  })
+
+  it('should handle network errors gracefully', async () => {
+    // Mock fetch to throw an error
+    global.fetch = jest.fn().mockImplementation(() => {
+      throw new Error('Network error')
+    })
+
+    // Spy on console.error to suppress error logs during test
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    const results = await getConfigs()
+
+    expect(results).toEqual([])
+
+    // Ensure fetch was called once
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    // Restore console.error
+    ;(console.error as jest.Mock).mockRestore()
+  })
+
+  it('should handle HTTP errors (non-200 responses)', async () => {
+    // Mock fetch to return a non-OK response
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    })
+
+    // Spy on console.error to suppress error logs during test
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    const results = await getConfigs()
+
+    expect(results).toEqual([])
+
+    // Ensure fetch was called once
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    // Restore console.error
+    ;(console.error as jest.Mock).mockRestore()
+  })
+
+  it('should handle empty results', async () => {
+    // Mock fetch response with empty results
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [],
+        next: null,
+      }),
+    })
+
+    const results = await getConfigs()
+
+    expect(results).toEqual([])
+
+    // Ensure fetch was called once
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('should handle missing next property', async () => {
+    // Mock fetch response without next property
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        results: [{ id: 1, name: 'Chain 1' }],
+      }),
+    })
+
+    const results = await getConfigs()
+
+    expect(results).toEqual([{ id: 1, name: 'Chain 1' }])
+
+    // Ensure fetch was called once
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/loadables/__tests__/useLoadChains.test.ts
+++ b/src/hooks/loadables/__tests__/useLoadChains.test.ts
@@ -1,20 +1,44 @@
-// getConfigs.test.ts
-
+jest.mock('@/pages/_app', () => ({
+  ...jest.requireActual('@/pages/_app'),
+  GATEWAY_URL: 'https://safe-client.safe.global',
+  __esModule: true,
+}))
+import { chainBuilder } from '@/tests/builders/chains'
 import { getConfigs } from '@/hooks/loadables/useLoadChains'
 
 // Mock data for testing
 const mockDataPage1 = {
   results: [
-    { id: 1, name: 'Chain 1' },
-    { id: 2, name: 'Chain 2' },
+    chainBuilder()
+      .with({
+        chainId: '0x1',
+        chainName: 'Chain 1',
+      })
+      .build(),
+    chainBuilder()
+      .with({
+        chainId: '0x2',
+        chainName: 'Chain 2',
+      })
+      .build(),
   ],
   next: 'https://safe-client.safe.global/v1/chains?cursor=limit%3D2%26offset%3D20',
 }
 
 const mockDataPage2 = {
   results: [
-    { id: 3, name: 'Chain 3' },
-    { id: 4, name: 'Chain 4' },
+    chainBuilder()
+      .with({
+        chainId: '0x3',
+        chainName: 'Chain 3',
+      })
+      .build(),
+    chainBuilder()
+      .with({
+        chainId: '0x4',
+        chainName: 'Chain 4',
+      })
+      .build(),
   ],
   next: null,
 }
@@ -42,18 +66,13 @@ describe('getConfigs', () => {
 
     const results = await getConfigs()
 
-    expect(results).toEqual([
-      { id: 1, name: 'Chain 1' },
-      { id: 2, name: 'Chain 2' },
-      { id: 3, name: 'Chain 3' },
-      { id: 4, name: 'Chain 4' },
-    ])
+    expect(results).toEqual([...mockDataPage1.results, ...mockDataPage2.results])
 
     // Ensure fetch was called twice
     expect(fetch).toHaveBeenCalledTimes(2)
 
     // Check that fetch was called with the correct URLs
-    expect(fetch).toHaveBeenCalledWith('https://safe-client.staging.5afe.dev/v1/chains')
+    expect(fetch).toHaveBeenCalledWith('https://safe-client.safe.global/v1/chains')
     expect(fetch).toHaveBeenCalledWith('https://safe-client.safe.global/v1/chains?cursor=limit%3D2%26offset%3D20')
   })
 
@@ -75,27 +94,27 @@ describe('getConfigs', () => {
     expect(fetch).toHaveBeenCalledTimes(1)
 
     // Check that fetch was called with the correct URL
-    expect(fetch).toHaveBeenCalledWith('https://safe-client.staging.5afe.dev/v1/chains')
+    expect(fetch).toHaveBeenCalledWith('https://safe-client.safe.global/v1/chains')
   })
 
-  it('should handle network errors gracefully', async () => {
+  it('should handle network errors', async () => {
     // Mock fetch to throw an error
     global.fetch = jest.fn().mockImplementation(() => {
       throw new Error('Network error')
     })
 
-    // Spy on console.error to suppress error logs during test
-    jest.spyOn(console, 'error').mockImplementation(() => {})
+    let error: Error | undefined = undefined
+    try {
+      await getConfigs()
+    } catch (e) {
+      error = e as Error
+    }
 
-    const results = await getConfigs()
-
-    expect(results).toEqual([])
+    expect(error).toBeDefined()
+    expect(error!.message).toBe('Network error')
 
     // Ensure fetch was called once
     expect(fetch).toHaveBeenCalledTimes(1)
-
-    // Restore console.error
-    ;(console.error as jest.Mock).mockRestore()
   })
 
   it('should handle HTTP errors (non-200 responses)', async () => {
@@ -105,18 +124,18 @@ describe('getConfigs', () => {
       status: 500,
     })
 
-    // Spy on console.error to suppress error logs during test
-    jest.spyOn(console, 'error').mockImplementation(() => {})
+    let error: Error | undefined = undefined
+    try {
+      await getConfigs()
+    } catch (e) {
+      error = e as Error
+    }
 
-    const results = await getConfigs()
-
-    expect(results).toEqual([])
+    expect(error).toBeDefined()
+    expect(error!.message).toBe('HTTP error! status: 500')
 
     // Ensure fetch was called once
     expect(fetch).toHaveBeenCalledTimes(1)
-
-    // Restore console.error
-    ;(console.error as jest.Mock).mockRestore()
   })
 
   it('should handle empty results', async () => {
@@ -142,13 +161,13 @@ describe('getConfigs', () => {
     global.fetch = jest.fn().mockResolvedValueOnce({
       ok: true,
       json: async () => ({
-        results: [{ id: 1, name: 'Chain 1' }],
+        results: [mockDataPage1.results[0]],
       }),
     })
 
     const results = await getConfigs()
 
-    expect(results).toEqual([{ id: 1, name: 'Chain 1' }])
+    expect(results).toEqual([mockDataPage1.results[0]])
 
     // Ensure fetch was called once
     expect(fetch).toHaveBeenCalledTimes(1)

--- a/src/hooks/loadables/helpers/__tests__/config.test.ts
+++ b/src/hooks/loadables/helpers/__tests__/config.test.ts
@@ -1,10 +1,11 @@
+import { getConfigs } from '@/hooks/loadables/helpers/config'
+
 jest.mock('@/pages/_app', () => ({
   ...jest.requireActual('@/pages/_app'),
   GATEWAY_URL: 'https://safe-client.safe.global',
   __esModule: true,
 }))
 import { chainBuilder } from '@/tests/builders/chains'
-import { getConfigs } from '@/hooks/loadables/useLoadChains'
 
 // Mock data for testing
 const mockDataPage1 = {

--- a/src/hooks/loadables/helpers/__tests__/config.test.ts
+++ b/src/hooks/loadables/helpers/__tests__/config.test.ts
@@ -9,38 +9,12 @@ import { chainBuilder } from '@/tests/builders/chains'
 
 // Mock data for testing
 const mockDataPage1 = {
-  results: [
-    chainBuilder()
-      .with({
-        chainId: '0x1',
-        chainName: 'Chain 1',
-      })
-      .build(),
-    chainBuilder()
-      .with({
-        chainId: '0x2',
-        chainName: 'Chain 2',
-      })
-      .build(),
-  ],
+  results: [chainBuilder().build(), chainBuilder().build()],
   next: 'https://safe-client.safe.global/v1/chains?cursor=limit%3D2%26offset%3D20',
 }
 
 const mockDataPage2 = {
-  results: [
-    chainBuilder()
-      .with({
-        chainId: '0x3',
-        chainName: 'Chain 3',
-      })
-      .build(),
-    chainBuilder()
-      .with({
-        chainId: '0x4',
-        chainName: 'Chain 4',
-      })
-      .build(),
-  ],
+  results: [chainBuilder().build(), chainBuilder().build()],
   next: null,
 }
 
@@ -82,14 +56,14 @@ describe('getConfigs', () => {
     global.fetch = jest.fn().mockResolvedValueOnce({
       ok: true,
       json: async () => ({
-        results: [{ id: 1, name: 'Chain 1' }],
+        results: [mockDataPage1.results[0]],
         next: null,
       }),
     })
 
     const results = await getConfigs()
 
-    expect(results).toEqual([{ id: 1, name: 'Chain 1' }])
+    expect(results).toEqual([mockDataPage1.results[0]])
 
     // Ensure fetch was called once
     expect(fetch).toHaveBeenCalledTimes(1)

--- a/src/hooks/loadables/helpers/config.ts
+++ b/src/hooks/loadables/helpers/config.ts
@@ -1,0 +1,20 @@
+import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { GATEWAY_URL } from '@/pages/_app'
+
+export const getConfigs = async (): Promise<ChainInfo[]> => {
+  let allResults: ChainInfo[] = []
+  let url = `${GATEWAY_URL}/v1/chains`
+
+  while (url) {
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`)
+    }
+    const data = await response.json()
+    const results = data.results || []
+    allResults = allResults.concat(results)
+    url = data.next
+  }
+
+  return allResults
+}

--- a/src/hooks/loadables/useLoadChains.ts
+++ b/src/hooks/loadables/useLoadChains.ts
@@ -1,26 +1,8 @@
 import { useEffect } from 'react'
 import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import useAsync, { type AsyncResult } from '../useAsync'
-import { logError, Errors } from '@/services/exceptions'
-import { GATEWAY_URL } from '@/pages/_app'
-
-export const getConfigs = async (): Promise<ChainInfo[]> => {
-  let allResults: ChainInfo[] = []
-  let url = `${GATEWAY_URL}/v1/chains`
-
-  while (url) {
-    const response = await fetch(url)
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`)
-    }
-    const data = await response.json()
-    const results = data.results || []
-    allResults = allResults.concat(results)
-    url = data.next
-  }
-
-  return allResults
-}
+import { Errors, logError } from '@/services/exceptions'
+import { getConfigs } from '@/hooks/loadables/helpers/config'
 
 export const useLoadChains = (): AsyncResult<ChainInfo[]> => {
   const [data, error, loading] = useAsync<ChainInfo[]>(getConfigs, [])

--- a/src/hooks/loadables/useLoadChains.ts
+++ b/src/hooks/loadables/useLoadChains.ts
@@ -9,19 +9,14 @@ export const getConfigs = async (): Promise<ChainInfo[]> => {
   let url = `${GATEWAY_URL}/v1/chains`
 
   while (url) {
-    try {
-      const response = await fetch(url)
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`)
-      }
-      const data = await response.json()
-      const results = data.results || []
-      allResults = allResults.concat(results)
-      url = data.next
-    } catch (error) {
-      console.error('Network error:', error)
-      break
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`)
     }
+    const data = await response.json()
+    const results = data.results || []
+    allResults = allResults.concat(results)
+    url = data.next
   }
 
   return allResults

--- a/src/hooks/loadables/useLoadChains.ts
+++ b/src/hooks/loadables/useLoadChains.ts
@@ -1,11 +1,30 @@
 import { useEffect } from 'react'
-import { getChainsConfig, type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import useAsync, { type AsyncResult } from '../useAsync'
 import { logError, Errors } from '@/services/exceptions'
+import { GATEWAY_URL } from '@/pages/_app'
 
-const getConfigs = async (): Promise<ChainInfo[]> => {
-  const data = await getChainsConfig()
-  return data.results || []
+export const getConfigs = async (): Promise<ChainInfo[]> => {
+  let allResults: ChainInfo[] = []
+  let url = `${GATEWAY_URL}/v1/chains`
+
+  while (url) {
+    try {
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`)
+      }
+      const data = await response.json()
+      const results = data.results || []
+      allResults = allResults.concat(results)
+      url = data.next
+    } catch (error) {
+      console.error('Network error:', error)
+      break
+    }
+  }
+
+  return allResults
 }
 
 export const useLoadChains = (): AsyncResult<ChainInfo[]> => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -45,7 +45,7 @@ import CounterfactualHooks from '@/features/counterfactual/CounterfactualHooks'
 import PkModulePopup from '@/services/private-key-module/PkModulePopup'
 import GeoblockingProvider from '@/components/common/GeoblockingProvider'
 
-const GATEWAY_URL = IS_PRODUCTION || cgwDebugStorage.get() ? GATEWAY_URL_PRODUCTION : GATEWAY_URL_STAGING
+export const GATEWAY_URL = IS_PRODUCTION || cgwDebugStorage.get() ? GATEWAY_URL_PRODUCTION : GATEWAY_URL_STAGING
 
 const reduxStore = makeStore()
 


### PR DESCRIPTION
## What it solves
We are not able to load more than 20 networks in the UI

Resolves #
https://github.com/safe-global/safe-wallet-web/issues/4336

## How this PR fixes it
The getConfigs function was using the client gateway sdk to fetch the chains. This call is limited to 20 items and we never try to fetch more. The config service now has more than 20 networks and we are missing them in the url. It turned out however that it is very difficult to provide the {offset, limit} arguments to the getChainInfo on the sdk. Something seems wrong and generated next url is wrong.

That’s why I opted out of using the sdk for this call and instead directly fetch the results and follow the next prop on the returned object until there is nothing more.

## How to test it
If using the production gateway the chiado network should be visible. 

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
