### PR TITLE
Fix/safenet auto registration

### DIFF
--- a/src/pages/settings/safenet.tsx
+++ b/src/pages/settings/safenet.tsx
@@ -11,11 +11,7 @@ import { useContext, useEffect, useMemo } from 'react'
 import { TxModalContext } from '@/components/tx-flow'
 import { EnableSafenetFlow } from '@/components/tx-flow/flows/EnableSafenet'
 import type { SafenetConfigEntity } from '@/store/safenet'
-import {
-  useLazyGetSafenetOffchainStatusQuery,
-  useRegisterSafenetMutation,
-  useGetSafenetConfigQuery,
-} from '@/store/safenet'
+import { useLazyGetSafenetOffchainStatusQuery, useGetSafenetConfigQuery } from '@/store/safenet'
 import type { ExtendedSafeInfo } from '@/store/safeInfoSlice'
 import { SAFE_FEATURES } from '@safe-global/protocol-kit/dist/src/utils'
 import { hasSafeFeature } from '@/utils/safe-versions'
@@ -56,28 +52,14 @@ const SafenetContent = ({ safenetConfig, safe }: { safenetConfig: SafenetConfigE
 
   // @ts-expect-error bad types. We don't want 404 to be an error - it just means that the safe is not registered
   const offchainLookupError = safenetOffchainStatusError?.status === 404 ? null : safenetOffchainStatusError
-  const registeredOffchainStatus =
-    !offchainLookupError && sameAddress(safenetOffchainStatus?.guard, safenetGuardAddress)
-
-  const safenetStatusQueryWorked =
-    safenetOffchainStatusStatus === QueryStatus.fulfilled || safenetOffchainStatusStatus === QueryStatus.rejected
-  const needsRegistration = safenetStatusQueryWorked && isSafenetGuardEnabled && !registeredOffchainStatus
-  const [registerSafenet, { error: registerSafenetError }] = useRegisterSafenetMutation()
-  const error = offchainLookupError || registerSafenetError
   const safenetAssets = useMemo(
     () => getSafenetTokensByChain(Number(safe.chainId), safenetConfig),
     [safe.chainId, safenetConfig],
   )
 
-  if (error) {
-    throw getRTKErrorMessage(error)
+  if (offchainLookupError) {
+    throw getRTKErrorMessage(offchainLookupError)
   }
-
-  useEffect(() => {
-    if (needsRegistration) {
-      registerSafenet({ chainId: safe.chainId, safeAddress: safe.address.value })
-    }
-  }, [needsRegistration, registerSafenet, safe.chainId, safe.address.value])
 
   useEffect(() => {
     if (chainSupported) {

--- a/src/pages/settings/safenet.tsx
+++ b/src/pages/settings/safenet.tsx
@@ -1,7 +1,6 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
 import { Button, CircularProgress, Grid, Paper, SvgIcon, Tooltip, Typography } from '@mui/material'
-import { QueryStatus } from '@reduxjs/toolkit/query'
 import InfoIcon from '@/public/images/notifications/info.svg'
 
 import SettingsHeader from '@/components/settings/SettingsHeader'

--- a/src/store/safenet.ts
+++ b/src/store/safenet.ts
@@ -73,6 +73,17 @@ export const safenetApi = createApi({
       query: ({ chainId, safeAddress }) => `/account/${chainId}/${safeAddress}`,
       providesTags: (_, __, arg) => [{ type: 'SafenetOffchainStatus', id: arg.safeAddress }],
     }),
+    registerSafenet: builder.mutation<boolean, { chainId: string; safeAddress: string }>({
+      query: ({ chainId, safeAddress }) => ({
+        url: `/account`,
+        method: 'POST',
+        body: {
+          chainId: Number(chainId),
+          safe: safeAddress,
+        },
+      }),
+      invalidatesTags: (_, __, arg) => [{ type: 'SafenetOffchainStatus', id: arg.safeAddress }],
+    }),
     getSafenetBalance: builder.query<SafenetBalanceEntity, { safeAddress: string }>({
       query: ({ safeAddress }) => `/balances/${safeAddress}`,
       providesTags: (_, __, arg) => [{ type: 'SafenetBalance', id: arg.safeAddress }],
@@ -94,9 +105,4 @@ export const safenetApi = createApi({
   }),
 })
 
-export const {
-  useLazyGetSafenetOffchainStatusQuery,
-  useGetSafenetConfigQuery,
-  useLazyGetSafenetBalanceQuery,
-  useLazySimulateSafenetTxQuery,
-} = safenetApi
+export const { useGetSafenetConfigQuery, useLazyGetSafenetBalanceQuery, useLazySimulateSafenetTxQuery } = safenetApi

--- a/src/store/safenet.ts
+++ b/src/store/safenet.ts
@@ -73,17 +73,6 @@ export const safenetApi = createApi({
       query: ({ chainId, safeAddress }) => `/account/${chainId}/${safeAddress}`,
       providesTags: (_, __, arg) => [{ type: 'SafenetOffchainStatus', id: arg.safeAddress }],
     }),
-    registerSafenet: builder.mutation<boolean, { chainId: string; safeAddress: string }>({
-      query: ({ chainId, safeAddress }) => ({
-        url: `/account`,
-        method: 'POST',
-        body: {
-          chainId: Number(chainId),
-          safe: safeAddress,
-        },
-      }),
-      invalidatesTags: (_, __, arg) => [{ type: 'SafenetOffchainStatus', id: arg.safeAddress }],
-    }),
     getSafenetBalance: builder.query<SafenetBalanceEntity, { safeAddress: string }>({
       query: ({ safeAddress }) => `/balances/${safeAddress}`,
       providesTags: (_, __, arg) => [{ type: 'SafenetBalance', id: arg.safeAddress }],
@@ -107,7 +96,6 @@ export const safenetApi = createApi({
 
 export const {
   useLazyGetSafenetOffchainStatusQuery,
-  useRegisterSafenetMutation,
   useGetSafenetConfigQuery,
   useLazyGetSafenetBalanceQuery,
   useLazySimulateSafenetTxQuery,


### PR DESCRIPTION
## What it solves

See [#91](https://github.com/safe-global/safenet/issues/91)

Use Processor events-listeners for Safenet registration instead of `POST /api/v1/account`


## How this PR fixes it

## How to test it

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
