### PR TITLE
fix: revalidate input when removing networks

### DIFF
--- a/src/components/common/NetworkSelector/NetworkMultiSelector.tsx
+++ b/src/components/common/NetworkSelector/NetworkMultiSelector.tsx
@@ -50,7 +50,7 @@ const NetworkMultiSelector = ({
       const currentValues: ChainInfo[] = getValues(name) || []
       const updatedValues = currentValues.filter((chain) => chain.chainId !== deletedChainId)
       updateCurrentNetwork(updatedValues)
-      setValue(name, updatedValues)
+      setValue(name, updatedValues, { shouldValidate: true })
     },
     [getValues, name, setValue, updateCurrentNetwork],
   )
@@ -128,7 +128,7 @@ const NetworkMultiSelector = ({
               ))
             }
             renderOption={(props, chain, { selected }) => (
-              <li key={chain.chainId} {...props}>
+              <li {...props} key={chain.chainId}>
                 <Checkbox data-testid="network-checkbox" size="small" checked={selected} />
                 <ChainIndicator chainId={chain.chainId} inline />
               </li>


### PR DESCRIPTION
## What it solves

Resolves #4382 

## How this PR fixes it
Triggers validation when removing a network.

## How to test it
- select some chains in the create Safe modal
- Remove all selected chains
- Observe the next button being disabled


## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
