### PR TITLE
fix: allowSpendingLimit in CheckWallet

### DIFF
--- a/src/components/common/CheckWallet/index.test.tsx
+++ b/src/components/common/CheckWallet/index.test.tsx
@@ -118,11 +118,6 @@ describe('CheckWallet', () => {
       useIsOnlySpendingLimitBeneficiary as jest.MockedFunction<typeof useIsOnlySpendingLimitBeneficiary>
     ).mockReturnValueOnce(true)
 
-    const { container } = renderButton()
-
-    expect(container.querySelector('button')).toBeDisabled()
-    getByLabelText(container, 'Your connected wallet is not a signer of this Safe Account')
-
     const { container: allowContainer } = render(
       <CheckWallet allowSpendingLimit>{(isOk) => <button disabled={!isOk}>Continue</button>}</CheckWallet>,
     )

--- a/src/components/common/CheckWallet/index.test.tsx
+++ b/src/components/common/CheckWallet/index.test.tsx
@@ -188,4 +188,17 @@ describe('CheckWallet', () => {
 
     expect(container.querySelector('button')).not.toBeDisabled()
   })
+
+  it('should not allow non-owners that have a spending limit without allowing spending limits', () => {
+    ;(useIsSafeOwner as jest.MockedFunction<typeof useIsSafeOwner>).mockReturnValueOnce(false)
+    ;(
+      useIsOnlySpendingLimitBeneficiary as jest.MockedFunction<typeof useIsOnlySpendingLimitBeneficiary>
+    ).mockReturnValueOnce(true)
+
+    const { container: allowContainer } = render(
+      <CheckWallet>{(isOk) => <button disabled={!isOk}>Continue</button>}</CheckWallet>,
+    )
+
+    expect(allowContainer.querySelector('button')).toBeDisabled()
+  })
 })

--- a/src/components/common/CheckWallet/index.tsx
+++ b/src/components/common/CheckWallet/index.tsx
@@ -50,7 +50,7 @@ const CheckWallet = ({
       return Message.SafeNotActivated
     }
 
-    if (!allowNonOwner && !isSafeOwner && !isDelegate && !isOnlySpendingLimit && !allowSpendingLimit) {
+    if (!allowNonOwner && !isSafeOwner && !isDelegate && (!isOnlySpendingLimit || !allowSpendingLimit)) {
       return Message.NotSafeOwner
     }
   }, [

--- a/src/components/common/CheckWallet/index.tsx
+++ b/src/components/common/CheckWallet/index.tsx
@@ -49,7 +49,8 @@ const CheckWallet = ({
     if (isUndeployedSafe && !allowUndeployedSafe) {
       return Message.SafeNotActivated
     }
-    if ((!allowNonOwner && !isSafeOwner && !isDelegate) || (isOnlySpendingLimit && !allowSpendingLimit)) {
+
+    if (!allowNonOwner && !isSafeOwner && !isDelegate && !isOnlySpendingLimit && !allowSpendingLimit) {
       return Message.NotSafeOwner
     }
   }, [


### PR DESCRIPTION
## What it solves
`allowSpendingLimits` in `CheckWallet` did not work anymore.

## How this PR fixes it
Fixes the conditions in `CheckWallet` and the unit test that did not pick up the error

## How to test it
- Connect with a wallet that only has a spending limit
- Observe the "New transaction" button to be available

## Screenshots

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
