### PR TITLE
Feat: add badge to unavaible chains

### DIFF
--- a/src/components/common/NetworkInput/index.tsx
+++ b/src/components/common/NetworkInput/index.tsx
@@ -1,7 +1,7 @@
 import ChainIndicator from '@/components/common/ChainIndicator'
 import { useDarkMode } from '@/hooks/useDarkMode'
 import { useTheme } from '@mui/material/styles'
-import { FormControl, InputLabel, ListSubheader, MenuItem, Select } from '@mui/material'
+import { FormControl, InputLabel, ListSubheader, MenuItem, Select, Typography } from '@mui/material'
 import partition from 'lodash/partition'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import css from './styles.module.css'
@@ -35,6 +35,11 @@ const NetworkInput = ({
           sx={{ '&:hover': { backgroundColor: 'inherit' } }}
         >
           <ChainIndicator chainId={chain.chainId} />
+          {isDisabled && (
+            <Typography variant="caption" component="span" className={css.disabledChip}>
+              Not available
+            </Typography>
+          )}
         </MenuItem>
       )
     },

--- a/src/components/common/NetworkInput/styles.module.css
+++ b/src/components/common/NetworkInput/styles.module.css
@@ -52,3 +52,11 @@
   align-items: center;
   gap: var(--space-1);
 }
+
+.disabledChip {
+  background-color: var(--color-border-light);
+  border-radius: 4px;
+  color: var(--color-text-primary);
+  padding: 4px 8px;
+  margin-left: auto;
+}


### PR DESCRIPTION
## What this PR changes
Add badge to unavailable networks in add network modal.

## How to test it
- Add a network to a Safe
- Observe that e.g. zkSync is marked as unavailable

## Screenshots
<img width="571" alt="Screenshot 2024-10-14 at 14 11 36" src="https://github.com/user-attachments/assets/dbde98ec-e74e-4bb6-acd7-28f8840b1466">


## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
