### PR TITLE
feat: Allow deletion of delegate transactions from the queue [SW-297]

### DIFF
--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -52,9 +52,13 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
   const isUnsigned =
     isMultisigExecutionInfo(txSummary.executionInfo) && txSummary.executionInfo.confirmationsSubmitted === 0
 
-  const isUntrusted =
+  const isTxFromProposer =
     isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo) &&
-    txDetails.detailedExecutionInfo.trusted === false
+    txDetails.detailedExecutionInfo.trusted &&
+    isUnsigned
+
+  const isUntrusted =
+    isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo) && !txDetails.detailedExecutionInfo.trusted
 
   // If we have no token list we always trust the transfer
   const isTrustedTransfer = !hasDefaultTokenlist || isTrustedTx(txSummary)
@@ -117,7 +121,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
       </div>
 
       {/* Signers */}
-      {!isUnsigned && (
+      {(!isUnsigned || isTxFromProposer) && (
         <div className={css.txSigners}>
           <TxSigners txDetails={txDetails} txSummary={txSummary} />
 

--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -123,7 +123,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
       {/* Signers */}
       {(!isUnsigned || isTxFromProposer) && (
         <div className={css.txSigners}>
-          <TxSigners txDetails={txDetails} txSummary={txSummary} />
+          <TxSigners txDetails={txDetails} txSummary={txSummary} isTxFromProposer={isTxFromProposer} />
 
           {isQueue && (
             <Box className={css.buttons}>

--- a/src/components/transactions/TxSigners/index.tsx
+++ b/src/components/transactions/TxSigners/index.tsx
@@ -105,9 +105,10 @@ const shouldHideConfirmations = (detailedExecutionInfo?: DetailedExecutionInfo):
 type TxSignersProps = {
   txDetails: TransactionDetails
   txSummary: TransactionSummary
+  isTxFromProposer: boolean
 }
 
-export const TxSigners = ({ txDetails, txSummary }: TxSignersProps): ReactElement | null => {
+export const TxSigners = ({ txDetails, txSummary, isTxFromProposer }: TxSignersProps): ReactElement | null => {
   const { detailedExecutionInfo, txInfo, txId } = txDetails
   const [hideConfirmations, setHideConfirmations] = useState<boolean>(shouldHideConfirmations(detailedExecutionInfo))
   const isPending = useIsPending(txId)
@@ -186,13 +187,23 @@ export const TxSigners = ({ txDetails, txSummary }: TxSignersProps): ReactElemen
             </ListItemText>
           </ListItem>
         )}
-        <ListItem>
+        <ListItem sx={{ alignItems: 'flex-start' }}>
           <StyledListItemIcon $state={executor ? StepState.CONFIRMED : StepState.DISABLED}>
             {executor ? <Check /> : <MissingConfirmation />}
           </StyledListItemIcon>
-          <ListItemText data-testid="tx-action-status" primaryTypographyProps={{ fontWeight: 700 }}>
-            {executor ? 'Executed' : isPending ? txStatus : 'Can be executed'}
-          </ListItemText>
+          <ListItemText
+            primary={
+              executor ? 'Executed' : isPending ? txStatus : isTxFromProposer ? 'Signer review' : 'Can be executed'
+            }
+            secondary={
+              isTxFromProposer
+                ? 'This transaction was created by a Proposer. Please review and either confirm or reject it. Once confirmed, it can be finalized and executed.'
+                : undefined
+            }
+            data-testid="tx-action-status"
+            primaryTypographyProps={{ fontWeight: 700 }}
+            secondaryTypographyProps={{ mt: 1 }}
+          />
         </ListItem>
       </List>
       {executor ? (


### PR DESCRIPTION
## What it solves

Resolves [SW-297](https://www.notion.so/safe-global/Delete-proposed-transaction-as-an-owner-that-created-the-delegate-11f8180fe573807a9689ff9713940d97)

## How this PR fixes it

- Shows the signer block if its an unsigned but trusted tranaction
- Allows to reject delegated transactions

## How to test it

There are a few limitations that need to be tested

1. Only the owner who created the delegate that proposed a transaction can delete their transactions
2. Owners and delegates can replace transactions
3. Only the last transaction or duplicate transactions can be deleted
4. Signed transactions should still offer a Reject option like before

## Screenshots

<img width="1257" alt="Screenshot 2024-10-25 at 11 46 58" src="https://github.com/user-attachments/assets/525aad69-13cd-4f3d-b161-bbd89ab1d454">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
