### PR TITLE
Small Fixes for Safenet Demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,4 @@ This app is built using the following frameworks:
 - MUI
 - ethers.js
 - web3-onboard
+

--- a/README.md
+++ b/README.md
@@ -141,4 +141,3 @@ This app is built using the following frameworks:
 - MUI
 - ethers.js
 - web3-onboard
-

--- a/src/components/transactions/TxDetails/Summary/index.tsx
+++ b/src/components/transactions/TxDetails/Summary/index.tsx
@@ -76,7 +76,7 @@ const Summary = ({ txDetails, defaultExpanded = false, hideDecodedData = false }
       )}
 
       <Box mt={1}>
-        <TxDataRow title="Safenet Simulation:">
+        <TxDataRow title="Safenet checks:">
           <GradientBoxSafenet className={css.safenetGradientRow}>
             <SafenetTxSimulation
               safe={safe.address.value}

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -31,7 +31,6 @@ import { findAllowingRole, findMostLikelyRole, useRoles } from './ExecuteThrough
 import { isAnyStakingTxInfo, isCustomTxInfo, isGenericConfirmation, isOrderTxInfo } from '@/utils/transaction-guards'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import { BlockaidBalanceChanges } from '../security/blockaid/BlockaidBalanceChange'
-import { Blockaid } from '../security/blockaid'
 
 import TxData from '@/components/transactions/TxDetails/TxData'
 import ConfirmationOrder from '@/components/tx/ConfirmationOrder'
@@ -223,8 +222,6 @@ export const SignOrExecuteForm = ({
         <NetworkWarning />
 
         {!isMultiChainMigration && <UnknownContractError />}
-
-        <Blockaid />
 
         {isCounterfactualSafe && !isDelegate && (
           <CounterfactualForm {...props} safeTx={safeTx} isCreation={isCreation} onSubmit={onFormSubmit} onlyExecute />

--- a/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/src/components/tx/SignOrExecuteForm/index.tsx
@@ -31,6 +31,7 @@ import { findAllowingRole, findMostLikelyRole, useRoles } from './ExecuteThrough
 import { isAnyStakingTxInfo, isCustomTxInfo, isGenericConfirmation, isOrderTxInfo } from '@/utils/transaction-guards'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import { BlockaidBalanceChanges } from '../security/blockaid/BlockaidBalanceChange'
+import { Blockaid } from '../security/blockaid'
 
 import TxData from '@/components/transactions/TxDetails/TxData'
 import ConfirmationOrder from '@/components/tx/ConfirmationOrder'
@@ -196,7 +197,7 @@ export const SignOrExecuteForm = ({
             />
           </ErrorBoundary>
         )}
-        {!isCounterfactualSafe && !props.isRejection && <BlockaidBalanceChanges />}
+        {!isSafenetEnabled && !isCounterfactualSafe && !props.isRejection && <BlockaidBalanceChanges />}
       </TxCard>
 
       {!isCounterfactualSafe && !props.isRejection && <TxChecks />}
@@ -222,6 +223,8 @@ export const SignOrExecuteForm = ({
         <NetworkWarning />
 
         {!isMultiChainMigration && <UnknownContractError />}
+
+        {!isSafenetEnabled && <Blockaid />}
 
         {isCounterfactualSafe && !isDelegate && (
           <CounterfactualForm {...props} safeTx={safeTx} isCreation={isCreation} onSubmit={onFormSubmit} onlyExecute />


### PR DESCRIPTION
Small fixes for the Safenet demo:
- Wording in transaction details
- Disable Blockaid for Safenet (as it doesn't seem to work because of the guard)