### PR TITLE
fix: Poll proposers when on the settings page [SW-427]

### DIFF
--- a/src/hooks/useProposers.ts
+++ b/src/hooks/useProposers.ts
@@ -1,3 +1,4 @@
+import { POLLING_INTERVAL } from '@/config/constants'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import useWallet from '@/hooks/wallets/useWallet'
 import { useGetProposersQuery } from '@/store/api/gateway'
@@ -9,7 +10,9 @@ const useProposers = () => {
     safeAddress,
   } = useSafeInfo()
 
-  return useGetProposersQuery(chainId && safeAddress ? { chainId, safeAddress } : skipToken)
+  return useGetProposersQuery(chainId && safeAddress ? { chainId, safeAddress } : skipToken, {
+    pollingInterval: POLLING_INTERVAL,
+  })
 }
 
 export const useIsWalletProposer = () => {


### PR DESCRIPTION
## What it solves

Resolves SW-427

## How this PR fixes it

- Adds polling every 15 seconds for the get proposers call

## How to test it

1. Open the settings page in two different tabs
2. Create a proposer
3. Switch to the other tab and observe the proposer appearing within 15 seconds

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
