### PR TITLE
Tests: Update e2e tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,5 +48,5 @@ NEXT_PUBLIC_SOCIAL_WALLET_OPTIONS_PRODUCTION=
 # Cypress wallet private keys
 CYPRESS_WALLET_CREDENTIALS=
 
-# Beamer keys for e2e tests
+# [optional] Beamer keys for e2e tests
 BEAMER_DATA_E2E=

--- a/cypress/e2e/regression/bulk_execution.cy.js
+++ b/cypress/e2e/regression/bulk_execution.cy.js
@@ -69,7 +69,7 @@ describe('Bulk execution', () => {
 
       cy.visit(constants.transactionsHistoryUrl + staticSafes.SEP_STATIC_SAFE_1)
       main.acceptCookies()
-
+      create_tx.toggleUntrustedTxs()
       create_tx.verifyBulkTxHistoryBlock(tx, data)
     },
   )

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -30,7 +30,7 @@ import * as ls from './localstorage_data'
 const { addCompareSnapshotCommand } = require('cypress-visual-regression/dist/command')
 addCompareSnapshotCommand()
 
-const beamer = JSON.parse(Cypress.env('BEAMER_DATA_E2E'))
+const beamer = JSON.parse(Cypress.env('BEAMER_DATA_E2E') || '{}')
 const productID = beamer.PRODUCT_ID
 
 before(() => {


### PR DESCRIPTION
## What it solves

## How this PR fixes it

- Fix regression test where hide suspicious token is used
- Add logic to enable e2e tests to still run without valid BEAMER_DATA_E2E
- Update .env.example file: added optional to BEAMER_DATA_E2E

## How to test it

- Run Cypress tests and observe outcome