### PR TITLE
Fix(Sidebar): Include sub safe in search results [SW-305]

### DIFF
--- a/src/features/myAccounts/components/AccountInfoChips/index.tsx
+++ b/src/features/myAccounts/components/AccountInfoChips/index.tsx
@@ -14,7 +14,10 @@ const AccountStatusChip = ({ isActivating }: { isActivating: boolean }) => {
   return (
     <Chip
       className={css.chip}
-      sx={{ backgroundColor: isActivating ? 'var(--color-info-light)' : 'var(--color-warning-light)' }}
+      sx={{
+        backgroundColor: isActivating ? 'var(--color-info-light)' : 'var(--color-warning-background)',
+        // backgroundColor: 'warning.background',
+      }}
       size="small"
       label={isActivating ? 'Activating account' : 'Not activated'}
       icon={

--- a/src/features/myAccounts/components/AccountItems/styles.module.css
+++ b/src/features/myAccounts/components/AccountItems/styles.module.css
@@ -52,7 +52,7 @@
 .safeLink {
   display: grid;
   padding: var(--space-2) var(--space-1) var(--space-2) var(--space-2);
-  grid-template-columns: 60px 10fr 3fr 3fr;
+  grid-template-columns: 60px 10fr 2fr 3fr;
   align-items: center;
 }
 

--- a/src/features/myAccounts/hooks/useSafesSearch.ts
+++ b/src/features/myAccounts/hooks/useSafesSearch.ts
@@ -24,13 +24,14 @@ const useSafesSearch = (safes: (SafeItem | MultiChainSafeItem)[], query: string)
     () =>
       safes.map((safe) => {
         if (isMultiChainSafeItem(safe)) {
-          const subChainNames = safe.safes.map(
+          const subSafeChains = safe.safes.map(
             (subSafe) => chains.data.find((chain) => chain.chainId === subSafe.chainId)?.chainName,
           )
-          return { ...safe, chainNames: subChainNames }
+          const subSafeNames = safe.safes.map((subSafe) => subSafe.name)
+          return { ...safe, chainNames: subSafeChains, names: subSafeNames }
         }
         const chain = chains.data.find((chain) => chain.chainId === safe.chainId)
-        return { ...safe, chainNames: [chain?.chainName] }
+        return { ...safe, chainNames: [chain?.chainName], names: [safe.name] }
       }),
     [safes, chains.data],
   )
@@ -38,7 +39,7 @@ const useSafesSearch = (safes: (SafeItem | MultiChainSafeItem)[], query: string)
   const fuse = useMemo(
     () =>
       new Fuse(safesWithChainNames, {
-        keys: [{ name: 'name' }, { name: 'address' }, { name: 'chainNames' }],
+        keys: [{ name: 'names' }, { name: 'address' }, { name: 'chainNames' }],
         threshold: 0.2,
         findAllMatches: true,
         ignoreLocation: true,
@@ -51,8 +52,8 @@ const useSafesSearch = (safes: (SafeItem | MultiChainSafeItem)[], query: string)
     () =>
       query
         ? fuse.search(query).map((result) => {
-            const { chainNames: _, ...safeWithoutChainNames } = result.item
-            return safeWithoutChainNames
+            const { chainNames: _chainNames, names: _names, ...safe } = result.item
+            return safe
           })
         : [],
     [fuse, query],


### PR DESCRIPTION
## What it solves

Resolves: https://www.notion.so/safe-global/Feedback-QA-1378180fe57380ef8c58c80deea0deea
https://www.notion.so/safe-global/Feedback-QA-1378180fe57380ef8c58c80deea0deea

## How this PR fixes it
- Searches multichain sub safes in when searching.
- Fixes undeployed safe chip color in dark mode
- Fixes issue with pending/ to confirm chips being cut off at a certain screen width

## How to test it
- For a multichain safe, edit the names of the sub safes in the address book, giving different names.
- Make sure all sub safe names are matched when searching  

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
