### PR TITLE
fix: Hide tooltip on confirm button for proposers [SW-431]

### DIFF
--- a/src/components/transactions/SignTxButton/index.tsx
+++ b/src/components/transactions/SignTxButton/index.tsx
@@ -1,4 +1,5 @@
 import useIsExpiredSwap from '@/features/swap/hooks/useIsExpiredSwap'
+import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import type { SyntheticEvent } from 'react'
 import { useContext, type ReactElement } from 'react'
 import { type TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
@@ -22,6 +23,7 @@ const SignTxButton = ({
 }): ReactElement => {
   const { setTxFlow } = useContext(TxModalContext)
   const wallet = useWallet()
+  const isSafeOwner = useIsSafeOwner()
   const isSignable = isSignableBy(txSummary, wallet?.address || '')
   const safeSDK = useSafeSDK()
   const expiredSwap = useIsExpiredSwap(txSummary.txInfo)
@@ -36,7 +38,7 @@ const SignTxButton = ({
   return (
     <CheckWallet>
       {(isOk) => (
-        <Tooltip title={isOk && !isSignable ? "You've already signed this transaction" : ''}>
+        <Tooltip title={isOk && !isSignable && isSafeOwner ? "You've already signed this transaction" : ''}>
           <span>
             <Track {...TX_LIST_EVENTS.CONFIRM}>
               <Button


### PR DESCRIPTION
## What it solves

Resolves SW-431

## How this PR fixes it

- Restricts the Tooltip in `SignTxButton` to only show for owners

## How to test it

1. Propose a transaction
2. Go to the queue
3. Hover the Confirm button as a proposer
4. Observe no tooltip
5. Switch to an owner
6. The buttons should be enabled as before

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
