### PR TITLE
refactor: simplify RTK Query `endpoints`

### DIFF
--- a/src/store/gateway.ts
+++ b/src/store/gateway.ts
@@ -1,51 +1,35 @@
-import { createApi } from '@reduxjs/toolkit/query/react'
+import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react'
 
 import { getTransactionDetails, type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
-import type { BaseQueryFn } from '@reduxjs/toolkit/dist/query/baseQueryTypes'
-import type { FetchBaseQueryError } from '@reduxjs/toolkit/dist/query/react'
+import { asError } from '@/services/exceptions/utils'
 import { getDelegates } from '@safe-global/safe-gateway-typescript-sdk'
 import type { DelegateResponse } from '@safe-global/safe-gateway-typescript-sdk/dist/types/delegates'
 
-const noopBaseQuery: BaseQueryFn<
-  unknown, // QueryArg type
-  unknown, // ResultType
-  FetchBaseQueryError, // ErrorType
-  {}, // DefinitionExtraOptions
-  {} // Meta
-> = async () => ({ data: null })
+async function buildQueryFn<T>(fn: () => Promise<T>) {
+  try {
+    return { data: await fn() }
+  } catch (error) {
+    return { error: asError(error) }
+  }
+}
 
 export const gatewayApi = createApi({
   reducerPath: 'gatewayApi',
-  baseQuery: noopBaseQuery,
+  baseQuery: fakeBaseQuery<Error>(),
   endpoints: (builder) => ({
     getTransactionDetails: builder.query<TransactionDetails, { chainId: string; txId: string }>({
-      async queryFn({ chainId, txId }) {
-        try {
-          const txDetails = await getTransactionDetails(chainId, txId)
-          return { data: txDetails }
-        } catch (error) {
-          return { error: error as FetchBaseQueryError }
-        }
+      queryFn({ chainId, txId }) {
+        return buildQueryFn(() => getTransactionDetails(chainId, txId))
       },
     }),
     getMultipleTransactionDetails: builder.query<TransactionDetails[], { chainId: string; txIds: string[] }>({
-      async queryFn({ chainId, txIds }) {
-        try {
-          const txDetails = await Promise.all(txIds.map((txId) => getTransactionDetails(chainId, txId)))
-          return { data: txDetails }
-        } catch (error) {
-          return { error: error as FetchBaseQueryError }
-        }
+      queryFn({ chainId, txIds }) {
+        return buildQueryFn(() => Promise.all(txIds.map((txId) => getTransactionDetails(chainId, txId))))
       },
     }),
     getDelegates: builder.query<DelegateResponse, { chainId: string; safeAddress: string }>({
-      async queryFn({ chainId, safeAddress }) {
-        try {
-          const delegates = await getDelegates(chainId, { safe: safeAddress })
-          return { data: delegates }
-        } catch (error) {
-          return { error: error as FetchBaseQueryError }
-        }
+      queryFn({ chainId, safeAddress }) {
+        return buildQueryFn(() => getDelegates(chainId, { safe: safeAddress }))
       },
     }),
   }),


### PR DESCRIPTION
## What it solves

Resolves #4359

## How this PR fixes it

Our `gatewayApi` has been refactored to use the `fakeBaseQuery` of RTK Query. It accepts a generic, with which we can specify the error type we expect - an `Error` instance in our case. A builder for the `queryFn` within `endpoints` then wraps all Client Gateway calls, returning such instances.

## How to test it

There should be no noticeable difference in the UI. Usage of the above can, however, be checked as such:

- [ ] Loading the transaction details of a transaction in the transaction list works as expected, and caches the response.
- [ ] Loading the transaction details of batched transactions works as expected, and caches the response.
- [ ] Speeding up a Safe transaction dispatches a "Speed up transaction" tracking event correctly.
- [ ] No tooltip warning regarding connecting a supported wallet is shown in the UI for deletgates.

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
