### PR TITLE
fix: Only show proposal chip if transaction is not pending [SW-434]

### DIFF
--- a/src/components/transactions/TxSummary/index.tsx
+++ b/src/components/transactions/TxSummary/index.tsx
@@ -75,7 +75,7 @@ const TxSummary = ({ item, isConflictGroup, isBulkGroup }: TxSummaryProps): Reac
 
       {isQueue && executionInfo && (
         <Box gridArea="confirmations">
-          {executionInfo.confirmationsSubmitted > 0 ? (
+          {executionInfo.confirmationsSubmitted > 0 || isPending ? (
             <TxConfirmations
               submittedConfirmations={executionInfo.confirmationsSubmitted}
               requiredConfirmations={executionInfo.confirmationsRequired}


### PR DESCRIPTION
## What it solves

Resolves SW-434

Immediately executed transaction showed the `Proposal` chip in the tx summary even if it wasn't a proposal because in both cases there is no signature returned.

## How this PR fixes it

- If a transaction is pending in the queue we don't show the `Proposal` chip in the summary

## How to test it

1. Create and execute a transaction in a 1/n safe
2. Observe that the pending transaction in the queue doesn't show the `Proposal` chip
3. Create a proposal
4. Execute the proposal with an owner
5. Observe the pending transaction doesn't show the `Proposal` chip

## Screenshots

<img width="1258" alt="Screenshot 2024-10-30 at 14 06 49" src="https://github.com/user-attachments/assets/327e05f9-6e8e-4927-a68e-406f9ddc320c">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
