### PR TITLE
[Multichain] fix: Only show network logo of activated safe [SW-287]

### DIFF
--- a/src/features/counterfactual/CounterfactualSuccessScreen.tsx
+++ b/src/features/counterfactual/CounterfactualSuccessScreen.tsx
@@ -28,6 +28,7 @@ const CounterfactualSuccessScreen = () => {
         if (event === SafeCreationEvent.INDEXED) {
           if ('chainId' in detail) {
             setChainId(detail.chainId)
+            setNetworks((prev) => prev.filter((network) => network.chainId === detail.chainId))
           }
 
           setSafeAddress(detail.safeAddress)


### PR DESCRIPTION
## What it solves

Resolves [SW-287](https://www.notion.so/safe-global/all-added-networks-are-displayed-instead-one-network-where-the-safe-was-activated-11c8180fe573802bb404e5e6bff339a6)

## How this PR fixes it

- Narrows down `networks` when receiving an INDEXED event

## How to test it

1. Create a multichain safe on at least 2 networks
2. Observe all the network logos on the success screen
3. Activate one of them
4. Observe only the activated network logo on the success screen
5. Reload the page
6. Activate another safe
7. Observe the correct network logo on the success screen

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
