### PR TITLE
feat: Show Proposal chip for unsigned transactions in the queue

### DIFF
--- a/src/components/transactions/TxSummary/index.tsx
+++ b/src/components/transactions/TxSummary/index.tsx
@@ -1,3 +1,4 @@
+import TxProposalChip from '@/features/proposers/components/TxProposalChip'
 import StatusLabel from '@/features/swap/components/StatusLabel'
 import useIsExpiredSwap from '@/features/swap/hooks/useIsExpiredSwap'
 import { Box } from '@mui/material'
@@ -74,10 +75,14 @@ const TxSummary = ({ item, isConflictGroup, isBulkGroup }: TxSummaryProps): Reac
 
       {isQueue && executionInfo && (
         <Box gridArea="confirmations">
-          <TxConfirmations
-            submittedConfirmations={executionInfo.confirmationsSubmitted}
-            requiredConfirmations={executionInfo.confirmationsRequired}
-          />
+          {executionInfo.confirmationsSubmitted > 0 ? (
+            <TxConfirmations
+              submittedConfirmations={executionInfo.confirmationsSubmitted}
+              requiredConfirmations={executionInfo.confirmationsRequired}
+            />
+          ) : (
+            <TxProposalChip />
+          )}
         </Box>
       )}
 

--- a/src/features/proposers/components/TxProposalChip.tsx
+++ b/src/features/proposers/components/TxProposalChip.tsx
@@ -1,0 +1,32 @@
+import { Chip, SvgIcon, Tooltip, Typography } from '@mui/material'
+import InfoIcon from '@/public/images/notifications/info.svg'
+
+const TxProposalChip = () => {
+  return (
+    <Tooltip title="This transaction was created by a Proposer. Reject or confirm it to proceed.">
+      <span>
+        <Chip
+          sx={{ backgroundColor: 'background.main', color: 'primary.light' }}
+          size="small"
+          label={
+            <Typography
+              variant="caption"
+              fontWeight="bold"
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              gap={0.7}
+            >
+              <SvgIcon component={InfoIcon} inheritViewBox fontSize="small" />
+              <Typography variant="caption" fontWeight="bold">
+                Proposal
+              </Typography>
+            </Typography>
+          }
+        />
+      </span>
+    </Tooltip>
+  )
+}
+
+export default TxProposalChip


### PR DESCRIPTION
## What it solves

Resolves [SW-367](https://www.notion.so/safe-global/Separate-delegate-transactions-from-other-transactions-in-the-queue-1268180fe573809fa33fc1e1ccd56865)

## How this PR fixes it

- Shows a new Chip in the tx summary saying `Proposal` instead of `0 out of 1`

## How to test it

1. Propose a transaction
2. Go to the queue
3. Observe the new chip

## Screenshots

<img width="1272" alt="Screenshot 2024-10-25 at 11 33 01" src="https://github.com/user-attachments/assets/7ea58972-b5d4-492a-8419-ff52f12c9b1b">
<img width="1265" alt="Screenshot 2024-10-25 at 11 33 08" src="https://github.com/user-attachments/assets/1e32bc59-f5e6-46d4-b66f-38afb1a2fa72">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
