### PR TITLE
fix: Advanced safe creation address computation

### DIFF
--- a/src/components/new-safe/create/AdvancedCreateSafe.tsx
+++ b/src/components/new-safe/create/AdvancedCreateSafe.tsx
@@ -1,3 +1,4 @@
+import { ECOSYSTEM_ID_ADDRESS } from '@/config/constants'
 import { Container, Typography, Grid } from '@mui/material'
 import { useRouter } from 'next/router'
 
@@ -98,6 +99,7 @@ const AdvancedCreateSafe = () => {
     threshold: 1,
     saltNonce: 0,
     safeVersion: getLatestSafeVersion(chain),
+    paymentReceiver: ECOSYSTEM_ID_ADDRESS,
   }
 
   const onClose = () => {

--- a/src/components/new-safe/create/index.tsx
+++ b/src/components/new-safe/create/index.tsx
@@ -28,10 +28,11 @@ export type NewSafeFormData = {
   networks: ChainInfo[]
   threshold: number
   owners: NamedAddress[]
-  saltNonce: number
+  saltNonce?: number
   safeVersion: SafeVersion
   safeAddress?: string
   willRelay?: boolean
+  paymentReceiver?: string
 }
 
 const staticHints: Record<
@@ -173,7 +174,6 @@ const CreateSafe = () => {
     networks: [],
     owners: [],
     threshold: 1,
-    saltNonce: 0,
     safeVersion: getLatestSafeVersion(chain) as SafeVersion,
   }
 

--- a/src/components/new-safe/create/logic/index.ts
+++ b/src/components/new-safe/create/logic/index.ts
@@ -202,7 +202,9 @@ export type UndeployedSafeWithoutSalt = Omit<ReplayedSafeProps, 'saltNonce'>
  */
 export const createNewUndeployedSafeWithoutSalt = (
   safeVersion: SafeVersion,
-  safeAccountConfig: Pick<ReplayedSafeProps['safeAccountConfig'], 'owners' | 'threshold'>,
+  safeAccountConfig: Pick<ReplayedSafeProps['safeAccountConfig'], 'owners' | 'threshold'> & {
+    paymentReceiver?: string
+  },
   chain: ChainInfo,
 ): UndeployedSafeWithoutSalt => {
   // Create universal deployment Data across chains:
@@ -243,7 +245,7 @@ export const createNewUndeployedSafeWithoutSalt = (
       fallbackHandler: fallbackHandlerAddress,
       to: includeMigration && safeToL2SetupAddress ? safeToL2SetupAddress : ZERO_ADDRESS,
       data: includeMigration ? safeToL2SetupInterface.encodeFunctionData('setupToL2', [safeL2Address]) : EMPTY_DATA,
-      paymentReceiver: ECOSYSTEM_ID_ADDRESS,
+      paymentReceiver: safeAccountConfig.paymentReceiver ?? ECOSYSTEM_ID_ADDRESS,
     },
     safeVersion,
   }

--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -184,11 +184,12 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
             {
               owners: data.owners.map((owner) => owner.address),
               threshold: data.threshold,
+              paymentReceiver: data.paymentReceiver,
             },
             chain,
           )
         : undefined,
-    [chain, data.owners, data.safeVersion, data.threshold],
+    [chain, data.owners, data.safeVersion, data.threshold, data.paymentReceiver],
   )
 
   const safePropsForGasEstimation = useMemo(() => {
@@ -226,12 +227,10 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
       setIsCreating(true)
 
       // Figure out the shared available nonce across chains
-      const nextAvailableNonce = await getAvailableSaltNonce(
-        customRPCs,
-        { ...newSafeProps, saltNonce: '0' },
-        data.networks,
-        knownAddresses,
-      )
+      const nextAvailableNonce =
+        data.saltNonce !== undefined
+          ? data.saltNonce.toString()
+          : await getAvailableSaltNonce(customRPCs, { ...newSafeProps, saltNonce: '0' }, data.networks, knownAddresses)
 
       const replayedSafeWithNonce = { ...newSafeProps, saltNonce: nextAvailableNonce }
 


### PR DESCRIPTION
## What it solves

Resolves #4560 

## How this PR fixes it

- Adds a `paymentReceiver` field to the advanced safe creation
- Uses the `ECOSYSTEM_ID_ADDRESS` as the default value for `paymentReceiver` during advanced safe creation
- Reuses `predictAddressBasedOnReplayData` during advanced safe creation for computing the safe address
- Uses `paymentReceiver` and `saltNonce` in `ReviewStep` if passed

## How to test it

Make sure that the advanced creation flags already created safes with and without the new paymentReceiver address

1. Go the `/new-safe/advanced-create`
2. Create an existing safe and go to the advanced options step
3. Observe that there is an error when using the same saltNonce
4. Choose any salt nonce, safe version and payment receiver
5. Go to the next step and submit the safe creation tx
6. Observe that the transaction data reflects previously chosen values for salt nonce, safe version and payment receiver

---

Make sure that multichain safe creation still works as expected

## Screenshots
<img width="803" alt="Screenshot 2024-11-25 at 13 15 59" src="https://github.com/user-attachments/assets/b6f2754c-622a-430c-9c4f-94ba1dfa340c">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
