### PR TITLE
Feat(sidebar): filter safes by search query [SW-305]

### DIFF
--- a/cypress/e2e/pages/sidebar.pages.js
+++ b/cypress/e2e/pages/sidebar.pages.js
@@ -30,7 +30,7 @@ const readOnlyVisibility = '[data-testid="read-only-visibility"]'
 const currencySection = '[data-testid="currency-section"]'
 const missingSignatureInfo = '[data-testid="missing-signature-info"]'
 const queuedTxInfo = '[data-testid="queued-tx-info"]'
-const showMoreBtn = '[data-testid="show-more-btn" ]'
+const expandSafesList = '[data-testid="expand-safes-list" ]'
 const importBtn = '[data-testid="import-btn"]'
 export const pendingActivationIcon = '[data-testid="pending-activation-icon"]'
 const safeItemMenuIcon = '[data-testid="MoreVertIcon"]'
@@ -77,10 +77,9 @@ export function clickOnSidebarImportBtn() {
 
 export function showAllSafes() {
   cy.get('body').then(($body) => {
-    if ($body.find(showMoreBtn).length > 0) {
-      cy.get(showMoreBtn).click()
+    if ($body.find(expandSafesList).length > 0) {
+      cy.get(expandSafesList).click()
       cy.wait(500)
-      showAllSafes()
     }
   })
 }

--- a/src/components/welcome/MyAccounts/OrderByButton.tsx
+++ b/src/components/welcome/MyAccounts/OrderByButton.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Button, ListItemText, MenuItem, SvgIcon } from '@mui/material'
+import { Box, Button, ListItemText, MenuItem, SvgIcon, Typography } from '@mui/material'
 import ContextMenu from '@/components/common/ContextMenu'
 import TransactionsIcon from '@/public/images/transactions/transactions.svg'
 import CheckIcon from '@/public/images/common/check.svg'
@@ -8,6 +8,11 @@ import { OrderByOption } from '@/store/orderByPreferenceSlice'
 type OrderByButtonProps = {
   orderBy: OrderByOption
   onOrderByChange: (orderBy: OrderByOption) => void
+}
+
+const orderByLabels = {
+  [OrderByOption.LAST_VISITED]: 'Most recent',
+  [OrderByOption.NAME]: 'Name',
 }
 
 const OrderByButton = ({ orderBy: orderBy, onOrderByChange: onOrderByChange }: OrderByButtonProps) => {
@@ -27,14 +32,16 @@ const OrderByButton = ({ orderBy: orderBy, onOrderByChange: onOrderByChange }: O
   }
 
   return (
-    <>
+    <Box display="flex">
       <Button
         onClick={handleClick}
         startIcon={<SvgIcon component={TransactionsIcon} inheritViewBox />}
-        sx={{ color: 'text.secondary' }}
+        sx={{ color: 'primary.light', fontWeight: 'normal' }}
         size="small"
       >
-        Sort
+        <Typography variant="body2" noWrap>
+          Sort by: {orderByLabels[orderBy]}
+        </Typography>
       </Button>
 
       <ContextMenu
@@ -56,15 +63,15 @@ const OrderByButton = ({ orderBy: orderBy, onOrderByChange: onOrderByChange }: O
           onClick={() => handleOrderByChange(OrderByOption.LAST_VISITED)}
           selected={orderBy === OrderByOption.LAST_VISITED}
         >
-          <ListItemText sx={{ mr: 2 }}>Most recent</ListItemText>
+          <ListItemText sx={{ mr: 2 }}>{orderByLabels[OrderByOption.LAST_VISITED]}</ListItemText>
           {orderBy === OrderByOption.LAST_VISITED && <CheckIcon sx={{ ml: 1 }} />}
         </MenuItem>
         <MenuItem onClick={() => handleOrderByChange(OrderByOption.NAME)} selected={orderBy === OrderByOption.NAME}>
-          <ListItemText>Name</ListItemText>
+          <ListItemText>{orderByLabels[OrderByOption.NAME]}</ListItemText>
           {orderBy === OrderByOption.NAME && <CheckIcon sx={{ ml: 1 }} />}
         </MenuItem>
       </ContextMenu>
-    </>
+    </Box>
   )
 }
 

--- a/src/components/welcome/MyAccounts/SafesList.tsx
+++ b/src/components/welcome/MyAccounts/SafesList.tsx
@@ -34,7 +34,11 @@ const SafesList = ({ safes, onLinkClick, useTransitions = true }: SafeListProps)
       ))}
     </TransitionGroup>
   ) : (
-    <>{safes.map((item) => renderSafeItem(item, onLinkClick))}</>
+    <>
+      {safes.map((item) => (
+        <div key={item.address}>{renderSafeItem(item, onLinkClick)}</div>
+      ))}
+    </>
   )
 }
 

--- a/src/components/welcome/MyAccounts/SafesList.tsx
+++ b/src/components/welcome/MyAccounts/SafesList.tsx
@@ -4,32 +4,37 @@ import { type MultiChainSafeItem } from './useAllSafesGrouped'
 import MultiAccountItem from './MultiAccountItem'
 import { isMultiChainSafeItem } from '@/features/multichain/utils/utils'
 import { TransitionGroup } from 'react-transition-group'
-import Collapse from '@mui/material/Collapse'
+import { Collapse } from '@mui/material'
 
 type SafeListProps = {
   safes?: (SafeItem | MultiChainSafeItem)[]
   onLinkClick?: () => void
+  useTransitions?: boolean
 }
 
-export const SafesList = ({ safes, onLinkClick }: SafeListProps) => {
+const renderSafeItem = (item: SafeItem | MultiChainSafeItem, onLinkClick?: () => void) => {
+  return isMultiChainSafeItem(item) ? (
+    <MultiAccountItem onLinkClick={onLinkClick} multiSafeAccountItem={item} />
+  ) : (
+    <AccountItem onLinkClick={onLinkClick} safeItem={item} />
+  )
+}
+
+const SafesList = ({ safes, onLinkClick, useTransitions = true }: SafeListProps) => {
   if (!safes || safes.length === 0) {
     return null
   }
 
-  return (
+  return useTransitions ? (
     <TransitionGroup>
-      {safes.map((item) =>
-        isMultiChainSafeItem(item) ? (
-          <Collapse key={item.address} timeout="auto">
-            <MultiAccountItem onLinkClick={onLinkClick} multiSafeAccountItem={item} />
-          </Collapse>
-        ) : (
-          <Collapse key={item.address} timeout="auto">
-            <AccountItem onLinkClick={onLinkClick} safeItem={item} key={item.chainId + item.address} />
-          </Collapse>
-        ),
-      )}
+      {safes.map((item) => (
+        <Collapse key={item.address} timeout="auto">
+          {renderSafeItem(item, onLinkClick)}
+        </Collapse>
+      ))}
     </TransitionGroup>
+  ) : (
+    <>{safes.map((item) => renderSafeItem(item, onLinkClick))}</>
   )
 }
 

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import {
   Accordion,
   AccordionDetails,
@@ -13,6 +13,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material'
+import debounce from 'lodash/debounce'
 import madProps from '@/utils/mad-props'
 import CreateButton from './CreateButton'
 import AddIcon from '@/public/images/common/add.svg'
@@ -20,11 +21,10 @@ import Track from '@/components/common/Track'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
 import { DataWidget } from '@/components/welcome/MyAccounts/DataWidget'
 import css from './styles.module.css'
-import { SafesList } from './SafesList'
+import SafesList from './SafesList'
 import { AppRoutes } from '@/config/routes'
 import useWallet from '@/hooks/wallets/useWallet'
 import { useRouter } from 'next/router'
-import useTrackSafesCount from './useTrackedSafesCount'
 import { type AllSafesGrouped, useAllSafesGrouped, type MultiChainSafeItem } from './useAllSafesGrouped'
 import { type SafeItem } from './useAllSafes'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
@@ -36,6 +36,8 @@ import SearchIcon from '@/public/images/common/search.svg'
 import type { OrderByOption } from '@/store/orderByPreferenceSlice'
 import { selectOrderByPreference, setOrderByPreference } from '@/store/orderByPreferenceSlice'
 import { useAppDispatch, useAppSelector } from '@/store'
+import { useSafesSearch } from './useSafesSearch'
+import useTrackSafesCount from './useTrackedSafesCount'
 
 type AccountsListProps = {
   safes: AllSafesGrouped
@@ -49,11 +51,13 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
   const { orderBy } = useAppSelector(selectOrderByPreference)
   const dispatch = useAppDispatch()
   const sortComparator = getComparator(orderBy)
+  const [searchQuery, setSearchQuery] = useState('')
 
   const allSafes = useMemo(
     () => [...(safes.allMultiChainSafes ?? []), ...(safes.allSingleSafes ?? [])].sort(sortComparator),
     [safes.allMultiChainSafes, safes.allSingleSafes, sortComparator],
   )
+  const filteredSafes = useSafesSearch(allSafes ?? [], searchQuery).sort(sortComparator)
 
   // We consider a multiChain account owned if at least one of the multiChain accounts is not on the watchlist
   const ownedMultiChainSafes = useMemo(
@@ -86,6 +90,9 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
   const handleOrderByChange = (orderBy: OrderByOption) => {
     dispatch(setOrderByPreference({ orderBy }))
   }
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const handleSearch = useCallback(debounce(setSearchQuery, 300), [])
 
   useTrackSafesCount(ownedSafes, watchlistSafes, wallet)
 
@@ -129,7 +136,9 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
                 aria-label="Search Safe list by name"
                 variant="filled"
                 hiddenLabel
-                onChange={() => {}}
+                onChange={(e) => {
+                  handleSearch(e.target.value)
+                }}
                 InputProps={{
                   startAdornment: (
                     <InputAdornment position="start">
@@ -148,61 +157,84 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
           {isSidebar && <Divider />}
 
           <Paper className={css.safeList}>
-            {/* Pinned Accounts */}
-            <Box mb={2} minHeight="170px">
-              <div className={css.listHeader}>
-                <SvgIcon
-                  component={BookmarkIcon}
-                  inheritViewBox
-                  fontSize="small"
-                  sx={{ mt: '2px', mr: 1, strokeWidth: 2 }}
-                />
+            {/* Search results */}
+            {searchQuery ? (
+              <>
                 <Typography variant="h5" fontWeight={700} mb={2}>
-                  Pinned
+                  Found {filteredSafes.length} result{filteredSafes.length === 1 ? '' : 's'}
                 </Typography>
-              </div>
-              {pinnedSafes.length > 0 ? (
-                <SafesList safes={pinnedSafes} onLinkClick={onLinkClick} />
-              ) : (
-                <Box className={css.noPinnedSafesMessage}>
-                  <Typography color="text.secondary" variant="body2" maxWidth="350px" textAlign="center">
-                    Personalize your account list by clicking the
+                <Box mt={1}>
+                  <SafesList safes={filteredSafes} onLinkClick={onLinkClick} useTransitions={false} />
+                </Box>
+              </>
+            ) : (
+              <>
+                {/* Pinned Accounts */}
+                <Box mb={2} minHeight="170px">
+                  <div className={css.listHeader}>
                     <SvgIcon
                       component={BookmarkIcon}
                       inheritViewBox
                       fontSize="small"
-                      sx={{ mx: '4px', color: 'text.secondary', position: 'relative', top: '2px' }}
+                      sx={{ mt: '2px', mr: 1, strokeWidth: 2 }}
                     />
-                    icon on the accounts most important to you.
-                  </Typography>
-                </Box>
-              )}
-            </Box>
-
-            {/* All Accounts */}
-            <Accordion defaultExpanded={pinnedSafes.length === 0} sx={{ border: 'none' }}>
-              <AccordionSummary
-                expandIcon={<ExpandMoreIcon sx={{ '& path': { fill: 'var(--color-text-secondary)' } }} />}
-                sx={{ padding: 0, '& .MuiAccordionSummary-content': { margin: '0 !important', mb: 1, flexGrow: 0 } }}
-              >
-                <div className={css.listHeader}>
-                  <Typography variant="h5" fontWeight={700}>
-                    Accounts
-                    {allSafes && allSafes.length > 0 && (
-                      <Typography component="span" color="text.secondary" fontSize="inherit" fontWeight="normal" mr={1}>
-                        {' '}
-                        ({allSafes.length})
+                    <Typography variant="h5" fontWeight={700} mb={2}>
+                      Pinned
+                    </Typography>
+                  </div>
+                  {pinnedSafes.length > 0 ? (
+                    <SafesList safes={pinnedSafes} onLinkClick={onLinkClick} />
+                  ) : (
+                    <Box className={css.noPinnedSafesMessage}>
+                      <Typography color="text.secondary" variant="body2" maxWidth="350px" textAlign="center">
+                        Personalize your account list by clicking the
+                        <SvgIcon
+                          component={BookmarkIcon}
+                          inheritViewBox
+                          fontSize="small"
+                          sx={{ mx: '4px', color: 'text.secondary', position: 'relative', top: '2px' }}
+                        />
+                        icon on the accounts most important to you.
                       </Typography>
-                    )}
-                  </Typography>
-                </div>
-              </AccordionSummary>
-              <AccordionDetails sx={{ padding: 0 }}>
-                <Box mt={1}>
-                  <SafesList safes={allSafes} onLinkClick={onLinkClick} />
+                    </Box>
+                  )}
                 </Box>
-              </AccordionDetails>
-            </Accordion>
+
+                {/* All Accounts */}
+                <Accordion sx={{ border: 'none' }}>
+                  <AccordionSummary
+                    expandIcon={<ExpandMoreIcon sx={{ '& path': { fill: 'var(--color-text-secondary)' } }} />}
+                    sx={{
+                      padding: 0,
+                      '& .MuiAccordionSummary-content': { margin: '0 !important', mb: 1, flexGrow: 0 },
+                    }}
+                  >
+                    <div className={css.listHeader}>
+                      <Typography variant="h5" fontWeight={700}>
+                        Accounts
+                        {allSafes && allSafes.length > 0 && (
+                          <Typography
+                            component="span"
+                            color="text.secondary"
+                            fontSize="inherit"
+                            fontWeight="normal"
+                            mr={1}
+                          >
+                            {' '}
+                            ({allSafes.length})
+                          </Typography>
+                        )}
+                      </Typography>
+                    </div>
+                  </AccordionSummary>
+                  <AccordionDetails sx={{ padding: 0 }}>
+                    <Box mt={1}>
+                      <SafesList safes={allSafes} onLinkClick={onLinkClick} />
+                    </Box>
+                  </AccordionDetails>
+                </Accordion>
+              </>
+            )}
           </Paper>
         </Paper>
         <DataWidget />

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -212,6 +212,7 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
                 {/* All Accounts */}
                 <Accordion sx={{ border: 'none' }}>
                   <AccordionSummary
+                    data-testid="expand-safes-list"
                     expandIcon={<ExpandMoreIcon sx={{ '& path': { fill: 'var(--color-text-secondary)' } }} />}
                     sx={{
                       padding: 0,

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -91,8 +91,12 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
     dispatch(setOrderByPreference({ orderBy }))
   }
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleSearch = useCallback(debounce(setSearchQuery, 300), [])
+  const handleSearch = useCallback((value: string) => {
+    const debouncedSearch = debounce((searchValue: string) => {
+      setSearchQuery(searchValue)
+    }, 300)
+    debouncedSearch(value)
+  }, [])
 
   useTrackSafesCount(ownedSafes, watchlistSafes, wallet)
 
@@ -142,7 +146,16 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
                 InputProps={{
                   startAdornment: (
                     <InputAdornment position="start">
-                      <SvgIcon component={SearchIcon} inheritViewBox color="border" fontSize="small" />
+                      <SvgIcon
+                        component={SearchIcon}
+                        inheritViewBox
+                        fontWeight="bold"
+                        fontSize="small"
+                        sx={{
+                          color: 'var(--color-border-main)',
+                          '.MuiInputBase-root.Mui-focused &': { color: 'var(--color-text-primary)' },
+                        }}
+                      />
                     </InputAdornment>
                   ),
                   disableUnderline: true,
@@ -160,7 +173,7 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
             {/* Search results */}
             {searchQuery ? (
               <>
-                <Typography variant="h5" fontWeight={700} mb={2}>
+                <Typography variant="h5" fontWeight="normal" mb={1} color="primary.light">
                   Found {filteredSafes.length} result{filteredSafes.length === 1 ? '' : 's'}
                 </Typography>
                 <Box mt={1}>

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -91,12 +91,8 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
     dispatch(setOrderByPreference({ orderBy }))
   }
 
-  const handleSearch = useCallback((value: string) => {
-    const debouncedSearch = debounce((searchValue: string) => {
-      setSearchQuery(searchValue)
-    }, 300)
-    debouncedSearch(value)
-  }, [])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const handleSearch = useCallback(debounce(setSearchQuery, 300), [])
 
   useTrackSafesCount(ownedSafes, watchlistSafes, wallet)
 

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -173,7 +173,7 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
             {/* Search results */}
             {searchQuery ? (
               <>
-                <Typography variant="h5" fontWeight="normal" mb={1} color="primary.light">
+                <Typography variant="h5" fontWeight="normal" mb={2} color="primary.light">
                   Found {filteredSafes.length} result{filteredSafes.length === 1 ? '' : 's'}
                 </Typography>
                 <Box mt={1}>

--- a/src/components/welcome/MyAccounts/useSafesSearch.ts
+++ b/src/components/welcome/MyAccounts/useSafesSearch.ts
@@ -1,13 +1,22 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import Fuse from 'fuse.js'
 import type { MultiChainSafeItem } from './useAllSafesGrouped'
 import type { SafeItem } from './useAllSafes'
 import { selectChains } from '@/store/chainsSlice'
 import { useAppSelector } from '@/store'
 import { isMultiChainSafeItem } from '@/features/multichain/utils/utils'
+import { OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
 
 const useSafesSearch = (safes: (SafeItem | MultiChainSafeItem)[], query: string): (SafeItem | MultiChainSafeItem)[] => {
   const chains = useAppSelector(selectChains)
+
+  useEffect(() => {
+    trackEvent({
+      category: OVERVIEW_EVENTS.SEARCH.category,
+      action: OVERVIEW_EVENTS.SEARCH.action,
+      label: query,
+    })
+  }, [query])
 
   // Include chain names in the search
   const safesWithChainNames = useMemo(

--- a/src/components/welcome/MyAccounts/useSafesSearch.ts
+++ b/src/components/welcome/MyAccounts/useSafesSearch.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react'
+import Fuse from 'fuse.js'
+import type { MultiChainSafeItem } from './useAllSafesGrouped'
+import type { SafeItem } from './useAllSafes'
+
+const useSafesSearch = (safes: (SafeItem | MultiChainSafeItem)[], query: string) => {
+  const fuse = useMemo(
+    () =>
+      new Fuse(safes, {
+        keys: [{ name: 'name' }],
+        threshold: 0.3,
+        findAllMatches: true,
+      }),
+    [safes],
+  )
+
+  const results = useMemo(() => (query ? fuse.search(query).map((result) => result.item) : []), [fuse, query])
+
+  return results
+}
+
+export { useSafesSearch }

--- a/src/components/welcome/MyAccounts/useSafesSearch.ts
+++ b/src/components/welcome/MyAccounts/useSafesSearch.ts
@@ -29,8 +29,9 @@ const useSafesSearch = (safes: (SafeItem | MultiChainSafeItem)[], query: string)
     () =>
       new Fuse(safesWithChainNames, {
         keys: [{ name: 'name' }, { name: 'address' }, { name: 'chainNames' }],
-        threshold: 0.3,
+        threshold: 0.2,
         findAllMatches: true,
+        ignoreLocation: true,
       }),
     [safesWithChainNames],
   )

--- a/src/components/welcome/MyAccounts/useSafesSearch.ts
+++ b/src/components/welcome/MyAccounts/useSafesSearch.ts
@@ -2,21 +2,50 @@ import { useMemo } from 'react'
 import Fuse from 'fuse.js'
 import type { MultiChainSafeItem } from './useAllSafesGrouped'
 import type { SafeItem } from './useAllSafes'
+import { selectChains } from '@/store/chainsSlice'
+import { useAppSelector } from '@/store'
+import { isMultiChainSafeItem } from '@/features/multichain/utils/utils'
 
-const useSafesSearch = (safes: (SafeItem | MultiChainSafeItem)[], query: string) => {
+const useSafesSearch = (safes: (SafeItem | MultiChainSafeItem)[], query: string): (SafeItem | MultiChainSafeItem)[] => {
+  const chains = useAppSelector(selectChains)
+
+  // Include chain names in the search
+  const safesWithChainNames = useMemo(
+    () =>
+      safes.map((safe) => {
+        if (isMultiChainSafeItem(safe)) {
+          const subChainNames = safe.safes.map(
+            (subSafe) => chains.data.find((chain) => chain.chainId === subSafe.chainId)?.chainName,
+          )
+          return { ...safe, chainNames: subChainNames }
+        }
+        const chain = chains.data.find((chain) => chain.chainId === safe.chainId)
+        return { ...safe, chainNames: [chain?.chainName] }
+      }),
+    [safes, chains.data],
+  )
+
   const fuse = useMemo(
     () =>
-      new Fuse(safes, {
-        keys: [{ name: 'name' }],
+      new Fuse(safesWithChainNames, {
+        keys: [{ name: 'name' }, { name: 'address' }, { name: 'chainNames' }],
         threshold: 0.3,
         findAllMatches: true,
       }),
-    [safes],
+    [safesWithChainNames],
   )
 
-  const results = useMemo(() => (query ? fuse.search(query).map((result) => result.item) : []), [fuse, query])
-
-  return results
+  // Return results in the original format
+  return useMemo(
+    () =>
+      query
+        ? fuse.search(query).map((result) => {
+            const { chainNames: _, ...safeWithoutChainNames } = result.item
+            return safeWithoutChainNames
+          })
+        : [],
+    [fuse, query],
+  )
 }
 
 export { useSafesSearch }

--- a/src/services/analytics/events/overview.ts
+++ b/src/services/analytics/events/overview.ts
@@ -57,6 +57,10 @@ export const OVERVIEW_EVENTS = {
     category: OVERVIEW_CATEGORY,
     event: EventType.META,
   },
+  SEARCH: {
+    action: 'Search safes',
+    category: OVERVIEW_CATEGORY,
+  },
   SIDEBAR: {
     action: 'Sidebar',
     category: OVERVIEW_CATEGORY,


### PR DESCRIPTION
## What it solves

Resolves: https://www.notion.so/safe-global/Add-search-to-safes-list-11f8180fe573800b952bd3189dca3b67?pvs=4

## How this PR fixes it
- When the user types in the search bar, renders a filtered list of all safes based on the search term.

## How to test it
- On the accounts page or sidebar, start typing in the search bar.
- Only safes with names matching the search query should be shown. It uses a fuzzy search, like the safe apps search.
- It should also match chain name and address

## Screenshots
![image](https://github.com/user-attachments/assets/ab383fdc-f7c7-443b-82ae-4f4acc93d1f1)


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
