### PR TITLE
Fix: add a guard for a possibly undefined safeAccountConfig

### DIFF
--- a/src/features/counterfactual/utils.ts
+++ b/src/features/counterfactual/utils.ts
@@ -356,27 +356,20 @@ export const extractCounterfactualSafeSetup = (
       saltNonce: string | undefined
     }
   | undefined => {
-  if (!undeployedSafe || !chainId) {
+  if (!undeployedSafe || !chainId || !undeployedSafe.props.safeAccountConfig) {
     return undefined
   }
-  if (isPredictedSafeProps(undeployedSafe.props)) {
-    return {
-      owners: undeployedSafe.props.safeAccountConfig.owners,
-      threshold: undeployedSafe.props.safeAccountConfig.threshold,
-      fallbackHandler: undeployedSafe.props.safeAccountConfig.fallbackHandler,
-      safeVersion: undeployedSafe.props.safeDeploymentConfig?.safeVersion,
-      saltNonce: undeployedSafe.props.safeDeploymentConfig?.saltNonce,
-    }
-  } else {
-    const { owners, threshold, fallbackHandler } = undeployedSafe.props.safeAccountConfig
+  const { owners, threshold, fallbackHandler } = undeployedSafe.props.safeAccountConfig
+  const { safeVersion, saltNonce } = isPredictedSafeProps(undeployedSafe.props)
+    ? undeployedSafe.props.safeDeploymentConfig ?? {}
+    : undeployedSafe.props
 
-    return {
-      owners,
-      threshold: Number(threshold),
-      fallbackHandler,
-      safeVersion: undeployedSafe.props.safeVersion,
-      saltNonce: undeployedSafe.props.saltNonce,
-    }
+  return {
+    owners,
+    threshold: Number(threshold),
+    fallbackHandler,
+    safeVersion,
+    saltNonce,
   }
 }
 


### PR DESCRIPTION
## What it solves

The app might crash when coming back after a 6-week vacation with an old localStorage.

![Screenshot 2024-11-16 at 18 34 38](https://github.com/user-attachments/assets/69c1205f-953f-4448-9ab3-3e871816db70)

## How to test

* Check out an old version of the app (from September 2024)
* Connect a wallet
* Add a few Safes to the watchlist
* Then check out the latest production code
* Connect wallet
* Open the Safe List sidebar
* App crashes
