### PR TITLE
fix: Use safe owner address for tenderly simulation with proposer [SW-429]

### DIFF
--- a/src/components/tx/security/tenderly/index.tsx
+++ b/src/components/tx/security/tenderly/index.tsx
@@ -1,3 +1,4 @@
+import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import { Alert, Button, Paper, SvgIcon, Tooltip, Typography } from '@mui/material'
 import { useContext, useEffect } from 'react'
 import type { ReactElement } from 'react'
@@ -34,6 +35,7 @@ export type TxSimulationProps = {
 const TxSimulationBlock = ({ transactions, disabled, gasLimit, executionOwner }: TxSimulationProps): ReactElement => {
   const { safe } = useSafeInfo()
   const wallet = useWallet()
+  const isSafeOwner = useIsSafeOwner()
   const isDarkMode = useDarkMode()
   const { safeTx } = useContext(SafeTxContext)
   const {
@@ -48,7 +50,8 @@ const TxSimulationBlock = ({ transactions, disabled, gasLimit, executionOwner }:
 
     simulateTransaction({
       safe,
-      executionOwner: executionOwner ?? wallet.address,
+      // fall back to the first owner of the safe in case the transaction is created by a proposer
+      executionOwner: executionOwner ?? isSafeOwner ? wallet.address : safe.owners[0].value,
       transactions,
       gasLimit,
     } as SimulationTxParams)


### PR DESCRIPTION
## What it solves

Resolves SW-429

## How this PR fixes it

- Uses the first safe owner address as the executor in case a proposer runs a tenderly simulation

## How to test it

1. Create a transaction as a proposer
2. Press simulate
3. Observe that the simulation does not fail

## Screenshots
<img width="775" alt="Screenshot 2024-10-30 at 11 58 44" src="https://github.com/user-attachments/assets/e4b40fa3-a96d-41b8-94b1-1a86438b26e9">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
