### PR TITLE
Refactor: pinned = added safes [SW-304]

### DIFF
--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -180,13 +180,13 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
     () =>
       chain
         ? createNewUndeployedSafeWithoutSalt(
-          data.safeVersion,
-          {
-            owners: data.owners.map((owner) => owner.address),
-            threshold: data.threshold,
-          },
-          chain,
-        )
+            data.safeVersion,
+            {
+              owners: data.owners.map((owner) => owner.address),
+              threshold: data.threshold,
+            },
+            chain,
+          )
         : undefined,
     [chain, data.owners, data.safeVersion, data.threshold],
   )
@@ -194,9 +194,9 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
   const safePropsForGasEstimation = useMemo(() => {
     return newSafeProps
       ? {
-        ...newSafeProps,
-        saltNonce: Date.now().toString(),
-      }
+          ...newSafeProps,
+          saltNonce: Date.now().toString(),
+        }
       : undefined
   }, [newSafeProps])
 
@@ -308,10 +308,10 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
 
       const options: DeploySafeProps['options'] = isEIP1559
         ? {
-          maxFeePerGas: maxFeePerGas?.toString(),
-          maxPriorityFeePerGas: maxPriorityFeePerGas?.toString(),
-          gasLimit: gasLimit?.toString(),
-        }
+            maxFeePerGas: maxFeePerGas?.toString(),
+            maxPriorityFeePerGas: maxPriorityFeePerGas?.toString(),
+            gasLimit: gasLimit?.toString(),
+          }
         : { gasPrice: maxFeePerGas?.toString(), gasLimit: gasLimit?.toString() }
 
       const onSubmitCallback = async (taskId?: string, txHash?: string) => {

--- a/src/components/new-safe/load/index.tsx
+++ b/src/components/new-safe/load/index.tsx
@@ -68,7 +68,7 @@ const LoadSafe = ({ initialData }: { initialData?: TxStepperProps<LoadSafeFormDa
               pb: 2,
             }}
           >
-            Add a read-only Safe Account
+            Add existing Safe Account
           </Typography>
         </Grid>
         <Grid

--- a/src/components/sidebar/SafeListContextMenu/index.tsx
+++ b/src/components/sidebar/SafeListContextMenu/index.tsx
@@ -61,12 +61,12 @@ const SafeListContextMenu = ({
 
   const handleOpenModal =
     (type: keyof typeof open, event: typeof OVERVIEW_EVENTS.SIDEBAR_RENAME | typeof OVERVIEW_EVENTS.SIDEBAR_RENAME) =>
-      () => {
-        handleCloseContextMenu()
-        setOpen((prev) => ({ ...prev, [type]: true }))
+    () => {
+      handleCloseContextMenu()
+      setOpen((prev) => ({ ...prev, [type]: true }))
 
-        trackEvent({ ...event, label: trackingLabel })
-      }
+      trackEvent({ ...event, label: trackingLabel })
+    }
 
   const handleCloseModal = () => {
     setOpen(defaultOpen)

--- a/src/components/sidebar/SafeListRemoveDialog/index.tsx
+++ b/src/components/sidebar/SafeListRemoveDialog/index.tsx
@@ -40,7 +40,7 @@ const SafeListRemoveDialog = ({
     <ModalDialog open onClose={handleClose} dialogTitle="Delete entry">
       <DialogContent sx={{ p: '24px !important' }}>
         <Typography>
-          Are you sure you want to remove <b>{safe}</b> from your Watchlist?
+          Are you sure you want to remove the <b>{safe}</b> account?
         </Typography>
       </DialogContent>
 

--- a/src/components/sidebar/WatchlistAddButton/index.tsx
+++ b/src/components/sidebar/WatchlistAddButton/index.tsx
@@ -58,7 +58,7 @@ const WatchlistAddButton = () => {
             sx={{ py: 1.3 }}
             startIcon={<VisibilityOutlined sx={{ verticalAlign: 'middle', marginRight: 1 }} />}
           >
-            Add as read-only
+            Add read-only
           </Button>
         </Track>
       )}

--- a/src/components/sidebar/WatchlistAddButton/index.tsx
+++ b/src/components/sidebar/WatchlistAddButton/index.tsx
@@ -43,7 +43,7 @@ const WatchlistAddButton = () => {
             disableElevation
             sx={{ py: 1.3, px: 1 }}
           >
-            Remove from watchlist
+            Remove account
           </Button>
         </Track>
       ) : (
@@ -58,7 +58,7 @@ const WatchlistAddButton = () => {
             sx={{ py: 1.3 }}
             startIcon={<VisibilityOutlined sx={{ verticalAlign: 'middle', marginRight: 1 }} />}
           >
-            Add to watchlist
+            Add as read-only
           </Button>
         </Track>
       )}

--- a/src/features/multichain/utils/utils.test.ts
+++ b/src/features/multichain/utils/utils.test.ts
@@ -13,7 +13,7 @@ describe('multiChain/utils', () => {
             {
               address: faker.finance.ethereumAddress(),
               chainId: '1',
-              isWatchlist: false,
+              isReadOnly: false,
               isPinned: false,
               lastVisited: 0,
               name: undefined,
@@ -31,7 +31,7 @@ describe('multiChain/utils', () => {
         isMultiChainSafeItem({
           address: faker.finance.ethereumAddress(),
           chainId: '1',
-          isWatchlist: false,
+          isReadOnly: false,
           isPinned: false,
           lastVisited: 0,
           name: undefined,
@@ -238,7 +238,7 @@ describe('multiChain/utils', () => {
             {
               address: faker.finance.ethereumAddress(),
               chainId: '1',
-              isWatchlist: false,
+              isReadOnly: false,
               isPinned: false,
               lastVisited: 0,
               name: undefined,
@@ -257,7 +257,7 @@ describe('multiChain/utils', () => {
             {
               address: faker.finance.ethereumAddress(),
               chainId: '1',
-              isWatchlist: false,
+              isReadOnly: false,
               isPinned: false,
               lastVisited: 0,
               name: undefined,
@@ -280,7 +280,7 @@ describe('multiChain/utils', () => {
             {
               address,
               chainId: '1',
-              isWatchlist: false,
+              isReadOnly: false,
               isPinned: false,
               lastVisited: 0,
               name: undefined,
@@ -288,7 +288,7 @@ describe('multiChain/utils', () => {
             {
               address,
               chainId: '100',
-              isWatchlist: false,
+              isReadOnly: false,
               isPinned: false,
               lastVisited: 0,
               name: undefined,
@@ -338,7 +338,7 @@ describe('multiChain/utils', () => {
             {
               address,
               chainId: '1',
-              isWatchlist: false,
+              isReadOnly: false,
               isPinned: false,
               lastVisited: 0,
               name: undefined,
@@ -346,7 +346,7 @@ describe('multiChain/utils', () => {
             {
               address,
               chainId: '100',
-              isWatchlist: false,
+              isReadOnly: false,
               isPinned: false,
               lastVisited: 0,
               name: undefined,
@@ -402,7 +402,7 @@ describe('multiChain/utils', () => {
             {
               address,
               chainId: '1',
-              isWatchlist: false,
+              isReadOnly: false,
               isPinned: false,
               lastVisited: 0,
               name: undefined,
@@ -410,7 +410,7 @@ describe('multiChain/utils', () => {
             {
               address,
               chainId: '100',
-              isWatchlist: false,
+              isReadOnly: false,
               isPinned: false,
               lastVisited: 0,
               name: undefined,
@@ -418,7 +418,7 @@ describe('multiChain/utils', () => {
             {
               address,
               chainId: '5',
-              isWatchlist: false,
+              isReadOnly: false,
               isPinned: false,
               lastVisited: 0,
               name: undefined,
@@ -472,7 +472,7 @@ describe('multiChain/utils', () => {
             {
               address,
               chainId: '1',
-              isWatchlist: false,
+              isReadOnly: false,
               isPinned: false,
               lastVisited: 0,
               name: undefined,
@@ -480,7 +480,7 @@ describe('multiChain/utils', () => {
             {
               address,
               chainId: '100',
-              isWatchlist: false,
+              isReadOnly: false,
               isPinned: false,
               lastVisited: 0,
               name: undefined,

--- a/src/features/myAccounts/components/AccountInfoChips/index.tsx
+++ b/src/features/myAccounts/components/AccountInfoChips/index.tsx
@@ -50,7 +50,7 @@ const ReadOnlyChip = () => {
 
 export const AccountInfoChips = ({
   isActivating,
-  isWatchlist,
+  isReadOnly,
   undeployedSafe,
   isVisible,
   safeOverview,
@@ -60,7 +60,7 @@ export const AccountInfoChips = ({
   trackingLabel,
 }: {
   isActivating: boolean
-  isWatchlist: boolean
+  isReadOnly: boolean
   isVisible: boolean
   undeployedSafe: boolean
   safeOverview: SafeOverview | null
@@ -71,7 +71,7 @@ export const AccountInfoChips = ({
 }) => {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
-  const showQueueActions = isVisible && !undeployedSafe && !isWatchlist
+  const showQueueActions = isVisible && !undeployedSafe && !isReadOnly
 
   return (
     <Box sx={{ width: '100%', mt: 0.3 }}>
@@ -88,7 +88,7 @@ export const AccountInfoChips = ({
             <AccountStatusChip isActivating={isActivating} />
           )}
         </>
-      ) : isWatchlist ? (
+      ) : isReadOnly ? (
         <>
           {isMobile ? (
             <Track {...OVERVIEW_EVENTS.OPEN_SAFE} label={trackingLabel}>

--- a/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
+++ b/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
@@ -103,8 +103,8 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountIte
 
   const deployedChainIds = useMemo(() => safes.map((safe) => safe.chainId), [safes])
 
-  const isWatchlist = useMemo(
-    () => multiSafeAccountItem.safes.every((safe) => safe.isWatchlist),
+  const isReadOnly = useMemo(
+    () => multiSafeAccountItem.safes.every((safe) => safe.isReadOnly),
     [multiSafeAccountItem.safes],
   )
 
@@ -160,7 +160,7 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountIte
     const isGroupAdded = safes.every((safe) => allAddedSafes[safe.chainId]?.[safe.address])
     if (isGroupAdded) {
       for (const safe of safes) {
-        dispatch(pinSafe({ chainId: safe.chainId, address: safe.address, removeOnUnpin: false }))
+        dispatch(pinSafe({ chainId: safe.chainId, address: safe.address }))
       }
     } else {
       for (const safe of safes) {
@@ -176,7 +176,7 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountIte
             },
           }),
         )
-        dispatch(pinSafe({ chainId: safe.chainId, address: safe.address, removeOnUnpin: true }))
+        dispatch(pinSafe({ chainId: safe.chainId, address: safe.address }))
       }
     }
     trackEvent({ ...OVERVIEW_EVENTS.PIN_SAFE, label: PIN_SAFE_LABELS.pin })
@@ -277,7 +277,7 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountIte
               />
             ))}
           </Box>
-          {!isWatchlist && hasReplayableSafe && (
+          {!isReadOnly && hasReplayableSafe && (
             <>
               <Divider sx={{ ml: '-12px', mr: '-12px' }} />
               <Box

--- a/src/features/myAccounts/components/AccountItems/SingleAccountItem.tsx
+++ b/src/features/myAccounts/components/AccountItems/SingleAccountItem.tsx
@@ -25,7 +25,7 @@ import useWallet from '@/hooks/wallets/useWallet'
 import { hasMultiChainAddNetworkFeature } from '@/features/multichain/utils/utils'
 import BookmarkIcon from '@/public/images/apps/bookmark.svg'
 import BookmarkedIcon from '@/public/images/apps/bookmarked.svg'
-import { addOrUpdateSafe, pinSafe, selectAddedSafes, unpinSafe } from '@/store/addedSafesSlice'
+import { addOrUpdateSafe, unpinSafe } from '@/store/addedSafesSlice'
 import SafeIcon from '@/components/common/SafeIcon'
 import useOnceVisible from '@/hooks/useOnceVisible'
 import { skipToken } from '@reduxjs/toolkit/query'
@@ -40,7 +40,7 @@ type AccountItemProps = {
 }
 
 const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
-  const { chainId, address, isPinned, isWatchlist } = safeItem
+  const { chainId, address, isReadOnly, isPinned } = safeItem
   const chain = useAppSelector((state) => selectChainById(state, chainId))
   const undeployedSafe = useAppSelector((state) => selectUndeployedSafe(state, chainId, address))
   const safeAddress = useSafeAddress()
@@ -49,8 +49,6 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
   const isCurrentSafe = chainId === currChainId && sameAddress(safeAddress, address)
   const isWelcomePage = router.pathname === AppRoutes.welcome.accounts
   const { address: walletAddress } = useWallet() ?? {}
-  const addedSafes = useAppSelector((state) => selectAddedSafes(state, chainId))
-  const isAdded = !!addedSafes?.[address]
   const elementRef = useRef<HTMLDivElement>(null)
   const isVisible = useOnceVisible(elementRef)
   const theme = useTheme()
@@ -76,18 +74,16 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
 
   const addNetworkFeatureEnabled = hasMultiChainAddNetworkFeature(chain)
   const isReplayable =
-    addNetworkFeatureEnabled &&
-    !safeItem.isWatchlist &&
-    (!undeployedSafe || !isPredictedSafeProps(undeployedSafe.props))
+    addNetworkFeatureEnabled && !isReadOnly && (!undeployedSafe || !isPredictedSafeProps(undeployedSafe.props))
 
   const { data: safeOverview } = useGetSafeOverviewQuery(
     undeployedSafe || !isVisible
       ? skipToken
       : {
-        chainId: safeItem.chainId,
-        safeAddress: safeItem.address,
-        walletAddress,
-      },
+          chainId: safeItem.chainId,
+          safeAddress: safeItem.address,
+          walletAddress,
+        },
   )
 
   const safeThreshold = safeOverview?.threshold ?? counterfactualSetup?.threshold ?? defaultSafeInfo.threshold
@@ -162,7 +158,7 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
             {!isMobile && (
               <AccountInfoChips
                 isActivating={isActivating}
-                isWatchlist={isWatchlist}
+                isReadOnly={isReadOnly}
                 undeployedSafe={!!undeployedSafe}
                 isVisible={isVisible}
                 safeOverview={safeOverview ?? null}
@@ -206,7 +202,7 @@ const AccountItem = ({ onLinkClick, safeItem }: AccountItemProps) => {
       {isMobile && (
         <AccountInfoChips
           isActivating={isActivating}
-          isWatchlist={isWatchlist}
+          isReadOnly={isReadOnly}
           undeployedSafe={!!undeployedSafe}
           isVisible={isVisible}
           safeOverview={safeOverview ?? null}

--- a/src/features/myAccounts/components/AccountItems/SubAccountItem.tsx
+++ b/src/features/myAccounts/components/AccountItems/SubAccountItem.tsx
@@ -102,7 +102,7 @@ const SubAccountItem = ({ onLinkClick, safeItem, safeOverview }: SubAccountItem)
             {!isMobile && (
               <AccountInfoChips
                 isActivating={isActivating}
-                isWatchlist={safeItem.isWatchlist}
+                isReadOnly={safeItem.isReadOnly}
                 undeployedSafe={!!undeployedSafe}
                 isVisible={isVisible}
                 safeOverview={safeOverview ?? null}
@@ -124,13 +124,20 @@ const SubAccountItem = ({ onLinkClick, safeItem, safeOverview }: SubAccountItem)
         </Link>
       </Track>
       {undeployedSafe && (
-        <SafeListContextMenu name={name} address={address} chainId={chainId} addNetwork={false} rename={false} />
+        <SafeListContextMenu
+          name={name}
+          address={address}
+          chainId={chainId}
+          addNetwork={false}
+          rename={false}
+          undeployedSafe={!!undeployedSafe}
+        />
       )}
 
       {isMobile && (
         <AccountInfoChips
           isActivating={isActivating}
-          isWatchlist={safeItem.isWatchlist}
+          isReadOnly={safeItem.isReadOnly}
           undeployedSafe={!!undeployedSafe}
           isVisible={isVisible}
           safeOverview={safeOverview ?? null}

--- a/src/features/myAccounts/hooks/useAllSafes.ts
+++ b/src/features/myAccounts/hooks/useAllSafes.ts
@@ -50,7 +50,7 @@ const useAllSafes = (): SafeItems | undefined => {
     if (walletAddress && allOwned === undefined) {
       return []
     }
-    const chains = uniq(Object.keys(allOwned || {}).concat(Object.keys(allAdded))).concat(Object.keys(allUndeployed))
+    const chains = uniq(Object.keys(allOwned || {}).concat(Object.keys(allAdded), Object.keys(allUndeployed)))
     chains.sort((a, b) => parseInt(a) - parseInt(b))
 
     return chains.flatMap((chainId) => {
@@ -58,7 +58,7 @@ const useAllSafes = (): SafeItems | undefined => {
       const addedOnChain = Object.keys(allAdded[chainId] || {})
       const ownedOnChain = (allOwned || {})[chainId]
       const undeployedOnChain = Object.keys(allUndeployed[chainId] || {})
-      const uniqueAddresses = uniq(addedOnChain.concat(ownedOnChain).concat(undeployedOnChain)).filter(Boolean)
+      const uniqueAddresses = uniq(addedOnChain.concat(ownedOnChain, undeployedOnChain).filter(Boolean))
       uniqueAddresses.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
 
       return uniqueAddresses.map((address) => {

--- a/src/features/myAccounts/hooks/useAllSafes.ts
+++ b/src/features/myAccounts/hooks/useAllSafes.ts
@@ -11,7 +11,7 @@ import useAllOwnedSafes from './useAllOwnedSafes'
 export type SafeItem = {
   chainId: string
   address: string
-  isWatchlist: boolean
+  isReadOnly: boolean
   isPinned: boolean
   lastVisited: number
   name: string | undefined
@@ -41,45 +41,44 @@ const useAllSafes = (): SafeItems | undefined => {
   const { address: walletAddress = '' } = useWallet() || {}
   const [allOwned] = useAllOwnedSafes(walletAddress)
   const allAdded = useAddedSafes()
+  const allUndeployed = useAppSelector(selectUndeployedSafes)
   const allVisitedSafes = useAppSelector(selectAllVisitedSafes)
   const { configs } = useChains()
-  const undeployedSafes = useAppSelector(selectUndeployedSafes)
   const allSafeNames = useAppSelector(selectAllAddressBooks)
 
   return useMemo<SafeItems>(() => {
     if (walletAddress && allOwned === undefined) {
       return []
     }
-    const chains = uniq(Object.keys(allOwned || {}).concat(Object.keys(allAdded)))
+    const chains = uniq(Object.keys(allOwned || {}).concat(Object.keys(allAdded))).concat(Object.keys(allUndeployed))
     chains.sort((a, b) => parseInt(a) - parseInt(b))
 
     return chains.flatMap((chainId) => {
       if (!configs.some((item) => item.chainId === chainId)) return []
       const addedOnChain = Object.keys(allAdded[chainId] || {})
       const ownedOnChain = (allOwned || {})[chainId]
-      const undeployedOnChain = Object.keys(undeployedSafes[chainId] || {})
-      const uniqueAddresses = uniq(addedOnChain.concat(ownedOnChain)).filter(Boolean)
+      const undeployedOnChain = Object.keys(allUndeployed[chainId] || {})
+      const uniqueAddresses = uniq(addedOnChain.concat(ownedOnChain).concat(undeployedOnChain)).filter(Boolean)
       uniqueAddresses.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
 
       return uniqueAddresses.map((address) => {
         const owners = allAdded?.[chainId]?.[address]?.owners
+        const isPinned = !!allAdded?.[chainId]?.[address]
         const isOwner = owners?.some(({ value }) => sameAddress(walletAddress, value))
         const isOwned = (ownedOnChain || []).includes(address) || isOwner
-        const isUndeployed = undeployedOnChain.includes(address)
-        const isPinned = Boolean(allAdded?.[chainId]?.[address]?.pinned)
         const lastVisited = allVisitedSafes?.[chainId]?.[address]?.lastVisited || 0
         const name = allSafeNames?.[chainId]?.[address]
         return {
           address,
           chainId,
-          isWatchlist: !isOwned && !isUndeployed,
+          isReadOnly: !isOwned,
           isPinned,
           lastVisited,
           name,
         }
       })
     })
-  }, [allAdded, allOwned, configs, undeployedSafes, walletAddress, allVisitedSafes, allSafeNames])
+  }, [allAdded, allOwned, allUndeployed, configs, walletAddress, allVisitedSafes, allSafeNames])
 }
 
 export default useAllSafes

--- a/src/features/myAccounts/hooks/useTrackedSafesCount.ts
+++ b/src/features/myAccounts/hooks/useTrackedSafesCount.ts
@@ -21,7 +21,7 @@ const useTrackSafesCount = (
   const isLoginPage = router.pathname === AppRoutes.welcome.accounts
 
   const ownedMultiChainSafes = useMemo(
-    () => safes.allMultiChainSafes?.filter((account) => account.safes.some(({ isWatchlist }) => !isWatchlist)),
+    () => safes.allMultiChainSafes?.filter((account) => account.safes.some(({ isReadOnly }) => !isReadOnly)),
     [safes],
   )
 
@@ -29,19 +29,19 @@ const useTrackSafesCount = (
   const watchlistMultiChainSafes = useMemo(
     () =>
       safes.allMultiChainSafes?.filter((account) =>
-        account.safes.some(({ isWatchlist, isPinned }) => isWatchlist && !isPinned),
+        account.safes.some(({ isReadOnly, isPinned }) => isReadOnly && !isPinned),
       ),
     [safes],
   )
 
   const ownedSafes = useMemo<(MultiChainSafeItem | SafeItem)[]>(
-    () => [...(ownedMultiChainSafes ?? []), ...(safes.allSingleSafes?.filter(({ isWatchlist }) => !isWatchlist) ?? [])],
+    () => [...(ownedMultiChainSafes ?? []), ...(safes.allSingleSafes?.filter(({ isReadOnly }) => !isReadOnly) ?? [])],
     [safes, ownedMultiChainSafes],
   )
   const watchlistSafes = useMemo<(MultiChainSafeItem | SafeItem)[]>(
     () => [
       ...(watchlistMultiChainSafes ?? []),
-      ...(safes.allSingleSafes?.filter(({ isWatchlist, isPinned }) => isWatchlist && !isPinned) ?? []),
+      ...(safes.allSingleSafes?.filter(({ isReadOnly, isPinned }) => isReadOnly && !isPinned) ?? []),
     ],
     [safes, watchlistMultiChainSafes],
   )

--- a/src/store/__tests__/safeOverviews.test.ts
+++ b/src/store/__tests__/safeOverviews.test.ts
@@ -223,7 +223,7 @@ describe('safeOverviews', () => {
           {
             address: faker.finance.ethereumAddress(),
             chainId: '1',
-            isWatchlist: false,
+            isReadOnly: false,
             isPinned: false,
             lastVisited: 0,
             name: undefined,
@@ -231,7 +231,7 @@ describe('safeOverviews', () => {
           {
             address: faker.finance.ethereumAddress(),
             chainId: '10',
-            isWatchlist: false,
+            isReadOnly: false,
             isPinned: false,
             lastVisited: 0,
             name: undefined,
@@ -280,7 +280,7 @@ describe('safeOverviews', () => {
           {
             address: faker.finance.ethereumAddress(),
             chainId: '1',
-            isWatchlist: false,
+            isReadOnly: false,
             isPinned: false,
             lastVisited: 0,
             name: undefined,
@@ -288,7 +288,7 @@ describe('safeOverviews', () => {
           {
             address: faker.finance.ethereumAddress(),
             chainId: '10',
-            isWatchlist: false,
+            isReadOnly: false,
             isPinned: false,
             lastVisited: 0,
             name: undefined,
@@ -319,7 +319,7 @@ describe('safeOverviews', () => {
           {
             address: faker.finance.ethereumAddress(),
             chainId: '1',
-            isWatchlist: false,
+            isReadOnly: false,
             isPinned: false,
             lastVisited: 0,
             name: undefined,
@@ -327,7 +327,7 @@ describe('safeOverviews', () => {
           {
             address: faker.finance.ethereumAddress(),
             chainId: '1',
-            isWatchlist: false,
+            isReadOnly: false,
             isPinned: false,
             lastVisited: 0,
             name: undefined,
@@ -335,7 +335,7 @@ describe('safeOverviews', () => {
           {
             address: faker.finance.ethereumAddress(),
             chainId: '1',
-            isWatchlist: false,
+            isReadOnly: false,
             isPinned: false,
             lastVisited: 0,
             name: undefined,
@@ -343,7 +343,7 @@ describe('safeOverviews', () => {
           {
             address: faker.finance.ethereumAddress(),
             chainId: '1',
-            isWatchlist: false,
+            isReadOnly: false,
             isPinned: false,
             lastVisited: 0,
             name: undefined,
@@ -351,7 +351,7 @@ describe('safeOverviews', () => {
           {
             address: faker.finance.ethereumAddress(),
             chainId: '1',
-            isWatchlist: false,
+            isReadOnly: false,
             isPinned: false,
             lastVisited: 0,
             name: undefined,
@@ -359,7 +359,7 @@ describe('safeOverviews', () => {
           {
             address: faker.finance.ethereumAddress(),
             chainId: '1',
-            isWatchlist: false,
+            isReadOnly: false,
             isPinned: false,
             lastVisited: 0,
             name: undefined,
@@ -367,7 +367,7 @@ describe('safeOverviews', () => {
           {
             address: faker.finance.ethereumAddress(),
             chainId: '1',
-            isWatchlist: false,
+            isReadOnly: false,
             isPinned: false,
             lastVisited: 0,
             name: undefined,
@@ -375,7 +375,7 @@ describe('safeOverviews', () => {
           {
             address: faker.finance.ethereumAddress(),
             chainId: '1',
-            isWatchlist: false,
+            isReadOnly: false,
             isPinned: false,
             lastVisited: 0,
             name: undefined,
@@ -383,7 +383,7 @@ describe('safeOverviews', () => {
           {
             address: faker.finance.ethereumAddress(),
             chainId: '1',
-            isWatchlist: false,
+            isReadOnly: false,
             isPinned: false,
             lastVisited: 0,
             name: undefined,
@@ -391,7 +391,7 @@ describe('safeOverviews', () => {
           {
             address: faker.finance.ethereumAddress(),
             chainId: '1',
-            isWatchlist: false,
+            isReadOnly: false,
             isPinned: false,
             lastVisited: 0,
             name: undefined,
@@ -399,7 +399,7 @@ describe('safeOverviews', () => {
           {
             address: faker.finance.ethereumAddress(),
             chainId: '1',
-            isWatchlist: false,
+            isReadOnly: false,
             isPinned: false,
             lastVisited: 0,
             name: undefined,
@@ -407,7 +407,7 @@ describe('safeOverviews', () => {
           {
             address: faker.finance.ethereumAddress(),
             chainId: '1',
-            isWatchlist: false,
+            isReadOnly: false,
             isPinned: false,
             lastVisited: 0,
             name: undefined,
@@ -415,7 +415,7 @@ describe('safeOverviews', () => {
           {
             address: faker.finance.ethereumAddress(),
             chainId: '1',
-            isWatchlist: false,
+            isReadOnly: false,
             isPinned: false,
             lastVisited: 0,
             name: undefined,
@@ -423,7 +423,7 @@ describe('safeOverviews', () => {
           {
             address: faker.finance.ethereumAddress(),
             chainId: '1',
-            isWatchlist: false,
+            isReadOnly: false,
             isPinned: false,
             lastVisited: 0,
             name: undefined,
@@ -431,7 +431,7 @@ describe('safeOverviews', () => {
           {
             address: faker.finance.ethereumAddress(),
             chainId: '1',
-            isWatchlist: false,
+            isReadOnly: false,
             isPinned: false,
             lastVisited: 0,
             name: undefined,

--- a/src/store/addedSafesSlice.ts
+++ b/src/store/addedSafesSlice.ts
@@ -7,8 +7,6 @@ export type AddedSafesOnChain = {
     owners: AddressEx[]
     threshold: number
     ethBalance?: string
-    pinned?: boolean
-    removeOnUnpin?: boolean
   }
 }
 
@@ -51,29 +49,18 @@ export const addedSafesSlice = createSlice({
         delete state[chainId]
       }
     },
-    pinSafe: (state, { payload }: PayloadAction<{ chainId: string; address: string; removeOnUnpin: boolean }>) => {
-      const { chainId, address, removeOnUnpin } = payload
+    pinSafe: (state, { payload }: PayloadAction<{ chainId: string; address: string }>) => {
+      const { chainId, address } = payload
       state[chainId] ??= {}
-      state[chainId][address] = {
-        ...(state[chainId][address] ?? {}),
-        pinned: true,
-        removeOnUnpin,
-      }
+      state[chainId][address] = state[chainId][address] ?? {}
     },
     unpinSafe: (state, { payload }: PayloadAction<{ chainId: string; address: string }>) => {
       const { chainId, address } = payload
-      const removeOnUnpin = state[chainId]?.[address]?.removeOnUnpin
 
-      if (removeOnUnpin) {
-        delete state[chainId]?.[address]
-        if (Object.keys(state[chainId]).length === 0) {
-          delete state[chainId]
-        }
-      } else if (state[chainId]?.[address]) {
-        state[chainId][address] = {
-          ...state[chainId][address],
-          pinned: false,
-        }
+      delete state[chainId]?.[address]
+
+      if (Object.keys(state[chainId]).length === 0) {
+        delete state[chainId]
       }
     },
   },


### PR DESCRIPTION
## What it solves

Simplify the code and the UI by treating all Added Safes as pinned.

There's now no distinction between "watchlist" Safes and "pinned" Safes. Watchlist Safes are simply pinned read-only Safes.

Counterfactual Safes will be now always displayed under Accounts because they are added to the `useAllSafes` hook.