### PR TITLE
fix: Adjust message when proposing transaction [SW-381]

### DIFF
--- a/src/components/tx/SignOrExecuteForm/ConfirmationTitle.tsx
+++ b/src/components/tx/SignOrExecuteForm/ConfirmationTitle.tsx
@@ -5,6 +5,7 @@ import css from './styles.module.css'
 export enum ConfirmationTitleTypes {
   sign = 'confirm',
   execute = 'execute',
+  propose = 'propose',
 }
 
 const ConfirmationTitle = ({ isCreation, variant }: { isCreation?: boolean; variant: ConfirmationTitleTypes }) => {

--- a/src/components/tx/SignOrExecuteForm/ProposerForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/ProposerForm.tsx
@@ -1,12 +1,11 @@
 import WalletRejectionError from '@/components/tx/SignOrExecuteForm/WalletRejectionError'
 import { isWalletRejection } from '@/utils/wallets'
 import { type ReactElement, type SyntheticEvent, useContext, useState } from 'react'
-import { Box, Button, CardActions, CircularProgress, Divider } from '@mui/material'
+import { Box, Button, CardActions, CircularProgress, Divider, Typography } from '@mui/material'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import CheckWallet from '@/components/common/CheckWallet'
 import { TxModalContext } from '@/components/tx-flow'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
-import ErrorMessage from '@/components/tx/ErrorMessage'
 import { TxSecurityContext } from '@/components/tx/security/shared/TxSecurityContext'
 import { useTxActions } from '@/components/tx/SignOrExecuteForm/hooks'
 import type { SignOrExecuteProps } from '@/components/tx/SignOrExecuteForm/index'
@@ -72,10 +71,10 @@ export const ProposerForm = ({
 
   return (
     <form onSubmit={handleSubmit}>
-      <ErrorMessage level="info">
-        You are creating this transaction as a delegate. It will not have any signatures until it is confirmed by an
-        owner.
-      </ErrorMessage>
+      <Typography>
+        As a <strong>Proposer</strong>, you&apos;re creating this transaction without any signatures. It will need
+        approval from a signer before it becomes a valid transaction.
+      </Typography>
 
       {isRejectedByUser && (
         <Box mt={1}>

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -1,47 +1,47 @@
-import ProposerForm from '@/components/tx/SignOrExecuteForm/ProposerForm'
-import CounterfactualForm from '@/features/counterfactual/CounterfactualForm'
-import { useIsWalletProposer } from '@/hooks/useProposers'
-import useSafeInfo from '@/hooks/useSafeInfo'
-import { type ReactElement, type ReactNode, useState, useContext, useCallback } from 'react'
-import madProps from '@/utils/mad-props'
-import DecodedTx from '../DecodedTx'
-import ExecuteCheckbox from '../ExecuteCheckbox'
-import { useImmediatelyExecutable, useValidateNonce } from './hooks'
-import ExecuteForm from './ExecuteForm'
-import SignForm from './SignForm'
-import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
-import ErrorMessage from '../ErrorMessage'
-import TxChecks from './TxChecks'
-import TxCard from '@/components/tx-flow/common/TxCard'
-import ConfirmationTitle, { ConfirmationTitleTypes } from '@/components/tx/SignOrExecuteForm/ConfirmationTitle'
-import { useAppSelector } from '@/store'
-import { selectSettings } from '@/store/settingsSlice'
-import UnknownContractError from './UnknownContractError'
-import useDecodeTx from '@/hooks/useDecodeTx'
-import { ErrorBoundary } from '@sentry/react'
-import ApprovalEditor from '../ApprovalEditor'
-import { isDelegateCall } from '@/services/tx/tx-sender/sdk'
-import { getTransactionTrackingType } from '@/services/analytics/tx-tracking'
-import { TX_EVENTS } from '@/services/analytics/events/transactions'
-import { trackEvent } from '@/services/analytics'
-import useChainId from '@/hooks/useChainId'
-import ExecuteThroughRoleForm from './ExecuteThroughRoleForm'
-import { findAllowingRole, findMostLikelyRole, useRoles } from './ExecuteThroughRoleForm/hooks'
-import { isAnyStakingTxInfo, isCustomTxInfo, isGenericConfirmation, isOrderTxInfo } from '@/utils/transaction-guards'
-import useIsSafeOwner from '@/hooks/useIsSafeOwner'
-import { BlockaidBalanceChanges } from '../security/blockaid/BlockaidBalanceChange'
-import { Blockaid } from '../security/blockaid'
+import NetworkWarning from '@/components/new-safe/create/NetworkWarning'
 
 import TxData from '@/components/transactions/TxDetails/TxData'
+import TxCard from '@/components/tx-flow/common/TxCard'
+import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import ConfirmationOrder from '@/components/tx/ConfirmationOrder'
-import { useApprovalInfos } from '../ApprovalEditor/hooks/useApprovalInfos'
-import { MigrateToL2Information } from './MigrateToL2Information'
+import ConfirmationTitle, { ConfirmationTitleTypes } from '@/components/tx/SignOrExecuteForm/ConfirmationTitle'
+import ProposerForm from '@/components/tx/SignOrExecuteForm/ProposerForm'
+import CounterfactualForm from '@/features/counterfactual/CounterfactualForm'
+import useChainId from '@/hooks/useChainId'
+import useDecodeTx from '@/hooks/useDecodeTx'
+import useIsSafeOwner from '@/hooks/useIsSafeOwner'
+import { useIsWalletProposer } from '@/hooks/useProposers'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import { trackEvent } from '@/services/analytics'
+import { TX_EVENTS } from '@/services/analytics/events/transactions'
+import { getTransactionTrackingType } from '@/services/analytics/tx-tracking'
+import { isDelegateCall } from '@/services/tx/tx-sender/sdk'
+import { useAppSelector } from '@/store'
+import { useGetTransactionDetailsQuery, useLazyGetTransactionDetailsQuery } from '@/store/api/gateway'
+import { selectSettings } from '@/store/settingsSlice'
+import madProps from '@/utils/mad-props'
+import { isAnyStakingTxInfo, isCustomTxInfo, isGenericConfirmation, isOrderTxInfo } from '@/utils/transaction-guards'
 import { extractMigrationL2MasterCopyAddress } from '@/utils/transactions'
+import { skipToken } from '@reduxjs/toolkit/query/react'
 
 import type { TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
-import { useGetTransactionDetailsQuery, useLazyGetTransactionDetailsQuery } from '@/store/api/gateway'
-import { skipToken } from '@reduxjs/toolkit/query/react'
-import NetworkWarning from '@/components/new-safe/create/NetworkWarning'
+import { ErrorBoundary } from '@sentry/react'
+import { type ReactElement, type ReactNode, useCallback, useContext, useState } from 'react'
+import ApprovalEditor from '../ApprovalEditor'
+import { useApprovalInfos } from '../ApprovalEditor/hooks/useApprovalInfos'
+import DecodedTx from '../DecodedTx'
+import ErrorMessage from '../ErrorMessage'
+import ExecuteCheckbox from '../ExecuteCheckbox'
+import { Blockaid } from '../security/blockaid'
+import { BlockaidBalanceChanges } from '../security/blockaid/BlockaidBalanceChange'
+import ExecuteForm from './ExecuteForm'
+import ExecuteThroughRoleForm from './ExecuteThroughRoleForm'
+import { findAllowingRole, findMostLikelyRole, useRoles } from './ExecuteThroughRoleForm/hooks'
+import { useImmediatelyExecutable, useValidateNonce } from './hooks'
+import { MigrateToL2Information } from './MigrateToL2Information'
+import SignForm from './SignForm'
+import TxChecks from './TxChecks'
+import UnknownContractError from './UnknownContractError'
 
 export type SubmitCallback = (txId: string, isExecuted?: boolean) => void
 
@@ -201,7 +201,13 @@ export const SignOrExecuteForm = ({
 
       <TxCard>
         <ConfirmationTitle
-          variant={willExecute ? ConfirmationTitleTypes.execute : ConfirmationTitleTypes.sign}
+          variant={
+            willExecute
+              ? ConfirmationTitleTypes.execute
+              : isProposer
+              ? ConfirmationTitleTypes.propose
+              : ConfirmationTitleTypes.sign
+          }
           isCreation={isCreation}
         />
 


### PR DESCRIPTION
## What it solves

Resolves [SW-381](https://www.notion.so/safe-global/Update-message-when-proposing-tx-1298180fe573806bbc3cf615a75febad)

## How this PR fixes it

- Adjusts the message shown to proposers when creating a tranaction
- Changes the confirmation title to `Propose`

## How to test it

1. Open a safe as a proposer
2. Create a transaction
3. Observe the new message when confirming

## Screenshots

<img width="715" alt="Screenshot 2024-10-28 at 10 10 32" src="https://github.com/user-attachments/assets/f6131724-6ace-4587-b156-4d60933e5483">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
