### PR TITLE
fix: Hide batch button for proposers [SW-457] [SW-458]

### DIFF
--- a/src/components/common/Header/index.test.tsx
+++ b/src/components/common/Header/index.test.tsx
@@ -1,0 +1,129 @@
+import Header from '@/components/common/Header/index'
+import * as useChains from '@/hooks/useChains'
+import * as useIsSafeOwner from '@/hooks/useIsSafeOwner'
+import * as useProposers from '@/hooks/useProposers'
+import * as useSafeAddress from '@/hooks/useSafeAddress'
+import * as useSafeTokenEnabled from '@/hooks/useSafeTokenEnabled'
+import { render } from '@/tests/test-utils'
+import { faker } from '@faker-js/faker'
+import { screen, fireEvent } from '@testing-library/react'
+
+jest.mock(
+  '@/components/common/SafeTokenWidget',
+  () =>
+    function SafeTokenWidget() {
+      return <div>SafeTokenWidget</div>
+    },
+)
+
+jest.mock(
+  '@/features/walletconnect/components',
+  () =>
+    function WalletConnect() {
+      return <div>WalletConnect</div>
+    },
+)
+
+jest.mock(
+  '@/components/common/NetworkSelector',
+  () =>
+    function NetworkSelector() {
+      return <div>NetworkSelector</div>
+    },
+)
+
+describe('Header', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders the menu button when onMenuToggle is provided', () => {
+    render(<Header onMenuToggle={jest.fn()} />)
+    expect(screen.getByLabelText('menu')).toBeInTheDocument()
+  })
+
+  it('does not render the menu button when onMenuToggle is not provided', () => {
+    render(<Header />)
+    expect(screen.queryByLabelText('menu')).not.toBeInTheDocument()
+  })
+
+  it('calls onMenuToggle when menu button is clicked', () => {
+    const onMenuToggle = jest.fn()
+    render(<Header onMenuToggle={onMenuToggle} />)
+
+    const menuButton = screen.getByLabelText('menu')
+    fireEvent.click(menuButton)
+
+    expect(onMenuToggle).toHaveBeenCalled()
+  })
+
+  it('renders the SafeTokenWidget when showSafeToken is true', () => {
+    jest.spyOn(useSafeTokenEnabled, 'useSafeTokenEnabled').mockReturnValue(true)
+
+    render(<Header />)
+    expect(screen.getByText('SafeTokenWidget')).toBeInTheDocument()
+  })
+
+  it('does not render the SafeTokenWidget when showSafeToken is false', () => {
+    jest.spyOn(useSafeTokenEnabled, 'useSafeTokenEnabled').mockReturnValue(false)
+
+    render(<Header />)
+    expect(screen.queryByText('SafeTokenWidget')).not.toBeInTheDocument()
+  })
+
+  it('displays the safe logo', () => {
+    render(<Header />)
+    expect(screen.getAllByAltText('Safe logo')[0]).toBeInTheDocument()
+  })
+
+  it('renders the BatchIndicator when showBatchButton is true', () => {
+    jest.spyOn(useSafeAddress, 'default').mockReturnValue(faker.finance.ethereumAddress())
+    jest.spyOn(useProposers, 'useIsWalletProposer').mockReturnValue(false)
+    jest.spyOn(useIsSafeOwner, 'default').mockReturnValue(false)
+
+    render(<Header />)
+    expect(screen.getByTitle('Batch')).toBeInTheDocument()
+  })
+
+  it('does not render the BatchIndicator when there is no safe address', () => {
+    jest.spyOn(useSafeAddress, 'default').mockReturnValue('')
+
+    render(<Header />)
+    expect(screen.queryByTitle('Batch')).not.toBeInTheDocument()
+  })
+
+  it('does not render the BatchIndicator when connected wallet is a proposer', () => {
+    jest.spyOn(useProposers, 'useIsWalletProposer').mockReturnValue(true)
+
+    render(<Header />)
+    expect(screen.queryByTitle('Batch')).not.toBeInTheDocument()
+  })
+
+  it('renders the WalletConnect component when enableWc is true', () => {
+    jest.spyOn(useChains, 'useHasFeature').mockReturnValue(true)
+
+    render(<Header />)
+    expect(screen.getByText('WalletConnect')).toBeInTheDocument()
+  })
+
+  it('does not render the WalletConnect component when enableWc is false', () => {
+    jest.spyOn(useChains, 'useHasFeature').mockReturnValue(false)
+
+    render(<Header />)
+    expect(screen.queryByText('WalletConnect')).not.toBeInTheDocument()
+  })
+
+  it('renders the NetworkSelector when safeAddress exists', () => {
+    jest.spyOn(useSafeAddress, 'default').mockReturnValue(faker.finance.ethereumAddress())
+
+    render(<Header />)
+    expect(screen.getByText('NetworkSelector')).toBeInTheDocument()
+  })
+
+  it('does not render the NetworkSelector when safeAddress is falsy', () => {
+    jest.spyOn(useSafeAddress, 'default').mockReturnValue('')
+
+    render(<Header />)
+    expect(screen.queryByText('NetworkSelector')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -1,3 +1,5 @@
+import useIsSafeOwner from '@/hooks/useIsSafeOwner'
+import { useIsWalletProposer } from '@/hooks/useProposers'
 import type { Dispatch, SetStateAction } from 'react'
 import { type ReactElement } from 'react'
 import { useRouter } from 'next/router'
@@ -39,6 +41,8 @@ function getLogoLink(router: ReturnType<typeof useRouter>): Url {
 const Header = ({ onMenuToggle, onBatchToggle }: HeaderProps): ReactElement => {
   const safeAddress = useSafeAddress()
   const showSafeToken = useSafeTokenEnabled()
+  const isProposer = useIsWalletProposer()
+  const isSafeOwner = useIsSafeOwner()
   const router = useRouter()
   const enableWc = useHasFeature(FEATURES.NATIVE_WALLETCONNECT)
 
@@ -58,6 +62,8 @@ const Header = ({ onMenuToggle, onBatchToggle }: HeaderProps): ReactElement => {
       onBatchToggle((isOpen) => !isOpen)
     }
   }
+
+  const showBatchButton = safeAddress && (!isProposer || isSafeOwner)
 
   return (
     <Paper className={css.container}>
@@ -91,7 +97,7 @@ const Header = ({ onMenuToggle, onBatchToggle }: HeaderProps): ReactElement => {
         <NotificationCenter />
       </div>
 
-      {safeAddress && (
+      {showBatchButton && (
         <div className={classnames(css.element, css.hideMobile)}>
           <BatchIndicator onClick={handleBatchToggle} />
         </div>

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -203,10 +203,10 @@ export const SignOrExecuteForm = ({
       <TxCard>
         <ConfirmationTitle
           variant={
-            willExecute
-              ? ConfirmationTitleTypes.execute
-              : isProposing
+            isProposing
               ? ConfirmationTitleTypes.propose
+              : willExecute
+              ? ConfirmationTitleTypes.execute
               : ConfirmationTitleTypes.sign
           }
           isCreation={isCreation}

--- a/src/hooks/useIsOnlySpendingLimitBeneficiary.tsx
+++ b/src/hooks/useIsOnlySpendingLimitBeneficiary.tsx
@@ -1,3 +1,4 @@
+import { useIsWalletProposer } from '@/hooks/useProposers'
 import { FEATURES } from '@/utils/chains'
 import { useAppSelector } from '@/store'
 import { selectSpendingLimits } from '@/store/spendingLimitsSlice'
@@ -10,8 +11,9 @@ const useIsOnlySpendingLimitBeneficiary = (): boolean => {
   const spendingLimits = useAppSelector(selectSpendingLimits)
   const wallet = useWallet()
   const isSafeOwner = useIsSafeOwner()
+  const isProposer = useIsWalletProposer()
 
-  if (isSafeOwner || !isEnabled || spendingLimits.length === 0) {
+  if (isSafeOwner || !isEnabled || spendingLimits.length === 0 || isProposer) {
     return false
   }
 


### PR DESCRIPTION
## What it solves

Resolves SW-457
Resolves SW-458

## How this PR fixes it

- Hides the Batch button in the header when connected as a proposers
- Unit tested the Header components
- Offers transaction creation when proposer also has a spending limit

## How to test it

1. Open a Safe as a proposer
2. Observe no Batch button in the header
3. Open a Safe as an owner who is also a proposer
4. Observe there is a Batch button in the header
5. Open a Safe as a proposer who also has a spending limit
6. Create a new transaction
7. Observe both options for sending funds

## Screenshots

<img width="706" alt="Screenshot 2024-11-01 at 11 51 10" src="https://github.com/user-attachments/assets/c998f206-fa01-4c2b-9063-7bb170fa375b">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
