### PR TITLE
fix: Allow owners to be added as proposers [SW-407] [SW-428] [SW-381]

### DIFF
--- a/src/components/common/AddressInput/styles.module.css
+++ b/src/components/common/AddressInput/styles.module.css
@@ -16,5 +16,4 @@
 
 .readOnly :global .MuiInputBase-input {
   visibility: hidden;
-  position: absolute;
 }

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -124,7 +124,7 @@ export const SignOrExecuteForm = ({
 
   const isSafeOwner = useIsSafeOwner()
   const isProposer = useIsWalletProposer()
-  const isProposing = isProposer && !isSafeOwner
+  const isProposing = isProposer && !isSafeOwner && isCreation
   const isCounterfactualSafe = !safe.deployed
   const multiChainMigrationTarget = extractMigrationL2MasterCopyAddress(safeTx)
   const isMultiChainMigration = !!multiChainMigrationTarget

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -117,13 +117,14 @@ export const SignOrExecuteForm = ({
     !isCustomTxInfo(txDetails.txInfo) &&
     !isAnyStakingTxInfo(txDetails.txInfo) &&
     !isOrderTxInfo(txDetails.txInfo)
-  const isProposer = useIsWalletProposer()
   const [trigger] = useLazyGetTransactionDetailsQuery()
   const [readableApprovals] = useApprovalInfos({ safeTransaction: safeTx })
   const isApproval = readableApprovals && readableApprovals.length > 0
-
   const { safe } = useSafeInfo()
+
   const isSafeOwner = useIsSafeOwner()
+  const isProposer = useIsWalletProposer()
+  const isProposing = isProposer && !isSafeOwner
   const isCounterfactualSafe = !safe.deployed
   const multiChainMigrationTarget = extractMigrationL2MasterCopyAddress(safeTx)
   const isMultiChainMigration = !!multiChainMigrationTarget
@@ -204,7 +205,7 @@ export const SignOrExecuteForm = ({
           variant={
             willExecute
               ? ConfirmationTitleTypes.execute
-              : isProposer
+              : isProposing
               ? ConfirmationTitleTypes.propose
               : ConfirmationTitleTypes.sign
           }
@@ -217,7 +218,7 @@ export const SignOrExecuteForm = ({
           </ErrorMessage>
         )}
 
-        {(canExecute || canExecuteThroughRole) && !props.onlyExecute && !isCounterfactualSafe && !isProposer && (
+        {(canExecute || canExecuteThroughRole) && !props.onlyExecute && !isCounterfactualSafe && !isProposing && (
           <ExecuteCheckbox onChange={setShouldExecute} />
         )}
 
@@ -227,10 +228,10 @@ export const SignOrExecuteForm = ({
 
         <Blockaid />
 
-        {isCounterfactualSafe && !isProposer && (
+        {isCounterfactualSafe && !isProposing && (
           <CounterfactualForm {...props} safeTx={safeTx} isCreation={isCreation} onSubmit={onFormSubmit} onlyExecute />
         )}
-        {!isCounterfactualSafe && willExecute && !isProposer && (
+        {!isCounterfactualSafe && willExecute && !isProposing && (
           <ExecuteForm {...props} safeTx={safeTx} isCreation={isCreation} onSubmit={onFormSubmit} />
         )}
         {!isCounterfactualSafe && willExecuteThroughRole && (
@@ -242,7 +243,7 @@ export const SignOrExecuteForm = ({
             role={(allowingRole || mostLikelyRole)!}
           />
         )}
-        {!isCounterfactualSafe && !willExecute && !willExecuteThroughRole && !isProposer && (
+        {!isCounterfactualSafe && !willExecute && !willExecuteThroughRole && !isProposing && (
           <SignForm
             {...props}
             safeTx={safeTx}
@@ -252,7 +253,7 @@ export const SignOrExecuteForm = ({
           />
         )}
 
-        {isProposer && <ProposerForm {...props} safeTx={safeTx} onSubmit={onProposerFormSubmit} />}
+        {isProposing && <ProposerForm {...props} safeTx={safeTx} onSubmit={onProposerFormSubmit} />}
       </TxCard>
     </>
   )

--- a/src/features/proposers/components/UpsertProposer.tsx
+++ b/src/features/proposers/components/UpsertProposer.tsx
@@ -7,7 +7,6 @@ import ErrorMessage from '@/components/tx/ErrorMessage'
 import { getDelegateTypedData } from '@/features/proposers/utils/utils'
 import useChainId from '@/hooks/useChainId'
 import useSafeAddress from '@/hooks/useSafeAddress'
-import useSafeInfo from '@/hooks/useSafeInfo'
 import useWallet from '@/hooks/wallets/useWallet'
 import { SETTINGS_EVENTS, trackEvent } from '@/services/analytics'
 import { getAssertedChainSigner } from '@/services/tx/tx-sender/sdk'
@@ -15,7 +14,7 @@ import { useAppDispatch } from '@/store'
 import { useAddProposerMutation } from '@/store/api/gateway'
 import { showNotification } from '@/store/notificationsSlice'
 import { shortenAddress } from '@/utils/formatters'
-import { addressIsNotCurrentSafe, addressIsNotOwner } from '@/utils/validation'
+import { addressIsNotCurrentSafe } from '@/utils/validation'
 import { signTypedData } from '@/utils/web3'
 import { Close } from '@mui/icons-material'
 import {
@@ -32,7 +31,7 @@ import {
   Typography,
 } from '@mui/material'
 import type { Delegate } from '@safe-global/safe-gateway-typescript-sdk/dist/types/delegates'
-import { type BaseSyntheticEvent, useMemo, useState } from 'react'
+import { type BaseSyntheticEvent, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 
 type UpsertProposerProps = {
@@ -56,7 +55,6 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [addProposer] = useAddProposerMutation()
   const dispatch = useAppDispatch()
-  const { safe } = useSafeInfo()
 
   const chainId = useChainId()
   const wallet = useWallet()
@@ -70,10 +68,7 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
     mode: 'onChange',
   })
 
-  const owners = useMemo(() => safe.owners.map((owner) => owner.value), [safe.owners])
-  const notAlreadyOwner = addressIsNotOwner(owners, 'Cannot add Owner as proposer')
   const notCurrentSafe = addressIsNotCurrentSafe(safeAddress, 'Cannot add Safe Account itself as proposer')
-  const combinedValidate = (address: string) => notAlreadyOwner(address) || notCurrentSafe(address)
 
   const { handleSubmit, formState } = methods
 
@@ -173,7 +168,7 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
                 <AddressBookInput
                   name="address"
                   label="Address"
-                  validate={combinedValidate}
+                  validate={notCurrentSafe}
                   variant="outlined"
                   fullWidth
                   required


### PR DESCRIPTION
## What it solves

Resolves SW-407
Resolves SW-428

## How this PR fixes it

- Removes the owner validation from the `UpsertProposer` form
- Removes the horizontal scrollbar when adding proposers

## How to test it

1. Add a new proposer and choose an address from your address book
2. Observe there is no horizontal scrollbar visible
3. Add an owner as a proposer
4. Observe no validation errors
5. Create a transaction as that owner
6. Observe no messages about being a proposer 

## Screenshots
<img width="640" alt="Screenshot 2024-10-30 at 12 19 59" src="https://github.com/user-attachments/assets/155f9c31-a83e-42c1-92a0-6d6f8d085ca6">
<img width="731" alt="Screenshot 2024-10-30 at 12 20 18" src="https://github.com/user-attachments/assets/3f686422-6d2d-4045-9116-c189fb2ee55e">
<img width="729" alt="Screenshot 2024-10-30 at 12 20 29" src="https://github.com/user-attachments/assets/1b12b7fb-cc65-4868-afc3-5930065bf35e">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
