### PR TITLE
Feat(sidebar): Add tracking events for search, sorting, and pinning/unpinning safes [SW-308]

### DIFF
--- a/src/components/welcome/MyAccounts/AccountItem.tsx
+++ b/src/components/welcome/MyAccounts/AccountItem.tsx
@@ -5,7 +5,7 @@ import { useMemo, useRef } from 'react'
 import { ListItemButton, Box, Typography, Chip, IconButton, SvgIcon, Skeleton } from '@mui/material'
 import Link from 'next/link'
 import Track from '@/components/common/Track'
-import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
+import { OVERVIEW_EVENTS, OVERVIEW_LABELS, PIN_SAFE_LABELS, trackEvent } from '@/services/analytics'
 import { AppRoutes } from '@/config/routes'
 import { useAppDispatch, useAppSelector } from '@/store'
 import { selectChainById } from '@/store/chainsSlice'
@@ -112,10 +112,12 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
     } else {
       dispatch(pinSafe({ chainId, address, removeOnUnpin: false }))
     }
+    trackEvent({ ...OVERVIEW_EVENTS.PIN_SAFE, label: PIN_SAFE_LABELS.pin })
   }
 
   const removeFromPinnedList = () => {
     dispatch(unpinSafe({ chainId, address }))
+    trackEvent({ ...OVERVIEW_EVENTS.PIN_SAFE, label: PIN_SAFE_LABELS.unpin })
   }
 
   return (

--- a/src/components/welcome/MyAccounts/MultiAccountItem.tsx
+++ b/src/components/welcome/MyAccounts/MultiAccountItem.tsx
@@ -16,7 +16,7 @@ import {
   IconButton,
 } from '@mui/material'
 import SafeIcon from '@/components/common/SafeIcon'
-import { OVERVIEW_EVENTS, OVERVIEW_LABELS, trackEvent } from '@/services/analytics'
+import { OVERVIEW_EVENTS, OVERVIEW_LABELS, PIN_SAFE_LABELS, trackEvent } from '@/services/analytics'
 import { AppRoutes } from '@/config/routes'
 import { useAppDispatch, useAppSelector } from '@/store'
 import css from './styles.module.css'
@@ -168,12 +168,14 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountIte
         dispatch(pinSafe({ chainId: safe.chainId, address: safe.address, removeOnUnpin: true }))
       }
     }
+    trackEvent({ ...OVERVIEW_EVENTS.PIN_SAFE, label: PIN_SAFE_LABELS.pin })
   }, [safes, allAddedSafes, dispatch, findOverview, address])
 
   const removeFromPinnedList = useCallback(() => {
     for (const safe of safes) {
       dispatch(unpinSafe({ chainId: safe.chainId, address: safe.address }))
     }
+    trackEvent({ ...OVERVIEW_EVENTS.PIN_SAFE, label: PIN_SAFE_LABELS.unpin })
   }, [safes, dispatch])
 
   return (

--- a/src/components/welcome/MyAccounts/OrderByButton.tsx
+++ b/src/components/welcome/MyAccounts/OrderByButton.tsx
@@ -4,6 +4,7 @@ import ContextMenu from '@/components/common/ContextMenu'
 import TransactionsIcon from '@/public/images/transactions/transactions.svg'
 import CheckIcon from '@/public/images/common/check.svg'
 import { OrderByOption } from '@/store/orderByPreferenceSlice'
+import { OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
 
 type OrderByButtonProps = {
   orderBy: OrderByOption
@@ -27,6 +28,7 @@ const OrderByButton = ({ orderBy: orderBy, onOrderByChange: onOrderByChange }: O
   }
 
   const handleOrderByChange = (newOrderBy: OrderByOption) => {
+    trackEvent({ ...OVERVIEW_EVENTS.SORT_SAFES, label: orderByLabels[newOrderBy] })
     onOrderByChange(newOrderBy)
     handleClose()
   }

--- a/src/components/welcome/MyAccounts/index.tsx
+++ b/src/components/welcome/MyAccounts/index.tsx
@@ -59,29 +59,6 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
   )
   const filteredSafes = useSafesSearch(allSafes ?? [], searchQuery).sort(sortComparator)
 
-  // We consider a multiChain account owned if at least one of the multiChain accounts is not on the watchlist
-  const ownedMultiChainSafes = useMemo(
-    () => safes.allMultiChainSafes?.filter((account) => account.safes.some(({ isWatchlist }) => !isWatchlist)),
-    [safes],
-  )
-
-  // If all safes of a multichain account are on the watchlist we put the entire account on the watchlist
-  const watchlistMultiChainSafes = useMemo(
-    () => safes.allMultiChainSafes?.filter((account) => !account.safes.some(({ isWatchlist }) => !isWatchlist)),
-    [safes],
-  )
-
-  const ownedSafes = useMemo<(MultiChainSafeItem | SafeItem)[]>(
-    () => [...(ownedMultiChainSafes ?? []), ...(safes.allSingleSafes?.filter(({ isWatchlist }) => !isWatchlist) ?? [])],
-    [safes, ownedMultiChainSafes],
-  )
-  const watchlistSafes = useMemo<(MultiChainSafeItem | SafeItem)[]>(
-    () => [
-      ...(watchlistMultiChainSafes ?? []),
-      ...(safes.allSingleSafes?.filter(({ isWatchlist }) => isWatchlist) ?? []),
-    ],
-    [safes, watchlistMultiChainSafes],
-  )
   const pinnedSafes = useMemo<(MultiChainSafeItem | SafeItem)[]>(
     () => [...(allSafes?.filter(({ isPinned }) => isPinned) ?? [])],
     [allSafes],
@@ -94,7 +71,7 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleSearch = useCallback(debounce(setSearchQuery, 300), [])
 
-  useTrackSafesCount(ownedSafes, watchlistSafes, wallet)
+  useTrackSafesCount(safes, pinnedSafes, wallet)
 
   const isLoginPage = router.pathname === AppRoutes.welcome.accounts
   const trackingLabel = isLoginPage ? OVERVIEW_LABELS.login_page : OVERVIEW_LABELS.sidebar

--- a/src/components/welcome/MyAccounts/useSafesSearch.ts
+++ b/src/components/welcome/MyAccounts/useSafesSearch.ts
@@ -15,7 +15,6 @@ const useSafesSearch = (safes: (SafeItem | MultiChainSafeItem)[], query: string)
       trackEvent({
         category: OVERVIEW_EVENTS.SEARCH.category,
         action: OVERVIEW_EVENTS.SEARCH.action,
-        label: query,
       })
     }
   }, [query])

--- a/src/components/welcome/MyAccounts/useSafesSearch.ts
+++ b/src/components/welcome/MyAccounts/useSafesSearch.ts
@@ -11,11 +11,13 @@ const useSafesSearch = (safes: (SafeItem | MultiChainSafeItem)[], query: string)
   const chains = useAppSelector(selectChains)
 
   useEffect(() => {
-    trackEvent({
-      category: OVERVIEW_EVENTS.SEARCH.category,
-      action: OVERVIEW_EVENTS.SEARCH.action,
-      label: query,
-    })
+    if (query) {
+      trackEvent({
+        category: OVERVIEW_EVENTS.SEARCH.category,
+        action: OVERVIEW_EVENTS.SEARCH.action,
+        label: query,
+      })
+    }
   }, [query])
 
   // Include chain names in the search

--- a/src/components/welcome/MyAccounts/useTrackedSafesCount.ts
+++ b/src/components/welcome/MyAccounts/useTrackedSafesCount.ts
@@ -29,7 +29,7 @@ const useTrackSafesCount = (
   const watchlistMultiChainSafes = useMemo(
     () =>
       safes.allMultiChainSafes?.filter(
-        (account) => !account.safes.some(({ isWatchlist, isPinned }) => !isWatchlist && !isPinned),
+        (account) => account.safes.some(({ isWatchlist, isPinned }) => isWatchlist && !isPinned),
       ),
     [safes],
   )

--- a/src/components/welcome/MyAccounts/useTrackedSafesCount.ts
+++ b/src/components/welcome/MyAccounts/useTrackedSafesCount.ts
@@ -27,7 +27,10 @@ const useTrackSafesCount = (
 
   // If all safes of a multichain account are on the watchlist we put the entire account on the watchlist
   const watchlistMultiChainSafes = useMemo(
-    () => safes.allMultiChainSafes?.filter((account) => !account.safes.some(({ isWatchlist }) => !isWatchlist)),
+    () =>
+      safes.allMultiChainSafes?.filter(
+        (account) => !account.safes.some(({ isWatchlist, isPinned }) => !isWatchlist && !isPinned),
+      ),
     [safes],
   )
 
@@ -38,7 +41,7 @@ const useTrackSafesCount = (
   const watchlistSafes = useMemo<(MultiChainSafeItem | SafeItem)[]>(
     () => [
       ...(watchlistMultiChainSafes ?? []),
-      ...(safes.allSingleSafes?.filter(({ isWatchlist }) => isWatchlist) ?? []),
+      ...(safes.allSingleSafes?.filter(({ isWatchlist, isPinned }) => isWatchlist && !isPinned) ?? []),
     ],
     [safes, watchlistMultiChainSafes],
   )
@@ -64,7 +67,7 @@ const useTrackSafesCount = (
       (prev, current) => prev + (isMultiChainSafeItem(current) ? current.safes.length : 1),
       0,
     )
-    if (wallet && !isPinnedSafesTracked && pinnedSafes && pinnedSafes.length > 0 && isLoginPage) {
+    if (!isPinnedSafesTracked && pinnedSafes && pinnedSafes.length > 0 && isLoginPage) {
       trackEvent({ ...OVERVIEW_EVENTS.TOTAL_SAFES_PINNED, label: totalSafesPinned })
       isPinnedSafesTracked = true
     }

--- a/src/components/welcome/MyAccounts/useTrackedSafesCount.ts
+++ b/src/components/welcome/MyAccounts/useTrackedSafesCount.ts
@@ -71,7 +71,7 @@ const useTrackSafesCount = (
       trackEvent({ ...OVERVIEW_EVENTS.TOTAL_SAFES_PINNED, label: totalSafesPinned })
       isPinnedSafesTracked = true
     }
-  }, [isLoginPage, pinnedSafes, wallet])
+  }, [isLoginPage, pinnedSafes])
 
   useEffect(() => {
     const totalSafesWatched = watchlistSafes?.reduce(

--- a/src/components/welcome/MyAccounts/useTrackedSafesCount.ts
+++ b/src/components/welcome/MyAccounts/useTrackedSafesCount.ts
@@ -28,8 +28,8 @@ const useTrackSafesCount = (
   // If all safes of a multichain account are on the watchlist we put the entire account on the watchlist
   const watchlistMultiChainSafes = useMemo(
     () =>
-      safes.allMultiChainSafes?.filter(
-        (account) => account.safes.some(({ isWatchlist, isPinned }) => isWatchlist && !isPinned),
+      safes.allMultiChainSafes?.filter((account) =>
+        account.safes.some(({ isWatchlist, isPinned }) => isWatchlist && !isPinned),
       ),
     [safes],
   )

--- a/src/services/analytics/events/overview.ts
+++ b/src/services/analytics/events/overview.ts
@@ -52,6 +52,11 @@ export const OVERVIEW_EVENTS = {
     category: OVERVIEW_CATEGORY,
     event: EventType.META,
   },
+  TOTAL_SAFES_PINNED: {
+    action: 'Total Safes pinned',
+    category: OVERVIEW_CATEGORY,
+    event: EventType.META,
+  },
   TOTAL_SAFES_WATCHLIST: {
     action: 'Total Safes watchlist',
     category: OVERVIEW_CATEGORY,

--- a/src/services/analytics/events/overview.ts
+++ b/src/services/analytics/events/overview.ts
@@ -66,6 +66,10 @@ export const OVERVIEW_EVENTS = {
     action: 'Search safes',
     category: OVERVIEW_CATEGORY,
   },
+  SORT_SAFES: {
+    action: 'Sort Safes',
+    category: OVERVIEW_CATEGORY,
+  },
   SIDEBAR: {
     action: 'Sidebar',
     category: OVERVIEW_CATEGORY,
@@ -138,6 +142,10 @@ export const OVERVIEW_EVENTS = {
     category: OVERVIEW_CATEGORY,
     //label: OPEN_SAFE_LABELS
   },
+  PIN_SAFE: {
+    action: 'Toggle Safe pinned state',
+    category: OVERVIEW_CATEGORY,
+  },
   // Track clicks on links to Safe Accounts
   EXPAND_MULTI_SAFE: {
     action: 'Expand multi Safe',
@@ -183,6 +191,11 @@ export const OVERVIEW_EVENTS = {
     action: 'Staking banner learn more',
     category: OVERVIEW_CATEGORY,
   },
+}
+
+export enum PIN_SAFE_LABELS {
+  pin = 'pin',
+  unpin = 'unpin',
 }
 
 export enum OPEN_SAFE_LABELS {


### PR DESCRIPTION
## What it solves

Resolves [SW-308]

## How this PR fixes it
- Adds events for new interactions added in the epic

## How to test it
- Open the accounts page. Observe that the number of owned safes and watchlist safes are tracked as before (once on the first load).
- In addition, the number of pinned safes should now be tracked also.
- Use the search bar to filter safes. An event should be emmitted for each search.
- Use the sort by button. Whenever the sort by value changes, an event should be emitted with the new sort by value.
- Pin or unpin a safe. An event should be emitted specifying which action took place.


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
