### PR TITLE
fix: Disable add proposer and delete proposer [SW-400] [SW-396]

### DIFF
--- a/src/components/common/CheckWallet/index.test.tsx
+++ b/src/components/common/CheckWallet/index.test.tsx
@@ -145,6 +145,17 @@ describe('CheckWallet', () => {
     expect(getByText('Continue')).toBeDisabled()
   })
 
+  it('should not disable the button for proposers that are also owners', () => {
+    ;(useIsSafeOwner as jest.MockedFunction<typeof useIsSafeOwner>).mockReturnValueOnce(true)
+    ;(useIsWalletProposer as jest.MockedFunction<typeof useIsWalletProposer>).mockReturnValueOnce(true)
+
+    const { getByText } = render(
+      <CheckWallet allowProposer={false}>{(isOk) => <button disabled={!isOk}>Continue</button>}</CheckWallet>,
+    )
+
+    expect(getByText('Continue')).not.toBeDisabled()
+  })
+
   it('should disable the button for counterfactual Safes', () => {
     ;(useIsSafeOwner as jest.MockedFunction<typeof useIsSafeOwner>).mockReturnValueOnce(true)
 

--- a/src/components/common/CheckWallet/index.test.tsx
+++ b/src/components/common/CheckWallet/index.test.tsx
@@ -125,13 +125,24 @@ describe('CheckWallet', () => {
     expect(allowContainer.querySelector('button')).not.toBeDisabled()
   })
 
-  it('should not disable the button for delegates', () => {
+  it('should not disable the button for proposers', () => {
     ;(useIsSafeOwner as jest.MockedFunction<typeof useIsSafeOwner>).mockReturnValueOnce(false)
     ;(useIsWalletProposer as jest.MockedFunction<typeof useIsWalletProposer>).mockReturnValueOnce(true)
 
     const { container } = renderButton()
 
     expect(container.querySelector('button')).not.toBeDisabled()
+  })
+
+  it('should disable the button for proposers if specified via flag', () => {
+    ;(useIsSafeOwner as jest.MockedFunction<typeof useIsSafeOwner>).mockReturnValueOnce(false)
+    ;(useIsWalletProposer as jest.MockedFunction<typeof useIsWalletProposer>).mockReturnValueOnce(true)
+
+    const { getByText } = render(
+      <CheckWallet allowProposer={false}>{(isOk) => <button disabled={!isOk}>Continue</button>}</CheckWallet>,
+    )
+
+    expect(getByText('Continue')).toBeDisabled()
   })
 
   it('should disable the button for counterfactual Safes', () => {

--- a/src/components/common/CheckWallet/index.tsx
+++ b/src/components/common/CheckWallet/index.tsx
@@ -57,7 +57,7 @@ const CheckWallet = ({
       return Message.NotSafeOwner
     }
 
-    if (!allowProposer && isProposer) {
+    if (!allowProposer && isProposer && !isSafeOwner) {
       return Message.NotSafeOwner
     }
   }, [

--- a/src/components/common/CheckWallet/index.tsx
+++ b/src/components/common/CheckWallet/index.tsx
@@ -15,6 +15,7 @@ type CheckWalletProps = {
   noTooltip?: boolean
   checkNetwork?: boolean
   allowUndeployedSafe?: boolean
+  allowProposer?: boolean
 }
 
 enum Message {
@@ -30,6 +31,7 @@ const CheckWallet = ({
   noTooltip,
   checkNetwork = false,
   allowUndeployedSafe = false,
+  allowProposer = true,
 }: CheckWalletProps): ReactElement => {
   const wallet = useWallet()
   const isSafeOwner = useIsSafeOwner()
@@ -46,6 +48,7 @@ const CheckWallet = ({
     if (!wallet) {
       return Message.WalletNotConnected
     }
+
     if (isUndeployedSafe && !allowUndeployedSafe) {
       return Message.SafeNotActivated
     }
@@ -53,8 +56,13 @@ const CheckWallet = ({
     if (!allowNonOwner && !isSafeOwner && !isProposer && (!isOnlySpendingLimit || !allowSpendingLimit)) {
       return Message.NotSafeOwner
     }
+
+    if (!allowProposer && isProposer) {
+      return Message.NotSafeOwner
+    }
   }, [
     allowNonOwner,
+    allowProposer,
     allowSpendingLimit,
     allowUndeployedSafe,
     isProposer,

--- a/src/components/settings/ProposersList/index.tsx
+++ b/src/components/settings/ProposersList/index.tsx
@@ -6,6 +6,7 @@ import Track from '@/components/common/Track'
 import AddProposer from '@/features/proposers/components/AddProposer'
 import DeleteProposer from '@/features/proposers/components/DeleteProposer'
 import useProposers from '@/hooks/useProposers'
+import useWallet from '@/hooks/wallets/useWallet'
 import AddIcon from '@/public/images/common/add.svg'
 import DeleteIcon from '@/public/images/common/delete.svg'
 import { SETTINGS_EVENTS } from '@/services/analytics'
@@ -19,6 +20,7 @@ const ProposersList = () => {
   const [deleteProposer, setDeleteProposer] = useState<string>()
   const [isAddDialogOpen, setIsAddDialogOpen] = useState<boolean>()
   const proposers = useProposers()
+  const wallet = useWallet()
 
   const rows = useMemo(() => {
     if (!proposers.data) return []
@@ -51,7 +53,9 @@ const ProposersList = () => {
                         onClick={() => onDelete(proposer.delegate)}
                         color="error"
                         size="small"
-                        disabled={!isOk}
+                        disabled={
+                          !isOk || (wallet?.address !== proposer.delegate && wallet?.address !== proposer.delegator)
+                        }
                       >
                         <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />
                       </IconButton>
@@ -64,7 +68,7 @@ const ProposersList = () => {
         },
       }
     })
-  }, [proposers.data])
+  }, [proposers.data, wallet?.address])
 
   if (!proposers.data?.results) return null
 
@@ -94,7 +98,7 @@ const ProposersList = () => {
             </Typography>
 
             <Box mb={2}>
-              <CheckWallet>
+              <CheckWallet allowProposer={false}>
                 {(isOk) => (
                   <Track {...SETTINGS_EVENTS.PROPOSERS.ADD_PROPOSER}>
                     <Button


### PR DESCRIPTION
## What it solves

Resolves [SW-400](https://www.notion.so/safe-global/As-a-proposer-I-can-go-throught-the-add-proposer-12a8180fe57380b4810cec062aaaa98c)
Resolves [SW-396](https://www.notion.so/safe-global/Only-owner-who-created-delegate-can-delete-them-12a8180fe57380ca84e9c8fb60e35004)

## How this PR fixes it

- Disables the `Add proposer` button for proposers
- Only enables the Delete proposer button if any of these conditions meet:
- - Connected wallet is the proposer itself
- - Connected wallet is the owner who created the proposer

## How to test it

1. Open a safe with proposers
2. Connect with one of the proposers
3. Observe you can't add new proposers
4. Observe you can only delete yourself
5. Connect with an owner that didn't create any proposers
6. Observe you can't delete them
7. Connect with an owner that created a proposer
8. Observe you can delete them

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
