### PR TITLE
fix: check deployments of migration contracts, upgrade safe-deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@safe-global/api-kit": "^2.4.6",
     "@safe-global/protocol-kit": "^4.1.1",
     "@safe-global/safe-apps-sdk": "^9.1.0",
-    "@safe-global/safe-deployments": "^1.37.12",
+    "@safe-global/safe-deployments": "1.37.12",
     "@safe-global/safe-client-gateway-sdk": "1.58.0-next-25bba61",
     "@safe-global/safe-gateway-typescript-sdk": "3.22.3-beta.15",
     "@safe-global/safe-modules-deployments": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@safe-global/api-kit": "^2.4.6",
     "@safe-global/protocol-kit": "^4.1.1",
     "@safe-global/safe-apps-sdk": "^9.1.0",
-    "@safe-global/safe-deployments": "^1.37.10",
+    "@safe-global/safe-deployments": "^1.37.12",
     "@safe-global/safe-client-gateway-sdk": "1.58.0-next-25bba61",
     "@safe-global/safe-gateway-typescript-sdk": "3.22.3-beta.15",
     "@safe-global/safe-modules-deployments": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@safe-global/api-kit": "^2.4.6",
     "@safe-global/protocol-kit": "^4.1.1",
     "@safe-global/safe-apps-sdk": "^9.1.0",
-    "@safe-global/safe-deployments": "^1.37.12",
+    "@safe-global/safe-deployments": "^1.37.13",
     "@safe-global/safe-client-gateway-sdk": "1.58.0-next-25bba61",
     "@safe-global/safe-gateway-typescript-sdk": "3.22.3-beta.15",
     "@safe-global/safe-modules-deployments": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@safe-global/api-kit": "^2.4.6",
     "@safe-global/protocol-kit": "^4.1.1",
     "@safe-global/safe-apps-sdk": "^9.1.0",
-    "@safe-global/safe-deployments": "^1.37.13",
+    "@safe-global/safe-deployments": "^1.37.12",
     "@safe-global/safe-client-gateway-sdk": "1.58.0-next-25bba61",
     "@safe-global/safe-gateway-typescript-sdk": "3.22.3-beta.15",
     "@safe-global/safe-modules-deployments": "^2.2.1",

--- a/src/components/common/NetworkSelector/NetworkMultiSelector.tsx
+++ b/src/components/common/NetworkSelector/NetworkMultiSelector.tsx
@@ -9,7 +9,7 @@ import { Controller, useFormContext, useWatch } from 'react-hook-form'
 import { useRouter } from 'next/router'
 import { getNetworkLink } from '.'
 import { SetNameStepFields } from '@/components/new-safe/create/steps/SetNameStep'
-import { getSafeSingletonDeployments } from '@safe-global/safe-deployments'
+import { getSafeSingletonDeployments, getSafeToL2SetupDeployments } from '@safe-global/safe-deployments'
 import { getLatestSafeVersion } from '@/utils/chains'
 import { hasCanonicalDeployment } from '@/services/contracts/deployments'
 import { hasMultiChainCreationFeatures } from '@/features/multichain/utils/utils'
@@ -74,22 +74,33 @@ const NetworkMultiSelector = ({
       }
 
       // Check if required deployments are available
-      const optionHasCanonicalSingletonDeployment = hasCanonicalDeployment(
-        getSafeSingletonDeployments({
-          network: optionNetwork.chainId,
-          version: getLatestSafeVersion(firstSelectedNetwork),
-        }),
-        optionNetwork.chainId,
-      )
-      const selectedHasCanonicalSingletonDeployment = hasCanonicalDeployment(
-        getSafeSingletonDeployments({
-          network: firstSelectedNetwork.chainId,
-          version: getLatestSafeVersion(firstSelectedNetwork),
-        }),
-        firstSelectedNetwork.chainId,
-      )
+      const optionHasCanonicalSingletonDeployment =
+        hasCanonicalDeployment(
+          getSafeSingletonDeployments({
+            network: optionNetwork.chainId,
+            version: getLatestSafeVersion(firstSelectedNetwork),
+          }),
+          optionNetwork.chainId,
+        ) &&
+        hasCanonicalDeployment(
+          getSafeToL2SetupDeployments({ network: optionNetwork.chainId, version: '1.4.1' }),
+          optionNetwork.chainId,
+        )
 
-      // Only 1.4.1 safes with canonical deployment addresses can be deployed as part of a multichain group
+      const selectedHasCanonicalSingletonDeployment =
+        hasCanonicalDeployment(
+          getSafeSingletonDeployments({
+            network: firstSelectedNetwork.chainId,
+            version: getLatestSafeVersion(firstSelectedNetwork),
+          }),
+          firstSelectedNetwork.chainId,
+        ) &&
+        hasCanonicalDeployment(
+          getSafeToL2SetupDeployments({ network: firstSelectedNetwork.chainId, version: '1.4.1' }),
+          firstSelectedNetwork.chainId,
+        )
+
+      // Only 1.4.1 safes with canonical deployment addresses and SafeToL2Setup can be deployed as part of a multichain group
       if (!selectedHasCanonicalSingletonDeployment) return !optionIsSelectedNetwork
       return !optionHasCanonicalSingletonDeployment
     },
@@ -128,7 +139,7 @@ const NetworkMultiSelector = ({
               ))
             }
             renderOption={(props, chain, { selected }) => (
-              <li key={chain.chainId} {...props}>
+              <li {...props} key={chain.chainId}>
                 <Checkbox data-testid="network-checkbox" size="small" checked={selected} />
                 <ChainIndicator chainId={chain.chainId} inline />
               </li>

--- a/src/components/new-safe/create/logic/index.ts
+++ b/src/components/new-safe/create/logic/index.ts
@@ -228,8 +228,9 @@ export const createNewUndeployedSafeWithoutSalt = (
   const safeToL2SetupAddress = safeToL2SetupDeployment?.networkAddresses[chain.chainId]
   const safeToL2SetupInterface = Safe_to_l2_setup__factory.createInterface()
 
-  // Only do migration if the chain supports multiChain deployments.
-  const includeMigration = hasMultiChainCreationFeatures(chain) && semverSatisfies(safeVersion, '>=1.4.1')
+  // Only do migration if the chain supports multiChain deployments and has a SafeToL2Setup deployment
+  const includeMigration =
+    hasMultiChainCreationFeatures(chain) && semverSatisfies(safeVersion, '>=1.4.1') && Boolean(safeToL2SetupAddress)
 
   const masterCopy = includeMigration ? safeL1Address : chain.l2 ? safeL2Address : safeL1Address
 

--- a/src/components/transactions/TxDetails/TxData/MigrationToL2TxData/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/MigrationToL2TxData/index.tsx
@@ -14,6 +14,7 @@ import ErrorMessage from '@/components/tx/ErrorMessage'
 import { useSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 import { MigrateToL2Information } from '@/components/tx/SignOrExecuteForm/MigrateToL2Information'
 import { Box } from '@mui/material'
+import { isMultisigDetailedExecutionInfo } from '@/utils/transaction-guards'
 
 export const MigrationToL2TxData = ({ txDetails }: { txDetails: TransactionDetails }) => {
   const readOnlyProvider = useWeb3ReadOnly()
@@ -47,19 +48,24 @@ export const MigrationToL2TxData = ({ txDetails }: { txDetails: TransactionDetai
       if (!execTxArgs || execTxArgs.length < 10) {
         return undefined
       }
-      return createTx({
-        to: execTxArgs[0],
-        value: execTxArgs[1].toString(),
-        data: execTxArgs[2],
-        operation: Number(execTxArgs[3]),
-        safeTxGas: execTxArgs[4].toString(),
-        baseGas: execTxArgs[5].toString(),
-        gasPrice: execTxArgs[6].toString(),
-        gasToken: execTxArgs[7].toString(),
-        refundReceiver: execTxArgs[8],
-      })
+      return createTx(
+        {
+          to: execTxArgs[0],
+          value: execTxArgs[1].toString(),
+          data: execTxArgs[2],
+          operation: Number(execTxArgs[3]),
+          safeTxGas: execTxArgs[4].toString(),
+          baseGas: execTxArgs[5].toString(),
+          gasPrice: execTxArgs[6].toString(),
+          gasToken: execTxArgs[7].toString(),
+          refundReceiver: execTxArgs[8],
+        },
+        isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo)
+          ? txDetails.detailedExecutionInfo.nonce
+          : undefined,
+      )
     }
-  }, [readOnlyProvider, txDetails.txHash, chain, safe.version, sdk])
+  }, [txDetails.txHash, txDetails.detailedExecutionInfo, chain, sdk, readOnlyProvider, safe.version])
 
   const [decodedRealTx, decodedRealTxError] = useDecodeTx(realSafeTx)
 

--- a/src/features/multichain/hooks/__tests__/useCompatibleNetworks.test.ts
+++ b/src/features/multichain/hooks/__tests__/useCompatibleNetworks.test.ts
@@ -36,6 +36,7 @@ describe('useCompatibleNetworks', () => {
         chainBuilder().with({ chainId: '100' }).build(), // This has the canonical and then the eip155 addresses
         chainBuilder().with({ chainId: '324' }).build(), // ZkSync has different addresses for all versions
         chainBuilder().with({ chainId: '480' }).build(), // Worldchain has 1.4.1 but not 1.1.1
+        chainBuilder().with({ chainId: '10200' }).build(), // Gnosis Chiado has no migration contracts
       ],
     })
   })
@@ -68,7 +69,7 @@ describe('useCompatibleNetworks', () => {
     expect(result.current.every((config) => config.available)).toEqual(false)
   })
 
-  it('should set everything to available except zkSync for 1.4.1 Safes', () => {
+  it('should set everything to available except zkSync and GnosisChain Chiado for 1.4.1 Safes', () => {
     const callData = {
       owners: [faker.finance.ethereumAddress()],
       threshold: 1,
@@ -89,8 +90,8 @@ describe('useCompatibleNetworks', () => {
       }
       const { result } = renderHook(() => useCompatibleNetworks(creationData))
       expect(result.current).toHaveLength(5)
-      expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480'])
-      expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, false, true])
+      expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480', '10200'])
+      expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, false, true, false])
     }
 
     {
@@ -103,8 +104,8 @@ describe('useCompatibleNetworks', () => {
       }
       const { result } = renderHook(() => useCompatibleNetworks(creationData))
       expect(result.current).toHaveLength(5)
-      expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480'])
-      expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, false, true])
+      expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480', '10200'])
+      expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, false, true, false])
     }
   })
 

--- a/src/features/multichain/hooks/__tests__/useCompatibleNetworks.test.ts
+++ b/src/features/multichain/hooks/__tests__/useCompatibleNetworks.test.ts
@@ -163,7 +163,7 @@ describe('useCompatibleNetworks', () => {
       const { result } = renderHook(() => useCompatibleNetworks(creationData))
       expect(result.current).toHaveLength(6)
       expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480', '10200'])
-      expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, false, true, false])
+      expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, false, false, false])
     }
 
     // 1.3.0, L2 and EIP155
@@ -178,7 +178,7 @@ describe('useCompatibleNetworks', () => {
       const { result } = renderHook(() => useCompatibleNetworks(creationData))
       expect(result.current).toHaveLength(6)
       expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480', '10200'])
-      expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, false, true, false])
+      expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, false, false, false])
     }
   })
 

--- a/src/features/multichain/hooks/__tests__/useCompatibleNetworks.test.ts
+++ b/src/features/multichain/hooks/__tests__/useCompatibleNetworks.test.ts
@@ -31,12 +31,12 @@ describe('useCompatibleNetworks', () => {
   beforeAll(() => {
     jest.spyOn(useChains, 'default').mockReturnValue({
       configs: [
-        chainBuilder().with({ chainId: '1' }).build(),
-        chainBuilder().with({ chainId: '10' }).build(), // This has the eip155 and then the canonical addresses
-        chainBuilder().with({ chainId: '100' }).build(), // This has the canonical and then the eip155 addresses
-        chainBuilder().with({ chainId: '324' }).build(), // ZkSync has different addresses for all versions
-        chainBuilder().with({ chainId: '480' }).build(), // Worldchain has 1.4.1 but not 1.1.1
-        chainBuilder().with({ chainId: '10200' }).build(), // Gnosis Chiado has no migration contracts
+        chainBuilder().with({ chainId: '1', l2: false }).build(),
+        chainBuilder().with({ chainId: '10', l2: true }).build(), // This has the eip155 and then the canonical addresses
+        chainBuilder().with({ chainId: '100', l2: true }).build(), // This has the canonical and then the eip155 addresses
+        chainBuilder().with({ chainId: '324', l2: true }).build(), // ZkSync has different addresses for all versions
+        chainBuilder().with({ chainId: '480', l2: true }).build(), // Worldchain has 1.4.1 but not 1.1.1
+        chainBuilder().with({ chainId: '10200', l2: true }).build(), // Gnosis Chiado has no migration contracts
       ],
     })
   })
@@ -89,7 +89,7 @@ describe('useCompatibleNetworks', () => {
         safeVersion: '1.4.1',
       }
       const { result } = renderHook(() => useCompatibleNetworks(creationData))
-      expect(result.current).toHaveLength(5)
+      expect(result.current).toHaveLength(6)
       expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480', '10200'])
       expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, false, true, false])
     }
@@ -103,7 +103,7 @@ describe('useCompatibleNetworks', () => {
         safeVersion: '1.4.1',
       }
       const { result } = renderHook(() => useCompatibleNetworks(creationData))
-      expect(result.current).toHaveLength(5)
+      expect(result.current).toHaveLength(6)
       expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480', '10200'])
       expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, false, true, false])
     }
@@ -121,7 +121,7 @@ describe('useCompatibleNetworks', () => {
       paymentReceiver: ECOSYSTEM_ID_ADDRESS,
     }
 
-    // 1.3.0, L1 and canonical
+    // 1.3.0, L1 and canonical, not available on Chiado as no migration exists
     {
       const creationData: ReplayedSafeProps = {
         factoryAddress: PROXY_FACTORY_130_DEPLOYMENTS?.canonical?.address!,
@@ -131,9 +131,9 @@ describe('useCompatibleNetworks', () => {
         safeVersion: '1.3.0',
       }
       const { result } = renderHook(() => useCompatibleNetworks(creationData))
-      expect(result.current).toHaveLength(5)
-      expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480'])
-      expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, false, true])
+      expect(result.current).toHaveLength(6)
+      expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480', '10200'])
+      expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, false, true, false])
     }
 
     // 1.3.0, L2 and canonical
@@ -146,12 +146,12 @@ describe('useCompatibleNetworks', () => {
         safeVersion: '1.3.0',
       }
       const { result } = renderHook(() => useCompatibleNetworks(creationData))
-      expect(result.current).toHaveLength(5)
-      expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480'])
-      expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, false, true])
+      expect(result.current).toHaveLength(6)
+      expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480', '10200'])
+      expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, false, true, true])
     }
 
-    // 1.3.0, L1 and EIP155 is not available on Worldchain
+    // 1.3.0, L1 and EIP155 is not available on Worldchain and Chiado
     {
       const creationData: ReplayedSafeProps = {
         factoryAddress: PROXY_FACTORY_130_DEPLOYMENTS?.eip155?.address!,
@@ -161,9 +161,9 @@ describe('useCompatibleNetworks', () => {
         safeVersion: '1.3.0',
       }
       const { result } = renderHook(() => useCompatibleNetworks(creationData))
-      expect(result.current).toHaveLength(5)
-      expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480'])
-      expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, false, false])
+      expect(result.current).toHaveLength(6)
+      expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480', '10200'])
+      expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, false, true, false])
     }
 
     // 1.3.0, L2 and EIP155
@@ -176,9 +176,9 @@ describe('useCompatibleNetworks', () => {
         safeVersion: '1.3.0',
       }
       const { result } = renderHook(() => useCompatibleNetworks(creationData))
-      expect(result.current).toHaveLength(5)
-      expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480'])
-      expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, false, false])
+      expect(result.current).toHaveLength(6)
+      expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480', '10200'])
+      expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, false, true, false])
     }
   })
 
@@ -202,8 +202,8 @@ describe('useCompatibleNetworks', () => {
       safeVersion: '1.1.1',
     }
     const { result } = renderHook(() => useCompatibleNetworks(creationData))
-    expect(result.current).toHaveLength(5)
-    expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480'])
-    expect(result.current.map((chain) => chain.available)).toEqual([false, false, false, false, false])
+    expect(result.current).toHaveLength(6)
+    expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480', '10200'])
+    expect(result.current.map((chain) => chain.available)).toEqual([false, false, false, false, false, false])
   })
 })

--- a/src/features/multichain/hooks/useCompatibleNetworks.ts
+++ b/src/features/multichain/hooks/useCompatibleNetworks.ts
@@ -69,14 +69,12 @@ export const useCompatibleNetworks = (
       hasCanonicalDeployment(getSafeToL2SetupDeployments({ network: config.chainId, version: '1.4.1' }), config.chainId)
 
     // If the masterCopy is L1 on a L2 chain, includes the setupToL2 Call or the Migration contract exists
-    const migrationContractExists =
-      !isL1MasterCopy ||
-      includesSetupToL2 ||
-      !config.l2 ||
-      hasCanonicalDeployment(
-        getSafeToL2MigrationDeployments({ network: config.chainId, version: '1.4.1' }),
-        config.chainId,
-      )
+    const isMigrationRequired = isL1MasterCopy && !includesSetupToL2 && config.l2
+    const isMigrationPossible = hasCanonicalDeployment(
+      getSafeToL2MigrationDeployments({ network: config.chainId, version: '1.4.1' }),
+      config.chainId,
+    )
+    const areMigrationConditionsMet = !isMigrationRequired || isMigrationPossible
 
     return {
       ...config,
@@ -85,7 +83,7 @@ export const useCompatibleNetworks = (
         proxyFactoryExists &&
         fallbackHandlerExists &&
         setupToL2ContractExists &&
-        migrationContractExists,
+        areMigrationConditionsMet,
     }
   })
 }

--- a/src/features/multichain/hooks/useCompatibleNetworks.ts
+++ b/src/features/multichain/hooks/useCompatibleNetworks.ts
@@ -64,7 +64,7 @@ export const useCompatibleNetworks = (
     const includesSetupToL2 = to !== ZERO_ADDRESS
 
     // If the creation includes the setupToL2 call, the contract needs to be deployed on the chain
-    const setupToL2ContractExists =
+    const areSetupToL2ConditionsMet =
       !includesSetupToL2 ||
       hasCanonicalDeployment(getSafeToL2SetupDeployments({ network: config.chainId, version: '1.4.1' }), config.chainId)
 
@@ -82,7 +82,7 @@ export const useCompatibleNetworks = (
         masterCopyExists &&
         proxyFactoryExists &&
         fallbackHandlerExists &&
-        setupToL2ContractExists &&
+        areSetupToL2ConditionsMet &&
         areMigrationConditionsMet,
     }
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4216,10 +4216,10 @@
   dependencies:
     abitype "^1.0.2"
 
-"@safe-global/safe-deployments@^1.37.12":
-  version "1.37.13"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.13.tgz#9965d6c5669db526a472a0576828063aa50234df"
-  integrity sha512-DXDbyW+pSK5W+eyrT7I2VHgHjCUhiXgcmSjekCzwmzrRXB5sW36DLLDwfC5c1gvo26ix6NcIGRSk2sf68BHdeg==
+"@safe-global/safe-deployments@1.37.12":
+  version "1.37.12"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.12.tgz#c01b0a272991ae0e63a37d506024a809de53c370"
+  integrity sha512-6UM5wS6b0h4Uu2BCK6sWLNC5UYFBd1Xu4YsuZpoSjlo/6UDbbK6lzYVEgtqbsy8p1z2ZO+Z73WgRo3mlh7awig==
   dependencies:
     semver "^7.6.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4216,7 +4216,7 @@
   dependencies:
     abitype "^1.0.2"
 
-"@safe-global/safe-deployments@^1.37.13":
+"@safe-global/safe-deployments@^1.37.12":
   version "1.37.13"
   resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.13.tgz#9965d6c5669db526a472a0576828063aa50234df"
   integrity sha512-DXDbyW+pSK5W+eyrT7I2VHgHjCUhiXgcmSjekCzwmzrRXB5sW36DLLDwfC5c1gvo26ix6NcIGRSk2sf68BHdeg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4216,10 +4216,10 @@
   dependencies:
     abitype "^1.0.2"
 
-"@safe-global/safe-deployments@^1.37.12":
-  version "1.37.12"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.12.tgz#c01b0a272991ae0e63a37d506024a809de53c370"
-  integrity sha512-6UM5wS6b0h4Uu2BCK6sWLNC5UYFBd1Xu4YsuZpoSjlo/6UDbbK6lzYVEgtqbsy8p1z2ZO+Z73WgRo3mlh7awig==
+"@safe-global/safe-deployments@^1.37.13":
+  version "1.37.13"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.13.tgz#9965d6c5669db526a472a0576828063aa50234df"
+  integrity sha512-DXDbyW+pSK5W+eyrT7I2VHgHjCUhiXgcmSjekCzwmzrRXB5sW36DLLDwfC5c1gvo26ix6NcIGRSk2sf68BHdeg==
   dependencies:
     semver "^7.6.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4216,7 +4216,14 @@
   dependencies:
     abitype "^1.0.2"
 
-"@safe-global/safe-deployments@^1.37.10", "@safe-global/safe-deployments@^1.37.9":
+"@safe-global/safe-deployments@^1.37.12":
+  version "1.37.12"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.12.tgz#c01b0a272991ae0e63a37d506024a809de53c370"
+  integrity sha512-6UM5wS6b0h4Uu2BCK6sWLNC5UYFBd1Xu4YsuZpoSjlo/6UDbbK6lzYVEgtqbsy8p1z2ZO+Z73WgRo3mlh7awig==
+  dependencies:
+    semver "^7.6.2"
+
+"@safe-global/safe-deployments@^1.37.9":
   version "1.37.10"
   resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.37.10.tgz#2f61a25bd479332821ba2e91a575237d77406ec3"
   integrity sha512-lcxX9CV+xdcLs4dF6Cx18zDww5JyqaX6RdcvU0o/34IgJ4Wjo3J/RNzJAoMhurCAfTGr+0vyJ9V13Qo50AR6JA==
@@ -17238,16 +17245,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -17343,14 +17341,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -19106,7 +19097,7 @@ workbox-window@7.0.0:
     "@types/trusted-types" "^2.0.2"
     workbox-core "7.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -19119,15 +19110,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## What it solves
If only worldchain is selected as network during Safe creation the SetupToL2 call was missing during deployment.

## How this PR fixes it
- Upgrade `safe-deployments` to latest version
- Check for all network options that they have a SetupToL2 deployment available if multiple networks are selected
- Check that target network has MigrateToL2 deployment when adding networks to existing Safes

## How to test it
- Create a Safe on only Worldchain
- Observe that it has the correct masterCopy
- Add Worldchain to a legacy L1 Safe
- Observe that it can be migrated

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
