### PR TITLE
feat: Display creator in the proposer list [SW-408] [SW-470]

### DIFF
--- a/src/components/settings/ProposersList/index.tsx
+++ b/src/components/settings/ProposersList/index.tsx
@@ -15,6 +15,21 @@ import ExternalLink from '@/components/common/ExternalLink'
 import { HelpCenterArticle } from '@/config/constants'
 import React, { useMemo, useState } from 'react'
 
+const headCells = [
+  {
+    id: 'proposer',
+    label: 'Proposer',
+  },
+  {
+    id: 'creator',
+    label: 'Creator',
+  },
+  {
+    id: 'Actions',
+    label: '',
+  },
+]
+
 const ProposersList = () => {
   const [isAddDialogOpen, setIsAddDialogOpen] = useState<boolean>()
   const proposers = useProposers()
@@ -33,9 +48,14 @@ const ProposersList = () => {
                 showCopyButton
                 hasExplorer
                 name={proposer.label || undefined}
-                shortAddress={false}
+                shortAddress
               />
             ),
+          },
+
+          creator: {
+            rawValue: proposer.delegator,
+            content: <EthHashInfo address={proposer.delegator} showCopyButton hasExplorer shortAddress />,
           },
           actions: {
             rawValue: '',
@@ -94,7 +114,7 @@ const ProposersList = () => {
               </CheckWallet>
             </Box>
 
-            {rows.length > 0 && <EnhancedTable rows={rows} headCells={[]} />}
+            {rows.length > 0 && <EnhancedTable rows={rows} headCells={headCells} />}
           </Grid>
 
           {isAddDialogOpen && (

--- a/src/features/proposers/components/DeleteProposerDialog.tsx
+++ b/src/features/proposers/components/DeleteProposerDialog.tsx
@@ -1,5 +1,6 @@
 import CheckWallet from '@/components/common/CheckWallet'
 import Track from '@/components/common/Track'
+import NetworkWarning from '@/components/new-safe/create/NetworkWarning'
 import { getDelegateTypedData } from '@/features/proposers/utils/utils'
 import useWallet from '@/hooks/wallets/useWallet'
 import DeleteIcon from '@/public/images/common/delete.svg'
@@ -92,6 +93,8 @@ const _DeleteProposer = ({ wallet, safeAddress, chainId, proposer }: DeletePropo
   const onCancel = () => {
     trackEvent(SETTINGS_EVENTS.PROPOSERS.CANCEL_REMOVE_PROPOSER)
     setOpen(false)
+    setIsLoading(false)
+    setError(undefined)
   }
 
   const canDelete = wallet?.address === proposer.delegate || wallet?.address === proposer.delegator
@@ -144,7 +147,7 @@ const _DeleteProposer = ({ wallet, safeAddress, chainId, proposer }: DeletePropo
         <Divider />
 
         <DialogContent>
-          <Box>
+          <Box mb={2}>
             <Typography>
               Deleting this proposer will permanently remove the address, and it won&apos;t be able to suggest
               transactions anymore.
@@ -159,6 +162,8 @@ const _DeleteProposer = ({ wallet, safeAddress, chainId, proposer }: DeletePropo
               <ErrorMessage error={error}>Error deleting proposer</ErrorMessage>
             </Box>
           )}
+
+          <NetworkWarning action="sign" />
         </DialogContent>
 
         <Divider />
@@ -168,18 +173,22 @@ const _DeleteProposer = ({ wallet, safeAddress, chainId, proposer }: DeletePropo
             No, keep it
           </Button>
 
-          <Button
-            size="small"
-            variant="danger"
-            onClick={onConfirm}
-            disabled={isLoading || !canDelete}
-            sx={{
-              minWidth: '122px',
-              minHeight: '36px',
-            }}
-          >
-            {isLoading ? <CircularProgress size={20} /> : 'Yes, delete'}
-          </Button>
+          <CheckWallet checkNetwork={!isLoading}>
+            {(isOk) => (
+              <Button
+                size="small"
+                variant="danger"
+                onClick={onConfirm}
+                disabled={!isOk || isLoading || !canDelete}
+                sx={{
+                  minWidth: '122px',
+                  minHeight: '36px',
+                }}
+              >
+                {isLoading ? <CircularProgress size={20} /> : 'Yes, delete'}
+              </Button>
+            )}
+          </CheckWallet>
         </DialogActions>
       </Dialog>
     </>

--- a/src/features/proposers/components/DeleteProposerDialog.tsx
+++ b/src/features/proposers/components/DeleteProposerDialog.tsx
@@ -61,7 +61,13 @@ const _DeleteProposer = ({ wallet, safeAddress, chainId, proposer }: DeletePropo
       const typedData = getDelegateTypedData(chainId, proposer.delegate)
       const signature = await signTypedData(signer, typedData)
 
-      await deleteProposer({ chainId, delegateAddress: proposer.delegate, safeAddress, signature })
+      await deleteProposer({
+        chainId,
+        delegateAddress: proposer.delegate,
+        delegator: wallet.address,
+        safeAddress,
+        signature,
+      })
 
       trackEvent(SETTINGS_EVENTS.PROPOSERS.SUBMIT_REMOVE_PROPOSER)
 

--- a/src/store/api/gateway/proposers.ts
+++ b/src/store/api/gateway/proposers.ts
@@ -74,8 +74,6 @@ export const proposerEndpoints = (
             (proposer: Delegate) => proposer.delegate === delegate && delegator === proposer.delegator,
           )
 
-          console.log(existingProposer)
-
           if (existingProposer !== -1) {
             // Update the existing delegate's label
             draft.results[existingProposer] = {


### PR DESCRIPTION
## What it solves

Resolves SW-408
Resolves SW-470

## How this PR fixes it

- Tightens validation when doing optimistic updates to the proposer list
- Displays the creator address in the proposer list

## How to test it

1. Open the settings and create a proposer
2. Observe the creator address is shown next to them
3. Add the same proposer twice with 2 different owners
4. Delete one of them
5. Observe the other proposer is still visible in the list
6. Add the same proposer twice with 2 different owners
7. Update the name of one of them
8. Observe the correct entry is updated

## Screenshots
<img width="826" alt="Screenshot 2024-11-04 at 17 58 48" src="https://github.com/user-attachments/assets/d6a3b027-3437-4aba-b5db-259150b01749">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
