### PR TITLE
Feat(Sidebar): Add pinned safes list to sidebar and accounts page [SW-304]

### DIFF
--- a/src/components/sidebar/Sidebar/index.tsx
+++ b/src/components/sidebar/Sidebar/index.tsx
@@ -52,7 +52,7 @@ const Sidebar = (): ReactElement => {
 
       <Drawer variant="temporary" anchor="left" open={isDrawerOpen} onClose={onDrawerToggle}>
         <div className={css.drawer}>
-          <MyAccounts onLinkClick={closeDrawer}></MyAccounts>
+          <MyAccounts onLinkClick={closeDrawer} isSidebar={true}></MyAccounts>
         </div>
       </Drawer>
     </div>

--- a/src/components/sidebar/Sidebar/index.tsx
+++ b/src/components/sidebar/Sidebar/index.tsx
@@ -52,7 +52,7 @@ const Sidebar = (): ReactElement => {
 
       <Drawer variant="temporary" anchor="left" open={isDrawerOpen} onClose={onDrawerToggle}>
         <div className={css.drawer}>
-          <MyAccounts onLinkClick={closeDrawer} isSidebar={true}></MyAccounts>
+          <MyAccounts onLinkClick={closeDrawer} isSidebar></MyAccounts>
         </div>
       </Drawer>
     </div>

--- a/src/components/welcome/MyAccounts/AccountItem.tsx
+++ b/src/components/welcome/MyAccounts/AccountItem.tsx
@@ -99,8 +99,8 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
             ...defaultSafeInfo,
             chainId,
             address: { value: address },
-            owners: safeOverview?.owners,
-            threshold: safeOverview?.threshold,
+            owners: safeOverview.owners,
+            threshold: safeOverview.threshold,
           },
         }),
       )

--- a/src/components/welcome/MyAccounts/AccountItem.tsx
+++ b/src/components/welcome/MyAccounts/AccountItem.tsx
@@ -91,6 +91,7 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
   // const safeOwners = safeOverview?.owners ?? counterfactualSetup?.owners
 
   const addToPinnedList = () => {
+    dispatch(pinSafe({ chainId, address }))
     if (!isAdded && safeOverview) {
       dispatch(
         // Adding a safe will make it pinned by default

--- a/src/components/welcome/MyAccounts/AccountItem.tsx
+++ b/src/components/welcome/MyAccounts/AccountItem.tsx
@@ -22,7 +22,7 @@ import { useRouter } from 'next/router'
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
 import type { SafeItem } from './useAllSafes'
 import { useGetHref } from './useGetHref'
-import { isPredictedSafeProps } from '@/features/counterfactual/utils'
+import { extractCounterfactualSafeSetup, isPredictedSafeProps } from '@/features/counterfactual/utils'
 import useWallet from '@/hooks/wallets/useWallet'
 import { hasMultiChainAddNetworkFeature } from '@/features/multichain/utils/utils'
 import BookmarkIcon from '@/public/images/apps/bookmark.svg'
@@ -55,17 +55,6 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
   const isAdded = !!addedSafes?.[address]
   const elementRef = useRef<HTMLDivElement>(null)
   const isVisible = useOnceVisible(elementRef)
-  // const [safeOverview, setSafeOverview] = useState<SafeOverview | null>(null)
-
-  // useEffect(() => {
-  //   if (isVisible && !undeployedSafe) {
-  //     const fetchSafeOverview = async () => {
-  //       const safeInfo = await getSafeInfo(chainId, safeAddress)
-  //       setSafeOverview(safeInfo)
-  //     }
-  //     fetchSafeOverview()
-  //   }
-  // }, [chainId, isVisible, safeAddress, undeployedSafe])
 
   const dispatch = useAppDispatch()
 
@@ -81,9 +70,9 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
 
   const isActivating = undeployedSafe?.status.status !== 'AWAITING_EXECUTION'
 
-  // const counterfactualSetup = undeployedSafe
-  //   ? extractCounterfactualSafeSetup(undeployedSafe, chain?.chainId)
-  //   : undefined
+  const counterfactualSetup = undeployedSafe
+    ? extractCounterfactualSafeSetup(undeployedSafe, chain?.chainId)
+    : undefined
 
   const addNetworkFeatureEnabled = hasMultiChainAddNetworkFeature(chain)
   const isReplayable =
@@ -101,8 +90,8 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
         },
   )
 
-  // const safeThreshold = safeOverview?.threshold ?? counterfactualSetup?.threshold
-  // const safeOwners = safeOverview?.owners ?? counterfactualSetup?.owners
+  const safeThreshold = safeOverview?.threshold ?? counterfactualSetup?.threshold
+  const safeOwners = safeOverview?.owners ?? counterfactualSetup?.owners
 
   const addToPinnedList = () => {
     if (!isAdded && !undeployedSafe) {
@@ -118,8 +107,9 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
           },
         }),
       )
+      dispatch(pinSafe({ chainId, address, removeOnUnpin: true }))
     } else {
-      dispatch(pinSafe({ chainId, address }))
+      dispatch(pinSafe({ chainId, address, removeOnUnpin: false }))
     }
   }
 

--- a/src/components/welcome/MyAccounts/AccountItem.tsx
+++ b/src/components/welcome/MyAccounts/AccountItem.tsx
@@ -2,7 +2,7 @@ import { LoopIcon } from '@/features/counterfactual/CounterfactualStatusButton'
 import { selectUndeployedSafe } from '@/features/counterfactual/store/undeployedSafesSlice'
 import { type SafeOverview } from '@safe-global/safe-gateway-typescript-sdk'
 import { useMemo, useRef } from 'react'
-import { ListItemButton, Box, Typography, Chip, Tooltip, IconButton, SvgIcon, Skeleton } from '@mui/material'
+import { ListItemButton, Box, Typography, Chip, IconButton, SvgIcon, Skeleton } from '@mui/material'
 import Link from 'next/link'
 import Track from '@/components/common/Track'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
@@ -177,16 +177,14 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
         </Link>
       </Track>
 
-      <Tooltip placement="top" arrow title="Pin this account">
-        <IconButton edge="end" size="medium" sx={{ mx: 1 }} onClick={isPinned ? removeFromPinnedList : addToPinnedList}>
-          <SvgIcon
-            component={isPinned ? BookmarkedIcon : BookmarkIcon}
-            inheritViewBox
-            color={isPinned ? 'primary' : undefined}
-            fontSize="small"
-          />
-        </IconButton>
-      </Tooltip>
+      <IconButton edge="end" size="medium" sx={{ mx: 1 }} onClick={isPinned ? removeFromPinnedList : addToPinnedList}>
+        <SvgIcon
+          component={isPinned ? BookmarkedIcon : BookmarkIcon}
+          inheritViewBox
+          color={isPinned ? 'primary' : undefined}
+          fontSize="small"
+        />
+      </IconButton>
       <SafeListContextMenu name={name} address={address} chainId={chainId} addNetwork={isReplayable} rename />
 
       {isVisible && (

--- a/src/components/welcome/MyAccounts/AccountItem.tsx
+++ b/src/components/welcome/MyAccounts/AccountItem.tsx
@@ -22,17 +22,16 @@ import { useRouter } from 'next/router'
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
 import type { SafeItem } from './useAllSafes'
 import { useGetHref } from './useGetHref'
-import { extractCounterfactualSafeSetup, isPredictedSafeProps } from '@/features/counterfactual/utils'
+import { isPredictedSafeProps } from '@/features/counterfactual/utils'
 import useWallet from '@/hooks/wallets/useWallet'
 import { hasMultiChainAddNetworkFeature } from '@/features/multichain/utils/utils'
 import BookmarkIcon from '@/public/images/apps/bookmark.svg'
 import BookmarkedIcon from '@/public/images/apps/bookmarked.svg'
 import { addOrUpdateSafe, pinSafe, selectAddedSafes, unpinSafe } from '@/store/addedSafesSlice'
 import SafeIcon from '@/components/common/SafeIcon'
-import { defaultSafeInfo } from '@/store/safeInfoSlice'
 import useOnceVisible from '@/hooks/useOnceVisible'
 import { skipToken } from '@reduxjs/toolkit/query'
-import { useGetSafeOverviewQuery } from '@/store/slices'
+import { defaultSafeInfo, useGetSafeOverviewQuery } from '@/store/slices'
 import FiatValue from '@/components/common/FiatValue'
 import QueueActions from './QueueActions'
 type AccountItemProps = {
@@ -70,9 +69,9 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
 
   const isActivating = undeployedSafe?.status.status !== 'AWAITING_EXECUTION'
 
-  const counterfactualSetup = undeployedSafe
-    ? extractCounterfactualSafeSetup(undeployedSafe, chain?.chainId)
-    : undefined
+  // const counterfactualSetup = undeployedSafe
+  //   ? extractCounterfactualSafeSetup(undeployedSafe, chain?.chainId)
+  //   : undefined
 
   const addNetworkFeatureEnabled = hasMultiChainAddNetworkFeature(chain)
   const isReplayable =
@@ -90,8 +89,8 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
         },
   )
 
-  const safeThreshold = safeOverview?.threshold ?? counterfactualSetup?.threshold
-  const safeOwners = safeOverview?.owners ?? counterfactualSetup?.owners
+  // const safeThreshold = safeOverview?.threshold ?? counterfactualSetup?.threshold
+  // const safeOwners = safeOverview?.owners ?? counterfactualSetup?.owners
 
   const addToPinnedList = () => {
     if (!isAdded && !undeployedSafe) {

--- a/src/components/welcome/MyAccounts/AccountItem.tsx
+++ b/src/components/welcome/MyAccounts/AccountItem.tsx
@@ -39,11 +39,10 @@ import VisibilityIcon from '@mui/icons-material/Visibility'
 type AccountItemProps = {
   safeItem: SafeItem
   safeOverview?: SafeOverview
-  loadBalances: boolean
   onLinkClick?: () => void
 }
 
-const AccountItem = ({ onLinkClick, safeItem, loadBalances }: AccountItemProps) => {
+const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
   const { chainId, address, isPinned, isWatchlist } = safeItem
   const chain = useAppSelector((state) => selectChainById(state, chainId))
   const undeployedSafe = useAppSelector((state) => selectUndeployedSafe(state, chainId, address))
@@ -152,7 +151,7 @@ const AccountItem = ({ onLinkClick, safeItem, loadBalances }: AccountItemProps) 
           <ChainIndicator chainId={chainId} responsive onlyLogo className={css.chainIndicator} />
 
           <Typography variant="body2" fontWeight="bold" textAlign="right" pl={2}>
-            {!loadBalances || undeployedSafe ? null : safeOverview && isVisible ? (
+            {undeployedSafe ? null : safeOverview ? (
               <FiatValue value={safeOverview.fiatTotal} />
             ) : (
               <Skeleton variant="text" sx={{ ml: 'auto' }} />

--- a/src/components/welcome/MyAccounts/AccountItem.tsx
+++ b/src/components/welcome/MyAccounts/AccountItem.tsx
@@ -178,7 +178,6 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
       </Track>
 
       <Tooltip placement="top" arrow title="Pin this account">
-        {/* <IconButton edge="end" size="medium" sx={{ mx: 1 }} onClick={() => {}}> */}
         <IconButton edge="end" size="medium" sx={{ mx: 1 }} onClick={isPinned ? removeFromPinnedList : addToPinnedList}>
           <SvgIcon
             component={isPinned ? BookmarkedIcon : BookmarkIcon}

--- a/src/components/welcome/MyAccounts/AccountItem.tsx
+++ b/src/components/welcome/MyAccounts/AccountItem.tsx
@@ -2,9 +2,8 @@ import { LoopIcon } from '@/features/counterfactual/CounterfactualStatusButton'
 import { selectUndeployedSafe } from '@/features/counterfactual/store/undeployedSafesSlice'
 import type { SafeOverview } from '@safe-global/safe-gateway-typescript-sdk'
 import { useMemo } from 'react'
-import { ListItemButton, Box, Typography, Chip, Skeleton, Tooltip, IconButton, SvgIcon } from '@mui/material'
+import { ListItemButton, Box, Typography, Chip, Tooltip, IconButton, SvgIcon } from '@mui/material'
 import Link from 'next/link'
-import SafeIcon from '@/components/common/SafeIcon'
 import Track from '@/components/common/Track'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
 import { AppRoutes } from '@/config/routes'
@@ -22,17 +21,14 @@ import classnames from 'classnames'
 import { useRouter } from 'next/router'
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
 import type { SafeItem } from './useAllSafes'
-import FiatValue from '@/components/common/FiatValue'
-import QueueActions from './QueueActions'
 import { useGetHref } from './useGetHref'
 import { extractCounterfactualSafeSetup, isPredictedSafeProps } from '@/features/counterfactual/utils'
-import { useGetSafeOverviewQuery } from '@/store/api/gateway'
 import useWallet from '@/hooks/wallets/useWallet'
-import { skipToken } from '@reduxjs/toolkit/query'
 import { hasMultiChainAddNetworkFeature } from '@/features/multichain/utils/utils'
 import BookmarkIcon from '@/public/images/apps/bookmark.svg'
 import BookmarkedIcon from '@/public/images/apps/bookmarked.svg'
 import { addOrUpdateSafe, pinSafe, selectAddedSafes, unpinSafe } from '@/store/addedSafesSlice'
+import SafeIcon from '@/components/common/SafeIcon'
 import { defaultSafeInfo } from '@/store/safeInfoSlice'
 type AccountItemProps = {
   safeItem: SafeItem
@@ -41,7 +37,7 @@ type AccountItemProps = {
 }
 
 const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
-  const { chainId, address, isPinned } = safeItem
+  const { chainId, address, isPinned, isWatchlist } = safeItem
   const chain = useAppSelector((state) => selectChainById(state, chainId))
   const undeployedSafe = useAppSelector((state) => selectUndeployedSafe(state, chainId, address))
   const safeAddress = useSafeAddress()
@@ -77,22 +73,21 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
     !safeItem.isWatchlist &&
     (!undeployedSafe || !isPredictedSafeProps(undeployedSafe.props))
 
-  const { data: safeOverview } = useGetSafeOverviewQuery(
-    undeployedSafe
-      ? skipToken
-      : {
-          chainId: safeItem.chainId,
-          safeAddress: safeItem.address,
-          walletAddress,
-        },
-  )
+  // const { data: safeOverview } = useGetSafeOverviewQuery(
+  //   undeployedSafe
+  //     ? skipToken
+  //     : {
+  //         chainId: safeItem.chainId,
+  //         safeAddress: safeItem.address,
+  //         walletAddress,
+  //       },
+  // )
 
   // const safeThreshold = safeOverview?.threshold ?? counterfactualSetup?.threshold
   // const safeOwners = safeOverview?.owners ?? counterfactualSetup?.owners
 
   const addToPinnedList = () => {
-    dispatch(pinSafe({ chainId, address }))
-    if (!isAdded && safeOverview) {
+    if (!isAdded) {
       dispatch(
         // Adding a safe will make it pinned by default
         addOrUpdateSafe({
@@ -100,8 +95,8 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
             ...defaultSafeInfo,
             chainId,
             address: { value: address },
-            owners: safeOverview.owners,
-            threshold: safeOverview.threshold,
+            // owners: safeOverview.owners,
+            // threshold: safeOverview.threshold,
           },
         }),
       )
@@ -125,8 +120,8 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
           <Box pr={2.5}>
             <SafeIcon
               address={address}
-              owners={safeOverview?.owners.length ?? counterfactualSetup?.owners.length}
-              threshold={safeOverview?.threshold ?? counterfactualSetup?.threshold}
+              // owners={safeOverview?.owners.length ?? counterfactualSetup?.owners.length}
+              // threshold={safeOverview?.threshold ?? counterfactualSetup?.threshold}
               chainId={chainId}
             />
           </Box>
@@ -159,21 +154,23 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
                 />
               </div>
             )}
+            {isWatchlist && <Typography fontSize="inherit">Readonly</Typography>}
           </Typography>
 
           <ChainIndicator chainId={chainId} responsive onlyLogo className={css.chainIndicator} />
 
           <Typography variant="body2" fontWeight="bold" textAlign="right" pl={2}>
-            {safeOverview ? (
+            {/* {safeOverview ? (
               <FiatValue value={safeOverview.fiatTotal} />
             ) : undeployedSafe ? null : (
               <Skeleton variant="text" sx={{ ml: 'auto' }} />
-            )}
+            )} */}
           </Typography>
         </Link>
       </Track>
 
       <Tooltip placement="top" arrow title="Pin this account">
+        {/* <IconButton edge="end" size="medium" sx={{ mx: 1 }} onClick={() => {}}> */}
         <IconButton edge="end" size="medium" sx={{ mx: 1 }} onClick={isPinned ? removeFromPinnedList : addToPinnedList}>
           <SvgIcon
             component={isPinned ? BookmarkedIcon : BookmarkIcon}
@@ -185,12 +182,12 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
       </Tooltip>
       <SafeListContextMenu name={name} address={address} chainId={chainId} addNetwork={isReplayable} rename />
 
-      <QueueActions
+      {/* <QueueActions
         queued={safeOverview?.queued || 0}
         awaitingConfirmation={safeOverview?.awaitingConfirmation || 0}
         safeAddress={address}
         chainShortName={chain?.shortName || ''}
-      />
+      /> */}
     </ListItemButton>
   )
 }

--- a/src/components/welcome/MyAccounts/AccountItem.tsx
+++ b/src/components/welcome/MyAccounts/AccountItem.tsx
@@ -130,8 +130,8 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
           <Box pr={2.5}>
             <SafeIcon
               address={address}
-              owners={safeOwners.length ?? undefined}
-              threshold={safeThreshold ?? undefined}
+              owners={safeOwners.length > 0 ? safeOwners.length : undefined}
+              threshold={safeThreshold > 0 ? safeThreshold : undefined}
               chainId={chainId}
             />
           </Box>

--- a/src/components/welcome/MyAccounts/CreateButton.tsx
+++ b/src/components/welcome/MyAccounts/CreateButton.tsx
@@ -2,7 +2,7 @@ import { Button } from '@mui/material'
 import Link from 'next/link'
 import { AppRoutes } from '@/config/routes'
 
-const buttonSx = { width: ['100%', 'auto'], height: '36px' }
+const buttonSx = { width: ['100%', 'auto'], height: '36px', px: 2 }
 
 const CreateButton = ({ isPrimary }: { isPrimary: boolean }) => {
   return (

--- a/src/components/welcome/MyAccounts/CreateButton.tsx
+++ b/src/components/welcome/MyAccounts/CreateButton.tsx
@@ -2,7 +2,7 @@ import { Button } from '@mui/material'
 import Link from 'next/link'
 import { AppRoutes } from '@/config/routes'
 
-const buttonSx = { width: ['100%', 'auto'] }
+const buttonSx = { width: ['100%', 'auto'], height: '36px' }
 
 const CreateButton = ({ isPrimary }: { isPrimary: boolean }) => {
   return (

--- a/src/components/welcome/MyAccounts/MultiAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/MultiAccountItem.tsx
@@ -43,13 +43,12 @@ import BookmarkIcon from '@/public/images/apps/bookmark.svg'
 import BookmarkedIcon from '@/public/images/apps/bookmarked.svg'
 import { addOrUpdateSafe, pinSafe, selectAllAddedSafes, unpinSafe } from '@/store/addedSafesSlice'
 import { defaultSafeInfo } from '@/store/safeInfoSlice'
-import { skipToken } from '@reduxjs/toolkit/query'
 
 type MultiAccountItemProps = {
   multiSafeAccountItem: MultiChainSafeItem
   safeOverviews?: SafeOverview[]
   onLinkClick?: () => void
-  loadOverview: boolean
+  loadBalances: boolean
 }
 
 const MultichainIndicator = ({ safes }: { safes: SafeItem[] }) => {
@@ -74,7 +73,7 @@ const MultichainIndicator = ({ safes }: { safes: SafeItem[] }) => {
   )
 }
 
-const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, loadOverview }: MultiAccountItemProps) => {
+const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, loadBalances }: MultiAccountItemProps) => {
   const { address, safes, isPinned } = multiSafeAccountItem
   const undeployedSafes = useAppSelector(selectUndeployedSafes)
   const safeAddress = useSafeAddress()
@@ -112,9 +111,7 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, loadOverview }: M
     () => safes.filter((safe) => undeployedSafes[safe.chainId]?.[safe.address] === undefined),
     [safes, undeployedSafes],
   )
-  const { data: safeOverviews } = useGetMultipleSafeOverviewsQuery(
-    loadOverview ? { currency, walletAddress, safes: deployedSafes } : skipToken,
-  )
+  const { data: safeOverviews } = useGetMultipleSafeOverviewsQuery({ currency, walletAddress, safes: deployedSafes })
 
   const safeSetups = useMemo(
     () => getSafeSetups(safes, safeOverviews ?? [], undeployedSafes),
@@ -212,7 +209,7 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, loadOverview }: M
             </Typography>
             <MultichainIndicator safes={safes} />
             <Typography variant="body2" fontWeight="bold" textAlign="right" pl={2}>
-              {!loadOverview ? null : totalFiatValue !== undefined ? (
+              {!loadBalances ? null : totalFiatValue !== undefined ? (
                 <FiatValue value={totalFiatValue} />
               ) : (
                 <Skeleton variant="text" sx={{ ml: 'auto' }} />

--- a/src/components/welcome/MyAccounts/MultiAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/MultiAccountItem.tsx
@@ -216,24 +216,22 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountIte
               )}
             </Typography>
           </Box>
-          <Tooltip placement="top" arrow title="Pin this account">
-            <IconButton
-              edge="end"
-              size="medium"
-              sx={{ mx: 1 }}
-              onClick={(event) => {
-                event.stopPropagation()
-                isPinned ? removeFromPinnedList() : addToPinnedList()
-              }}
-            >
-              <SvgIcon
-                component={isPinned ? BookmarkedIcon : BookmarkIcon}
-                inheritViewBox
-                color={isPinned ? 'primary' : undefined}
-                fontSize="small"
-              />
-            </IconButton>
-          </Tooltip>
+          <IconButton
+            edge="end"
+            size="medium"
+            sx={{ mx: 1 }}
+            onClick={(event) => {
+              event.stopPropagation()
+              isPinned ? removeFromPinnedList() : addToPinnedList()
+            }}
+          >
+            <SvgIcon
+              component={isPinned ? BookmarkedIcon : BookmarkIcon}
+              inheritViewBox
+              color={isPinned ? 'primary' : undefined}
+              fontSize="small"
+            />
+          </IconButton>
           <MultiAccountContextMenu
             name={name ?? ''}
             address={address}

--- a/src/components/welcome/MyAccounts/MultiAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/MultiAccountItem.tsx
@@ -164,8 +164,8 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountIte
               threshold: overview ? overview.threshold : defaultSafeInfo.threshold,
             },
           }),
-          dispatch(pinSafe({ chainId: safe.chainId, address: safe.address, removeOnUnpin: true })),
         )
+        dispatch(pinSafe({ chainId: safe.chainId, address: safe.address, removeOnUnpin: true }))
       }
     }
   }, [safes, allAddedSafes, dispatch, findOverview, address])

--- a/src/components/welcome/MyAccounts/MultiAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/MultiAccountItem.tsx
@@ -16,7 +16,7 @@ import {
 import SafeIcon from '@/components/common/SafeIcon'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS, trackEvent } from '@/services/analytics'
 import { AppRoutes } from '@/config/routes'
-import { useAppSelector } from '@/store'
+import { useAppDispatch, useAppSelector } from '@/store'
 import css from './styles.module.css'
 import { selectAllAddressBooks } from '@/store/addressBookSlice'
 import useSafeAddress from '@/hooks/useSafeAddress'
@@ -75,6 +75,10 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountIte
   const isWelcomePage = router.pathname === AppRoutes.welcome.accounts
   const [expanded, setExpanded] = useState(isCurrentSafe)
   const chains = useAppSelector(selectChains)
+
+  // const addedSafes = useAppSelector((state) => selectAddedSafes(state, chainId))
+  // const isAdded = !!addedSafes?.[address]
+  const dispatch = useAppDispatch()
 
   const deployedChainIds = useMemo(() => safes.map((safe) => safe.chainId), [safes])
 
@@ -136,6 +140,29 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountIte
     [safeOverviews],
   )
 
+  // const addToPinnedList = () => {
+  //   if (!isAdded && safeOverview) {
+  //     dispatch(
+  //       // Adding a safe will make it pinned by default
+  //       addOrUpdateSafe({
+  //         safe: {
+  //           ...defaultSafeInfo,
+  //           chainId,
+  //           address: { value: address },
+  //           owners: safeOverview?.owners,
+  //           threshold: safeOverview?.threshold,
+  //         },
+  //       }),
+  //     )
+  //   } else {
+  //     dispatch(pinSafe({ chainId, address }))
+  //   }
+  // }
+
+  // const removeFromPinnedList = () => {
+  //   dispatch(unpinSafe({ chainId, address }))
+  // }
+
   return (
     <ListItemButton
       data-testid="safe-list-item"
@@ -175,6 +202,21 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountIte
               )}
             </Typography>
           </Box>
+          {/* <Tooltip placement="top" arrow title="Pin this account">
+            <IconButton
+              edge="end"
+              size="medium"
+              sx={{ mx: 1 }}
+              onClick={isPinned ? removeFromPinnedList : addToPinnedList}
+            >
+              <SvgIcon
+                component={isPinned ? BookmarkedIcon : BookmarkIcon}
+                inheritViewBox
+                color={isPinned ? 'primary' : undefined}
+                fontSize="small"
+              />
+            </IconButton>
+          </Tooltip> */}
           <MultiAccountContextMenu
             name={name ?? ''}
             address={address}

--- a/src/components/welcome/MyAccounts/MultiAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/MultiAccountItem.tsx
@@ -48,7 +48,6 @@ type MultiAccountItemProps = {
   multiSafeAccountItem: MultiChainSafeItem
   safeOverviews?: SafeOverview[]
   onLinkClick?: () => void
-  loadBalances: boolean
 }
 
 const MultichainIndicator = ({ safes }: { safes: SafeItem[] }) => {
@@ -73,7 +72,7 @@ const MultichainIndicator = ({ safes }: { safes: SafeItem[] }) => {
   )
 }
 
-const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, loadBalances }: MultiAccountItemProps) => {
+const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountItemProps) => {
   const { address, safes, isPinned } = multiSafeAccountItem
   const undeployedSafes = useAppSelector(selectUndeployedSafes)
   const safeAddress = useSafeAddress()
@@ -209,7 +208,7 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, loadBalances }: M
             </Typography>
             <MultichainIndicator safes={safes} />
             <Typography variant="body2" fontWeight="bold" textAlign="right" pl={2}>
-              {!loadBalances ? null : totalFiatValue !== undefined ? (
+              {totalFiatValue !== undefined ? (
                 <FiatValue value={totalFiatValue} />
               ) : (
                 <Skeleton variant="text" sx={{ ml: 'auto' }} />

--- a/src/components/welcome/MyAccounts/MultiAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/MultiAccountItem.tsx
@@ -43,11 +43,13 @@ import BookmarkIcon from '@/public/images/apps/bookmark.svg'
 import BookmarkedIcon from '@/public/images/apps/bookmarked.svg'
 import { addOrUpdateSafe, pinSafe, selectAllAddedSafes, unpinSafe } from '@/store/addedSafesSlice'
 import { defaultSafeInfo } from '@/store/safeInfoSlice'
+import { skipToken } from '@reduxjs/toolkit/query'
 
 type MultiAccountItemProps = {
   multiSafeAccountItem: MultiChainSafeItem
   safeOverviews?: SafeOverview[]
   onLinkClick?: () => void
+  loadOverview: boolean
 }
 
 const MultichainIndicator = ({ safes }: { safes: SafeItem[] }) => {
@@ -72,7 +74,7 @@ const MultichainIndicator = ({ safes }: { safes: SafeItem[] }) => {
   )
 }
 
-const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountItemProps) => {
+const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, loadOverview }: MultiAccountItemProps) => {
   const { address, safes, isPinned } = multiSafeAccountItem
   const undeployedSafes = useAppSelector(selectUndeployedSafes)
   const safeAddress = useSafeAddress()
@@ -83,7 +85,6 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountIte
   const chains = useAppSelector(selectChains)
 
   const allAddedSafes = useAppSelector((state) => selectAllAddedSafes(state))
-  // const isAdded = !!addedSafes?.[address]
   const dispatch = useAppDispatch()
 
   const deployedChainIds = useMemo(() => safes.map((safe) => safe.chainId), [safes])
@@ -111,7 +112,9 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountIte
     () => safes.filter((safe) => undeployedSafes[safe.chainId]?.[safe.address] === undefined),
     [safes, undeployedSafes],
   )
-  const { data: safeOverviews } = useGetMultipleSafeOverviewsQuery({ currency, walletAddress, safes: deployedSafes })
+  const { data: safeOverviews } = useGetMultipleSafeOverviewsQuery(
+    loadOverview ? { currency, walletAddress, safes: deployedSafes } : skipToken,
+  )
 
   const safeSetups = useMemo(
     () => getSafeSetups(safes, safeOverviews ?? [], undeployedSafes),
@@ -209,7 +212,7 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountIte
             </Typography>
             <MultichainIndicator safes={safes} />
             <Typography variant="body2" fontWeight="bold" textAlign="right" pl={2}>
-              {totalFiatValue !== undefined ? (
+              {!loadOverview ? null : totalFiatValue !== undefined ? (
                 <FiatValue value={totalFiatValue} />
               ) : (
                 <Skeleton variant="text" sx={{ ml: 'auto' }} />

--- a/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
+++ b/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
@@ -1,10 +1,12 @@
 import { type ReactNode } from 'react'
-import { Typography } from '@mui/material'
+import { Box, Typography } from '@mui/material'
 import AccountItem from './AccountItem'
 import { type SafeItem } from './useAllSafes'
 import { type MultiChainSafeItem } from './useAllSafesGrouped'
 import MultiAccountItem from './MultiAccountItem'
 import { isMultiChainSafeItem } from '@/features/multichain/utils/utils'
+import { TransitionGroup } from 'react-transition-group'
+import Collapse from '@mui/material/Collapse'
 
 type SafeListProps = {
   safes?: (SafeItem | MultiChainSafeItem)[]
@@ -126,18 +128,21 @@ type SafeListProps = {
 
 export const SafesList = ({ safes, noSafesMessage, onLinkClick }: SafeListProps) => {
   return (
-    // <Paper className={css.safeList}>
-    <>
+    <Box>
       {safes && safes.length > 0 ? (
-        <>
+        <TransitionGroup>
           {safes.map((item) =>
             isMultiChainSafeItem(item) ? (
-              <MultiAccountItem onLinkClick={onLinkClick} key={item.address} multiSafeAccountItem={item} />
+              <Collapse key={item.address}>
+                <MultiAccountItem onLinkClick={onLinkClick} multiSafeAccountItem={item} />
+              </Collapse>
             ) : (
-              <AccountItem onLinkClick={onLinkClick} safeItem={item} key={item.chainId + item.address} />
+              <Collapse key={item.address}>
+                <AccountItem onLinkClick={onLinkClick} safeItem={item} key={item.chainId + item.address} />
+              </Collapse>
             ),
           )}
-        </>
+        </TransitionGroup>
       ) : (
         <Typography
           component="div"
@@ -151,7 +156,7 @@ export const SafesList = ({ safes, noSafesMessage, onLinkClick }: SafeListProps)
           {noSafesMessage}
         </Typography>
       )}
-    </>
+    </Box>
     // </Paper>
   )
 }

--- a/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
+++ b/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
@@ -1,107 +1,141 @@
-import { type ReactElement, type ReactNode, useState, useCallback, useEffect, useMemo } from 'react'
-import { Paper, Typography } from '@mui/material'
+import { type ReactNode } from 'react'
+import { Typography } from '@mui/material'
 import AccountItem from './AccountItem'
 import { type SafeItem } from './useAllSafes'
-import css from './styles.module.css'
-import InfiniteScroll from '@/components/common/InfiniteScroll'
 import { type MultiChainSafeItem } from './useAllSafesGrouped'
 import MultiAccountItem from './MultiAccountItem'
 import { isMultiChainSafeItem } from '@/features/multichain/utils/utils'
 
-type PaginatedSafeListProps = {
+type SafeListProps = {
   safes?: (SafeItem | MultiChainSafeItem)[]
-  title: ReactNode
   noSafesMessage?: ReactNode
-  action?: ReactElement
   onLinkClick?: () => void
 }
+// type PaginatedSafeListProps = {
+//   safes?: (SafeItem | MultiChainSafeItem)[]
+//   title: ReactNode
+//   noSafesMessage?: ReactNode
+//   action?: ReactElement
+//   onLinkClick?: () => void
+// }
 
-type SafeListPageProps = {
-  safes: (SafeItem | MultiChainSafeItem)[]
-  onLinkClick: PaginatedSafeListProps['onLinkClick']
-}
+// type SafeListPageProps = {
+//   safes: (SafeItem | MultiChainSafeItem)[]
+//   onLinkClick: PaginatedSafeListProps['onLinkClick']
+// }
 
-const DEFAULT_PAGE_SIZE = 10
+// const DEFAULT_PAGE_SIZE = 10
 
-export const SafeListPage = ({ safes, onLinkClick }: SafeListPageProps) => {
+// export const SafeListPage = ({ safes, onLinkClick }: SafeListPageProps) => {
+//   return (
+//     <>
+//       {safes.map((item) =>
+//         isMultiChainSafeItem(item) ? (
+//           <MultiAccountItem onLinkClick={onLinkClick} key={item.address} multiSafeAccountItem={item} />
+//         ) : (
+//           <AccountItem onLinkClick={onLinkClick} safeItem={item} key={item.chainId + item.address} />
+//         ),
+//       )}
+//     </>
+//   )
+// }
+
+// const AllSafeListPages = ({
+//   safes,
+//   onLinkClick,
+//   pageSize = DEFAULT_PAGE_SIZE,
+// }: SafeListPageProps & { pageSize?: number }) => {
+//   const totalPages = Math.ceil(safes.length / pageSize)
+//   const [pages, setPages] = useState<(SafeItem | MultiChainSafeItem)[][]>([])
+
+//   const onNextPage = useCallback(() => {
+//     setPages((prev) => {
+//       const pageIndex = prev.length
+//       const nextPage = safes.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize)
+//       return prev.concat([nextPage])
+//     })
+//   }, [safes, pageSize])
+
+//   useEffect(() => {
+//     if (safes.length > 0) {
+//       setPages([safes.slice(0, pageSize)])
+//     }
+//   }, [safes, pageSize])
+
+//   return (
+//     <>
+//       {pages.map((pageSafes, index) => (
+//         <SafeListPage key={index} safes={pageSafes} onLinkClick={onLinkClick} />
+//       ))}
+
+//       {totalPages > pages.length && <InfiniteScroll onLoadMore={onNextPage} key={pages.length} />}
+//     </>
+//   )
+// }
+
+// const PaginatedSafeList = ({ safes, title, action, noSafesMessage, onLinkClick }: PaginatedSafeListProps) => {
+//   const multiChainSafes = useMemo(() => safes?.filter(isMultiChainSafeItem), [safes])
+//   const singleChainSafes = useMemo(() => safes?.filter((safe) => !isMultiChainSafeItem(safe)), [safes])
+
+//   const totalMultiChainSafes = multiChainSafes?.length ?? 0
+//   const totalSingleChainSafes = singleChainSafes?.length ?? 0
+//   const totalSafes = totalMultiChainSafes + totalSingleChainSafes
+
+//   return (
+//     <Paper className={css.safeList}>
+//       <div className={css.listHeader}>
+//         <Typography variant="h5" fontWeight={700} mb={2} className={css.listTitle}>
+//           {title}
+
+//           {safes && safes.length > 0 && (
+//             <Typography component="span" color="var(--color-primary-light)" fontSize="inherit" fontWeight="normal">
+//               {' '}
+//               ({safes.length})
+//             </Typography>
+//           )}
+//         </Typography>
+
+//         {action}
+//       </div>
+
+//       {totalSafes > 0 ? (
+//         <>
+//           {multiChainSafes && multiChainSafes.length > 0 && (
+//             <AllSafeListPages safes={multiChainSafes} onLinkClick={onLinkClick} pageSize={1} />
+//           )}
+//           {singleChainSafes && singleChainSafes.length > 0 && (
+//             <AllSafeListPages safes={singleChainSafes} onLinkClick={onLinkClick} pageSize={10} />
+//           )}
+//         </>
+//       ) : (
+//         <Typography
+//           component="div"
+//           variant="body2"
+//           color="text.secondary"
+//           textAlign="center"
+//           py={3}
+//           mx="auto"
+//           width={250}
+//         >
+//           {noSafesMessage}
+//         </Typography>
+//       )}
+//     </Paper>
+//   )
+// }
+
+export const SafesList = ({ safes, noSafesMessage, onLinkClick }: SafeListProps) => {
   return (
+    // <Paper className={css.safeList}>
     <>
-      {safes.map((item) =>
-        isMultiChainSafeItem(item) ? (
-          <MultiAccountItem onLinkClick={onLinkClick} key={item.address} multiSafeAccountItem={item} />
-        ) : (
-          <AccountItem onLinkClick={onLinkClick} safeItem={item} key={item.chainId + item.address} />
-        ),
-      )}
-    </>
-  )
-}
-
-const AllSafeListPages = ({
-  safes,
-  onLinkClick,
-  pageSize = DEFAULT_PAGE_SIZE,
-}: SafeListPageProps & { pageSize?: number }) => {
-  const totalPages = Math.ceil(safes.length / pageSize)
-  const [pages, setPages] = useState<(SafeItem | MultiChainSafeItem)[][]>([])
-
-  const onNextPage = useCallback(() => {
-    setPages((prev) => {
-      const pageIndex = prev.length
-      const nextPage = safes.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize)
-      return prev.concat([nextPage])
-    })
-  }, [safes, pageSize])
-
-  useEffect(() => {
-    if (safes.length > 0) {
-      setPages([safes.slice(0, pageSize)])
-    }
-  }, [safes, pageSize])
-
-  return (
-    <>
-      {pages.map((pageSafes, index) => (
-        <SafeListPage key={index} safes={pageSafes} onLinkClick={onLinkClick} />
-      ))}
-
-      {totalPages > pages.length && <InfiniteScroll onLoadMore={onNextPage} key={pages.length} />}
-    </>
-  )
-}
-
-const PaginatedSafeList = ({ safes, title, action, noSafesMessage, onLinkClick }: PaginatedSafeListProps) => {
-  const multiChainSafes = useMemo(() => safes?.filter(isMultiChainSafeItem), [safes])
-  const singleChainSafes = useMemo(() => safes?.filter((safe) => !isMultiChainSafeItem(safe)), [safes])
-
-  const totalMultiChainSafes = multiChainSafes?.length ?? 0
-  const totalSingleChainSafes = singleChainSafes?.length ?? 0
-  const totalSafes = totalMultiChainSafes + totalSingleChainSafes
-
-  return (
-    <Paper className={css.safeList}>
-      <div className={css.listHeader}>
-        <Typography variant="h5" fontWeight={700} mb={2} className={css.listTitle}>
-          {title}
-
-          {safes && safes.length > 0 && (
-            <Typography component="span" color="var(--color-primary-light)" fontSize="inherit" fontWeight="normal">
-              {' '}
-              ({safes.length})
-            </Typography>
-          )}
-        </Typography>
-
-        {action}
-      </div>
-
-      {totalSafes > 0 ? (
+      {safes && safes.length > 0 ? (
         <>
-          {multiChainSafes && multiChainSafes.length > 0 && (
-            <AllSafeListPages safes={multiChainSafes} onLinkClick={onLinkClick} pageSize={1} />
-          )}
-          {singleChainSafes && singleChainSafes.length > 0 && (
-            <AllSafeListPages safes={singleChainSafes} onLinkClick={onLinkClick} pageSize={10} />
+          {safes.map((item) =>
+            isMultiChainSafeItem(item) ? (
+              <MultiAccountItem onLinkClick={onLinkClick} key={item.address} multiSafeAccountItem={item} />
+            ) : (
+              <AccountItem onLinkClick={onLinkClick} safeItem={item} key={item.chainId + item.address} />
+            ),
           )}
         </>
       ) : (
@@ -117,8 +151,9 @@ const PaginatedSafeList = ({ safes, title, action, noSafesMessage, onLinkClick }
           {noSafesMessage}
         </Typography>
       )}
-    </Paper>
+    </>
+    // </Paper>
   )
 }
 
-export default PaginatedSafeList
+export default SafesList

--- a/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
+++ b/src/components/welcome/MyAccounts/PaginatedSafeList.tsx
@@ -1,5 +1,3 @@
-import { type ReactNode } from 'react'
-import { Box, Typography } from '@mui/material'
 import AccountItem from './AccountItem'
 import { type SafeItem } from './useAllSafes'
 import { type MultiChainSafeItem } from './useAllSafesGrouped'
@@ -10,154 +8,28 @@ import Collapse from '@mui/material/Collapse'
 
 type SafeListProps = {
   safes?: (SafeItem | MultiChainSafeItem)[]
-  noSafesMessage?: ReactNode
   onLinkClick?: () => void
 }
-// type PaginatedSafeListProps = {
-//   safes?: (SafeItem | MultiChainSafeItem)[]
-//   title: ReactNode
-//   noSafesMessage?: ReactNode
-//   action?: ReactElement
-//   onLinkClick?: () => void
-// }
 
-// type SafeListPageProps = {
-//   safes: (SafeItem | MultiChainSafeItem)[]
-//   onLinkClick: PaginatedSafeListProps['onLinkClick']
-// }
+export const SafesList = ({ safes, onLinkClick }: SafeListProps) => {
+  if (!safes || safes.length === 0) {
+    return null
+  }
 
-// const DEFAULT_PAGE_SIZE = 10
-
-// export const SafeListPage = ({ safes, onLinkClick }: SafeListPageProps) => {
-//   return (
-//     <>
-//       {safes.map((item) =>
-//         isMultiChainSafeItem(item) ? (
-//           <MultiAccountItem onLinkClick={onLinkClick} key={item.address} multiSafeAccountItem={item} />
-//         ) : (
-//           <AccountItem onLinkClick={onLinkClick} safeItem={item} key={item.chainId + item.address} />
-//         ),
-//       )}
-//     </>
-//   )
-// }
-
-// const AllSafeListPages = ({
-//   safes,
-//   onLinkClick,
-//   pageSize = DEFAULT_PAGE_SIZE,
-// }: SafeListPageProps & { pageSize?: number }) => {
-//   const totalPages = Math.ceil(safes.length / pageSize)
-//   const [pages, setPages] = useState<(SafeItem | MultiChainSafeItem)[][]>([])
-
-//   const onNextPage = useCallback(() => {
-//     setPages((prev) => {
-//       const pageIndex = prev.length
-//       const nextPage = safes.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize)
-//       return prev.concat([nextPage])
-//     })
-//   }, [safes, pageSize])
-
-//   useEffect(() => {
-//     if (safes.length > 0) {
-//       setPages([safes.slice(0, pageSize)])
-//     }
-//   }, [safes, pageSize])
-
-//   return (
-//     <>
-//       {pages.map((pageSafes, index) => (
-//         <SafeListPage key={index} safes={pageSafes} onLinkClick={onLinkClick} />
-//       ))}
-
-//       {totalPages > pages.length && <InfiniteScroll onLoadMore={onNextPage} key={pages.length} />}
-//     </>
-//   )
-// }
-
-// const PaginatedSafeList = ({ safes, title, action, noSafesMessage, onLinkClick }: PaginatedSafeListProps) => {
-//   const multiChainSafes = useMemo(() => safes?.filter(isMultiChainSafeItem), [safes])
-//   const singleChainSafes = useMemo(() => safes?.filter((safe) => !isMultiChainSafeItem(safe)), [safes])
-
-//   const totalMultiChainSafes = multiChainSafes?.length ?? 0
-//   const totalSingleChainSafes = singleChainSafes?.length ?? 0
-//   const totalSafes = totalMultiChainSafes + totalSingleChainSafes
-
-//   return (
-//     <Paper className={css.safeList}>
-//       <div className={css.listHeader}>
-//         <Typography variant="h5" fontWeight={700} mb={2} className={css.listTitle}>
-//           {title}
-
-//           {safes && safes.length > 0 && (
-//             <Typography component="span" color="var(--color-primary-light)" fontSize="inherit" fontWeight="normal">
-//               {' '}
-//               ({safes.length})
-//             </Typography>
-//           )}
-//         </Typography>
-
-//         {action}
-//       </div>
-
-//       {totalSafes > 0 ? (
-//         <>
-//           {multiChainSafes && multiChainSafes.length > 0 && (
-//             <AllSafeListPages safes={multiChainSafes} onLinkClick={onLinkClick} pageSize={1} />
-//           )}
-//           {singleChainSafes && singleChainSafes.length > 0 && (
-//             <AllSafeListPages safes={singleChainSafes} onLinkClick={onLinkClick} pageSize={10} />
-//           )}
-//         </>
-//       ) : (
-//         <Typography
-//           component="div"
-//           variant="body2"
-//           color="text.secondary"
-//           textAlign="center"
-//           py={3}
-//           mx="auto"
-//           width={250}
-//         >
-//           {noSafesMessage}
-//         </Typography>
-//       )}
-//     </Paper>
-//   )
-// }
-
-export const SafesList = ({ safes, noSafesMessage, onLinkClick }: SafeListProps) => {
   return (
-    <Box>
-      {safes && safes.length > 0 ? (
-        <TransitionGroup>
-          {safes.map((item) =>
-            isMultiChainSafeItem(item) ? (
-              <Collapse key={item.address}>
-                <MultiAccountItem onLinkClick={onLinkClick} multiSafeAccountItem={item} />
-              </Collapse>
-            ) : (
-              <Collapse key={item.address}>
-                <AccountItem onLinkClick={onLinkClick} safeItem={item} key={item.chainId + item.address} />
-              </Collapse>
-            ),
-          )}
-        </TransitionGroup>
-      ) : (
-        <Typography
-          component="div"
-          variant="body2"
-          color="text.secondary"
-          textAlign="center"
-          py={3}
-          mx="auto"
-          width={250}
-        >
-          {noSafesMessage}
-        </Typography>
+    <TransitionGroup>
+      {safes.map((item) =>
+        isMultiChainSafeItem(item) ? (
+          <Collapse key={item.address} timeout={600}>
+            <MultiAccountItem onLinkClick={onLinkClick} multiSafeAccountItem={item} />
+          </Collapse>
+        ) : (
+          <Collapse key={item.address} timeout={600}>
+            <AccountItem onLinkClick={onLinkClick} safeItem={item} key={item.chainId + item.address} />
+          </Collapse>
+        ),
       )}
-    </Box>
-    // </Paper>
+    </TransitionGroup>
   )
 }
 

--- a/src/components/welcome/MyAccounts/QueueActions.tsx
+++ b/src/components/welcome/MyAccounts/QueueActions.tsx
@@ -44,27 +44,25 @@ const QueueActions = ({
   }
 
   return (
-    <Box width="100%">
-      <Track {...OVERVIEW_EVENTS.OPEN_MISSING_SIGNATURES}>
-        <NextLink href={queueLink}>
-          <Box px={2} pb={2} display="flex" gap={1} alignItems="center">
-            {queued > 0 && (
-              <ChipLink>
-                <SvgIcon component={TransactionsIcon} inheritViewBox fontSize="small" />
-                {queued} pending transaction{queued > 1 ? 's' : ''}
-              </ChipLink>
-            )}
+    <Track {...OVERVIEW_EVENTS.OPEN_MISSING_SIGNATURES}>
+      <NextLink href={queueLink}>
+        <Box px={2} pb={2} display="flex" gap={1} alignItems="center">
+          {queued > 0 && (
+            <ChipLink>
+              <SvgIcon component={TransactionsIcon} inheritViewBox fontSize="small" />
+              {queued} pending transaction{queued > 1 ? 's' : ''}
+            </ChipLink>
+          )}
 
-            {awaitingConfirmation > 0 && (
-              <ChipLink color="warning">
-                <SvgIcon component={CheckIcon} inheritViewBox fontSize="small" color="warning" />
-                {awaitingConfirmation} to confirm
-              </ChipLink>
-            )}
-          </Box>
-        </NextLink>
-      </Track>
-    </Box>
+          {awaitingConfirmation > 0 && (
+            <ChipLink color="warning">
+              <SvgIcon component={CheckIcon} inheritViewBox fontSize="small" color="warning" />
+              {awaitingConfirmation} to confirm
+            </ChipLink>
+          )}
+        </Box>
+      </NextLink>
+    </Track>
   )
 }
 

--- a/src/components/welcome/MyAccounts/SafesList.tsx
+++ b/src/components/welcome/MyAccounts/SafesList.tsx
@@ -9,9 +9,10 @@ import Collapse from '@mui/material/Collapse'
 type SafeListProps = {
   safes?: (SafeItem | MultiChainSafeItem)[]
   onLinkClick?: () => void
+  loadOverviews: boolean
 }
 
-export const SafesList = ({ safes, onLinkClick }: SafeListProps) => {
+export const SafesList = ({ safes, onLinkClick, loadOverviews }: SafeListProps) => {
   if (!safes || safes.length === 0) {
     return null
   }
@@ -21,11 +22,16 @@ export const SafesList = ({ safes, onLinkClick }: SafeListProps) => {
       {safes.map((item) =>
         isMultiChainSafeItem(item) ? (
           <Collapse key={item.address} timeout={600}>
-            <MultiAccountItem onLinkClick={onLinkClick} multiSafeAccountItem={item} />
+            <MultiAccountItem onLinkClick={onLinkClick} multiSafeAccountItem={item} loadOverview={loadOverviews} />
           </Collapse>
         ) : (
           <Collapse key={item.address} timeout={600}>
-            <AccountItem onLinkClick={onLinkClick} safeItem={item} key={item.chainId + item.address} />
+            <AccountItem
+              onLinkClick={onLinkClick}
+              safeItem={item}
+              key={item.chainId + item.address}
+              loadOverview={loadOverviews}
+            />
           </Collapse>
         ),
       )}

--- a/src/components/welcome/MyAccounts/SafesList.tsx
+++ b/src/components/welcome/MyAccounts/SafesList.tsx
@@ -9,10 +9,10 @@ import Collapse from '@mui/material/Collapse'
 type SafeListProps = {
   safes?: (SafeItem | MultiChainSafeItem)[]
   onLinkClick?: () => void
-  loadOverviews: boolean
+  loadBalances: boolean
 }
 
-export const SafesList = ({ safes, onLinkClick, loadOverviews }: SafeListProps) => {
+export const SafesList = ({ safes, onLinkClick, loadBalances }: SafeListProps) => {
   if (!safes || safes.length === 0) {
     return null
   }
@@ -22,7 +22,7 @@ export const SafesList = ({ safes, onLinkClick, loadOverviews }: SafeListProps) 
       {safes.map((item) =>
         isMultiChainSafeItem(item) ? (
           <Collapse key={item.address} timeout={600}>
-            <MultiAccountItem onLinkClick={onLinkClick} multiSafeAccountItem={item} loadOverview={loadOverviews} />
+            <MultiAccountItem onLinkClick={onLinkClick} multiSafeAccountItem={item} loadBalances={loadBalances} />
           </Collapse>
         ) : (
           <Collapse key={item.address} timeout={600}>
@@ -30,7 +30,7 @@ export const SafesList = ({ safes, onLinkClick, loadOverviews }: SafeListProps) 
               onLinkClick={onLinkClick}
               safeItem={item}
               key={item.chainId + item.address}
-              loadOverview={loadOverviews}
+              loadBalances={loadBalances}
             />
           </Collapse>
         ),

--- a/src/components/welcome/MyAccounts/SafesList.tsx
+++ b/src/components/welcome/MyAccounts/SafesList.tsx
@@ -9,10 +9,9 @@ import Collapse from '@mui/material/Collapse'
 type SafeListProps = {
   safes?: (SafeItem | MultiChainSafeItem)[]
   onLinkClick?: () => void
-  loadBalances: boolean
 }
 
-export const SafesList = ({ safes, onLinkClick, loadBalances }: SafeListProps) => {
+export const SafesList = ({ safes, onLinkClick }: SafeListProps) => {
   if (!safes || safes.length === 0) {
     return null
   }
@@ -22,16 +21,11 @@ export const SafesList = ({ safes, onLinkClick, loadBalances }: SafeListProps) =
       {safes.map((item) =>
         isMultiChainSafeItem(item) ? (
           <Collapse key={item.address} timeout={600}>
-            <MultiAccountItem onLinkClick={onLinkClick} multiSafeAccountItem={item} loadBalances={loadBalances} />
+            <MultiAccountItem onLinkClick={onLinkClick} multiSafeAccountItem={item} />
           </Collapse>
         ) : (
           <Collapse key={item.address} timeout={600}>
-            <AccountItem
-              onLinkClick={onLinkClick}
-              safeItem={item}
-              key={item.chainId + item.address}
-              loadBalances={loadBalances}
-            />
+            <AccountItem onLinkClick={onLinkClick} safeItem={item} key={item.chainId + item.address} />
           </Collapse>
         ),
       )}

--- a/src/components/welcome/MyAccounts/SafesList.tsx
+++ b/src/components/welcome/MyAccounts/SafesList.tsx
@@ -20,11 +20,11 @@ export const SafesList = ({ safes, onLinkClick }: SafeListProps) => {
     <TransitionGroup>
       {safes.map((item) =>
         isMultiChainSafeItem(item) ? (
-          <Collapse key={item.address} timeout={600}>
+          <Collapse key={item.address} timeout="auto">
             <MultiAccountItem onLinkClick={onLinkClick} multiSafeAccountItem={item} />
           </Collapse>
         ) : (
-          <Collapse key={item.address} timeout={600}>
+          <Collapse key={item.address} timeout="auto">
             <AccountItem onLinkClick={onLinkClick} safeItem={item} key={item.chainId + item.address} />
           </Collapse>
         ),

--- a/src/components/welcome/MyAccounts/SubAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/SubAccountItem.tsx
@@ -1,7 +1,7 @@
 import { LoopIcon } from '@/features/counterfactual/CounterfactualStatusButton'
 import { selectUndeployedSafe } from '@/features/counterfactual/store/undeployedSafesSlice'
 import type { SafeOverview } from '@safe-global/safe-gateway-typescript-sdk'
-import { useMemo } from 'react'
+import { useMemo, useRef } from 'react'
 import { ListItemButton, Box, Typography, Chip, Skeleton } from '@mui/material'
 import Link from 'next/link'
 import SafeIcon from '@/components/common/SafeIcon'
@@ -25,6 +25,7 @@ import QueueActions from './QueueActions'
 import { useGetHref } from './useGetHref'
 import { extractCounterfactualSafeSetup } from '@/features/counterfactual/utils'
 import VisibilityIcon from '@mui/icons-material/Visibility'
+import useOnceVisible from '@/hooks/useOnceVisible'
 
 type SubAccountItem = {
   safeItem: SafeItem
@@ -41,6 +42,8 @@ const SubAccountItem = ({ onLinkClick, safeItem, safeOverview }: SubAccountItem)
   const router = useRouter()
   const isCurrentSafe = chainId === currChainId && sameAddress(safeAddress, address)
   const isWelcomePage = router.pathname === AppRoutes.welcome.accounts
+  const elementRef = useRef<HTMLDivElement>(null)
+  const isVisible = useOnceVisible(elementRef)
 
   const trackingLabel = isWelcomePage ? OVERVIEW_LABELS.login_page : OVERVIEW_LABELS.sidebar
 
@@ -58,6 +61,7 @@ const SubAccountItem = ({ onLinkClick, safeItem, safeOverview }: SubAccountItem)
 
   return (
     <ListItemButton
+      ref={elementRef}
       data-testid="safe-list-item"
       selected={isCurrentSafe}
       className={classnames(css.listItem, { [css.currentListItem]: isCurrentSafe }, css.subItem)}
@@ -83,24 +87,6 @@ const SubAccountItem = ({ onLinkClick, safeItem, safeOverview }: SubAccountItem)
             <Typography color="var(--color-primary-light)" fontSize="inherit" component="span">
               {chain?.chainName}
             </Typography>
-            {undeployedSafe && (
-              <div>
-                <Chip
-                  size="small"
-                  label={isActivating ? 'Activating account' : 'Not activated'}
-                  icon={
-                    isActivating ? (
-                      <LoopIcon fontSize="small" className={css.pendingLoopIcon} sx={{ mr: '-4px', ml: '4px' }} />
-                    ) : (
-                      <ErrorOutlineIcon fontSize="small" color="warning" />
-                    )
-                  }
-                  className={classnames(css.chip, {
-                    [css.pendingAccount]: isActivating,
-                  })}
-                />
-              </div>
-            )}
           </Typography>
 
           <Typography variant="body2" fontWeight="bold" textAlign="right" pr={5}>
@@ -113,10 +99,33 @@ const SubAccountItem = ({ onLinkClick, safeItem, safeOverview }: SubAccountItem)
         </Link>
       </Track>
 
-      {safeItem.isWatchlist && (
-        <Box width="100%">
+      {undeployedSafe && (
+        <SafeListContextMenu name={name} address={address} chainId={chainId} addNetwork={false} rename={false} />
+      )}
+
+      <Box width="100%">
+        {undeployedSafe ? (
           <Track {...OVERVIEW_EVENTS.OPEN_SAFE} label={trackingLabel}>
-            <Link onClick={onLinkClick} href={href} className={classnames(css.safeSubLink, css.statusChip)}>
+            <Link className={css.statusChip} onClick={onLinkClick} href={href}>
+              <Chip
+                size="small"
+                label={isActivating ? 'Activating account' : 'Not activated'}
+                icon={
+                  isActivating ? (
+                    <LoopIcon fontSize="small" className={css.pendingLoopIcon} sx={{ mr: '-4px', ml: '4px' }} />
+                  ) : (
+                    <ErrorOutlineIcon fontSize="small" color="warning" />
+                  )
+                }
+                className={classnames(css.chip, {
+                  [css.pendingAccount]: isActivating,
+                })}
+              />
+            </Link>
+          </Track>
+        ) : safeItem.isWatchlist ? (
+          <Track {...OVERVIEW_EVENTS.OPEN_SAFE} label={trackingLabel}>
+            <Link className={css.statusChip} onClick={onLinkClick} href={href}>
               <Chip
                 className={css.readOnlyChip}
                 variant="outlined"
@@ -130,19 +139,15 @@ const SubAccountItem = ({ onLinkClick, safeItem, safeOverview }: SubAccountItem)
               />
             </Link>
           </Track>
-        </Box>
-      )}
-
-      {undeployedSafe && (
-        <SafeListContextMenu name={name} address={address} chainId={chainId} addNetwork={false} rename={false} />
-      )}
-
-      <QueueActions
-        queued={safeOverview?.queued || 0}
-        awaitingConfirmation={safeOverview?.awaitingConfirmation || 0}
-        safeAddress={address}
-        chainShortName={chain?.shortName || ''}
-      />
+        ) : isVisible ? (
+          <QueueActions
+            queued={safeOverview?.queued || 0}
+            awaitingConfirmation={safeOverview?.awaitingConfirmation || 0}
+            safeAddress={address}
+            chainShortName={chain?.shortName || ''}
+          />
+        ) : null}
+      </Box>
     </ListItemButton>
   )
 }

--- a/src/components/welcome/MyAccounts/SubAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/SubAccountItem.tsx
@@ -104,9 +104,9 @@ const SubAccountItem = ({ onLinkClick, safeItem, safeOverview }: SubAccountItem)
           </Typography>
 
           <Typography variant="body2" fontWeight="bold" textAlign="right" pr={5}>
-            {safeOverview ? (
+            {undeployedSafe ? null : safeOverview ? (
               <FiatValue value={safeOverview.fiatTotal} />
-            ) : undeployedSafe ? null : (
+            ) : (
               <Skeleton variant="text" />
             )}
           </Typography>

--- a/src/components/welcome/MyAccounts/SubAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/SubAccountItem.tsx
@@ -24,6 +24,7 @@ import FiatValue from '@/components/common/FiatValue'
 import QueueActions from './QueueActions'
 import { useGetHref } from './useGetHref'
 import { extractCounterfactualSafeSetup } from '@/features/counterfactual/utils'
+import VisibilityIcon from '@mui/icons-material/Visibility'
 
 type SubAccountItem = {
   safeItem: SafeItem
@@ -111,6 +112,26 @@ const SubAccountItem = ({ onLinkClick, safeItem, safeOverview }: SubAccountItem)
           </Typography>
         </Link>
       </Track>
+
+      {safeItem.isWatchlist && (
+        <Box width="100%">
+          <Track {...OVERVIEW_EVENTS.OPEN_SAFE} label={trackingLabel}>
+            <Link onClick={onLinkClick} href={href} className={classnames(css.safeSubLink, css.statusChip)}>
+              <Chip
+                className={css.readOnlyChip}
+                variant="outlined"
+                size="small"
+                icon={<VisibilityIcon className={css.visibilityIcon} />}
+                label={
+                  <Typography variant="caption" display="flex" alignItems="center" gap={0.5}>
+                    Read-only
+                  </Typography>
+                }
+              />
+            </Link>
+          </Track>
+        </Box>
+      )}
 
       {undeployedSafe && (
         <SafeListContextMenu name={name} address={address} chainId={chainId} addNetwork={false} rename={false} />

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -26,12 +26,14 @@ import { type AllSafesGrouped, useAllSafesGrouped, type MultiChainSafeItem } fro
 import { type SafeItem } from './useAllSafes'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import BookmarkIcon from '@/public/images/apps/bookmark.svg'
+import classNames from 'classnames'
 
 type AccountsListProps = {
   safes: AllSafesGrouped
+  isSidebar?: boolean
   onLinkClick?: () => void
 }
-const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
+const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListProps) => {
   const wallet = useWallet()
   const router = useRouter()
   const allSafes = [...(safes.allMultiChainSafes ?? []), ...(safes.allSingleSafes ?? [])]
@@ -74,29 +76,30 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
 
   return (
     <Box data-testid="sidebar-safe-container" className={css.container}>
-      <Box className={css.myAccounts}>
-        <Box className={css.header}>
+      <Box className={classNames(css.myAccounts, { [css.sidebarAccounts]: isSidebar })}>
+        <Box className={classNames(css.header, { [css.sidebarHeader]: isSidebar })}>
           <Typography variant="h1" fontWeight={700} className={css.title}>
             My accounts
           </Typography>
-          <Track {...OVERVIEW_EVENTS.ADD_TO_WATCHLIST} label={trackingLabel}>
-            <Link href={AppRoutes.newSafe.load}>
-              <Button
-                disableElevation
-                variant="outlined"
-                size="small"
-                onClick={onLinkClick}
-                startIcon={<SvgIcon component={AddIcon} inheritViewBox fontSize="small" />}
-                sx={{ height: '36px' }}
-              >
-                Add
-              </Button>
-            </Link>
-          </Track>
-
-          <Track {...OVERVIEW_EVENTS.CREATE_NEW_SAFE} label={trackingLabel}>
-            <CreateButton isPrimary={!!wallet} />
-          </Track>
+          <Box className={css.headerButtons}>
+            <Track {...OVERVIEW_EVENTS.ADD_TO_WATCHLIST} label={trackingLabel}>
+              <Link href={AppRoutes.newSafe.load}>
+                <Button
+                  disableElevation
+                  variant="outlined"
+                  size="small"
+                  onClick={onLinkClick}
+                  startIcon={<SvgIcon component={AddIcon} inheritViewBox fontSize="small" />}
+                  sx={{ height: '36px', width: '100%', px: 2 }}
+                >
+                  Add
+                </Button>
+              </Link>
+            </Track>
+            <Track {...OVERVIEW_EVENTS.CREATE_NEW_SAFE} label={trackingLabel}>
+              <CreateButton isPrimary={!!wallet} />
+            </Track>
+          </Box>
         </Box>
 
         <Paper className={css.safeList}>
@@ -114,7 +117,7 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
               </Typography>
             </div>
             {pinnedSafes.length > 0 ? (
-              <SafesList safes={pinnedSafes} onLinkClick={onLinkClick} loadOverviews={true} />
+              <SafesList safes={pinnedSafes} onLinkClick={onLinkClick} loadBalances={true} />
             ) : (
               <Box className={css.noPinnedSafesMessage}>
                 <Typography color="text.secondary" maxWidth="350px" textAlign="center" fontSize="14px">
@@ -151,12 +154,12 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
             </AccordionSummary>
             <AccordionDetails sx={{ padding: 0 }}>
               <Box mt={1}>
-                <SafesList safes={allSafes} onLinkClick={onLinkClick} loadOverviews={false} />
+                <SafesList safes={allSafes} onLinkClick={onLinkClick} loadBalances={false} />
               </Box>
             </AccordionDetails>
           </Accordion>
-          <DataWidget />
         </Paper>
+        <DataWidget />
       </Box>
     </Box>
   )

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -17,7 +17,7 @@ import Track from '@/components/common/Track'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
 import { DataWidget } from '@/components/welcome/MyAccounts/DataWidget'
 import css from './styles.module.css'
-import { SafesList } from './PaginatedSafeList'
+import { SafesList } from './SafesList'
 import { AppRoutes } from '@/config/routes'
 import useWallet from '@/hooks/wallets/useWallet'
 import { useRouter } from 'next/router'
@@ -114,7 +114,7 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
               </Typography>
             </div>
             {pinnedSafes.length > 0 ? (
-              <SafesList safes={pinnedSafes} onLinkClick={onLinkClick} />
+              <SafesList safes={pinnedSafes} onLinkClick={onLinkClick} loadOverviews={true} />
             ) : (
               <Box className={css.noPinnedSafesMessage}>
                 <Typography color="text.secondary" maxWidth="350px" textAlign="center" fontSize="14px">
@@ -151,7 +151,7 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
             </AccordionSummary>
             <AccordionDetails sx={{ padding: 0 }}>
               <Box mt={1}>
-                <SafesList safes={allSafes} onLinkClick={onLinkClick} />
+                <SafesList safes={allSafes} onLinkClick={onLinkClick} loadOverviews={false} />
               </Box>
             </AccordionDetails>
           </Accordion>

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Box, Button, Link, SvgIcon, Typography } from '@mui/material'
+import { Box, Typography } from '@mui/material'
 import madProps from '@/utils/mad-props'
 import CreateButton from './CreateButton'
 import Track from '@/components/common/Track'
@@ -7,8 +7,6 @@ import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
 import { DataWidget } from '@/components/welcome/MyAccounts/DataWidget'
 import css from './styles.module.css'
 import PaginatedSafeList from './PaginatedSafeList'
-import { VisibilityOutlined } from '@mui/icons-material'
-import AddIcon from '@/public/images/common/add.svg'
 import { AppRoutes } from '@/config/routes'
 import ConnectWalletButton from '@/components/common/ConnectWallet/ConnectWalletButton'
 import useWallet from '@/hooks/wallets/useWallet'
@@ -70,7 +68,7 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
         </Box>
 
         <PaginatedSafeList
-          title="My accounts"
+          title="All accounts"
           safes={ownedSafes}
           onLinkClick={onLinkClick}
           noSafesMessage={
@@ -87,7 +85,7 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
           }
         />
 
-        <PaginatedSafeList
+        {/* <PaginatedSafeList
           title={
             <>
               <VisibilityOutlined sx={{ verticalAlign: 'middle', marginRight: '10px' }} fontSize="small" />
@@ -111,7 +109,7 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
           }
           noSafesMessage={NO_WATCHED_MESSAGE}
           onLinkClick={onLinkClick}
-        />
+        /> */}
 
         <DataWidget />
       </Box>

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -135,7 +135,7 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
           </Box>
 
           {/* All Accounts */}
-          <Accordion expanded={pinnedSafes.length === 0} sx={{ border: 'none' }}>
+          <Accordion defaultExpanded={pinnedSafes.length === 0} sx={{ border: 'none' }}>
             <AccordionSummary
               expandIcon={<ExpandMoreIcon sx={{ '& path': { fill: 'var(--color-text-secondary)' } }} />}
               sx={{ padding: 0, '& .MuiAccordionSummary-content': { margin: '0 !important', mb: 1, flexGrow: 0 } }}

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -120,7 +120,7 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
               <SafesList safes={pinnedSafes} onLinkClick={onLinkClick} />
             ) : (
               <Box className={css.noPinnedSafesMessage}>
-                <Typography color="text.secondary" maxWidth="350px" textAlign="center" fontSize="14px">
+                <Typography color="text.secondary" variant="body2" maxWidth="350px" textAlign="center">
                   Personalize your account list by clicking the
                   <SvgIcon
                     component={BookmarkIcon}
@@ -135,7 +135,7 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
           </Box>
 
           {/* All Accounts */}
-          <Accordion sx={{ border: 'none' }}>
+          <Accordion expanded={pinnedSafes.length === 0} sx={{ border: 'none' }}>
             <AccordionSummary
               expandIcon={<ExpandMoreIcon sx={{ '& path': { fill: 'var(--color-text-secondary)' } }} />}
               sx={{ padding: 0, '& .MuiAccordionSummary-content': { margin: '0 !important', mb: 1, flexGrow: 0 } }}

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -1,7 +1,18 @@
 import { useMemo } from 'react'
-import { Accordion, AccordionDetails, AccordionSummary, Box, Paper, SvgIcon, Typography } from '@mui/material'
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Button,
+  Link,
+  Paper,
+  SvgIcon,
+  Typography,
+} from '@mui/material'
 import madProps from '@/utils/mad-props'
 import CreateButton from './CreateButton'
+import AddIcon from '@/public/images/common/add.svg'
 import Track from '@/components/common/Track'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
 import { DataWidget } from '@/components/welcome/MyAccounts/DataWidget'
@@ -69,8 +80,23 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
       <Box className={css.myAccounts}>
         <Box className={css.header}>
           <Typography variant="h1" fontWeight={700} className={css.title}>
-            Safe accounts
+            My accounts
           </Typography>
+          <Track {...OVERVIEW_EVENTS.ADD_TO_WATCHLIST} label={trackingLabel}>
+            <Link href={AppRoutes.newSafe.load}>
+              <Button
+                disableElevation
+                variant="outlined"
+                size="small"
+                onClick={onLinkClick}
+                startIcon={<SvgIcon component={AddIcon} inheritViewBox fontSize="small" />}
+                sx={{ height: '36px' }}
+              >
+                Add
+              </Button>
+            </Link>
+          </Track>
+
           <Track {...OVERVIEW_EVENTS.CREATE_NEW_SAFE} label={trackingLabel}>
             <CreateButton isPrimary={!!wallet} />
           </Track>
@@ -94,10 +120,14 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
           </Box>
 
           {/* All Accounts */}
-          <Accordion>
-            <AccordionSummary expandIcon={<ExpandMoreIcon fontSize="small" />}>
+
+          <Accordion sx={{ border: 'none' }}>
+            <AccordionSummary
+              expandIcon={<ExpandMoreIcon />}
+              sx={{ padding: 0, '& .MuiAccordionSummary-content': { margin: '0 !important', mb: 1, flexGrow: 0 } }}
+            >
               <div className={css.listHeader}>
-                <Typography variant="h5" fontWeight={700} mb={2} className={css.listTitle}>
+                <Typography variant="h5" fontWeight={700}>
                   Accounts
                   {allSafes && allSafes.length > 0 && (
                     <Typography
@@ -114,7 +144,7 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
                 </Typography>
               </div>
             </AccordionSummary>
-            <AccordionDetails>
+            <AccordionDetails sx={{ padding: 0 }}>
               <Box mt={1}>
                 <SafesList
                   safes={allSafes}

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -1,12 +1,12 @@
 import { useMemo } from 'react'
-import { Box, Typography } from '@mui/material'
+import { Accordion, AccordionDetails, AccordionSummary, Box, Paper, Typography } from '@mui/material'
 import madProps from '@/utils/mad-props'
 import CreateButton from './CreateButton'
 import Track from '@/components/common/Track'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
 import { DataWidget } from '@/components/welcome/MyAccounts/DataWidget'
 import css from './styles.module.css'
-import PaginatedSafeList from './PaginatedSafeList'
+import { SafesList } from './PaginatedSafeList'
 import { AppRoutes } from '@/config/routes'
 import ConnectWalletButton from '@/components/common/ConnectWallet/ConnectWalletButton'
 import useWallet from '@/hooks/wallets/useWallet'
@@ -14,6 +14,7 @@ import { useRouter } from 'next/router'
 import useTrackSafesCount from './useTrackedSafesCount'
 import { type AllSafesGrouped, useAllSafesGrouped, type MultiChainSafeItem } from './useAllSafesGrouped'
 import { type SafeItem } from './useAllSafes'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 
 const NO_SAFES_MESSAGE = "You don't have any Safe Accounts yet"
 const NO_WATCHED_MESSAGE = 'Watch any Safe Account to keep an eye on its activity'
@@ -25,6 +26,7 @@ type AccountsListProps = {
 const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
   const wallet = useWallet()
   const router = useRouter()
+  const allSafes = [...(safes.allMultiChainSafes ?? []), ...(safes.allSingleSafes ?? [])]
 
   // We consider a multiChain account owned if at least one of the multiChain accounts is not on the watchlist
   const ownedMultiChainSafes = useMemo(
@@ -67,25 +69,50 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
           </Track>
         </Box>
 
-        <PaginatedSafeList
-          title="All accounts"
-          safes={ownedSafes}
-          onLinkClick={onLinkClick}
-          noSafesMessage={
-            wallet ? (
-              NO_SAFES_MESSAGE
-            ) : (
-              <>
-                <Box mb={2}>Connect a wallet to view your Safe Accounts or to create a new one</Box>
-                <Track {...OVERVIEW_EVENTS.OPEN_ONBOARD} label={trackingLabel}>
-                  <ConnectWalletButton text="Connect a wallet" contained />
-                </Track>
-              </>
-            )
-          }
-        />
+        <Paper className={css.safeList}>
+          <Accordion className={css.allAccountsAccordion}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon fontSize="small" />}>
+              <div className={css.listHeader}>
+                <Typography variant="h5" fontWeight={700} mb={2} className={css.listTitle}>
+                  All Accounts
+                  {allSafes && allSafes.length > 0 && (
+                    <Typography
+                      component="span"
+                      color="var(--color-primary-light)"
+                      fontSize="inherit"
+                      fontWeight="normal"
+                      mr={1}
+                    >
+                      {' '}
+                      ({allSafes.length})
+                    </Typography>
+                  )}
+                </Typography>
+              </div>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Box mt={1}>
+                <SafesList
+                  safes={allSafes}
+                  onLinkClick={onLinkClick}
+                  noSafesMessage={
+                    wallet ? (
+                      NO_SAFES_MESSAGE
+                    ) : (
+                      <>
+                        <Box mb={2}>Connect a wallet to view your Safe Accounts or to create a new one</Box>
+                        <Track {...OVERVIEW_EVENTS.OPEN_ONBOARD} label={trackingLabel}>
+                          <ConnectWalletButton text="Connect a wallet" contained />
+                        </Track>
+                      </>
+                    )
+                  }
+                />
+              </Box>
+            </AccordionDetails>
+          </Accordion>
 
-        {/* <PaginatedSafeList
+          {/* <PaginatedSafeList
           title={
             <>
               <VisibilityOutlined sx={{ verticalAlign: 'middle', marginRight: '10px' }} fontSize="small" />
@@ -111,7 +138,8 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
           onLinkClick={onLinkClick}
         /> */}
 
-        <DataWidget />
+          <DataWidget />
+        </Paper>
       </Box>
     </Box>
   )

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -117,7 +117,7 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
               </Typography>
             </div>
             {pinnedSafes.length > 0 ? (
-              <SafesList safes={pinnedSafes} onLinkClick={onLinkClick} loadBalances={true} />
+              <SafesList safes={pinnedSafes} onLinkClick={onLinkClick} />
             ) : (
               <Box className={css.noPinnedSafesMessage}>
                 <Typography color="text.secondary" maxWidth="350px" textAlign="center" fontSize="14px">
@@ -154,7 +154,7 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
             </AccordionSummary>
             <AccordionDetails sx={{ padding: 0 }}>
               <Box mt={1}>
-                <SafesList safes={allSafes} onLinkClick={onLinkClick} loadBalances={false} />
+                <SafesList safes={allSafes} onLinkClick={onLinkClick} />
               </Box>
             </AccordionDetails>
           </Accordion>

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -19,7 +19,6 @@ import { DataWidget } from '@/components/welcome/MyAccounts/DataWidget'
 import css from './styles.module.css'
 import { SafesList } from './PaginatedSafeList'
 import { AppRoutes } from '@/config/routes'
-import ConnectWalletButton from '@/components/common/ConnectWallet/ConnectWalletButton'
 import useWallet from '@/hooks/wallets/useWallet'
 import { useRouter } from 'next/router'
 import useTrackSafesCount from './useTrackedSafesCount'
@@ -27,8 +26,6 @@ import { type AllSafesGrouped, useAllSafesGrouped, type MultiChainSafeItem } fro
 import { type SafeItem } from './useAllSafes'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import BookmarkIcon from '@/public/images/apps/bookmark.svg'
-
-const NO_SAFES_MESSAGE = "You don't have any Safe Accounts yet"
 
 type AccountsListProps = {
   safes: AllSafesGrouped
@@ -104,39 +101,47 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
 
         <Paper className={css.safeList}>
           {/* Pinned Accounts */}
-          <Box mb={3} sx={{ minHeight: '200px' }}>
+          <Box mb={2} minHeight="170px">
             <div className={css.listHeader}>
               <SvgIcon
                 component={BookmarkIcon}
                 inheritViewBox
                 fontSize="small"
-                sx={{ mt: '2px', mr: 1, fontWeight: 900, strokeWidth: 2 }}
+                sx={{ mt: '2px', mr: 1, strokeWidth: 2 }}
               />
               <Typography variant="h5" fontWeight={700} mb={2}>
                 Pinned
               </Typography>
             </div>
-            <SafesList safes={pinnedSafes} onLinkClick={onLinkClick} />
+            {pinnedSafes.length > 0 ? (
+              <SafesList safes={pinnedSafes} onLinkClick={onLinkClick} />
+            ) : (
+              <Box className={css.noPinnedSafesMessage}>
+                <Typography color="text.secondary" maxWidth="350px" textAlign="center" fontSize="14px">
+                  Personalize your account list by clicking the
+                  <SvgIcon
+                    component={BookmarkIcon}
+                    inheritViewBox
+                    fontSize="small"
+                    sx={{ mx: '4px', color: 'text.secondary', position: 'relative', top: '2px' }}
+                  />
+                  icon on the accounts most important to you.
+                </Typography>
+              </Box>
+            )}
           </Box>
 
           {/* All Accounts */}
-
           <Accordion sx={{ border: 'none' }}>
             <AccordionSummary
-              expandIcon={<ExpandMoreIcon />}
+              expandIcon={<ExpandMoreIcon sx={{ '& path': { fill: 'var(--color-text-secondary)' } }} />}
               sx={{ padding: 0, '& .MuiAccordionSummary-content': { margin: '0 !important', mb: 1, flexGrow: 0 } }}
             >
               <div className={css.listHeader}>
                 <Typography variant="h5" fontWeight={700}>
                   Accounts
                   {allSafes && allSafes.length > 0 && (
-                    <Typography
-                      component="span"
-                      color="var(--color-primary-light)"
-                      fontSize="inherit"
-                      fontWeight="normal"
-                      mr={1}
-                    >
+                    <Typography component="span" color="text.secondary" fontSize="inherit" fontWeight="normal" mr={1}>
                       {' '}
                       ({allSafes.length})
                     </Typography>
@@ -146,52 +151,10 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
             </AccordionSummary>
             <AccordionDetails sx={{ padding: 0 }}>
               <Box mt={1}>
-                <SafesList
-                  safes={allSafes}
-                  onLinkClick={onLinkClick}
-                  noSafesMessage={
-                    wallet ? (
-                      NO_SAFES_MESSAGE
-                    ) : (
-                      <>
-                        <Box mb={2}>Connect a wallet to view your Safe Accounts or to create a new one</Box>
-                        <Track {...OVERVIEW_EVENTS.OPEN_ONBOARD} label={trackingLabel}>
-                          <ConnectWalletButton text="Connect a wallet" contained />
-                        </Track>
-                      </>
-                    )
-                  }
-                />
+                <SafesList safes={allSafes} onLinkClick={onLinkClick} />
               </Box>
             </AccordionDetails>
           </Accordion>
-
-          {/* <PaginatedSafeList
-          title={
-            <>
-              <VisibilityOutlined sx={{ verticalAlign: 'middle', marginRight: '10px' }} fontSize="small" />
-              Watchlist
-            </>
-          }
-          safes={watchlistSafes || []}
-          action={
-            <Track {...OVERVIEW_EVENTS.ADD_TO_WATCHLIST} label={trackingLabel}>
-              <Link href={AppRoutes.newSafe.load}>
-                <Button
-                  disableElevation
-                  size="small"
-                  onClick={onLinkClick}
-                  startIcon={<SvgIcon component={AddIcon} inheritViewBox fontSize="small" />}
-                >
-                  Add
-                </Button>
-              </Link>
-            </Track>
-          }
-          noSafesMessage={NO_WATCHED_MESSAGE}
-          onLinkClick={onLinkClick}
-        /> */}
-
           <DataWidget />
         </Paper>
       </Box>

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Accordion, AccordionDetails, AccordionSummary, Box, Paper, Typography } from '@mui/material'
+import { Accordion, AccordionDetails, AccordionSummary, Box, Paper, SvgIcon, Typography } from '@mui/material'
 import madProps from '@/utils/mad-props'
 import CreateButton from './CreateButton'
 import Track from '@/components/common/Track'
@@ -15,9 +15,9 @@ import useTrackSafesCount from './useTrackedSafesCount'
 import { type AllSafesGrouped, useAllSafesGrouped, type MultiChainSafeItem } from './useAllSafesGrouped'
 import { type SafeItem } from './useAllSafes'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import BookmarkIcon from '@/public/images/apps/bookmark.svg'
 
 const NO_SAFES_MESSAGE = "You don't have any Safe Accounts yet"
-const NO_WATCHED_MESSAGE = 'Watch any Safe Account to keep an eye on its activity'
 
 type AccountsListProps = {
   safes: AllSafesGrouped
@@ -51,6 +51,13 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
     ],
     [safes, watchlistMultiChainSafes],
   )
+  const pinnedSafes = useMemo<(MultiChainSafeItem | SafeItem)[]>(
+    () => [
+      ...(safes.allSingleSafes?.filter(({ isPinned }) => isPinned) ?? []),
+      ...(safes.allMultiChainSafes?.filter(({ isPinned }) => isPinned) ?? []),
+    ],
+    [safes],
+  )
 
   useTrackSafesCount(ownedSafes, watchlistSafes, wallet)
 
@@ -70,11 +77,28 @@ const AccountsList = ({ safes, onLinkClick }: AccountsListProps) => {
         </Box>
 
         <Paper className={css.safeList}>
-          <Accordion className={css.allAccountsAccordion}>
+          {/* Pinned Accounts */}
+          <Box mb={3} sx={{ minHeight: '200px' }}>
+            <div className={css.listHeader}>
+              <SvgIcon
+                component={BookmarkIcon}
+                inheritViewBox
+                fontSize="small"
+                sx={{ mt: '2px', mr: 1, fontWeight: 900, strokeWidth: 2 }}
+              />
+              <Typography variant="h5" fontWeight={700} mb={2}>
+                Pinned
+              </Typography>
+            </div>
+            <SafesList safes={pinnedSafes} onLinkClick={onLinkClick} />
+          </Box>
+
+          {/* All Accounts */}
+          <Accordion>
             <AccordionSummary expandIcon={<ExpandMoreIcon fontSize="small" />}>
               <div className={css.listHeader}>
                 <Typography variant="h5" fontWeight={700} mb={2} className={css.listTitle}>
-                  All Accounts
+                  Accounts
                   {allSafes && allSafes.length > 0 && (
                     <Typography
                       component="span"

--- a/src/components/welcome/MyAccounts/styles.module.css
+++ b/src/components/welcome/MyAccounts/styles.module.css
@@ -105,7 +105,7 @@
 .safeLink {
   display: grid;
   padding: var(--space-2) var(--space-1) var(--space-2) var(--space-2);
-  grid-template-columns: 60px 4fr 6fr minmax(auto, 3fr);
+  grid-template-columns: 60px 6fr 10fr minmax(auto, 2fr);
   align-items: center;
 }
 

--- a/src/components/welcome/MyAccounts/styles.module.css
+++ b/src/components/welcome/MyAccounts/styles.module.css
@@ -80,7 +80,7 @@
 
 .safeLink {
   display: grid;
-  padding: var(--space-2) var(--space-1) var(--space-2) var(--space-2);
+  padding: var(--space-2) var(--space-6) var(--space-2) var(--space-2);
   grid-template-columns: 60px 3fr 3fr minmax(auto, 2fr);
   align-items: center;
 }

--- a/src/components/welcome/MyAccounts/styles.module.css
+++ b/src/components/welcome/MyAccounts/styles.module.css
@@ -6,14 +6,14 @@
 }
 
 .myAccounts {
-  width: 100%;
+  width: 100vw;
   max-width: 750px;
   margin: var(--space-2);
 }
 
 .safeList {
   padding: var(--space-2);
-  margin-bottom: var(--space-3);
+  margin-bottom: var(--space-1);
 }
 
 .header {
@@ -25,6 +25,15 @@
 
 .title {
   flex-grow: 1;
+}
+
+.noPinnedSafesMessage {
+  display: flex;
+  justify-content: center;
+  border: 1px solid var(--color-border-light);
+  padding: var(--space-3);
+  border-radius: var(--space-1);
+  border-style: dashed;
 }
 
 .listItem {
@@ -102,6 +111,10 @@
   display: flex;
 }
 
+.listHeader path {
+  stroke: var(--color-text-primary);
+}
+
 .card {
   margin: auto;
   padding: var(--space-3);
@@ -169,7 +182,7 @@
 }
 
 .safeList :global .MuiAccordionSummary-root {
-  background: white !important;
+  background: var(--color-background-paper) !important;
   padding-left: 0;
   min-height: 0;
   justify-content: left;

--- a/src/components/welcome/MyAccounts/styles.module.css
+++ b/src/components/welcome/MyAccounts/styles.module.css
@@ -100,13 +100,8 @@
 }
 
 .listHeader {
-  /* padding-bottom: var(--space-1); */
   display: flex;
-  justify-content: space-between;
-}
-
-.listTitle {
-  margin: auto 0;
+  margin-bottom: var(--space-1);
 }
 
 .card {

--- a/src/components/welcome/MyAccounts/styles.module.css
+++ b/src/components/welcome/MyAccounts/styles.module.css
@@ -11,20 +11,35 @@
   margin: var(--space-2);
 }
 
+.sidebarAccounts {
+  margin: 0 !important;
+}
+
 .safeList {
-  padding: var(--space-2);
+  padding: var(--space-2) var(--space-2) var(--space-3);
   margin-bottom: var(--space-1);
 }
 
 .header {
   display: flex;
-  flex-wrap: wrap;
+  justify-content: space-between;
   padding: var(--space-3) 0;
-  gap: var(--space-1);
+  gap: var(--space-2);
 }
 
-.title {
-  flex-grow: 1;
+.sidebarHeader {
+  padding: var(--space-3) var(--space-2);
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.sidebarHeader > h1 {
+  font-size: 24px;
+}
+
+.headerButtons {
+  display: flex;
+  flex-direction: row;
+  gap: var(--space-1);
 }
 
 .noPinnedSafesMessage {
@@ -77,6 +92,7 @@
   border-radius: 6px;
   border: 1px solid var(--color-border-light);
 }
+
 .subItem.currentListItem .borderLeft {
   border-left: 4px solid var(--color-secondary-light);
 }
@@ -89,7 +105,7 @@
 .safeLink {
   display: grid;
   padding: var(--space-2) var(--space-1) var(--space-2) var(--space-2);
-  grid-template-columns: 60px 4fr 6fr minmax(auto, 1fr);
+  grid-template-columns: 60px 4fr 6fr minmax(auto, 3fr);
   align-items: center;
 }
 
@@ -107,11 +123,25 @@
   text-overflow: ellipsis;
 }
 
+.readOnlyChip {
+  border-radius: var(--space-2);
+  color: var(--color-primary-light);
+  border-color: var(--color-border-light);
+  font-size: 14px;
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+.visibilityIcon {
+  font-size: 16px !important;
+  color: var(--color-border-main) !important;
+}
+
 .listHeader {
   display: flex;
 }
 
-.listHeader path {
+.listHeader svg path {
   stroke: var(--color-text-primary);
 }
 
@@ -143,7 +173,6 @@
 .chip {
   border-radius: 4px;
   background-color: var(--color-warning-background);
-  margin-top: 4px;
 }
 
 .pendingAccount {
@@ -152,6 +181,17 @@
 
 .pendingLoopIcon {
   color: var(--color-info-dark) !important;
+}
+
+.statusChip {
+  display: flex;
+  gap: var(--space-1);
+  padding: 0 var(--space-2) var(--space-2);
+  width: 100%;
+}
+
+.statusChips:empty {
+  display: none;
 }
 
 .multiChains {
@@ -218,24 +258,15 @@
   .chainIndicator {
     justify-content: flex-start;
   }
-}
-
-@container my-accounts-container (max-width: 500px) {
-  .myAccounts {
-    margin: 0;
-  }
-
   .header {
-    padding: var(--space-2);
-    border-bottom: 1px solid var(--color-border-light);
+    flex-direction: column;
   }
 
-  .safeList {
-    border-radius: 0;
-    margin-bottom: 0;
+  .headerButtons > span {
+    flex: 1;
   }
 
-  .title {
-    font-size: 20px;
+  .headerButtons > span > a {
+    width: 100%;
   }
 }

--- a/src/components/welcome/MyAccounts/styles.module.css
+++ b/src/components/welcome/MyAccounts/styles.module.css
@@ -7,25 +7,24 @@
 
 .myAccounts {
   width: 100%;
-  max-width: 600px;
+  max-width: 750px;
   margin: var(--space-2);
 }
 
 .safeList {
-  padding: var(--space-3);
+  padding: var(--space-2);
   margin-bottom: var(--space-3);
-}
-
-.safeList :last-child {
-  margin-bottom: 0;
 }
 
 .header {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
   padding: var(--space-3) 0;
   gap: var(--space-1);
+}
+
+.title {
+  flex-grow: 1;
 }
 
 .listItem {
@@ -80,8 +79,8 @@
 
 .safeLink {
   display: grid;
-  padding: var(--space-2) var(--space-6) var(--space-2) var(--space-2);
-  grid-template-columns: 60px 3fr 3fr minmax(auto, 2fr);
+  padding: var(--space-2) var(--space-1) var(--space-2) var(--space-2);
+  grid-template-columns: 60px 4fr 6fr minmax(auto, 1fr);
   align-items: center;
 }
 
@@ -101,7 +100,6 @@
 
 .listHeader {
   display: flex;
-  margin-bottom: var(--space-1);
 }
 
 .card {
@@ -170,25 +168,12 @@
   }
 }
 
-.safeList :global .MuiAccordionDetails-root {
-  padding: 0;
-}
-.safeList :global .MuiAccordion-root {
-  padding: 0;
-  border: none;
-}
-
 .safeList :global .MuiAccordionSummary-root {
   background: white !important;
   padding-left: 0;
   min-height: 0;
   justify-content: left;
   vertical-align: middle;
-}
-
-.safeList :global .MuiAccordionSummary-content {
-  margin: 0;
-  /* flex-grow: 0; */
 }
 
 @media (max-width: 599.95px) {
@@ -216,6 +201,10 @@
   .multiChains {
     justify-content: flex-start;
   }
+
+  .chainIndicator {
+    justify-content: flex-start;
+  }
 }
 
 @container my-accounts-container (max-width: 500px) {
@@ -224,7 +213,7 @@
   }
 
   .header {
-    padding: var(--space-3);
+    padding: var(--space-2);
     border-bottom: 1px solid var(--color-border-light);
   }
 
@@ -235,9 +224,5 @@
 
   .title {
     font-size: 20px;
-  }
-
-  .card {
-    border-top: 1px solid var(--color-border-light);
   }
 }

--- a/src/components/welcome/MyAccounts/styles.module.css
+++ b/src/components/welcome/MyAccounts/styles.module.css
@@ -100,7 +100,7 @@
 }
 
 .listHeader {
-  padding-bottom: var(--space-1);
+  /* padding-bottom: var(--space-1); */
   display: flex;
   justify-content: space-between;
 }
@@ -173,6 +173,27 @@
   .safeLink {
     padding-right: 0;
   }
+}
+
+.safeList :global .MuiAccordionDetails-root {
+  padding: 0;
+}
+.safeList :global .MuiAccordion-root {
+  padding: 0;
+  border: none;
+}
+
+.safeList :global .MuiAccordionSummary-root {
+  background: white !important;
+  padding-left: 0;
+  min-height: 0;
+  justify-content: left;
+  vertical-align: middle;
+}
+
+.safeList :global .MuiAccordionSummary-content {
+  margin: 0;
+  /* flex-grow: 0; */
 }
 
 @media (max-width: 599.95px) {

--- a/src/components/welcome/MyAccounts/useAllSafes.ts
+++ b/src/components/welcome/MyAccounts/useAllSafes.ts
@@ -46,7 +46,9 @@ const useAllSafes = (): SafeItems | undefined => {
     if (walletAddress && (allOwned === undefined || allOwnedLoading)) {
       return undefined
     }
-    const chains = uniq(Object.keys(allAdded).concat(Object.keys(allOwned || {})))
+    const chains = uniq(Object.keys(allOwned || {}).concat(Object.keys(allAdded)))
+    // sort chains by chainId
+    chains.sort((a, b) => parseInt(a) - parseInt(b))
 
     return chains.flatMap((chainId) => {
       if (!configs.some((item) => item.chainId === chainId)) return []
@@ -54,6 +56,8 @@ const useAllSafes = (): SafeItems | undefined => {
       const ownedOnChain = (allOwned || {})[chainId]
       const undeployedOnChain = Object.keys(undeployedSafes[chainId] || {})
       const uniqueAddresses = uniq(addedOnChain.concat(ownedOnChain)).filter(Boolean)
+      // sort addresses by address
+      uniqueAddresses.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
 
       return uniqueAddresses.map((address) => {
         const owners = allAdded?.[chainId]?.[address]?.owners

--- a/src/components/welcome/MyAccounts/useAllSafes.ts
+++ b/src/components/welcome/MyAccounts/useAllSafes.ts
@@ -37,14 +37,14 @@ export const useHasSafes = () => {
 
 const useAllSafes = (): SafeItems | undefined => {
   const { address: walletAddress = '' } = useWallet() || {}
-  const [allOwned, , allOwnedLoading] = useAllOwnedSafes(walletAddress)
+  const [allOwned] = useAllOwnedSafes(walletAddress)
   const allAdded = useAddedSafes()
   const { configs } = useChains()
   const undeployedSafes = useAppSelector(selectUndeployedSafes)
 
-  return useMemo<SafeItems | undefined>(() => {
-    if (walletAddress && (allOwned === undefined || allOwnedLoading)) {
-      return undefined
+  return useMemo<SafeItems>(() => {
+    if (walletAddress && allOwned === undefined) {
+      return []
     }
     const chains = uniq(Object.keys(allOwned || {}).concat(Object.keys(allAdded)))
     // todo: replace with sortBy logic
@@ -73,7 +73,7 @@ const useAllSafes = (): SafeItems | undefined => {
         }
       })
     })
-  }, [allAdded, allOwned, allOwnedLoading, configs, undeployedSafes, walletAddress])
+  }, [allAdded, allOwned, configs, undeployedSafes, walletAddress])
 }
 
 export default useAllSafes

--- a/src/components/welcome/MyAccounts/useAllSafes.ts
+++ b/src/components/welcome/MyAccounts/useAllSafes.ts
@@ -47,8 +47,6 @@ const useAllSafes = (): SafeItems | undefined => {
       return undefined
     }
     const chains = uniq(Object.keys(allOwned || {}).concat(Object.keys(allAdded)))
-    // sort chains by chainId
-    chains.sort((a, b) => parseInt(a) - parseInt(b))
 
     return chains.flatMap((chainId) => {
       if (!configs.some((item) => item.chainId === chainId)) return []
@@ -56,8 +54,6 @@ const useAllSafes = (): SafeItems | undefined => {
       const ownedOnChain = (allOwned || {})[chainId]
       const undeployedOnChain = Object.keys(undeployedSafes[chainId] || {})
       const uniqueAddresses = uniq(addedOnChain.concat(ownedOnChain)).filter(Boolean)
-      // sort addresses by address
-      uniqueAddresses.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
 
       return uniqueAddresses.map((address) => {
         const owners = allAdded?.[chainId]?.[address]?.owners

--- a/src/components/welcome/MyAccounts/useAllSafes.ts
+++ b/src/components/welcome/MyAccounts/useAllSafes.ts
@@ -47,7 +47,7 @@ const useAllSafes = (): SafeItems | undefined => {
       return undefined
     }
     const chains = uniq(Object.keys(allOwned || {}).concat(Object.keys(allAdded)))
-    // sort chains by chainId
+    // todo: replace with sortBy logic
     chains.sort((a, b) => parseInt(a) - parseInt(b))
 
     return chains.flatMap((chainId) => {
@@ -56,7 +56,7 @@ const useAllSafes = (): SafeItems | undefined => {
       const ownedOnChain = (allOwned || {})[chainId]
       const undeployedOnChain = Object.keys(undeployedSafes[chainId] || {})
       const uniqueAddresses = uniq(addedOnChain.concat(ownedOnChain)).filter(Boolean)
-      // sort addresses by address
+      // todo: replace with sortBy logic
       uniqueAddresses.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
 
       return uniqueAddresses.map((address) => {

--- a/src/components/welcome/MyAccounts/useAllSafes.ts
+++ b/src/components/welcome/MyAccounts/useAllSafes.ts
@@ -12,6 +12,7 @@ export type SafeItem = {
   chainId: string
   address: string
   isWatchlist: boolean
+  isPinned: boolean
 }
 
 export type SafeItems = SafeItem[]
@@ -57,12 +58,14 @@ const useAllSafes = (): SafeItems | undefined => {
       return uniqueAddresses.map((address) => {
         const owners = allAdded?.[chainId]?.[address]?.owners
         const isOwner = owners?.some(({ value }) => sameAddress(walletAddress, value))
-        const isUndeployed = undeployedOnChain.includes(address)
         const isOwned = (ownedOnChain || []).includes(address) || isOwner
+        const isUndeployed = undeployedOnChain.includes(address)
+        const isPinned = Boolean(allAdded?.[chainId]?.[address]?.pinned)
         return {
           address,
           chainId,
           isWatchlist: !isOwned && !isUndeployed,
+          isPinned,
         }
       })
     })

--- a/src/components/welcome/MyAccounts/useAllSafes.ts
+++ b/src/components/welcome/MyAccounts/useAllSafes.ts
@@ -47,6 +47,8 @@ const useAllSafes = (): SafeItems | undefined => {
       return undefined
     }
     const chains = uniq(Object.keys(allOwned || {}).concat(Object.keys(allAdded)))
+    // sort chains by chainId
+    chains.sort((a, b) => parseInt(a) - parseInt(b))
 
     return chains.flatMap((chainId) => {
       if (!configs.some((item) => item.chainId === chainId)) return []
@@ -54,6 +56,8 @@ const useAllSafes = (): SafeItems | undefined => {
       const ownedOnChain = (allOwned || {})[chainId]
       const undeployedOnChain = Object.keys(undeployedSafes[chainId] || {})
       const uniqueAddresses = uniq(addedOnChain.concat(ownedOnChain)).filter(Boolean)
+      // sort addresses by address
+      uniqueAddresses.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
 
       return uniqueAddresses.map((address) => {
         const owners = allAdded?.[chainId]?.[address]?.owners

--- a/src/components/welcome/MyAccounts/useAllSafesGrouped.ts
+++ b/src/components/welcome/MyAccounts/useAllSafesGrouped.ts
@@ -3,7 +3,7 @@ import useAllSafes, { type SafeItem, type SafeItems } from './useAllSafes'
 import { useMemo } from 'react'
 import { sameAddress } from '@/utils/addresses'
 
-export type MultiChainSafeItem = { address: string; safes: SafeItem[] }
+export type MultiChainSafeItem = { address: string; safes: SafeItem[]; isPinned: boolean }
 
 export type AllSafesGrouped = {
   allSingleSafes: SafeItems | undefined
@@ -12,9 +12,10 @@ export type AllSafesGrouped = {
 
 const getMultiChainAccounts = (safes: SafeItems): MultiChainSafeItem[] => {
   const groupedByAddress = groupBy(safes, (safe) => safe.address)
+  const isPinned = safes.some((safe) => safe.isPinned)
   const multiChainSafeItems = Object.entries(groupedByAddress)
     .filter((entry) => entry[1].length > 1)
-    .map((entry): MultiChainSafeItem => ({ address: entry[0], safes: entry[1] }))
+    .map((entry): MultiChainSafeItem => ({ address: entry[0], safes: entry[1], isPinned }))
 
   return multiChainSafeItems
 }

--- a/src/components/welcome/MyAccounts/useAllSafesGrouped.ts
+++ b/src/components/welcome/MyAccounts/useAllSafesGrouped.ts
@@ -12,7 +12,6 @@ export type AllSafesGrouped = {
 
 const getMultiChainAccounts = (safes: SafeItems): MultiChainSafeItem[] => {
   const groupedByAddress = groupBy(safes, (safe) => safe.address)
-  // loop through the groupedByAddress and check if any of the safes is pinned
   const multiChainSafeItems = Object.entries(groupedByAddress)
     .filter((entry) => entry[1].length > 1)
     .map((entry) => {

--- a/src/components/welcome/MyAccounts/useAllSafesGrouped.ts
+++ b/src/components/welcome/MyAccounts/useAllSafesGrouped.ts
@@ -12,11 +12,14 @@ export type AllSafesGrouped = {
 
 const getMultiChainAccounts = (safes: SafeItems): MultiChainSafeItem[] => {
   const groupedByAddress = groupBy(safes, (safe) => safe.address)
-  const isPinned = safes.some((safe) => safe.isPinned)
+  // loop through the groupedByAddress and check if any of the safes is pinned
   const multiChainSafeItems = Object.entries(groupedByAddress)
     .filter((entry) => entry[1].length > 1)
-    .map((entry): MultiChainSafeItem => ({ address: entry[0], safes: entry[1], isPinned }))
-
+    .map((entry) => {
+      const [address, safes] = entry
+      const isPinned = safes.some((safe) => safe.isPinned)
+      return { address, safes, isPinned }
+    })
   return multiChainSafeItems
 }
 

--- a/src/features/multichain/utils/utils.test.ts
+++ b/src/features/multichain/utils/utils.test.ts
@@ -14,8 +14,10 @@ describe('multiChain/utils', () => {
               address: faker.finance.ethereumAddress(),
               chainId: '1',
               isWatchlist: false,
+              isPinned: false,
             },
           ],
+          isPinned: false,
         }),
       ).toBeTruthy()
     })
@@ -26,6 +28,7 @@ describe('multiChain/utils', () => {
           address: faker.finance.ethereumAddress(),
           chainId: '1',
           isWatchlist: false,
+          isPinned: false,
         }),
       ).toBeFalsy()
     })
@@ -230,6 +233,7 @@ describe('multiChain/utils', () => {
               address: faker.finance.ethereumAddress(),
               chainId: '1',
               isWatchlist: false,
+              isPinned: false,
             },
           ],
           [],
@@ -246,6 +250,7 @@ describe('multiChain/utils', () => {
               address: faker.finance.ethereumAddress(),
               chainId: '1',
               isWatchlist: false,
+              isPinned: false,
             },
           ],
           [],
@@ -266,11 +271,13 @@ describe('multiChain/utils', () => {
               address,
               chainId: '1',
               isWatchlist: false,
+              isPinned: false,
             },
             {
               address,
               chainId: '100',
               isWatchlist: false,
+              isPinned: false,
             },
           ],
           [
@@ -318,11 +325,13 @@ describe('multiChain/utils', () => {
               address,
               chainId: '1',
               isWatchlist: false,
+              isPinned: false,
             },
             {
               address,
               chainId: '100',
               isWatchlist: false,
+              isPinned: false,
             },
           ],
           [],
@@ -376,16 +385,19 @@ describe('multiChain/utils', () => {
               address,
               chainId: '1',
               isWatchlist: false,
+              isPinned: false,
             },
             {
               address,
               chainId: '100',
               isWatchlist: false,
+              isPinned: false,
             },
             {
               address,
               chainId: '5',
               isWatchlist: false,
+              isPinned: false,
             },
           ],
           [
@@ -437,11 +449,13 @@ describe('multiChain/utils', () => {
               address,
               chainId: '1',
               isWatchlist: false,
+              isPinned: false,
             },
             {
               address,
               chainId: '100',
               isWatchlist: false,
+              isPinned: false,
             },
           ],
           [

--- a/src/store/__tests__/safeOverviews.test.ts
+++ b/src/store/__tests__/safeOverviews.test.ts
@@ -220,8 +220,8 @@ describe('safeOverviews', () => {
       const request = {
         currency: 'usd',
         safes: [
-          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false },
-          { address: faker.finance.ethereumAddress(), chainId: '10', isWatchlist: false },
+          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false, isPinned: false },
+          { address: faker.finance.ethereumAddress(), chainId: '10', isWatchlist: false, isPinned: false },
         ],
       }
 
@@ -263,8 +263,8 @@ describe('safeOverviews', () => {
       const request = {
         currency: 'usd',
         safes: [
-          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false },
-          { address: faker.finance.ethereumAddress(), chainId: '10', isWatchlist: false },
+          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false, isPinned: false },
+          { address: faker.finance.ethereumAddress(), chainId: '10', isWatchlist: false, isPinned: false },
         ],
       }
 
@@ -288,21 +288,21 @@ describe('safeOverviews', () => {
       const request = {
         currency: 'usd',
         safes: [
-          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false },
-          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false },
-          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false },
-          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false },
-          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false },
-          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false },
-          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false },
-          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false },
-          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false },
-          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false },
-          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false },
-          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false },
-          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false },
-          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false },
-          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false },
+          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false, isPinned: false },
+          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false, isPinned: false },
+          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false, isPinned: false },
+          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false, isPinned: false },
+          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false, isPinned: false },
+          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false, isPinned: false },
+          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false, isPinned: false },
+          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false, isPinned: false },
+          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false, isPinned: false },
+          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false, isPinned: false },
+          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false, isPinned: false },
+          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false, isPinned: false },
+          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false, isPinned: false },
+          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false, isPinned: false },
+          { address: faker.finance.ethereumAddress(), chainId: '1', isWatchlist: false, isPinned: false },
         ],
       }
 

--- a/src/store/addedSafesSlice.ts
+++ b/src/store/addedSafesSlice.ts
@@ -8,6 +8,7 @@ export type AddedSafesOnChain = {
     threshold: number
     ethBalance?: string
     pinned?: boolean
+    removeOnUnpin?: boolean
   }
 }
 
@@ -39,7 +40,6 @@ export const addedSafesSlice = createSlice({
         ...(state[chainId][address.value] ?? {}),
         owners,
         threshold,
-        pinned: true,
       }
     },
     removeSafe: (state, { payload }: PayloadAction<{ chainId: string; address: string }>) => {
@@ -51,14 +51,24 @@ export const addedSafesSlice = createSlice({
         delete state[chainId]
       }
     },
-    pinSafe: (state, { payload }: PayloadAction<{ chainId: string; address: string }>) => {
-      const { chainId, address } = payload
+    pinSafe: (state, { payload }: PayloadAction<{ chainId: string; address: string; removeOnUnpin: boolean }>) => {
+      const { chainId, address, removeOnUnpin } = payload
       state[chainId] ??= {}
       state[chainId][address].pinned = true
+      state[chainId][address].removeOnUnpin = removeOnUnpin
     },
     unpinSafe: (state, { payload }: PayloadAction<{ chainId: string; address: string }>) => {
       const { chainId, address } = payload
-      state[chainId][address].pinned = false
+      const { removeOnUnpin } = state[chainId]?.[address]
+
+      if (removeOnUnpin) {
+        delete state[chainId]?.[address]
+        if (Object.keys(state[chainId]).length === 0) {
+          delete state[chainId]
+        }
+      } else {
+        state[chainId][address].pinned = false
+      }
     },
   },
 })

--- a/src/store/addedSafesSlice.ts
+++ b/src/store/addedSafesSlice.ts
@@ -54,8 +54,11 @@ export const addedSafesSlice = createSlice({
     pinSafe: (state, { payload }: PayloadAction<{ chainId: string; address: string; removeOnUnpin: boolean }>) => {
       const { chainId, address, removeOnUnpin } = payload
       state[chainId] ??= {}
-      state[chainId][address].pinned = true
-      state[chainId][address].removeOnUnpin = removeOnUnpin
+      state[chainId][address] = {
+        ...(state[chainId][address] ?? {}),
+        pinned: true,
+        removeOnUnpin,
+      }
     },
     unpinSafe: (state, { payload }: PayloadAction<{ chainId: string; address: string }>) => {
       const { chainId, address } = payload
@@ -67,7 +70,10 @@ export const addedSafesSlice = createSlice({
           delete state[chainId]
         }
       } else {
-        state[chainId][address].pinned = false
+        state[chainId][address] = {
+          ...(state[chainId][address] ?? {}),
+          pinned: false,
+        }
       }
     },
   },

--- a/src/store/addedSafesSlice.ts
+++ b/src/store/addedSafesSlice.ts
@@ -69,9 +69,9 @@ export const addedSafesSlice = createSlice({
         if (Object.keys(state[chainId]).length === 0) {
           delete state[chainId]
         }
-      } else {
+      } else if (state[chainId]?.[address]) {
         state[chainId][address] = {
-          ...(state[chainId][address] ?? {}),
+          ...state[chainId][address],
           pinned: false,
         }
       }

--- a/src/store/addedSafesSlice.ts
+++ b/src/store/addedSafesSlice.ts
@@ -62,7 +62,7 @@ export const addedSafesSlice = createSlice({
     },
     unpinSafe: (state, { payload }: PayloadAction<{ chainId: string; address: string }>) => {
       const { chainId, address } = payload
-      const { removeOnUnpin } = state[chainId]?.[address]
+      const removeOnUnpin = state[chainId]?.[address]?.removeOnUnpin
 
       if (removeOnUnpin) {
         delete state[chainId]?.[address]

--- a/src/store/addedSafesSlice.ts
+++ b/src/store/addedSafesSlice.ts
@@ -7,6 +7,7 @@ export type AddedSafesOnChain = {
     owners: AddressEx[]
     threshold: number
     ethBalance?: string
+    pinned?: boolean
   }
 }
 
@@ -38,6 +39,7 @@ export const addedSafesSlice = createSlice({
         ...(state[chainId][address.value] ?? {}),
         owners,
         threshold,
+        pinned: true,
       }
     },
     removeSafe: (state, { payload }: PayloadAction<{ chainId: string; address: string }>) => {
@@ -49,10 +51,19 @@ export const addedSafesSlice = createSlice({
         delete state[chainId]
       }
     },
+    pinSafe: (state, { payload }: PayloadAction<{ chainId: string; address: string }>) => {
+      const { chainId, address } = payload
+      state[chainId] ??= {}
+      state[chainId][address].pinned = true
+    },
+    unpinSafe: (state, { payload }: PayloadAction<{ chainId: string; address: string }>) => {
+      const { chainId, address } = payload
+      state[chainId][address].pinned = false
+    },
   },
 })
 
-export const { addOrUpdateSafe, removeSafe } = addedSafesSlice.actions
+export const { addOrUpdateSafe, removeSafe, pinSafe, unpinSafe } = addedSafesSlice.actions
 
 export const selectAllAddedSafes = (state: RootState): AddedSafesState => {
   return state[addedSafesSlice.name]


### PR DESCRIPTION
## What it solves

Resolves: https://www.notion.so/safe-global/Create-pinned-accounts-list-in-sidebar-and-accounts-page-11f8180fe573806da36dc2327ce063ad?pvs=4

## How this PR fixes it
Replaces the existing safe lists in the sidebar with `Accounts`, containing all owned and read only accounts, and `Pinned` containing safes that have been manually added to the list.
- Adds a pinned flag to the added safes slice
- When you pin a safe, it adds it to the added safes list (if not already added) and sets this flag to true.
- Pinned safes appear in both the pinned list and also in the full list below.

## How to test it
On the accounts page or the sidebar:
- Make sure you can pin and unpin safes (single chain and multichain should behave the same)
- Pinned safes should persist, even when connecting with a different wallet, or in the disconnected state.
- Pinned safes should be duplicated in both lists. 

## Screenshots
Sidebar:
![image](https://github.com/user-attachments/assets/ca13aa83-71ef-4111-a49d-fa7766563642)

Accounts page:
![image](https://github.com/user-attachments/assets/036de8c5-877d-4496-b441-1c6fe219a50f)

Mobile:
![image](https://github.com/user-attachments/assets/c49746cc-43e4-418f-a049-7e59a594c59f)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
