### PR TITLE
Tests: Fix prod tests

### DIFF
--- a/.github/workflows/e2e-prod-ondemand.yml
+++ b/.github/workflows/e2e-prod-ondemand.yml
@@ -48,7 +48,7 @@ jobs:
         if: always()
         run: |
           pip install trcli
-          trcli -y \
+          if ! trcli -y \
           -h https://gno.testrail.io/ \
           --project "Safe- Web App" \
           --username ${{ secrets.TESTRAIL_USERNAME }} \
@@ -56,4 +56,6 @@ jobs:
           parse_junit \
           --title "Automated Tests, branch: ${GITHUB_REF_NAME}" \
           --run-description ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \
-          -f "reports/junit-report.xml"
+          -f "reports/junit-report.xml"; then
+            echo -e "\e[41;32mTestRail upload failed. Pipeline will continue, please check the upload process.\e[0m"
+          fi

--- a/cypress/e2e/prodhealthcheck/swaps_tokens.cy.js
+++ b/cypress/e2e/prodhealthcheck/swaps_tokens.cy.js
@@ -4,6 +4,7 @@ import * as swaps from '../pages/swaps.pages.js'
 import * as assets from '../pages/assets.pages.js'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
 import * as wallet from '../../support/utils/wallet.js'
+import * as ls from '../../support/localstorage_data.js'
 
 let staticSafes = []
 const walletCredentials = JSON.parse(Cypress.env('CYPRESS_WALLET_CREDENTIALS'))
@@ -39,6 +40,12 @@ describe('[PROD] Swaps token tests', () => {
   it('Verify swap button are displayed in assets table and dashboard', () => {
     assets.selectTokenList(assets.tokenListOptions.allTokens)
     main.verifyElementsCount(swaps.assetsSwapBtn, 4)
+    cy.window().then((window) => {
+      window.localStorage.setItem(
+        constants.localStorageKeys.SAFE_v2__settings,
+        JSON.stringify(ls.safeSettings.slimitSettings),
+      )
+    })
     cy.visit(constants.homeUrl + staticSafes.SEP_STATIC_SAFE_1)
     main.verifyElementsCount(swaps.assetsSwapBtn, 4)
     main.verifyElementsCount(swaps.dashboardSwapBtn, 1)

--- a/cypress/e2e/regression/swaps_tokens.cy.js
+++ b/cypress/e2e/regression/swaps_tokens.cy.js
@@ -4,6 +4,7 @@ import * as swaps from '../pages/swaps.pages.js'
 import * as assets from '../pages/assets.pages.js'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
 import * as wallet from '../../support/utils/wallet.js'
+import * as ls from '../../support/localstorage_data.js'
 
 let staticSafes = []
 const walletCredentials = JSON.parse(Cypress.env('CYPRESS_WALLET_CREDENTIALS'))
@@ -41,6 +42,12 @@ describe('[SMOKE] Swaps token tests', () => {
   it('Verify swap button are displayed in assets table and dashboard', () => {
     assets.selectTokenList(assets.tokenListOptions.allTokens)
     main.verifyElementsCount(swaps.assetsSwapBtn, 4)
+    cy.window().then((window) => {
+      window.localStorage.setItem(
+        constants.localStorageKeys.SAFE_v2__settings,
+        JSON.stringify(ls.safeSettings.slimitSettings),
+      )
+    })
     cy.visit(constants.homeUrl + staticSafes.SEP_STATIC_SAFE_1)
     main.verifyElementsCount(swaps.assetsSwapBtn, 4)
     main.verifyElementsCount(swaps.dashboardSwapBtn, 1)


### PR DESCRIPTION
## What it solves

## How this PR fixes it

- Sometimes tests failed due to incorrect amount of assets shown on dashboard. This was specifically noted in automation flow. Manual flow works as expected. To overcome this issue, SAFE_v2__settings was added to local storage to retrieve correct number of assets in dashboard. 

- Adjust prod tests workflow to avoid TestRail step failing in pipeline


## How to test it

- Run Cypress tests and observe outcome
