### PR TITLE
fix: Staking banner corrections [SW-380]

### DIFF
--- a/src/components/dashboard/StakingBanner/index.tsx
+++ b/src/components/dashboard/StakingBanner/index.tsx
@@ -108,8 +108,8 @@ const StakingBanner = ({ large = false }: { large?: boolean } = {}) => {
               )}
             </Grid>
 
-            <Grid item xs={12}>
-              <Stack direction="row" spacing={2}>
+            <Grid item container xs={12} spacing={2} textAlign="center">
+              <Grid item xs={12} md="auto">
                 <NextLink
                   href={AppRoutes.stake && { pathname: AppRoutes.stake, query: { safe: router.query.safe } }}
                   passHref
@@ -120,10 +120,12 @@ const StakingBanner = ({ large = false }: { large?: boolean } = {}) => {
                     Stake ETH
                   </Button>
                 </NextLink>
+              </Grid>
+              <Grid item xs={12} md="auto">
                 <Button variant="text" onClick={onHide}>
                   Don&apos;t show again
                 </Button>
-              </Stack>
+              </Grid>
             </Grid>
           </Grid>
         </Card>
@@ -138,7 +140,7 @@ const StakingBanner = ({ large = false }: { large?: boolean } = {}) => {
 
         <Stack
           direction={{ xs: 'column', md: 'row' }}
-          spacing={{ xs: 2, md: 0 }}
+          spacing={2}
           alignItems={{ xs: 'initial', md: 'center' }}
           justifyContent="space-between"
         >
@@ -167,7 +169,7 @@ const StakingBanner = ({ large = false }: { large?: boolean } = {}) => {
             </Typography>
           </Stack>
 
-          <Stack direction="row" spacing={1} alignItems="flex-end">
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ xs: 'center', md: 'flex-end' }}>
             <Button variant="text" onClick={onHide} size="small" sx={{ whiteSpace: 'nowrap' }}>
               Don&apos;t show again
             </Button>
@@ -176,6 +178,7 @@ const StakingBanner = ({ large = false }: { large?: boolean } = {}) => {
               passHref
               rel="noreferrer"
               onClick={onClick}
+              className={classNames(css.stakeButton)}
             >
               <Button fullWidth size="small" variant="contained">
                 Stake

--- a/src/components/dashboard/StakingBanner/index.tsx
+++ b/src/components/dashboard/StakingBanner/index.tsx
@@ -148,7 +148,11 @@ const StakingBanner = ({ large = false }: { large?: boolean } = {}) => {
             <Typography variant="body2">
               <strong>Stake ETH and earn rewards up to 5% APY.</strong> Lock 32 ETH to become a validator via the Kiln
               widget. You can also{' '}
-              <NextLink href={{ pathname: AppRoutes.apps.index, query: router.query }} passHref type="link">
+              <NextLink
+                href={{ pathname: AppRoutes.apps.index, query: { ...router.query, categories: ['Staking'] } }}
+                passHref
+                type="link"
+              >
                 <Link>explore Safe Apps</Link>
               </NextLink>{' '}
               and home staking for other options. Staking involves risks like slashing.

--- a/src/components/dashboard/StakingBanner/index.tsx
+++ b/src/components/dashboard/StakingBanner/index.tsx
@@ -19,11 +19,13 @@ import { formatUnits } from 'ethers'
 import { TokenType } from '@safe-global/safe-gateway-typescript-sdk'
 import useIsStakingBannerEnabled from '@/features/stake/hooks/useIsStakingBannerEnabled'
 
-const LOCAL_STORAGE_KEY_HIDE_WIDGET = 'hideStakingBanner'
 const LEARN_MORE_LINK = 'https://help.safe.global/en/articles/222615-safe-staking'
 const MIN_NATIVE_TOKEN_BALANCE = 32
 
-const StakingBanner = ({ large = false }: { large?: boolean } = {}) => {
+const StakingBanner = ({
+  large = false,
+  hideLocalStorageKey = 'hideStakingBanner',
+}: { large?: boolean; hideLocalStorageKey?: string } = {}) => {
   const isDarkMode = useDarkMode()
   const router = useRouter()
   const { balances } = useBalances()
@@ -37,7 +39,7 @@ const StakingBanner = ({ large = false }: { large?: boolean } = {}) => {
     nativeTokenBalance != null &&
     Number(formatUnits(nativeTokenBalance.balance, nativeTokenBalance.tokenInfo.decimals)) >= MIN_NATIVE_TOKEN_BALANCE
 
-  const [widgetHidden = false, setWidgetHidden] = useLocalStorage<boolean>(LOCAL_STORAGE_KEY_HIDE_WIDGET)
+  const [widgetHidden = false, setWidgetHidden] = useLocalStorage<boolean>(hideLocalStorageKey)
 
   const isStakingBannerEnabled = useIsStakingBannerEnabled()
 

--- a/src/components/dashboard/StakingBanner/styles.module.css
+++ b/src/components/dashboard/StakingBanner/styles.module.css
@@ -60,6 +60,10 @@
   padding-right: var(--space-8);
 }
 
+.stakeButton {
+  width: 100%;
+}
+
 @media (max-width: 899.99px) {
   .header {
     padding: 0;

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -49,7 +49,7 @@ const Dashboard = (): ReactElement => {
           <>
             {isStakingBannerEnabled && (
               <Grid item xs={12} xl={isSAPBannerEnabled ? 6 : 12} className={css.hideIfEmpty}>
-                <StakingBanner large />
+                <StakingBanner hideLocalStorageKey="hideStakingBannerDashboard" large />
               </Grid>
             )}
 


### PR DESCRIPTION
This pull request includes several updates to the `StakingBanner` component to enhance its flexibility and styling.
* Use full width for buttons on mobile screen
* "explore Safe Apps" link leads to apps view filtered by Staking category
* "Don't show again" button hides the banner only on the page where it was clicked

## What it solves

Resolves [#SW-380](https://www.notion.so/safe-global/Staking-banner-notes-mobile-view-filtering-don-t-show-again-1298180fe57380768fb1e90d283fc54a?pvs=4)

## How this PR fixes it

* [`src/components/dashboard/StakingBanner/index.tsx`](diffhunk://#diff-b79df4b94dde2ad15a3cbb6b6f50a36c2208b9e5b39c757d90c795f010591a9eL22-R28): Added `hideLocalStorageKey` prop to the `StakingBanner` component to allow customization of the local storage key used to hide the widget. [[1]](diffhunk://#diff-b79df4b94dde2ad15a3cbb6b6f50a36c2208b9e5b39c757d90c795f010591a9eL22-R28) [[2]](diffhunk://#diff-b79df4b94dde2ad15a3cbb6b6f50a36c2208b9e5b39c757d90c795f010591a9eL40-R42)
* [`src/components/dashboard/index.tsx`](diffhunk://#diff-55f42e0427f40a290cb06611c4740215af6e5ed241e4f4ade08a3e118e4ccb5bL52-R52): Updated the `StakingBanner` usage to use the new `hideLocalStorageKey` prop with a different key for the dashboard.

## How to test it
Load the app for an account that has >= 32 ETH and visit the dashboard and assets pages where the banner should appear at the top. Alternatively, update the `MIN_NATIVE_TOKEN_BALANCE` constant in the StakingBanner component.


## Screenshots
<img width="687" alt="Screenshot 2024-10-25 at 13 49 20" src="https://github.com/user-attachments/assets/1727f57f-3c45-43ce-a48e-f9a72e0ef665">
<img width="681" alt="Screenshot 2024-10-25 at 13 48 17" src="https://github.com/user-attachments/assets/b5be0915-7e7b-4e46-920d-ef2706fd70dc">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
