### PR TITLE
[Multichain] fix: Copy owners to address book when replaying safe [SW-270]

### DIFF
--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -263,7 +263,7 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
       gtmSetChainId(chain.chainId)
 
       if (isCounterfactualEnabled && payMethod === PayMethod.PayLater) {
-        router?.push({
+        await router?.push({
           pathname: AppRoutes.home,
           query: { safe: `${data.networks[0].shortName}:${safeAddress}` },
         })

--- a/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
+++ b/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
@@ -75,7 +75,6 @@ const ReplaySafeDialog = ({
     trackEvent({ ...OVERVIEW_EVENTS.CANCEL_ADD_NEW_NETWORK })
     onClose()
   }
-  console.log(addressBook)
 
   const onFormSubmit = handleSubmit(async (data) => {
     setIsSubmitting(true)

--- a/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
+++ b/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
@@ -2,6 +2,7 @@ import ModalDialog from '@/components/common/ModalDialog'
 import NetworkInput from '@/components/common/NetworkInput'
 import { updateAddressBook } from '@/components/new-safe/create/logic/address-book'
 import ErrorMessage from '@/components/tx/ErrorMessage'
+import useAddressBook from '@/hooks/useAddressBook'
 import { CREATE_SAFE_CATEGORY, CREATE_SAFE_EVENTS, OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
 import { gtmSetChainId } from '@/services/analytics/gtm'
 import { showNotification } from '@/store/notificationsSlice'
@@ -60,6 +61,7 @@ const ReplaySafeDialog = ({
   })
   const { handleSubmit, formState } = formMethods
   const router = useRouter()
+  const addressBook = useAddressBook()
 
   const customRpc = useAppSelector(selectRpc)
   const dispatch = useAppDispatch()
@@ -73,6 +75,7 @@ const ReplaySafeDialog = ({
     trackEvent({ ...OVERVIEW_EVENTS.CANCEL_ADD_NEW_NETWORK })
     onClose()
   }
+  console.log(addressBook)
 
   const onFormSubmit = handleSubmit(async (data) => {
     setIsSubmitting(true)
@@ -127,7 +130,10 @@ const ReplaySafeDialog = ({
           [selectedChain.chainId],
           safeAddress,
           currentName || '',
-          safeCreationData.safeAccountConfig.owners.map((owner) => ({ address: owner, name: '' })),
+          safeCreationData.safeAccountConfig.owners.map((owner) => ({
+            address: owner,
+            name: addressBook[owner] || '',
+          })),
           safeCreationData.safeAccountConfig.threshold,
         ),
       )


### PR DESCRIPTION
## What it solves

Resolves [SW-270](https://www.notion.so/safe-global/Adding-new-network-does-not-update-address-book-1198180fe5738025b835d3aeb84d5162)

## How this PR fixes it

- Looks up the owner entry in the address book when replaying a safe and copies it over if it exists

## How to test it

1. Create a Safe and add owner names
2. Observe them in the address book
3. Replay the safe on another chain
4. Observe them still being in the address book on the new chain

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
