### PR TITLE
[ SW-467 ] fix(threshold-info): Display right info in the change threshold confirmation screen

### DIFF
--- a/src/components/tx-flow/flows/ChangeThreshold/context.tsx
+++ b/src/components/tx-flow/flows/ChangeThreshold/context.tsx
@@ -1,5 +1,3 @@
 import { createContext } from 'react'
 
-export const ChangeThresholdReviewContext = createContext({
-  newThreshold: 0,
-})
+export const ChangeThresholdReviewContext = createContext<{ newThreshold?: number }>({})

--- a/src/components/tx/confirmation-views/ChangeThreshold/ChangeThreshold.stories.tsx
+++ b/src/components/tx/confirmation-views/ChangeThreshold/ChangeThreshold.stories.tsx
@@ -30,4 +30,6 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+export const Default: Story = {
+  args: {},
+}

--- a/src/components/tx/confirmation-views/ChangeThreshold/index.tsx
+++ b/src/components/tx/confirmation-views/ChangeThreshold/index.tsx
@@ -5,8 +5,8 @@ import commonCss from '@/components/tx-flow/common/styles.module.css'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { ChangeThresholdReviewContext } from '@/components/tx-flow/flows/ChangeThreshold/context'
 import { ChangeSignerSetupWarning } from '@/features/multichain/components/SignerSetupWarning/ChangeSignerSetupWarning'
-import { SettingsInfoType, type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
-import { isSettingsChangeTxInfo } from '@/utils/transaction-guards'
+import { type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
+import { isChangeThresholdView } from '../utils'
 
 interface ChangeThresholdProps {
   txDetails?: TransactionDetails
@@ -15,11 +15,7 @@ interface ChangeThresholdProps {
 function ChangeThreshold({ txDetails }: ChangeThresholdProps) {
   const { safe } = useSafeInfo()
   const { newThreshold } = useContext(ChangeThresholdReviewContext)
-  const threshold =
-    txDetails &&
-    isSettingsChangeTxInfo(txDetails.txInfo) &&
-    txDetails.txInfo.settingsInfo?.type === SettingsInfoType.CHANGE_THRESHOLD &&
-    txDetails.txInfo.settingsInfo.threshold
+  const threshold = txDetails && isChangeThresholdView(txDetails.txInfo) && txDetails.txInfo.settingsInfo?.threshold
 
   return (
     <>

--- a/src/components/tx/confirmation-views/ChangeThreshold/index.tsx
+++ b/src/components/tx/confirmation-views/ChangeThreshold/index.tsx
@@ -5,10 +5,21 @@ import commonCss from '@/components/tx-flow/common/styles.module.css'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { ChangeThresholdReviewContext } from '@/components/tx-flow/flows/ChangeThreshold/context'
 import { ChangeSignerSetupWarning } from '@/features/multichain/components/SignerSetupWarning/ChangeSignerSetupWarning'
+import { SettingsInfoType, type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
+import { isSettingsChangeTxInfo } from '@/utils/transaction-guards'
 
-function ChangeThreshold() {
+interface ChangeThresholdProps {
+  txDetails?: TransactionDetails
+}
+
+function ChangeThreshold({ txDetails }: ChangeThresholdProps) {
   const { safe } = useSafeInfo()
   const { newThreshold } = useContext(ChangeThresholdReviewContext)
+  const threshold =
+    txDetails &&
+    isSettingsChangeTxInfo(txDetails.txInfo) &&
+    txDetails.txInfo.settingsInfo?.type === SettingsInfoType.CHANGE_THRESHOLD &&
+    txDetails.txInfo.settingsInfo.threshold
 
   return (
     <>
@@ -20,7 +31,7 @@ function ChangeThreshold() {
         </Typography>
 
         <Typography aria-label="threshold">
-          <b>{newThreshold}</b> out of <b>{safe.owners.length} signer(s)</b>
+          <b>{newThreshold || threshold}</b> out of <b>{safe.owners.length} signer(s)</b>
         </Typography>
       </div>
       <Box my={1}>

--- a/src/components/tx/confirmation-views/index.tsx
+++ b/src/components/tx/confirmation-views/index.tsx
@@ -29,7 +29,7 @@ const getConfirmationViewComponent = ({
   txInfo,
   txFlow,
 }: NarrowConfirmationViewProps & { txFlow?: JSX.Element }) => {
-  if (isChangeThresholdView(txInfo)) return <ChangeThreshold />
+  if (isChangeThresholdView(txInfo)) return <ChangeThreshold txDetails={txDetails} />
 
   if (isConfirmBatchView(txFlow)) return <BatchTransactions />
 

--- a/src/components/tx/confirmation-views/utils.ts
+++ b/src/components/tx/confirmation-views/utils.ts
@@ -1,4 +1,4 @@
-import type { TransactionInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import type { ChangeThreshold, SettingsChange, TransactionInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { SettingsInfoType, TransactionInfoType } from '@safe-global/safe-gateway-typescript-sdk'
 import { ConfirmBatchFlow } from '@/components/tx-flow/flows'
 
@@ -6,5 +6,7 @@ export const isSettingsChangeView = (txInfo: TransactionInfo) => txInfo.type ===
 
 export const isConfirmBatchView = (txFlow?: JSX.Element) => txFlow?.type === ConfirmBatchFlow
 
-export const isChangeThresholdView = (txInfo: TransactionInfo) =>
+export const isChangeThresholdView = (
+  txInfo: TransactionInfo,
+): txInfo is SettingsChange & { settingsInfo: ChangeThreshold } =>
   txInfo.type === TransactionInfoType.SETTINGS_CHANGE && txInfo.settingsInfo?.type === SettingsInfoType.CHANGE_THRESHOLD


### PR DESCRIPTION
## What it solves
Confirm threshold screen is showing 0 of (n) when user comes from the transaction list.

## How this PR fixes it
Before we were grabbing the threshold information from the changeThreshold screen flow, but this information is not available when user comes from the transactions list (for eg, in order to confirm a `change threshold` transaction)

## How to test it
- Change the threshold of your account
- sign but do not execute it
- go to the transaction list and try to confirm or execute it from there.
- The amount of required signers now should be working as expected instead of showing "0 out (n)"

## Screenshots
<img width="1183" alt="Screenshot 2024-11-04 at 12 21 11" src="https://github.com/user-attachments/assets/fdc8f344-581b-44fc-bd72-96e11c14ad6c">

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
