### PR TITLE
feat: Support hardware wallets for adding and removing proposers [SW-407]

### DIFF
--- a/src/features/proposers/components/DeleteProposerDialog.tsx
+++ b/src/features/proposers/components/DeleteProposerDialog.tsx
@@ -1,6 +1,6 @@
 import CheckWallet from '@/components/common/CheckWallet'
 import Track from '@/components/common/Track'
-import { getDelegateTypedData } from '@/features/proposers/utils/utils'
+import { signProposerData, signProposerTypedData } from '@/features/proposers/utils/utils'
 import useWallet from '@/hooks/wallets/useWallet'
 import DeleteIcon from '@/public/images/common/delete.svg'
 import { SETTINGS_EVENTS, trackEvent } from '@/services/analytics'
@@ -8,7 +8,7 @@ import { useAppDispatch } from '@/store'
 import { useDeleteProposerMutation } from '@/store/api/gateway'
 import { showNotification } from '@/store/notificationsSlice'
 import { shortenAddress } from '@/utils/formatters'
-import { signTypedData } from '@/utils/web3'
+import { isHardwareWallet } from '@/utils/wallets'
 import type { Delegate } from '@safe-global/safe-gateway-typescript-sdk/dist/types/delegates'
 import React, { useState } from 'react'
 import {
@@ -57,11 +57,20 @@ const _DeleteProposer = ({ wallet, safeAddress, chainId, proposer }: DeletePropo
     }
 
     try {
+      const hardwareWallet = isHardwareWallet(wallet)
       const signer = await getAssertedChainSigner(wallet.provider)
-      const typedData = getDelegateTypedData(chainId, proposer.delegate)
-      const signature = await signTypedData(signer, typedData)
+      const signature = hardwareWallet
+        ? await signProposerData(proposer.delegate, signer)
+        : await signProposerTypedData(chainId, proposer.delegate, signer)
 
-      await deleteProposer({ chainId, delegateAddress: proposer.delegate, safeAddress, signature })
+      await deleteProposer({
+        chainId,
+        delegateAddress: proposer.delegate,
+        delegator: proposer.delegator,
+        safeAddress,
+        signature,
+        isHardwareWallet: hardwareWallet,
+      })
 
       trackEvent(SETTINGS_EVENTS.PROPOSERS.SUBMIT_REMOVE_PROPOSER)
 

--- a/src/features/proposers/utils/utils.ts
+++ b/src/features/proposers/utils/utils.ts
@@ -1,4 +1,7 @@
-export const getDelegateTypedData = (chainId: string, delegateAddress: string) => {
+import { signTypedData } from '@/utils/web3'
+import type { JsonRpcSigner } from 'ethers'
+
+const getProposerDataV2 = (chainId: string, proposerAddress: string) => {
   const totp = Math.floor(Date.now() / 1000 / 3600)
 
   const domain = {
@@ -15,7 +18,7 @@ export const getDelegateTypedData = (chainId: string, delegateAddress: string) =
   }
 
   const message = {
-    delegateAddress,
+    delegateAddress: proposerAddress,
     totp,
   }
 
@@ -24,4 +27,21 @@ export const getDelegateTypedData = (chainId: string, delegateAddress: string) =
     types,
     message,
   }
+}
+
+export const signProposerTypedData = async (chainId: string, proposerAddress: string, signer: JsonRpcSigner) => {
+  const typedData = getProposerDataV2(chainId, proposerAddress)
+  return signTypedData(signer, typedData)
+}
+
+const getProposerDataV1 = (proposerAddress: string) => {
+  const totp = Math.floor(Date.now() / 1000 / 3600)
+
+  return `${proposerAddress}${totp}`
+}
+
+export const signProposerData = (proposerAddress: string, signer: JsonRpcSigner) => {
+  const data = getProposerDataV1(proposerAddress)
+
+  return signer.signMessage(data)
 }


### PR DESCRIPTION
## What it solves

Resolves SW-407

## How this PR fixes it

- Uses the v1 endpoints for adding and deleting a proposer when a hardware wallet is detected

## How to test it

1. Connect with a hardware wallet (Alternatively hard-code the `isHardwareWallet` to be true)
2. Go to the settings page and add a proposer
3. Observe the message to be signed is not typed data
4. Observe a success message
5. Delete a proposer
6. Observe the message to be signed is not typed data
7. Observe a success message

## Screenshots
<img width="1037" alt="Screenshot 2024-11-04 at 12 42 06" src="https://github.com/user-attachments/assets/c8ed6922-2ac7-4a5f-b677-83565445a1df">
<img width="1073" alt="Screenshot 2024-11-04 at 12 42 40" src="https://github.com/user-attachments/assets/e21987ae-56db-4d25-b21e-751f3b9534ed">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
