### PR TITLE
Refactor Account Items to use Gradient Box

### DIFF
--- a/src/components/common/GradientBoxSafenet/index.tsx
+++ b/src/components/common/GradientBoxSafenet/index.tsx
@@ -7,18 +7,21 @@ const GradientBoxSafenet = ({
   children,
   className,
   style,
+  variant = 'full',
 }: {
   heading?: string
   children?: ReactNode
   className?: string
   style?: CSSProperties
+  variant?: 'full' | 'bottom'
 }) => {
+  const br = 'calc(var(--space-1) - 1px)'
   return (
     <Box
       className={className}
       style={{
         background: 'linear-gradient(90deg, #32f970 0%, #eed509 100%)',
-        borderRadius: 'calc(var(--space-1) - 1px)',
+        borderRadius: variant === 'full' ? br : `0 0 ${br} ${br}`,
         display: 'flex',
         alignItems: 'stretch',
         flexDirection: 'column',
@@ -26,26 +29,28 @@ const GradientBoxSafenet = ({
         ...style,
       }}
     >
-      <Box
-        style={{
-          color: 'var(--color-static-main)',
-          padding: 'calc(var(--space-1) / 2) var(--space-1)',
-          display: 'flex',
-          flexDirection: 'row',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-        }}
-      >
-        <SvgIcon component={SafenetIcon} inheritViewBox fontSize="small" />
-        <Typography variant="h5" fontSize="small">
-          {heading ?? 'Powered by Safenet'}
-        </Typography>
-      </Box>
+      {variant === 'full' && (
+        <Box
+          style={{
+            color: 'var(--color-static-main)',
+            padding: 'calc(var(--space-1) / 2) var(--space-1)',
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <SvgIcon component={SafenetIcon} inheritViewBox fontSize="small" />
+          <Typography variant="h5" fontSize="small">
+            {heading ?? 'Powered by Safenet'}
+          </Typography>
+        </Box>
+      )}
       <Box
         style={{
           background: 'var(--color-background-paper)',
           borderRadius: '0 0 var(--space-1) var(--space-1)',
-          margin: '1px',
+          margin: '0 1px 1px 1px',
         }}
       >
         {children}

--- a/src/components/common/GradientBoxSafenet/index.tsx
+++ b/src/components/common/GradientBoxSafenet/index.tsx
@@ -38,11 +38,10 @@ const GradientBoxSafenet = ({
       >
         <SvgIcon component={SafenetIcon} inheritViewBox fontSize="small" />
         <Typography variant="h5" fontSize="small">
-          {heading ?? 'Safenet'}
+          {heading ?? 'Powered by Safenet'}
         </Typography>
       </Box>
       <Box
-        className="GradientBoxSafenet-content"
         style={{
           background: 'var(--color-background-paper)',
           borderRadius: '0 0 var(--space-1) var(--space-1)',

--- a/src/components/sidebar/Sidebar/styles.module.css
+++ b/src/components/sidebar/Sidebar/styles.module.css
@@ -58,7 +58,7 @@
   cursor: pointer;
   border-right: 1px solid transparent;
   background-color: var(--color-background-main);
-  transform: translateX(-1px);
+  transform: translateX(-1px) translateY(90%);
 }
 
 .drawerButton:hover {

--- a/src/components/sidebar/SidebarHeader/index.tsx
+++ b/src/components/sidebar/SidebarHeader/index.tsx
@@ -31,6 +31,7 @@ import ExplorerButton from '@/components/common/ExplorerButton'
 import CopyTooltip from '@/components/common/CopyTooltip'
 import FiatValue from '@/components/common/FiatValue'
 import { useAddressResolver } from '@/hooks/useAddressResolver'
+import GradientBoxSafenet from '@/components/common/GradientBoxSafenet'
 
 const SafeHeader = (): ReactElement => {
   const { balances } = useVisibleBalances()
@@ -46,76 +47,78 @@ const SafeHeader = (): ReactElement => {
   const blockExplorerLink = chain ? getBlockExplorerLink(chain, safeAddress) : undefined
 
   return (
-    <div className={css.container}>
-      <div className={css.info}>
-        <div data-testid="safe-header-info" className={css.safe}>
-          <div data-testid="safe-icon">
-            {safeAddress ? (
-              <SafeIcon address={safeAddress} threshold={threshold} owners={owners?.length} />
-            ) : (
-              <Skeleton variant="circular" width={40} height={40} />
-            )}
-          </div>
-
-          <div className={css.address}>
-            {safeAddress ? (
-              <EthHashInfo address={safeAddress} shortAddress showAvatar={false} name={ens} />
-            ) : (
-              <Typography variant="body2">
-                <Skeleton variant="text" width={86} />
-                <Skeleton variant="text" width={120} />
-              </Typography>
-            )}
-
-            <Typography data-testid="currency-section" variant="body2" fontWeight={700}>
-              {safe.deployed ? (
-                balances.fiatTotal ? (
-                  <FiatValue value={balances.fiatTotal} />
-                ) : (
-                  <Skeleton variant="text" width={60} />
-                )
+    <GradientBoxSafenet variant="bottom">
+      <div className={css.container}>
+        <div className={css.info}>
+          <div data-testid="safe-header-info" className={css.safe}>
+            <div data-testid="safe-icon">
+              {safeAddress ? (
+                <SafeIcon address={safeAddress} threshold={threshold} owners={owners?.length} />
               ) : (
-                <TokenAmount
-                  value={balances.items[0]?.balance}
-                  decimals={balances.items[0]?.tokenInfo.decimals}
-                  tokenSymbol={balances.items[0]?.tokenInfo.symbol}
-                />
+                <Skeleton variant="circular" width={40} height={40} />
               )}
-            </Typography>
+            </div>
+
+            <div className={css.address}>
+              {safeAddress ? (
+                <EthHashInfo address={safeAddress} shortAddress showAvatar={false} name={ens} />
+              ) : (
+                <Typography variant="body2">
+                  <Skeleton variant="text" width={86} />
+                  <Skeleton variant="text" width={120} />
+                </Typography>
+              )}
+
+              <Typography data-testid="currency-section" variant="body2" fontWeight={700}>
+                {safe.deployed ? (
+                  balances.fiatTotal ? (
+                    <FiatValue value={balances.fiatTotal} />
+                  ) : (
+                    <Skeleton variant="text" width={60} />
+                  )
+                ) : (
+                  <TokenAmount
+                    value={balances.items[0]?.balance}
+                    decimals={balances.items[0]?.tokenInfo.decimals}
+                    tokenSymbol={balances.items[0]?.tokenInfo.symbol}
+                  />
+                )}
+              </Typography>
+            </div>
+          </div>
+
+          <div className={css.iconButtons}>
+            <Track {...OVERVIEW_EVENTS.SHOW_QR} label="sidebar">
+              <QrCodeButton>
+                <Tooltip title="Open QR code" placement="top">
+                  <IconButton className={css.iconButton}>
+                    <SvgIcon component={QrIconBold} inheritViewBox color="primary" fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              </QrCodeButton>
+            </Track>
+
+            <Track {...OVERVIEW_EVENTS.COPY_ADDRESS}>
+              <CopyTooltip text={addressCopyText}>
+                <IconButton data-testid="copy-address-btn" className={css.iconButton}>
+                  <SvgIcon component={CopyIconBold} inheritViewBox color="primary" fontSize="small" />
+                </IconButton>
+              </CopyTooltip>
+            </Track>
+
+            <Track {...OVERVIEW_EVENTS.OPEN_EXPLORER}>
+              <ExplorerButton {...blockExplorerLink} className={css.iconButton} icon={LinkIconBold} />
+            </Track>
+
+            <CounterfactualStatusButton />
+
+            <EnvHintButton />
           </div>
         </div>
 
-        <div className={css.iconButtons}>
-          <Track {...OVERVIEW_EVENTS.SHOW_QR} label="sidebar">
-            <QrCodeButton>
-              <Tooltip title="Open QR code" placement="top">
-                <IconButton className={css.iconButton}>
-                  <SvgIcon component={QrIconBold} inheritViewBox color="primary" fontSize="small" />
-                </IconButton>
-              </Tooltip>
-            </QrCodeButton>
-          </Track>
-
-          <Track {...OVERVIEW_EVENTS.COPY_ADDRESS}>
-            <CopyTooltip text={addressCopyText}>
-              <IconButton data-testid="copy-address-btn" className={css.iconButton}>
-                <SvgIcon component={CopyIconBold} inheritViewBox color="primary" fontSize="small" />
-              </IconButton>
-            </CopyTooltip>
-          </Track>
-
-          <Track {...OVERVIEW_EVENTS.OPEN_EXPLORER}>
-            <ExplorerButton {...blockExplorerLink} className={css.iconButton} icon={LinkIconBold} />
-          </Track>
-
-          <CounterfactualStatusButton />
-
-          <EnvHintButton />
-        </div>
+        <NewTxButton />
       </div>
-
-      <NewTxButton />
-    </div>
+    </GradientBoxSafenet>
   )
 }
 

--- a/src/components/sidebar/SidebarHeader/styles.module.css
+++ b/src/components/sidebar/SidebarHeader/styles.module.css
@@ -3,7 +3,6 @@
   border-bottom-left-radius: 8px;
   border-bottom-right-radius: 8px;
   border-top-width: 0;
-  border: 1px solid var(--safenet, #32f970);
 }
 
 .info {

--- a/src/components/transactions/TxDetails/Summary/index.tsx
+++ b/src/components/transactions/TxDetails/Summary/index.tsx
@@ -77,7 +77,7 @@ const Summary = ({ txDetails, defaultExpanded = false, hideDecodedData = false }
 
       <Box mt={1}>
         <TxDataRow title="Safenet Simulation:">
-          <GradientBoxSafenet heading="Powered by Safenet" className={css.safenetGradientRow}>
+          <GradientBoxSafenet className={css.safenetGradientRow}>
             <SafenetTxSimulation
               safe={safe.address.value}
               chainId={safe.chainId}

--- a/src/components/transactions/TxDetails/Summary/styles.module.css
+++ b/src/components/transactions/TxDetails/Summary/styles.module.css
@@ -2,3 +2,9 @@
   margin-top: 8px;
   padding: 0;
 }
+
+.safenetGradientRow > div:last-child > div:first-child {
+  border: none;
+  border-radius-left-top: 0;
+  border-radius-right-top: 0;
+}

--- a/src/components/tx/SignOrExecuteForm/SafenetTxChecks.tsx
+++ b/src/components/tx/SignOrExecuteForm/SafenetTxChecks.tsx
@@ -19,7 +19,7 @@ const SafenetTxChecks = ({ safeTx }: { safeTx: SafeTransaction }): ReactElement 
   }
 
   return (
-    <GradientBoxSafenet heading="Powered by Safenet" className={css.safenetGradientCard}>
+    <GradientBoxSafenet className={css.safenetGradientCard}>
       <TxCard>
         <Typography variant="h5">Safenet checks</Typography>
         <SafenetTxSimulation safe={safe} chainId={chainId} safeTx={safeTx} />

--- a/src/components/tx/SignOrExecuteForm/styles.module.css
+++ b/src/components/tx/SignOrExecuteForm/styles.module.css
@@ -80,6 +80,6 @@
   margin-bottom: var(--space-2);
 }
 
-.safenetGradientCard > div:last-child > div {
+.safenetGradientCard > div:last-child > div:first-child {
   margin-bottom: 0;
 }

--- a/src/components/tx/security/safenet/index.tsx
+++ b/src/components/tx/security/safenet/index.tsx
@@ -1,9 +1,10 @@
 import { Button, CircularProgress, List, ListItem, ListItemText, Paper, SvgIcon, Typography } from '@mui/material'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import CopyTooltip from '@/components/common/CopyTooltip'
 import useDecodeTx from '@/hooks/useDecodeTx'
 import CheckIcon from '@/public/images/common/check.svg'
 import CloseIcon from '@/public/images/common/close.svg'
-import LinkIcon from '@/public/images/common/link.svg'
+import CopyIcon from '@/public/images/common/copy.svg'
 import type { SafenetSimulationResponse } from '@/store/safenet'
 import { useLazySimulateSafenetTxQuery } from '@/store/safenet'
 import { hashTypedData } from '@/utils/web3'
@@ -86,16 +87,16 @@ const StatusAction = ({ status, link }: { status: string; link?: string }): Reac
     )
   } else if (status === 'pending' && link) {
     return (
-      <Button
-        variant="outlined"
-        size="small"
-        href={link}
-        target="_blank"
-        sx={{ width: '100%', py: 0.5 }}
-        startIcon={<SvgIcon component={LinkIcon} inheritViewBox fontSize="small" />}
-      >
-        Verify recipient
-      </Button>
+      <CopyTooltip text={link}>
+        <Button
+          variant="outlined"
+          size="small"
+          sx={{ width: '100%', py: 0.5 }}
+          startIcon={<SvgIcon component={CopyIcon} inheritViewBox fontSize="small" />}
+        >
+          Share verification link
+        </Button>
+      </CopyTooltip>
     )
   } else {
     return (

--- a/src/components/welcome/MyAccounts/MultiAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/MultiAccountItem.tsx
@@ -37,7 +37,7 @@ import { useGetMultipleSafeOverviewsQuery } from '@/store/api/gateway'
 import useWallet from '@/hooks/wallets/useWallet'
 import { selectCurrency } from '@/store/settingsSlice'
 import { selectChains } from '@/store/chainsSlice'
-import Image from 'next/image'
+import GradientBoxSafenet from '@/components/common/GradientBoxSafenet'
 
 type MultiAccountItemProps = {
   multiSafeAccountItem: MultiChainSafeItem
@@ -138,98 +138,94 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, hasSafenetEnabled
     [safeOverviews],
   )
 
-  return (
-    <>
-      {hasSafenetEnabled && (
-        <Box className={css.safenetHeader} display="flex" alignItems="center" justifyContent="space-between">
-          <Image src="/images/safenet.svg" alt="Safenet Logo" width={12} height={12} />
-          <Typography variant="body2" fontWeight="bold" fontSize="12px" color="var(--color-static-main)">
-            Powered by Safenet
-          </Typography>
-        </Box>
-      )}
-      <ListItemButton
-        data-testid="safe-list-item"
-        selected={isCurrentSafe}
-        className={classnames(css.multiListItem, css.listItem, css.safenet, {
-          [css.currentListItem]: isCurrentSafe && !hasSafenetEnabled,
-        })}
-        sx={{
-          p: 0,
+  const listItem = (
+    <ListItemButton
+      data-testid="safe-list-item"
+      selected={isCurrentSafe}
+      className={classnames(css.multiListItem, css.listItem, {
+        [css.currentListItem]: isCurrentSafe,
+      })}
+      sx={{
+        p: 0,
+        borderTopLeftRadius: 0,
+        borderTopRightRadius: 0,
+        '&>.MuiPaper-root': {
           borderTopLeftRadius: 0,
           borderTopRightRadius: 0,
-          '&>.MuiPaper-root': {
-            borderTopLeftRadius: 0,
-            borderTopRightRadius: 0,
-          },
-        }}
-      >
-        <Accordion expanded={expanded} sx={{ border: 'none' }}>
-          <AccordionSummary
-            onClick={toggleExpand}
-            sx={{
-              pl: 0,
-              '& .MuiAccordionSummary-content': { m: '0 !important', alignItems: 'center' },
-              '&.Mui-expanded': { backgroundColor: 'transparent !important' },
-            }}
-          >
-            <Box className={css.safeLink} width="100%">
-              <Box pr={2.5}>
-                <SafeIcon address={address} owners={sharedSetup?.owners.length} threshold={sharedSetup?.threshold} />
-              </Box>
-              <Typography variant="body2" component="div" className={css.safeAddress}>
-                {name && (
-                  <Typography variant="subtitle2" component="p" fontWeight="bold" className={css.safeName}>
-                    {name}
-                  </Typography>
-                )}
-                <Typography color="var(--color-primary-light)" fontSize="inherit" component="span">
-                  {shortenAddress(address)}
+        },
+      }}
+    >
+      <Accordion expanded={expanded} sx={{ border: 'none' }}>
+        <AccordionSummary
+          onClick={toggleExpand}
+          sx={{
+            pl: 0,
+            '& .MuiAccordionSummary-content': { m: '0 !important', alignItems: 'center' },
+            '&.Mui-expanded': { backgroundColor: 'transparent !important' },
+          }}
+        >
+          <Box className={css.safeLink} width="100%">
+            <Box pr={2.5}>
+              <SafeIcon address={address} owners={sharedSetup?.owners.length} threshold={sharedSetup?.threshold} />
+            </Box>
+            <Typography variant="body2" component="div" className={css.safeAddress}>
+              {name && (
+                <Typography variant="subtitle2" component="p" fontWeight="bold" className={css.safeName}>
+                  {name}
                 </Typography>
+              )}
+              <Typography color="var(--color-primary-light)" fontSize="inherit" component="span">
+                {shortenAddress(address)}
               </Typography>
-              <MultichainIndicator safes={safes} />
-              <Typography variant="body2" fontWeight="bold" textAlign="right" pl={2}>
-                {totalFiatValue !== undefined ? (
-                  <FiatValue value={totalFiatValue} safenet />
-                ) : (
-                  <Skeleton variant="text" sx={{ ml: 'auto' }} />
-                )}
-              </Typography>
-            </Box>
-            <MultiAccountContextMenu
-              name={name ?? ''}
-              address={address}
-              chainIds={deployedChainIds}
-              addNetwork={hasReplayableSafe}
-            />
-          </AccordionSummary>
-          <AccordionDetails sx={{ padding: '0px 12px' }}>
-            <Box>
-              {safes.map((safeItem) => (
-                <SubAccountItem
-                  onLinkClick={onLinkClick}
-                  safeItem={safeItem}
-                  key={`${safeItem.chainId}:${safeItem.address}`}
-                  safeOverview={findOverview(safeItem)}
+            </Typography>
+            <MultichainIndicator safes={safes} />
+            <Typography variant="body2" fontWeight="bold" textAlign="right" pl={2}>
+              {totalFiatValue !== undefined ? (
+                <FiatValue value={totalFiatValue} safenet />
+              ) : (
+                <Skeleton variant="text" sx={{ ml: 'auto' }} />
+              )}
+            </Typography>
+          </Box>
+          <MultiAccountContextMenu
+            name={name ?? ''}
+            address={address}
+            chainIds={deployedChainIds}
+            addNetwork={hasReplayableSafe}
+          />
+        </AccordionSummary>
+        <AccordionDetails sx={{ padding: '0px 12px' }}>
+          <Box>
+            {safes.map((safeItem) => (
+              <SubAccountItem
+                onLinkClick={onLinkClick}
+                safeItem={safeItem}
+                key={`${safeItem.chainId}:${safeItem.address}`}
+                safeOverview={findOverview(safeItem)}
+              />
+            ))}
+          </Box>
+          {!isWatchlist && hasReplayableSafe && (
+            <>
+              <Divider sx={{ ml: '-12px', mr: '-12px' }} />
+              <Box display="flex" alignItems="center" justifyContent="center" sx={{ ml: '-12px', mr: '-12px' }}>
+                <AddNetworkButton
+                  currentName={name}
+                  safeAddress={address}
+                  deployedChains={safes.map((safe) => safe.chainId)}
                 />
-              ))}
-            </Box>
-            {!isWatchlist && hasReplayableSafe && (
-              <>
-                <Divider sx={{ ml: '-12px', mr: '-12px' }} />
-                <Box display="flex" alignItems="center" justifyContent="center" sx={{ ml: '-12px', mr: '-12px' }}>
-                  <AddNetworkButton
-                    currentName={name}
-                    safeAddress={address}
-                    deployedChains={safes.map((safe) => safe.chainId)}
-                  />
-                </Box>
-              </>
-            )}
-          </AccordionDetails>
-        </Accordion>
-      </ListItemButton>
-    </>
+              </Box>
+            </>
+          )}
+        </AccordionDetails>
+      </Accordion>
+    </ListItemButton>
+  )
+
+  return hasSafenetEnabled ? (
+    <GradientBoxSafenet className={css.safenetListItem}>{listItem}</GradientBoxSafenet>
+  ) : (
+    listItem
   )
 }
 

--- a/src/components/welcome/MyAccounts/styles.module.css
+++ b/src/components/welcome/MyAccounts/styles.module.css
@@ -233,5 +233,6 @@
 
 .safenetListItem .listItem {
   border: none;
-  border-radius: 0;
+  border-radius-left-top: 0;
+  border-radius-right-top: 0;
 }

--- a/src/components/welcome/MyAccounts/styles.module.css
+++ b/src/components/welcome/MyAccounts/styles.module.css
@@ -227,20 +227,11 @@
   }
 }
 
-.safenet {
-  border: 1px solid var(--safenet, #32f970);
-  border-bottom-left-radius: var(--space-1);
-  border-bottom-right-radius: var(--space-1);
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-  border-top-width: 0;
+.safenetListItem {
+  margin-bottom: 12px;
 }
 
-.safenetHeader {
-  background: linear-gradient(90deg, #32f970 0%, #eed509 100%);
-  border-top-left-radius: inherit;
-  border-top-right-radius: inherit;
-  padding: calc(var(--space-1) / 2) var(--space-1);
-  border-top-right-radius: var(--space-1);
-  border-top-left-radius: var(--space-1);
+.safenetListItem .listItem {
+  border: none;
+  border-radius: 0;
 }


### PR DESCRIPTION
This PR changes the account item list to use the `GradientBoxSafenet` component so that the appearance is consistent:
- Icon size/colors are guaranteed to be the same
- uses gradient border

Additionally, https://github.com/safe-global/safe-wallet-web/pull/4487/commits/74b5325c1616ecc0d38592296e68d3ce74474e57 was meant to be included with #4486 but was accidentally omitted and included in this PR instead.

## Screenshots

![image](https://github.com/user-attachments/assets/8ee19917-3231-4860-862e-d634a648e08a)


![image](https://github.com/user-attachments/assets/8709ae7b-f8a8-4464-a835-62d8ecd411a6)