### PR TITLE
fix: hide suspicious transactions by default

### DIFF
--- a/cypress/e2e/pages/create_tx.pages.js
+++ b/cypress/e2e/pages/create_tx.pages.js
@@ -42,6 +42,7 @@ const addressItem = '[data-testid="address-item"]'
 const radioSelector = 'div[role="radiogroup"]'
 const rejectTxBtn = '[data-testid="reject-btn"]'
 const deleteTxModalBtn = '[data-testid="delete-tx-btn"]'
+const toggleUntrustedBtn = '[data-testid="toggle-untrusted"]'
 
 const viewTransactionBtn = 'View transaction'
 const transactionDetailsTitle = 'Transaction details'
@@ -606,4 +607,8 @@ export function verifyBulkExecuteBtnIsDisabled() {
   cy.get('button').contains(bulkExecuteBtnStr).should('be.disabled')
   cy.get('button').contains(bulkExecuteBtnStr).trigger('mouseover', { force: true })
   cy.contains(disabledBultExecuteBtnTooltip).should('exist')
+}
+
+export function toggleUntrustedTxs() {
+  cy.get(toggleUntrustedBtn).click()
 }

--- a/cypress/e2e/smoke/tx_history.cy.js
+++ b/cypress/e2e/smoke/tx_history.cy.js
@@ -86,6 +86,7 @@ describe('[SMOKE] Tx history tests', () => {
   })
 
   it('[SMOKE] Verify that copying sender address of untrusted token shows warning popup', () => {
+    createTx.toggleUntrustedTxs()
     createTx.clickOnTransactionItemByName(typeUntrustedToken.summaryTitle, typeUntrustedToken.summaryTxInfo)
     createTx.clickOnCopyBtn(0)
     createTx.verifyWarningModalVisible()

--- a/cypress/e2e/smoke/tx_history.cy.js
+++ b/cypress/e2e/smoke/tx_history.cy.js
@@ -75,6 +75,7 @@ describe('[SMOKE] Tx history tests', () => {
   })
 
   it('[SMOKE] Verify summary for untrusted token', () => {
+    createTx.toggleUntrustedTxs()
     createTx.verifySummaryByName(
       typeUntrustedToken.summaryTitle,
       typeUntrustedToken.summaryTxInfo,

--- a/src/hooks/loadables/useLoadTxHistory.ts
+++ b/src/hooks/loadables/useLoadTxHistory.ts
@@ -14,8 +14,8 @@ export const useLoadTxHistory = (): AsyncResult<TransactionListPage> => {
   const { chainId, txHistoryTag } = safe
   const { hideSuspiciousTransactions } = useAppSelector(selectSettings)
   const hasDefaultTokenlist = useHasFeature(FEATURES.DEFAULT_TOKENLIST)
-  const hideUntrustedTxs = (hasDefaultTokenlist && hideSuspiciousTransactions) || false
-  const hideImitationTxs = hideSuspiciousTransactions || false
+  const hideUntrustedTxs = (hasDefaultTokenlist && hideSuspiciousTransactions) || true
+  const hideImitationTxs = hideSuspiciousTransactions || true
 
   // Re-fetch when chainId, address, hideSuspiciousTransactions, or txHistoryTag changes
   const [data, error, loading] = useAsync<TransactionListPage>(

--- a/src/hooks/loadables/useLoadTxHistory.ts
+++ b/src/hooks/loadables/useLoadTxHistory.ts
@@ -14,8 +14,8 @@ export const useLoadTxHistory = (): AsyncResult<TransactionListPage> => {
   const { chainId, txHistoryTag } = safe
   const { hideSuspiciousTransactions } = useAppSelector(selectSettings)
   const hasDefaultTokenlist = useHasFeature(FEATURES.DEFAULT_TOKENLIST)
-  const hideUntrustedTxs = (hasDefaultTokenlist && hideSuspiciousTransactions) || true
-  const hideImitationTxs = hideSuspiciousTransactions || true
+  const hideUntrustedTxs = (hasDefaultTokenlist && hideSuspiciousTransactions) ?? true
+  const hideImitationTxs = hideSuspiciousTransactions ?? true
 
   // Re-fetch when chainId, address, hideSuspiciousTransactions, or txHistoryTag changes
   const [data, error, loading] = useAsync<TransactionListPage>(

--- a/src/hooks/useTxHistory.ts
+++ b/src/hooks/useTxHistory.ts
@@ -22,8 +22,8 @@ const useTxHistory = (
   const [filter] = useTxFilter()
   const { hideSuspiciousTransactions } = useAppSelector(selectSettings)
   const hasDefaultTokenlist = useHasFeature(FEATURES.DEFAULT_TOKENLIST)
-  const hideUntrustedTxs = (hasDefaultTokenlist && hideSuspiciousTransactions) || false
-  const hideImitationTxs = hideSuspiciousTransactions || false
+  const hideUntrustedTxs = (hasDefaultTokenlist && hideSuspiciousTransactions) || true
+  const hideImitationTxs = hideSuspiciousTransactions || true
 
   const {
     safe: { chainId },

--- a/src/hooks/useTxHistory.ts
+++ b/src/hooks/useTxHistory.ts
@@ -22,8 +22,8 @@ const useTxHistory = (
   const [filter] = useTxFilter()
   const { hideSuspiciousTransactions } = useAppSelector(selectSettings)
   const hasDefaultTokenlist = useHasFeature(FEATURES.DEFAULT_TOKENLIST)
-  const hideUntrustedTxs = (hasDefaultTokenlist && hideSuspiciousTransactions) || true
-  const hideImitationTxs = hideSuspiciousTransactions || true
+  const hideUntrustedTxs = (hasDefaultTokenlist && hideSuspiciousTransactions) ?? true
+  const hideImitationTxs = hideSuspiciousTransactions ?? true
 
   const {
     safe: { chainId },

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -53,7 +53,7 @@ export const initialState: SettingsState = {
 
   hiddenTokens: {},
 
-  hideSuspiciousTransactions: false,
+  hideSuspiciousTransactions: true,
 
   shortName: {
     copy: true,


### PR DESCRIPTION
## What it solves

Hiding suspicious transactions by default

## How this PR fixes it

The default preference to hide suspicious transactions is now set to `true`.

## How to test it

Ensuring no preferences are set, observe the "Hide suspicious" switch to be on by default in the transaction history.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
