### PR TITLE
Slim Down Docker Image (Attempt 2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,39 @@
-FROM node:18-alpine
+FROM --platform=$BUILDPLATFORM node:18-alpine AS build
+ARG BUILDPLATFORM
+
+# install build dependencies
 RUN apk add --no-cache libc6-compat git python3 py3-pip make g++ libusb-dev eudev-dev linux-headers
 WORKDIR /app
 COPY . .
 
-# Fix arm64 timeouts
-RUN yarn config set network-timeout 300000 && yarn global add node-gyp
-
-# install deps
+# install NPM dependencies
 RUN yarn install --frozen-lockfile
 RUN yarn after-install
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
-# Next.js collects completely anonymous telemetry data about general usage.
-# Learn more here: https://nextjs.org/telemetry
-# Uncomment the following line in case you want to disable telemetry during the build.
-ENV NEXT_TELEMETRY_DISABLED 1
+# disable Next.js telemetry
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN yarn build
+
+FROM alpine
+
+RUN apk add busybox-extras tini
+WORKDIR /www
+COPY --from=build /app/out /www
+
+# Next.js automatically adds `.html` extensions to URLs, but static HTTP file
+# servers don't generally do this. You can work around this by creating symbolic
+# links from `my-page.html` to either `my-page/index.html` or `my-page`
+# depending on whether or not a `my-page` directory exists.
+RUN find /www -name '*.html' -exec sh -c 'f="{}"; b="${f%.*}"; [ -d "$b" ] && ln -s "$f" "$b/index.html" || ln -s "$f" "$b"' ';'
 
 EXPOSE 3000
 
-ENV PORT 3000
+ENV PORT=3000
+RUN echo '#!/bin/sh' > /usr/local/bin/docker-entrypoint.sh &&\
+    echo 'busybox-extras httpd -fvv -h /www -p 0.0.0.0:${PORT:-3000}' >> /usr/local/bin/docker-entrypoint.sh &&\
+    chmod +x /usr/local/bin/docker-entrypoint.sh
 
-CMD ["yarn", "static-serve"]
+CMD ["tini", "--", "docker-entrypoint.sh"]


### PR DESCRIPTION
## What it solves

This is a long awaited follow up to #3707, which reduces the Docker image size of the web interface from ~6GB to ~70MB. This iteration addresses build issues that it introduced in the previous version.

In particular, we now use a multi-stage Docker build, where building the web assets is done on the `BUILDPLATFORM` (i.e. the native build platform) instead of the target platform. This means that the image for `linux/arm64` will first build the front-end on the native architecture of the CI runner (`linux/amd64` by default) before copying. This should make building the Docker image MUCH quicker, while still producing a multi-platform image, and avoid the Docker build timeouts that were happening in CI. Documentation on how `BUILDPLATFORM` works and can be used for cross-compilation can be found [here](https://docs.docker.com/build/building/multi-platform/#cross-compilation).

## How this PR fixes it

The docker image size is significantly reduced by using a multistage build where the first stage builds the static website, and the actual image just hosts the static webside (here using BusyBox `httpd` which is nice and lightweight).

This gets the image down to around 70MB, around 1% of the original image size _(sizes computed from Docker images built on amd64 Linux)_.

Note that there is one weird detail is that static HTTP servers typically don't have support for automatically adding `.html` endings to URL paths. It was worked around here with symlinks. See comment in the Dockerfile for more details.

## How to test it

Build the docker image and run the container locally:

```sh
docker build . -t safe-wallet-web
docker run --rm -p 3000:3000 safe-wallet-web
```

This should give you a local interface at <http://localhost:3000>.

It was also able to successfully [build in CI](https://github.com/safe-global/safe-wallet-web/actions/runs/11686228763/job/32541499128?pr=4481) without timing out:

![image](https://github.com/user-attachments/assets/8c656f3b-634d-4dc2-b04e-69b6c0b08201)


## "Screenshots"

```
$ docker images
REPOSITORY                            TAG          IMAGE ID      CREATED             SIZE
localhost/safe-wallet-web             latest       a78bd066aacd  About a minute ago  67.1 MB
```

## Checklist

* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
    * Analytics are not affected
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
    * Not applicable
