### PR TITLE
fix: cypress test fails due to incorrect nonce

### DIFF
--- a/cypress/e2e/regression/swaps.cy.js
+++ b/cypress/e2e/regression/swaps.cy.js
@@ -194,7 +194,7 @@ describe('Swaps tests', () => {
         swaps.clickOnSwapBtn()
         swaps.clickOnSwapBtn()
       })
-      create_tx.changeNonce(22)
+      create_tx.changeNonce(24)
       create_tx.clickOnSignTransactionBtn()
       create_tx.clickViewTransaction()
       navigation.clickOnWalletExpandMoreIcon()


### PR DESCRIPTION
## What it solves
The cypress test was failing because we had to execute some transactions in the safe that we use for testing.

## How this PR fixes it
Updates the nonce (in theory the nonce should not change again and that's why we don't need to automate it).

## How to test it
Run the cypress test and it should succeed.

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
