### PR TITLE
Tests: Add timeout for infomodal test

### DIFF
--- a/cypress/e2e/pages/safeapps.pages.js
+++ b/cypress/e2e/pages/safeapps.pages.js
@@ -252,7 +252,7 @@ export function verifyInfoModalAcceptance() {
     return cy
       .findByRole('button', { name: continueBtnStr })
       .click()
-      .wait(500)
+      .wait(2000)
       .should(() => {
         const storedInfoModal = JSON.parse(
           localStorage.getItem(constants.localStorageKeys.SAFE_v2__SafeApps__infoModal),


### PR DESCRIPTION
## What it solves

## How this PR fixes it

- Add more timeout to info modal test as sometimes it is not enough time to retrieve values from local storage

## How to test it

- Run Cypress tests and observe outcome