### PR TITLE
fix: update `wallet_getCallsStatus` spec.

### DIFF
--- a/src/utils/hex.ts
+++ b/src/utils/hex.ts
@@ -1,3 +1,3 @@
 export const isEmptyHexData = (encodedData: string): boolean => encodedData !== '' && isNaN(parseInt(encodedData, 16))
 
-export const numberToHex = (value: number) => `0x${value.toString(16)}`
+export const numberToHex = (value: number | bigint): `0x${string}` => `0x${value.toString(16)}`


### PR DESCRIPTION
## What it solves

Resolves incorrect `wallet_getCallsStatus` implementation

## How this PR fixes it

Our [EIP-5792](https://eips.ethereum.org/EIPS/eip-5792) implementation adhers to an outdated spec. In particular, the `wallet_getCallsStatus` method returns an incorrect response.

This updates the return type according to the latest spec. (similar to the [Safe Apps SDK update](wallet_getCallsStatus)):

```ts
async wallet_getCallsStatus(safeTxHash: string): Promise<{
  status: BundleStatus
  receipts?: Array<{
    logs: TransactionReceipt['logs']
    status: `0x${string}` // Hex 1 or 0 for success or failure, respectively
    chainId: `0x${string}`
    blockHash: `0x${string}`
    blockNumber: `0x${string}`
    gasUsed: `0x${string}`
    transactionHash: `0x${string}`
  }>
}>
```
## How to test it

Connect an EIP-5792 capable DApp via WalletConnect and observe status requests returning as expected, e.g. pending until execution thereafter confirmed, with receipts.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
