### PR TITLE
Tests: Add safe apps tests

### DIFF
--- a/cypress/e2e/happypath_2/proposers.cy.js
+++ b/cypress/e2e/happypath_2/proposers.cy.js
@@ -2,9 +2,7 @@ import * as constants from '../../support/constants.js'
 import * as owner from '../pages/owners.pages.js'
 import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
 import * as wallet from '../../support/utils/wallet.js'
-import * as navigation from '../pages/navigation.page.js'
 import * as proposer from '../pages/proposers.pages.js'
-import { getSafeDelegates } from '../../support/utils/cgw.js'
 
 let staticSafes = []
 const walletCredentials = JSON.parse(Cypress.env('CYPRESS_WALLET_CREDENTIALS'))

--- a/cypress/e2e/pages/proposers.pages.js
+++ b/cypress/e2e/pages/proposers.pages.js
@@ -1,11 +1,7 @@
-import * as constants from '../../support/constants'
 import * as main from './main.page'
-import * as createWallet from './create_wallet.pages'
-import * as navigation from './navigation.page'
 import * as addressBook from './address_book.page'
 import * as batch from './batches.pages'
 import * as create_tx from './create_tx.pages'
-import { getSafeDelegates } from '../../support/utils/cgw.js'
 
 export const proposersSection = '[data-testid="proposer-section"]'
 const addProposerBtn = '[data-testid="add-proposer-btn"]'

--- a/cypress/e2e/pages/safeapps.pages.js
+++ b/cypress/e2e/pages/safeapps.pages.js
@@ -100,6 +100,7 @@ export const dummyTxStr = 'Trigger dummy tx (safe.txs.send)'
 export const signOnchainMsgStr = 'Sign message (on-chain)'
 export const pinWalletConnectStr = /pin walletconnect/i
 export const transactionBuilderStr = 'Transaction Builder'
+export const cowswapStr = 'CowSwap'
 export const testAddressValueStr = 'testAddressValue'
 export const logoWalletConnect = /logo.*walletconnect/i
 export const walletConnectHeadlinePreview = /walletconnect/i
@@ -117,6 +118,10 @@ export const linkNames = {
   wcLogo: /WalletConnect logo/i,
   txBuilderLogo: /Transaction Builder logo/i,
 }
+const featuredAppsStr = /featured apps/i
+const pinnedAppsStr = 'My pinned apps'
+const pinnedAppsStrR = /my pinned apps/i
+
 export const abi =
   '[{"inputs":[{"internalType":"address","name":"_singleton","type":"address"}],"stateMutability":"nonpayable","type":"constructor"},{"stateMutability":"payable","type":"fallback"},{"inputs":[{"internalType":"address","name":"target","type":"address"}],"name":"AddressEmptyCode","type":"error"},{"inputs":[{"internalType":"address","name":"account","type":"address"}],"name":"balanceOf","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"approve","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"}]'
 
@@ -197,7 +202,9 @@ export function verifyNoAppsTextPresent() {
 
 export function pinApp(index, app, pin = true) {
   const option = pin ? 'Pin' : 'Unpin'
+  const option_ = pin ? 'Unpin' : 'Pin'
   cy.get(`[aria-label="${option} ${app}"]`).eq(index).click()
+  cy.get(`[aria-label="${option_} ${app}"]`).should('exist')
 }
 
 export function clickOnBookmarkedAppsTab() {
@@ -213,7 +220,23 @@ export function verifyCustomAppCount(count) {
 }
 
 export function verifyPinnedAppCount(count) {
-  cy.findByText(`My pinned apps (${count})`).should(count ? 'be.visible' : 'not.exist')
+  cy.findByText(`${pinnedAppsStr} (${count})`).should(count ? 'be.visible' : 'not.exist')
+}
+
+export function verifyAppInFeaturedList(app) {
+  cy.findByText(featuredAppsStr)
+    .next('ul')
+    .within(() => {
+      cy.findByText(app).should('exist')
+    })
+}
+
+export function verifyAppInPinnedList(app) {
+  cy.findByText(pinnedAppsStrR)
+    .next('ul')
+    .within(() => {
+      cy.findByText(app).should('exist')
+    })
 }
 
 export function clickOnCustomAppsTab() {

--- a/cypress/e2e/pages/sidebar.pages.js
+++ b/cypress/e2e/pages/sidebar.pages.js
@@ -345,6 +345,7 @@ export function renameSafeItem(oldName, newName) {
 
 export function removeSafeItem(name) {
   clickOnSafeItemOptionsBtn(name)
+  cy.wait(1000)
   clickOnRemoveBtn()
   confirmSafeItemRemoval()
   verifyModalRemoved()

--- a/cypress/e2e/safe-apps/apps_list.cy.js
+++ b/cypress/e2e/safe-apps/apps_list.cy.js
@@ -76,4 +76,15 @@ describe('Safe Apps list tests', () => {
     safeapps.verifyCustomAppCount(1)
     safeapps.verifyAppDescription(myCustomAppDescrAdded)
   })
+
+  it('Verify the featured apps list', () => {
+    safeapps.verifyAppInFeaturedList(safeapps.transactionBuilderStr)
+    safeapps.verifyAppInFeaturedList(safeapps.cowswapStr)
+  })
+
+  it('Verify that pinned app can be in pinned section and in featured at the same time', () => {
+    safeapps.pinApp(0, safeapps.transactionBuilderStr)
+    safeapps.verifyAppInFeaturedList(safeapps.transactionBuilderStr)
+    safeapps.verifyAppInPinnedList(safeapps.transactionBuilderStr)
+  })
 })


### PR DESCRIPTION
## What it solves

## How this PR fixes it

With introduction of the Featured apps section, there is a need to add additional tests. The following were added:

- Verify the featured apps list
- Verify that pinned app can be in pinned section and in featured at the same time

Part of this PR also includes minor refactoring: delete unused imports, adding extra verification to a test.

## How to test it

- Run Cypress tests and observe outcome