### PR TITLE
fix: upgrade transactions for 1.0.0 Safes

### DIFF
--- a/src/services/tx/__tests__/safeUpdateParams.test.ts
+++ b/src/services/tx/__tests__/safeUpdateParams.test.ts
@@ -30,7 +30,7 @@ describe('safeUpgradeParams', () => {
 
   jest.spyOn(sdkHelpers, 'getSafeProvider').mockImplementation(() => getMockSafeProviderForChain(1))
 
-  it('Should add setFallbackHandler transaction data for older 1.0.0 Safes', async () => {
+  it('Should add setFallbackHandler transaction data for 1.0.0 Safes', async () => {
     const mockSafe = {
       address: {
         value: MOCK_SAFE_ADDRESS,

--- a/src/services/tx/__tests__/safeUpdateParams.test.ts
+++ b/src/services/tx/__tests__/safeUpdateParams.test.ts
@@ -30,7 +30,7 @@ describe('safeUpgradeParams', () => {
 
   jest.spyOn(sdkHelpers, 'getSafeProvider').mockImplementation(() => getMockSafeProviderForChain(1))
 
-  it('Should add empty setFallbackHandler transaction data for older Safes', async () => {
+  it('Should add setFallbackHandler transaction data for older 1.0.0 Safes', async () => {
     const mockSafe = {
       address: {
         value: MOCK_SAFE_ADDRESS,
@@ -58,7 +58,12 @@ describe('safeUpgradeParams', () => {
     // Check setFallbackHandler
     expect(sameAddress(fallbackHandlerTx.to, MOCK_SAFE_ADDRESS)).toBeTruthy()
     expect(fallbackHandlerTx.value).toEqual('0')
-    expect(fallbackHandlerTx.data).toEqual('0x')
+    expect(
+      sameAddress(
+        decodeSetFallbackHandlerAddress(fallbackHandlerTx.data),
+        getFallbackHandlerDeployment({ version: getLatestSafeVersion(mockChainInfo), network: '1' })?.defaultAddress,
+      ),
+    ).toBeTruthy()
   })
 
   it('Should upgrade L1 safe to L1 1.4.1', async () => {


### PR DESCRIPTION
## What it solves
Upgrade transactions for 1.0.0 Safes included an empty transaction instead of the `setFallbackHandler` call.

## How this PR fixes it
Uses the Safe contract interface of the upgraded Safe's version instead of the current Safe's version.
This is correct as we first upgrade and change the masterCopy and then set the FallbackHandler.

## How to test it
- Create a 1.0.0 Safe on e.g. Gnosis Chain
- Upgrade it to 1.4.1 through our interface

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
