### PR TITLE
Fix: catch erros in message decoding

### DIFF
--- a/src/components/safe-messages/DecodedMsg/index.tsx
+++ b/src/components/safe-messages/DecodedMsg/index.tsx
@@ -10,6 +10,7 @@ import { isAddress } from 'ethers'
 import type { ReactElement } from 'react'
 import Msg from '../Msg'
 import css from './styles.module.css'
+import { logError, Errors } from '@/services/exceptions'
 
 const EIP712_DOMAIN_TYPE = 'EIP712Domain'
 
@@ -75,7 +76,13 @@ export const DecodedMsg = ({
   }
 
   // Normalize message such that we know the primaryType
-  const normalizedMsg = normalizeTypedData(message)
+  let normalizedMsg: EIP712Normalized
+  try {
+    normalizedMsg = normalizeTypedData(message)
+  } catch (error) {
+    logError(Errors._809, error)
+    normalizedMsg = message as EIP712Normalized
+  }
 
   return (
     <Box

--- a/src/components/safe-messages/MsgListItem/ExpandableMsgItem.tsx
+++ b/src/components/safe-messages/MsgListItem/ExpandableMsgItem.tsx
@@ -1,7 +1,8 @@
-import { Accordion, AccordionDetails, AccordionSummary } from '@mui/material'
+import { Accordion, AccordionDetails, AccordionSummary, Box } from '@mui/material'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import type { ReactElement } from 'react'
 import type { SafeMessage } from '@safe-global/safe-gateway-typescript-sdk'
+import { ErrorBoundary } from '@sentry/react'
 
 import MsgDetails from '@/components/safe-messages/MsgDetails'
 import MsgSummary from '@/components/safe-messages/MsgSummary'
@@ -26,7 +27,9 @@ const ExpandableMsgItem = ({ msg, expanded = false }: { msg: SafeMessage; expand
       </AccordionSummary>
 
       <AccordionDetails sx={{ padding: 0 }}>
-        <MsgDetails msg={msg} />
+        <ErrorBoundary fallback={<Box sx={{ p: 2 }}>Failed to render message details</Box>}>
+          <MsgDetails msg={msg} />
+        </ErrorBoundary>
       </AccordionDetails>
     </Accordion>
   )


### PR DESCRIPTION
## What it solves

Resolves #4561

## How this PR fixes it

I've added a catch-all error boundary around message details but also smaller localized try-catches for a couple places where it was failing in a specific safe.