### PR TITLE
fix(staking): stake icon was not rendred properly in dark mode

### DIFF
--- a/src/hooks/useTransactionType.tsx
+++ b/src/hooks/useTransactionType.tsx
@@ -8,6 +8,7 @@ import {
   type TransactionSummary,
 } from '@safe-global/safe-gateway-typescript-sdk'
 import SwapIcon from '@/public/images/common/swap.svg'
+import StakeIcon from '@/public/images/common/stake.svg'
 
 import {
   isCancellationTxInfo,
@@ -84,25 +85,25 @@ export const getTransactionType = (tx: TransactionSummary, addressBook: AddressB
     }
     case TransactionInfoType.TWAP_ORDER: {
       return {
-        icon: '/images/common/swap.svg',
+        icon: <SvgIcon component={SwapIcon} inheritViewBox fontSize="small" alt="Twap Order" />,
         text: TWAP_ORDER_TITLE,
       }
     }
     case TransactionInfoType.NATIVE_STAKING_DEPOSIT: {
       return {
-        icon: '/images/common/stake.svg',
+        icon: <SvgIcon component={StakeIcon} inheritViewBox fontSize="small" alt="Stake" />,
         text: 'Stake',
       }
     }
     case TransactionInfoType.NATIVE_STAKING_VALIDATORS_EXIT: {
       return {
-        icon: '/images/common/stake.svg',
+        icon: <StakeIcon component={StakeIcon} inheritViewBox fontSize="small" alt="Withdraw request" />,
         text: 'Withdraw request',
       }
     }
     case TransactionInfoType.NATIVE_STAKING_WITHDRAW: {
       return {
-        icon: '/images/common/stake.svg',
+        icon: <StakeIcon component={StakeIcon} inheritViewBox fontSize="small" alt="Claim" />,
         text: 'Claim',
       }
     }


### PR DESCRIPTION
## What it solves
The icon in dark mode for stake txs was barely visible
![grafik](https://github.com/user-attachments/assets/626f451e-e15c-4413-b0b1-c27580e50af6)

Resolves #

## How this PR fixes it
The image was not loaded as SVG. Now we load it as SVG and that solves the issue.

## How to test it
check this safe in dark mode: transactions/history?safe=holesky:0x00780312A5F6c561328566Ed01C77fc7596141a6

## Screenshots
![grafik](https://github.com/user-attachments/assets/bac2b975-70c0-4c66-9c02-fb6cf664a5c3)


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
