### PR TITLE
fix: Init Safe SDK for replayed safes

### DIFF
--- a/src/hooks/coreSDK/safeCoreSDK.ts
+++ b/src/hooks/coreSDK/safeCoreSDK.ts
@@ -11,7 +11,7 @@ import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import semverSatisfies from 'semver/functions/satisfies'
 import { isValidMasterCopy } from '@/services/contracts/safeContracts'
 import { sameAddress } from '@/utils/addresses'
-import { isPredictedSafeProps } from '@/features/counterfactual/utils'
+import { isPredictedSafeProps, isReplayedSafeProps } from '@/features/counterfactual/utils'
 
 export const isLegacyVersion = (safeVersion: string): boolean => {
   const LEGACY_VERSION = '<1.3.0'
@@ -82,7 +82,7 @@ export const initSafeSDK = async ({
   }
 
   if (undeployedSafe) {
-    if (isPredictedSafeProps(undeployedSafe.props)) {
+    if (isPredictedSafeProps(undeployedSafe.props) || isReplayedSafeProps(undeployedSafe.props)) {
       return Safe.init({
         provider: provider._getConnection().url,
         isL1SafeSingleton,


### PR DESCRIPTION
## What it solves

Follow-up on #4404 

The local storage structure of undeployed safes changed with multichain but during SDK initialization we only checked for the old structure instead of also the new one. This results in the Activate now button always being disabled for new counterfactual safes.

## How this PR fixes it

- Init the Safe SDK if undeployed safe `isReplayedSafeProps` or `isPredictedSafeProps`

## How to test it

1. Create a new counterfactual safe
2. Observe that the Activate now button is enabled

## Screenshots

<img width="692" alt="Screenshot 2024-11-26 at 11 51 07" src="https://github.com/user-attachments/assets/5587126e-b84f-4c31-901e-1566bc217aeb">


## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
