### PR TITLE
Typo corrections

### DIFF
--- a/src/markdown/terms/terms.md
+++ b/src/markdown/terms/terms.md
@@ -161,7 +161,7 @@ Our Services do not consist of:
 
 * You know of the inherent risks of cryptographic and Blockchain-based systems and the high volatility of Token markets. Transactions undertaken in the Blockchain are irrevocable and irreversible and there is no possibility to refund Token that have been deployed.
 
-* You should read the license requirements, terms and conditions as well as privacy policy of each Third-Party Safe Appz and Third-Party Service that you access or use. Certain Third-Party Safe Apps and Third-Party Services may involve complex Transactions that entail a high degree of risk.
+* You should read the license requirements, terms and conditions as well as privacy policy of each Third-Party Safe Apps and Third-Party Service that you access or use. Certain Third-Party Safe Apps and Third-Party Services may involve complex Transactions that entail a high degree of risk.
 
 * If you contribute integrations to Third-Party Safe Apps and Third-Party Services, you are responsible for all content you contribute, in any manner, and you must have all rights necessary to do so, in the manner in which you contribute it. You are responsible for all your activity in connection with any such Third-Party Safe Apps and Third-Party Services.
 

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -120,7 +120,7 @@ const SafePrivacyPolicy = () => (
         <a href="#section-13">Changes to this Privacy Policy</a>
       </li>
       <li>
-        <a href="#section-14">Contacts us</a>
+        <a href="#section-14">Contact us</a>
       </li>
     </ol>
     <h3 id="section-2">2. Glossary</h3>


### PR DESCRIPTION
## What it solves

Typo corrections

## How this PR fixes it

**safe-wallet-web/src/pages/privacy.tsx**

Typo in "Contact us" Link.
The correct phrase is "Contact us," not "Contacts us."

**safe-wallet-web/src/markdown/terms/terms.md**

"Third-Party Safe Appz" contains a typographical error. The word should be "Third-Party Safe Apps".

## How to test it

I checked it with a dictionary and spelling rules.

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
