### PR TITLE
fix(Multichain): allow missing paymentToken when adding networks

### DIFF
--- a/src/features/multichain/hooks/useSafeCreationData.ts
+++ b/src/features/multichain/hooks/useSafeCreationData.ts
@@ -54,7 +54,10 @@ const getUndeployedSafeCreationData = async (undeployedSafe: UndeployedSafe): Pr
 
 const validateAccountConfig = (safeAccountConfig: SafeAccountConfig) => {
   // Safes that used the reimbursement logic are not supported
-  if ((safeAccountConfig.payment && safeAccountConfig.payment > 0) || safeAccountConfig.paymentToken !== ZERO_ADDRESS) {
+  if (
+    (safeAccountConfig.payment && safeAccountConfig.payment > 0) ||
+    (safeAccountConfig.paymentToken && safeAccountConfig.paymentToken !== ZERO_ADDRESS)
+  ) {
     throw new Error(SAFE_CREATION_DATA_ERRORS.PAYMENT_SAFE)
   }
 


### PR DESCRIPTION
## What it solves
Replaying counterfactual Safes without paymentToken set lead to a wrong error.

## How this PR fixes it
Corrects the check for reimbursements

## How to test it
- Create a new counterfactual Safe
- Try to add a network without activating first

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
