### PR TITLE
feat: Show proposer address in queue [SW-309] [SW-426]

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@safe-global/protocol-kit": "^4.1.1",
     "@safe-global/safe-apps-sdk": "^9.1.0",
     "@safe-global/safe-deployments": "1.37.12",
-    "@safe-global/safe-client-gateway-sdk": "1.58.0-next-88d97c1",
+    "@safe-global/safe-client-gateway-sdk": "1.60.1-next-069fa2b",
     "@safe-global/safe-gateway-typescript-sdk": "3.22.3-beta.15",
     "@safe-global/safe-modules-deployments": "^2.2.1",
     "@sentry/react": "^7.91.0",

--- a/src/components/settings/ProposersList/index.tsx
+++ b/src/components/settings/ProposersList/index.tsx
@@ -116,7 +116,7 @@ const ProposersList = () => {
               </CheckWallet>
             </Box>
 
-            <EnhancedTable rows={rows} headCells={[]} />
+            {rows.length > 0 && <EnhancedTable rows={rows} headCells={[]} />}
           </Grid>
 
           {deleteProposer && (

--- a/src/components/transactions/TxDetails/index.tsx
+++ b/src/components/transactions/TxDetails/index.tsx
@@ -64,10 +64,12 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
   const isTrustedTransfer = !hasDefaultTokenlist || isTrustedTx(txSummary)
   const isImitationTransaction = isImitation(txSummary)
 
-  let proposer, safeTxHash
+  let proposer, safeTxHash, proposedByDelegate
   if (isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo)) {
     proposer = txDetails.detailedExecutionInfo.proposer?.value
     safeTxHash = txDetails.detailedExecutionInfo.safeTxHash
+    // @ts-expect-error TODO: Need to update the types from the new SDK
+    proposedByDelegate = txDetails.detailedExecutionInfo.proposedByDelegate
   }
 
   const expiredSwap = useIsExpiredSwap(txSummary.txInfo)
@@ -123,7 +125,12 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
       {/* Signers */}
       {(!isUnsigned || isTxFromProposer) && (
         <div className={css.txSigners}>
-          <TxSigners txDetails={txDetails} txSummary={txSummary} isTxFromProposer={isTxFromProposer} />
+          <TxSigners
+            txDetails={txDetails}
+            txSummary={txSummary}
+            isTxFromProposer={isTxFromProposer}
+            proposer={proposedByDelegate}
+          />
 
           {isQueue && (
             <Box className={css.buttons}>

--- a/src/components/transactions/TxSigners/index.tsx
+++ b/src/components/transactions/TxSigners/index.tsx
@@ -12,6 +12,7 @@ import {
   type ListItemIconProps,
 } from '@mui/material'
 import type {
+  AddressEx,
   DetailedExecutionInfo,
   TransactionDetails,
   TransactionSummary,
@@ -106,9 +107,15 @@ type TxSignersProps = {
   txDetails: TransactionDetails
   txSummary: TransactionSummary
   isTxFromProposer: boolean
+  proposer?: AddressEx
 }
 
-export const TxSigners = ({ txDetails, txSummary, isTxFromProposer }: TxSignersProps): ReactElement | null => {
+export const TxSigners = ({
+  txDetails,
+  txSummary,
+  isTxFromProposer,
+  proposer,
+}: TxSignersProps): ReactElement | null => {
   const { detailedExecutionInfo, txInfo, txId } = txDetails
   const [hideConfirmations, setHideConfirmations] = useState<boolean>(shouldHideConfirmations(detailedExecutionInfo))
   const isPending = useIsPending(txId)
@@ -155,15 +162,29 @@ export const TxSigners = ({ txDetails, txSummary, isTxFromProposer }: TxSignersP
           )}
         </ListItem>
 
-        <ListItem>
-          <StyledListItemIcon $state={isConfirmed ? StepState.CONFIRMED : StepState.ACTIVE}>
-            {isConfirmed ? <Check /> : <MissingConfirmation />}
-          </StyledListItemIcon>
-          <ListItemText data-testid="confirmation-action" primaryTypographyProps={{ fontWeight: 700 }}>
-            Confirmations{' '}
-            <Box className={css.confirmationsTotal}>({`${confirmationsCount} of ${confirmationsRequired}`})</Box>
-          </ListItemText>
-        </ListItem>
+        {proposer && (
+          <ListItem key={proposer.value} sx={{ py: 0 }}>
+            <StyledListItemIcon $state={StepState.CONFIRMED}>
+              <Dot />
+            </StyledListItemIcon>
+            <ListItemText data-testid="signer">
+              <EthHashInfo address={proposer.value} hasExplorer showCopyButton />
+            </ListItemText>
+          </ListItem>
+        )}
+
+        {confirmations.length > 0 && (
+          <ListItem>
+            <StyledListItemIcon $state={isConfirmed ? StepState.CONFIRMED : StepState.ACTIVE}>
+              {isConfirmed ? <Check /> : <MissingConfirmation />}
+            </StyledListItemIcon>
+            <ListItemText data-testid="confirmation-action" primaryTypographyProps={{ fontWeight: 700 }}>
+              Confirmations{' '}
+              <Box className={css.confirmationsTotal}>({`${confirmationsCount} of ${confirmationsRequired}`})</Box>
+            </ListItemText>
+          </ListItem>
+        )}
+
         {!hideConfirmations &&
           confirmations.map(({ signer }) => (
             <ListItem key={signer.value} sx={{ py: 0 }}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4195,10 +4195,10 @@
     "@safe-global/safe-gateway-typescript-sdk" "^3.5.3"
     viem "^2.1.1"
 
-"@safe-global/safe-client-gateway-sdk@1.58.0-next-88d97c1":
-  version "1.58.0-next-88d97c1"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-client-gateway-sdk/-/safe-client-gateway-sdk-1.58.0-next-88d97c1.tgz#8cec956eb1d6aec0225e0735b5e2fd43543c2b9c"
-  integrity sha512-7o7UVnmSuWc7A1IIQZyRNc3e4dkQwzTQxHG3hWEu8DQkkseGoePJ3wEVYn3wNi+iuYFvg+5hCoh6mGuD11vKOw==
+"@safe-global/safe-client-gateway-sdk@1.60.1-next-069fa2b":
+  version "1.60.1-next-069fa2b"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-client-gateway-sdk/-/safe-client-gateway-sdk-1.60.1-next-069fa2b.tgz#5a4ac69661713dd08b33bbcc15fa7d870339ed0a"
+  integrity sha512-gS+AcYuX1L6l79q87TA/A6vS34wovUgypRKS8lXzo4nDbHE333i/yp7JoOAcxKXFlJDHJXHIbPRkOKoMjdylEA==
   dependencies:
     openapi-fetch "0.10.5"
 


### PR DESCRIPTION
## What it solves

Resolves SW-309

## How this PR fixes it

- Updates the CGW SDK to the newest version
- Uses the new `proposedByDelegate` field to display the address in the queue for proposed transactions

## How to test it

1. Propose a transaction
2. Go to the queue
3. Open the transaction details
4. Observe the proposer address

## Screenshots
<img width="1261" alt="Screenshot 2024-10-30 at 11 17 38" src="https://github.com/user-attachments/assets/b820a84f-d395-430c-a753-cbc572565436">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
