### PR TITLE
fix: Track number of delegate transactions

### DIFF
--- a/src/components/tx/SignOrExecuteForm/DelegateForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/DelegateForm.tsx
@@ -21,6 +21,7 @@ export const DelegateForm = ({
   disableSubmit = false,
   txActions,
   txSecurity,
+  onSubmit,
 }: SignOrExecuteProps & {
   txActions: ReturnType<typeof useTxActions>
   txSecurity: ReturnType<typeof useTxSecurityContext>
@@ -51,7 +52,8 @@ export const DelegateForm = ({
     setIsRejectedByUser(false)
 
     try {
-      await signDelegateTx(safeTx)
+      const txId = await signDelegateTx(safeTx)
+      onSubmit?.(txId)
     } catch (_err) {
       const err = asError(_err)
       if (isWalletRejection(err)) {

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -63,8 +63,13 @@ const trackTxEvents = (
   isCreation: boolean,
   isExecuted: boolean,
   isRoleExecution: boolean,
+  isDelegateCreation: boolean,
 ) => {
-  const creationEvent = isRoleExecution ? TX_EVENTS.CREATE_VIA_ROLE : TX_EVENTS.CREATE
+  const creationEvent = isRoleExecution
+    ? TX_EVENTS.CREATE_VIA_ROLE
+    : isDelegateCreation
+    ? TX_EVENTS.CREATE_VIA_DELEGATE
+    : TX_EVENTS.CREATE
   const executionEvent = isRoleExecution ? TX_EVENTS.EXECUTE_VIA_ROLE : TX_EVENTS.EXECUTE
   const event = isCreation ? creationEvent : isExecuted ? executionEvent : TX_EVENTS.CONFIRM
   const txType = getTransactionTrackingType(details)
@@ -135,18 +140,23 @@ export const SignOrExecuteForm = ({
     (props.onlyExecute || shouldExecute) && canExecuteThroughRole && (!canExecute || preferThroughRole)
 
   const onFormSubmit = useCallback(
-    async (txId: string, isExecuted = false, isRoleExecution = false) => {
+    async (txId: string, isExecuted = false, isRoleExecution = false, isDelegateCreation = false) => {
       onSubmit?.(txId, isExecuted)
 
       const { data: details } = await trigger({ chainId, txId })
       // Track tx event
-      trackTxEvents(details, isCreation, isExecuted, isRoleExecution)
+      trackTxEvents(details, isCreation, isExecuted, isRoleExecution, isDelegateCreation)
     },
     [chainId, isCreation, onSubmit, trigger],
   )
 
   const onRoleExecutionSubmit = useCallback<typeof onFormSubmit>(
     (txId, isExecuted) => onFormSubmit(txId, isExecuted, true),
+    [onFormSubmit],
+  )
+
+  const onDelegateFormSubmit = useCallback<typeof onFormSubmit>(
+    (txId, isExecuted) => onFormSubmit(txId, isExecuted, false, true),
     [onFormSubmit],
   )
 
@@ -230,7 +240,7 @@ export const SignOrExecuteForm = ({
           />
         )}
 
-        {isDelegate && <DelegateForm {...props} safeTx={safeTx} onSubmit={onFormSubmit} />}
+        {isDelegate && <DelegateForm {...props} safeTx={safeTx} onSubmit={onDelegateFormSubmit} />}
       </TxCard>
     </>
   )

--- a/src/services/analytics/events/transactions.ts
+++ b/src/services/analytics/events/transactions.ts
@@ -48,6 +48,11 @@ export const TX_EVENTS = {
     action: 'Create via spending limit',
     category: TX_CATEGORY,
   },
+  CREATE_VIA_DELEGATE: {
+    event: EventType.TX_CREATED,
+    action: 'Create via delegate',
+    category: TX_CATEGORY,
+  },
   CONFIRM: {
     event: EventType.TX_CONFIRMED,
     action: 'Confirm transaction',


### PR DESCRIPTION
## What it solves

Resolves #4206

## How this PR fixes it

- Extends `trackTxEvents` to handle delegate form submissions

## How to test it

1. Open a Safe that has a delegate
2. Create a transaction as a delegate
3. Observe a GA event being emitted once the user submits the tx in their wallet

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
