### PR TITLE
fix: Add fallbacks when parsing erc20 symbol and decimals

### DIFF
--- a/src/utils/__tests__/tokens.test.ts
+++ b/src/utils/__tests__/tokens.test.ts
@@ -1,0 +1,77 @@
+import * as web3 from '@/hooks/wallets/web3'
+import { ERC20__factory } from '@/types/contracts'
+import { getERC20TokenInfoOnChain } from '@/utils/tokens'
+import { faker } from '@faker-js/faker'
+import { keccak256, toUtf8Bytes } from 'ethers'
+
+describe('tokens', () => {
+  describe('getERC20TokenInfoOnChain', () => {
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should return undefined if there is no provider', async () => {
+      jest.spyOn(web3, 'getWeb3ReadOnly').mockReturnValue(undefined)
+
+      const result = await getERC20TokenInfoOnChain(faker.finance.ethereumAddress())
+
+      expect(result).toBeUndefined()
+    })
+
+    it('should return symbol and decimals for a token', async () => {
+      jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
+        () =>
+          ({
+            call: (tx: { data: string; to: string }) => {
+              {
+                const decimalsSigHash = keccak256(toUtf8Bytes('decimals()')).slice(0, 10)
+                const symbolSigHash = keccak256(toUtf8Bytes('symbol()')).slice(0, 10)
+
+                if (tx.data.startsWith(decimalsSigHash)) {
+                  return ERC20__factory.createInterface().encodeFunctionResult('decimals', [18])
+                }
+                if (tx.data.startsWith(symbolSigHash)) {
+                  return ERC20__factory.createInterface().encodeFunctionResult('symbol', ['UNI'])
+                }
+              }
+            },
+            _isProvider: true,
+            resolveName: (name: string) => name,
+          } as any),
+      )
+
+      const result = await getERC20TokenInfoOnChain('0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984')
+
+      expect(result?.symbol).toEqual('UNI')
+      expect(result?.decimals).toEqual(18)
+    })
+
+    it('should decode bytes32 symbol', async () => {
+      jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(
+        () =>
+          ({
+            call: (tx: { data: string; to: string }) => {
+              {
+                const decimalsSigHash = keccak256(toUtf8Bytes('decimals()')).slice(0, 10)
+                const symbolSigHash = keccak256(toUtf8Bytes('symbol()')).slice(0, 10)
+
+                if (tx.data.startsWith(decimalsSigHash)) {
+                  return ERC20__factory.createInterface().encodeFunctionResult('decimals', [18])
+                }
+                if (tx.data.startsWith(symbolSigHash)) {
+                  return Promise.reject({ value: '0x4d4b520000000000000000000000000000000000000000000000000000000000' })
+                }
+              }
+            },
+            _isProvider: true,
+            resolveName: (name: string) => name,
+          } as any),
+      )
+
+      const result = await getERC20TokenInfoOnChain('0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984')
+
+      expect(result?.symbol).toEqual('MKR')
+      expect(result?.decimals).toEqual(18)
+    })
+  })
+})

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -1,5 +1,6 @@
 import { getWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { ERC20__factory, ERC721__factory } from '@/types/contracts'
+import { parseBytes32String } from '@ethersproject/strings'
 import { type TokenInfo, TokenType } from '@safe-global/safe-gateway-typescript-sdk'
 
 export const UNLIMITED_APPROVAL_AMOUNT = 2n ** 256n - 1n
@@ -19,7 +20,18 @@ export const getERC20TokenInfoOnChain = async (
   if (!web3) return
 
   const erc20 = ERC20__factory.connect(address, web3)
-  const [symbol, decimals] = await Promise.all([erc20.symbol(), erc20.decimals()])
+
+  const symbol = await erc20
+    .symbol()
+    .then((symbol) => symbol)
+    .catch((error) => parseBytes32String(error.value)) // Some older contracts use bytes32 instead of string
+    .finally(() => '')
+
+  const decimals = await erc20
+    .decimals()
+    .then((decimals) => decimals)
+    .catch(() => BigInt(18))
+
   return {
     address,
     symbol,

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -27,10 +27,7 @@ export const getERC20TokenInfoOnChain = async (
     .catch((error) => parseBytes32String(error.value)) // Some older contracts use bytes32 instead of string
     .finally(() => '')
 
-  const decimals = await erc20
-    .decimals()
-    .then((decimals) => decimals)
-    .catch(() => BigInt(18))
+  const decimals = await erc20.decimals()
 
   return {
     address,


### PR DESCRIPTION
## What it solves

Resolves #4376 

## How this PR fixes it

- Tries to parse erc20 symbols with `parseBytes32String` in case it throws
- Adds fallbacks for symbol and decimals

## How to test it

1. Open a safe with MKR as a spending limit
2. Observe it showing up in the table

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
