### PR TITLE
fix(sidebar):  fix designs for data widget and empty/disconnected state [SW-507]

### DIFF
--- a/src/features/myAccounts/components/DataWidget/index.tsx
+++ b/src/features/myAccounts/components/DataWidget/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Grid, SvgIcon, Card, CardHeader, CardContent, Tooltip } from '@mui/material'
+import { Button, SvgIcon, Card, CardHeader, CardContent, Tooltip, Box } from '@mui/material'
 import { useState } from 'react'
 import type { ReactElement } from 'react'
 
@@ -56,37 +56,33 @@ export const DataWidget = (): ReactElement => {
         }
       />
       <CardContent>
-        <Grid container spacing={2} sx={{ maxWidth: 240, margin: 'auto', paddingRight: 2 }}>
+        <Box display="flex" gap={2} justifyContent="center" sx={{ maxWidth: 240, margin: 'auto' }}>
           {hasData && (
-            <Grid item xs={6}>
-              <Track {...OVERVIEW_EVENTS.EXPORT_DATA} label={trackingLabel}>
-                <Button
-                  variant="outlined"
-                  size="small"
-                  onClick={exportAppData}
-                  startIcon={<SvgIcon component={ExportIcon} inheritViewBox fontSize="small" />}
-                  sx={{ width: '100%', py: 0.5 }}
-                >
-                  Export
-                </Button>
-              </Track>
-            </Grid>
-          )}
-          <Grid item xs={6}>
-            <Track {...OVERVIEW_EVENTS.IMPORT_DATA} label={trackingLabel}>
+            <Track {...OVERVIEW_EVENTS.EXPORT_DATA} label={trackingLabel}>
               <Button
-                data-testid="import-btn"
                 variant="outlined"
                 size="small"
-                onClick={onImport}
-                startIcon={<SvgIcon component={ImportIcon} inheritViewBox fontSize="small" />}
-                sx={{ width: '100%', py: 0.5 }}
+                onClick={exportAppData}
+                startIcon={<SvgIcon component={ExportIcon} inheritViewBox fontSize="small" />}
+                sx={{ width: '100%', py: 0.5, px: 2, mt: 2 }}
               >
-                Import
+                Export
               </Button>
             </Track>
-          </Grid>
-        </Grid>
+          )}
+          <Track {...OVERVIEW_EVENTS.IMPORT_DATA} label={trackingLabel}>
+            <Button
+              data-testid="import-btn"
+              variant="outlined"
+              size="small"
+              onClick={onImport}
+              startIcon={<SvgIcon component={ImportIcon} inheritViewBox fontSize="small" />}
+              sx={{ width: '100%', py: 0.5, px: 2, mt: 2 }}
+            >
+              Import
+            </Button>
+          </Track>
+        </Box>
       </CardContent>
       {importModalOpen && (
         <ImportDialog

--- a/src/features/myAccounts/index.tsx
+++ b/src/features/myAccounts/index.tsx
@@ -42,6 +42,7 @@ import { useSafesSearch } from '@/features/myAccounts/hooks/useSafesSearch'
 import useTrackSafesCount from '@/features/myAccounts/hooks/useTrackedSafesCount'
 import { DataWidget } from '@/features/myAccounts/components/DataWidget'
 import OrderByButton from '@/features/myAccounts/components/OrderByButton'
+import ConnectWalletButton from '@/components/common/ConnectWallet/ConnectWalletButton'
 
 type AccountsListProps = {
   safes: AllSafesGrouped
@@ -102,9 +103,16 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
                 </Button>
               </Link>
             </Track>
-            <Track {...OVERVIEW_EVENTS.CREATE_NEW_SAFE} label={trackingLabel}>
-              <CreateButton isPrimary={!!wallet} />
-            </Track>
+
+            {wallet ? (
+              <Track {...OVERVIEW_EVENTS.CREATE_NEW_SAFE} label={trackingLabel}>
+                <CreateButton isPrimary />
+              </Track>
+            ) : (
+              <Box sx={{ '& button': { height: '36px' } }}>
+                <ConnectWalletButton small={true} />
+              </Box>
+            )}
           </Box>
         </Box>
 
@@ -147,9 +155,9 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
           {isSidebar && <Divider />}
 
           <Paper className={css.safeList}>
-            {/* Search results */}
             {searchQuery ? (
               <>
+                {/* Search results */}
                 <Typography variant="h5" fontWeight="normal" mb={2} color="primary.light">
                   Found {filteredSafes.length} result{filteredSafes.length === 1 ? '' : 's'}
                 </Typography>
@@ -219,9 +227,26 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
                     </div>
                   </AccordionSummary>
                   <AccordionDetails sx={{ padding: 0 }}>
-                    <Box mt={1}>
-                      <SafesList safes={allSafes} onLinkClick={onLinkClick} />
-                    </Box>
+                    {allSafes.length > 0 ? (
+                      <Box mt={1}>
+                        <SafesList safes={allSafes} onLinkClick={onLinkClick} />
+                      </Box>
+                    ) : (
+                      <Typography
+                        component="div"
+                        variant="body2"
+                        color="text.secondary"
+                        textAlign="center"
+                        py={3}
+                        mx="auto"
+                        width={250}
+                      >
+                        <Box mb={2}>Connect a wallet to view your Safe Accounts or to create a new one</Box>
+                        <Track {...OVERVIEW_EVENTS.OPEN_ONBOARD} label={trackingLabel}>
+                          <ConnectWalletButton text="Connect a wallet" contained />
+                        </Track>
+                      </Typography>
+                    )}
                   </AccordionDetails>
                 </Accordion>
               </>

--- a/src/features/myAccounts/index.tsx
+++ b/src/features/myAccounts/index.tsx
@@ -199,7 +199,7 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
                 </Box>
 
                 {/* All Accounts */}
-                <Accordion sx={{ border: 'none' }}>
+                <Accordion sx={{ border: 'none' }} defaultExpanded={!isSidebar}>
                   <AccordionSummary
                     data-testid="expand-safes-list"
                     expandIcon={<ExpandMoreIcon sx={{ '& path': { fill: 'var(--color-text-secondary)' } }} />}
@@ -241,10 +241,16 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
                         mx="auto"
                         width={250}
                       >
-                        <Box mb={2}>Connect a wallet to view your Safe Accounts or to create a new one</Box>
-                        <Track {...OVERVIEW_EVENTS.OPEN_ONBOARD} label={trackingLabel}>
-                          <ConnectWalletButton text="Connect a wallet" contained />
-                        </Track>
+                        {!wallet ? (
+                          <>
+                            <Box mb={2}>Connect a wallet to view your Safe Accounts or to create a new one</Box>
+                            <Track {...OVERVIEW_EVENTS.OPEN_ONBOARD} label={trackingLabel}>
+                              <ConnectWalletButton text="Connect a wallet" contained />
+                            </Track>
+                          </>
+                        ) : (
+                          "You don't have any safes yet"
+                        )}
                       </Typography>
                     )}
                   </AccordionDetails>
@@ -253,6 +259,7 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
             )}
           </Paper>
         </Paper>
+        {isSidebar && <Divider />}
         <DataWidget />
       </Box>
     </Box>


### PR DESCRIPTION
## What it solves

Resolves SW-507

## How to test it
See that the accounts page and sidebar matches the designs for:
- when no wallet is connected
- when there are no safes in the list. 
- the datawidget when no data is available.

## Screenshots
No safes:
![image](https://github.com/user-attachments/assets/e887a0de-9cf3-4c2d-b11a-61e222ef8fc4)

Not connected:
![image](https://github.com/user-attachments/assets/ab504322-8051-4981-99b5-d4d7b6496667)

Sidebar data widget:
![image](https://github.com/user-attachments/assets/99a29236-97db-4230-8b7b-30510e59f10a)


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
