### PR TITLE
fix: Show different message in success screen when safe is deployed

### DIFF
--- a/src/features/counterfactual/CounterfactualSuccessScreen.tsx
+++ b/src/features/counterfactual/CounterfactualSuccessScreen.tsx
@@ -18,7 +18,7 @@ const CounterfactualSuccessScreen = () => {
   const [networks, setNetworks] = useState<ChainInfo[]>([])
   const addressBooks = useAllAddressBooks()
   const safeName = safeAddress && chain ? addressBooks?.[chain.chainId]?.[safeAddress] : ''
-  const isCFCreation = !!networks.length
+  const isCFCreation = !!networks.length && !chainId
   const isMultiChain = networks.length > 1
   const chainName = isMultiChain ? '' : isCFCreation ? networks[0].chainName : chain?.chainName
 
@@ -46,6 +46,11 @@ const CounterfactualSuccessScreen = () => {
       unsubFns.forEach((unsub) => unsub())
     }
   }, [])
+
+  const onClose = () => {
+    setChainId(undefined)
+    setOpen(false)
+  }
 
   return (
     <Dialog open={open}>
@@ -106,7 +111,7 @@ const CounterfactualSuccessScreen = () => {
           </Box>
         )}
 
-        <Button variant="contained" onClick={() => setOpen(false)} data-testid="cf-creation-lets-go-btn">
+        <Button variant="contained" onClick={onClose} data-testid="cf-creation-lets-go-btn">
           Let&apos;s go
         </Button>
       </DialogContent>

--- a/src/features/counterfactual/CounterfactualSuccessScreen.tsx
+++ b/src/features/counterfactual/CounterfactualSuccessScreen.tsx
@@ -13,18 +13,21 @@ const CounterfactualSuccessScreen = () => {
   const [open, setOpen] = useState<boolean>(false)
   const [safeAddress, setSafeAddress] = useState<string>()
   const [chainId, setChainId] = useState<string>()
+  const [event, setEvent] = useState<SafeCreationEvent>()
   const currentChain = useCurrentChain()
   const chain = useChain(chainId || currentChain?.chainId || '')
   const [networks, setNetworks] = useState<ChainInfo[]>([])
   const addressBooks = useAllAddressBooks()
   const safeName = safeAddress && chain ? addressBooks?.[chain.chainId]?.[safeAddress] : ''
-  const isCFCreation = !!networks.length && !chainId
+  const isCFCreation = event === SafeCreationEvent.AWAITING_EXECUTION
   const isMultiChain = networks.length > 1
   const chainName = isMultiChain ? '' : isCFCreation ? networks[0].chainName : chain?.chainName
 
   useEffect(() => {
     const unsubFns = Object.entries(safeCreationPendingStatuses).map(([event]) =>
       safeCreationSubscribe(event as SafeCreationEvent, async (detail) => {
+        setEvent(event as SafeCreationEvent)
+
         if (event === SafeCreationEvent.INDEXED) {
           if ('chainId' in detail) {
             setChainId(detail.chainId)


### PR DESCRIPTION
## What it solves

Resolves #4383 

## How this PR fixes it

- If there is a `chainId` we assume it is not a counterfactual deployment and show a different message

## How to test it

1. Create a single safe and deploy immediately
2. Observe the success screen is saying "Your Account is all set"
3. Create a single safe and pay later
4. Observe the success screen is saying "Your account is almost set"
5. Create a multichain safe
6. Observe the success screen is saying "Your account is almost set"
7. Deploy one of the accounts
8. Observe the success screen is saying "Your account is all set"


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
