### PR TITLE
refactor: use sendTokensBtn instead of sendTokenButn

### DIFF
--- a/cypress/e2e/pages/batches.pages.js
+++ b/cypress/e2e/pages/batches.pages.js
@@ -4,7 +4,7 @@ const tokenSelectorText = 'G(ö|oe)rli Ether'
 const noLaterString = 'No, later'
 const yesExecuteString = 'Yes, execute'
 export const newTransactionBtnStr = 'New transaction'
-const sendTokensButn = 'Send tokens'
+const sendTokensBtn = 'Send tokens'
 const nextBtn = 'Next'
 const executeBtn = 'Execute'
 export const addToBatchBtn = 'Add to batch'
@@ -72,7 +72,7 @@ export function openBatchtransactionsModal() {
 
 export function openNewTransactionModal() {
   cy.get(addNewTxBatch).click()
-  cy.contains(sendTokensButn).click()
+  cy.contains(sendTokensBtn).click()
 }
 
 export function addNewTransactionToBatch(EOA, currentNonce, funds_first_tx) {


### PR DESCRIPTION
## What it solves

Resolves the namingly-off button variable in cypress test.

## How this PR fixes it

Standardizing the naming convention for buttons as in btn. ~`sendTokensButn`~ -> `sendTokensBtn`

## How to test it

### Cypress tests

Build a static site:

```
yarn build
```

Serve the static files:

```
yarn serve
```

Launch the Cypress UI:

```
yarn cypress:open
```

## Screenshots
Not applicable

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
