### PR TITLE
fix: Batch icon in dark mode

### DIFF
--- a/src/hooks/useTransactionType.tsx
+++ b/src/hooks/useTransactionType.tsx
@@ -10,6 +10,7 @@ import {
 import SwapIcon from '@/public/images/common/swap.svg'
 import StakeIcon from '@/public/images/common/stake.svg'
 import NestedSafeIcon from '@/public/images/transactions/nestedTx.svg'
+import BatchIcon from '@/public/images/common/multisend.svg'
 
 import {
   isCancellationTxInfo,
@@ -113,7 +114,7 @@ export const getTransactionType = (tx: TransactionSummary, addressBook: AddressB
     case TransactionInfoType.CUSTOM: {
       if (isMultiSendTxInfo(tx.txInfo) && !tx.safeAppInfo) {
         return {
-          icon: '/images/common/multisend.svg',
+          icon: <SvgIcon component={BatchIcon} inheritViewBox fontSize="small" alt="Batch" />,
           text: 'Batch',
         }
       }


### PR DESCRIPTION
## What it solves

Resolves #4384 

## How this PR fixes it

- Uses `SvgIcon` to insert batch icon in transactions list

## How to test it

1. Open a safe with batched transactions
2. Go to the history
3. Observe the batch icon is visible in dark and light mode

## Screenshots
<img width="687" alt="Screenshot 2024-11-11 at 21 16 48" src="https://github.com/user-attachments/assets/e923ddea-012a-40b8-92f8-7605a7de5774">
<img width="701" alt="Screenshot 2024-11-11 at 21 16 57" src="https://github.com/user-attachments/assets/4b5d6338-6c32-498e-818c-f89df5cf682c">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
