### PR TITLE
Remove duplicates when merging balances

### DIFF
--- a/src/hooks/loadables/useLoadBalances.ts
+++ b/src/hooks/loadables/useLoadBalances.ts
@@ -28,7 +28,6 @@ export const useTokenListSetting = (): boolean | undefined => {
 }
 
 const mergeBalances = (cgw: SafeBalanceResponse, sn: SafeBalanceResponse): SafeBalanceResponse => {
-  console.log({ cgw, sn })
   // Create a Map using token addresses as keys
   const uniqueBalances = new Map(
     // Process SafeNet items last so they take precedence by overwriting the CGW items

--- a/src/hooks/loadables/useLoadBalances.ts
+++ b/src/hooks/loadables/useLoadBalances.ts
@@ -27,10 +27,19 @@ export const useTokenListSetting = (): boolean | undefined => {
   return isTrustedTokenList
 }
 
-const mergeBalances = (balance1: SafeBalanceResponse, balance2: SafeBalanceResponse): SafeBalanceResponse => {
+const mergeBalances = (cgw: SafeBalanceResponse, sn: SafeBalanceResponse): SafeBalanceResponse => {
+  console.log({ cgw, sn })
+  // Create a Map using token addresses as keys
+  const uniqueBalances = new Map(
+    // Process SafeNet items last so they take precedence by overwriting the CGW items
+    [...cgw.items, ...sn.items].map((item) => [item.tokenInfo.address, item]),
+  )
+
   return {
-    fiatTotal: balance1.fiatTotal + balance2.fiatTotal,
-    items: [...balance1.items, ...balance2.items],
+    // We do not sum the fiatTotal as SafeNet doesn't return it
+    // And if it did, we would have to do something fancy with calculations so balances aren't double counted
+    fiatTotal: cgw.fiatTotal,
+    items: Array.from(uniqueBalances.values()),
   }
 }
 


### PR DESCRIPTION
This pull request includes a significant change to the `mergeBalances` function in the `src/hooks/loadables/useLoadBalances.ts` file. The update focuses on improving how balances are merged by ensuring unique token addresses and giving precedence to SafeNet items.

Key changes:

### Improvements to balance merging:

* [`src/hooks/loadables/useLoadBalances.ts`](diffhunk://#diff-719a07107449842c596d71bdde56928c6ea1844db785ed06f58b814ab62bc8e8L30-R39): Modified the `mergeBalances` function to use a `Map` for merging balances, ensuring that token addresses are unique and SafeNet items take precedence.