### PR TITLE
fix: fetch safe overviews including untrusted token fiatTotal

### DIFF
--- a/src/store/__tests__/safeOverviews.test.ts
+++ b/src/store/__tests__/safeOverviews.test.ts
@@ -175,7 +175,7 @@ describe('safeOverviews', () => {
           ],
           {
             currency: 'usd',
-            trusted: true,
+            trusted: false,
             exclude_spam: true,
           },
         )
@@ -344,12 +344,12 @@ describe('safeOverviews', () => {
       expect(mockedGetSafeOverviews).toHaveBeenCalledTimes(2)
       expect(mockedGetSafeOverviews).toHaveBeenCalledWith(
         request.safes.slice(0, 10).map((safe) => `1:${safe.address}`),
-        { currency: 'usd', exclude_spam: true, trusted: true },
+        { currency: 'usd', exclude_spam: true, trusted: false },
       )
 
       expect(mockedGetSafeOverviews).toHaveBeenCalledWith(
         request.safes.slice(10).map((safe) => `1:${safe.address}`),
-        { currency: 'usd', exclude_spam: true, trusted: true },
+        { currency: 'usd', exclude_spam: true, trusted: false },
       )
     })
   })

--- a/src/store/api/gateway/safeOverviews.ts
+++ b/src/store/api/gateway/safeOverviews.ts
@@ -35,7 +35,7 @@ class SafeOverviewFetcher {
     currency: string
   }) {
     return await getSafeOverviews(safeIds, {
-      trusted: true,
+      trusted: false,
       exclude_spam: true,
       currency,
       wallet_address: walletAddress,

--- a/src/store/api/gateway/safeOverviews.ts
+++ b/src/store/api/gateway/safeOverviews.ts
@@ -35,6 +35,10 @@ class SafeOverviewFetcher {
     currency: string
   }) {
     return await getSafeOverviews(safeIds, {
+      /**
+       * This flag can only be set once for all cross chain `safeIds`.
+       * If we set `trusted` to `true` we will get 0 as `fiatTotal` for all Safes on networks without Default tokenlists.
+       */
       trusted: false,
       exclude_spam: true,
       currency,


### PR DESCRIPTION
## What it solves

Resolves #4479

## How this PR fixes it
Requests `fiatTotal` in `SafeOverviews` using `trusted=false` as we otherwise receive 0 balances for Safes on networks without Default tokenlists.

## How to test it
- Open a Safe with ERC20 tokens on a network without default token list.
- Compare the balance in the sidebar / network selector with the one in e.g. the dashboard

## Screenshots

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
