### PR TITLE
feat: add "Featured apps" section to Safe Apps

### DIFF
--- a/src/components/safe-apps/SafeAppList/index.tsx
+++ b/src/components/safe-apps/SafeAppList/index.tsx
@@ -22,6 +22,7 @@ type SafeAppListProps = {
   title: string
   query?: string
   isFiltered?: boolean
+  showNativeSwapsCard?: boolean
 }
 
 const SafeAppList = ({
@@ -34,6 +35,7 @@ const SafeAppList = ({
   title,
   query,
   isFiltered = false,
+  showNativeSwapsCard = false,
 }: SafeAppListProps) => {
   const { isPreviewDrawerOpen, previewDrawerApp, openPreviewDrawer, closePreviewDrawer } = useSafeAppPreviewDrawer()
   const { openedSafeAppIds } = useOpenedSafeApps()
@@ -72,7 +74,7 @@ const SafeAppList = ({
             </li>
           ))}
 
-        {!isFiltered && !addCustomApp && <NativeSwapsCard />}
+        {!isFiltered && showNativeSwapsCard && <NativeSwapsCard />}
 
         {/* Flat list filtered by search query */}
         {safeAppsList.map((safeApp) => (

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { useCallback, useEffect, useMemo } from 'react'
 import debounce from 'lodash/debounce'
+import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
 
 import { useSafeApps } from '@/hooks/safe-apps/useSafeApps'
 import SafeAppsSDKLink from '@/components/safe-apps/SafeAppsSDKLink'
@@ -21,6 +22,11 @@ const SafeApps: NextPage = () => {
     useSafeAppsFilters(remoteSafeApps)
   const isFiltered = filteredApps.length !== remoteSafeApps.length
   const isSafeAppsEnabled = useHasFeature(FEATURES.SAFE_APPS)
+
+  const featuredSafeApps = useMemo(() => {
+    // TODO: Remove assertion after migrating to new SDK
+    return remoteSafeApps.filter((app) => (app as SafeAppData & { featured: boolean }).featured)
+  }, [remoteSafeApps])
 
   const nonPinnedApps = useMemo(
     () => remoteSafeApps.filter((app) => !pinnedSafeAppIds.has(app.id)),
@@ -70,6 +76,16 @@ const SafeApps: NextPage = () => {
           />
         )}
 
+        {/* Featured apps */}
+        {!isFiltered && featuredSafeApps.length > 0 && (
+          <SafeAppList
+            title="Featured apps"
+            safeAppsList={featuredSafeApps}
+            bookmarkedSafeAppsId={pinnedSafeAppIds}
+            onBookmarkSafeApp={togglePin}
+          />
+        )}
+
         {/* All apps */}
         <SafeAppList
           title="All apps"
@@ -79,6 +95,7 @@ const SafeApps: NextPage = () => {
           bookmarkedSafeAppsId={pinnedSafeAppIds}
           onBookmarkSafeApp={togglePin}
           query={query}
+          showNativeSwapsCard
         />
       </main>
     </>


### PR DESCRIPTION
## What it solves

Adds a new "Featured apps" section to Safe Apps

## How this PR fixes it

A [new `featured` flag](https://github.com/safe-global/safe-client-gateway/pull/2085) is returned with each Safe App.

This adds a new "Featured apps" section above "All apps" on the Safe Apps page. Said section is not shown if there are no featuredApps on the given chain, or there is a search term. Should pinned Apps exist, they are above those featured.

## How to test it

1. On the Safe Apps pane, observing the following:
  - "Featured apps" is only shown if App(s) are `featured` on the chain
  - "Featured apps" is below "My pinned apps"
  - "Featured apps" is above "All apps"
  - "Featured apps" is not shown if there is a search term
  - "Featured apps" is not shown on the "My custom apps" tab
 
Note: as of the creation of the PR, Transaction Builder is `featured`.

## Screenshots

![image](https://github.com/user-attachments/assets/91c112be-5aa1-4a0c-a372-29d032a82446)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
