### PR TITLE
fix: Delete proposer as proposer, adjust status widget

### DIFF
--- a/src/components/tx-flow/common/TxStatusWidget/index.tsx
+++ b/src/components/tx-flow/common/TxStatusWidget/index.tsx
@@ -1,3 +1,5 @@
+import useIsSafeOwner from '@/hooks/useIsSafeOwner'
+import { useIsWalletProposer } from '@/hooks/useProposers'
 import { useContext } from 'react'
 import { Divider, IconButton, List, ListItem, ListItemIcon, ListItemText, Paper, Typography } from '@mui/material'
 import CreatedIcon from '@/public/images/messages/created.svg'
@@ -29,12 +31,18 @@ const TxStatusWidget = ({
   const { safe } = useSafeInfo()
   const { nonceNeeded } = useContext(SafeTxContext)
   const { threshold } = safe
+  const isSafeOwner = useIsSafeOwner()
+  const isProposer = useIsWalletProposer()
+  const isProposing = isProposer && !isSafeOwner
 
   const { executionInfo = undefined } = txSummary || {}
   const { confirmationsSubmitted = 0 } = isMultisigExecutionInfo(executionInfo) ? executionInfo : {}
 
-  const canConfirm = txSummary ? isConfirmableBy(txSummary, wallet?.address || '') : safe.threshold === 1
-  const canSign = txSummary ? isSignableBy(txSummary, wallet?.address || '') : true
+  const canConfirm = txSummary
+    ? isConfirmableBy(txSummary, wallet?.address || '')
+    : safe.threshold === 1 && !isProposing
+
+  const canSign = txSummary ? isSignableBy(txSummary, wallet?.address || '') : !isProposing
 
   return (
     <Paper>

--- a/src/features/proposers/components/DeleteProposerDialog.tsx
+++ b/src/features/proposers/components/DeleteProposerDialog.tsx
@@ -67,7 +67,7 @@ const _DeleteProposer = ({ wallet, safeAddress, chainId, proposer }: DeletePropo
       await deleteProposer({
         chainId,
         delegateAddress: proposer.delegate,
-        delegator: wallet.address,
+        delegator: proposer.delegator,
         safeAddress,
         signature,
         isHardwareWallet: hardwareWallet,


### PR DESCRIPTION
## How this PR fixes it

- Passes the correct delegator address when deleting a proposer
- Adjusts `canSign` and `canConfirm` conditions to account for proposers in `TxStatusWidget`

## How to test it

1. Add a proposer
2. Switch to the proposer address
3. Delete yourself as proposer
4. Observe no network error
5. Create a transaction as a proposer
6. Observe the status widget shows confirmations greyed out

## Screenshots
<img width="1159" alt="Screenshot 2024-11-07 at 09 42 22" src="https://github.com/user-attachments/assets/41633f9d-4e64-442a-a507-99679e5451e1">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
