### PR TITLE
fix: Don't break array elements in tx details into multiple lines if …

### DIFF
--- a/src/components/transactions/TxDetails/TxData/DecodedData/ValueArray/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/ValueArray/index.tsx
@@ -35,24 +35,26 @@ export const Value = ({ type, value, ...props }: ValueArrayProps): ReactElement 
     return (
       <Typography component="div" variant="body2">
         [
-        <div className={css.nestedWrapper}>
-          {parsedValue.map((address, index) => {
-            const key = `${props.key || props.method}-${index}`
-            if (Array.isArray(address)) {
-              const newProps = {
-                type,
-                ...props,
-                value: address,
+        {parsedValue.length > 0 && (
+          <div className={css.nestedWrapper}>
+            {parsedValue.map((address, index) => {
+              const key = `${props.key || props.method}-${index}`
+              if (Array.isArray(address)) {
+                const newProps = {
+                  type,
+                  ...props,
+                  value: address,
+                }
+                return <Value key={key} {...newProps} />
               }
-              return <Value key={key} {...newProps} />
-            }
-            return (
-              <div key={`${address}_${key}`}>
-                <EthHashInfo address={address} showAvatar={false} shortAddress={false} showCopyButton hasExplorer />
-              </div>
-            )
-          })}
-        </div>
+              return (
+                <div key={`${address}_${key}`}>
+                  <EthHashInfo address={address} showAvatar={false} shortAddress={false} showCopyButton hasExplorer />
+                </div>
+              )
+            })}
+          </div>
+        )}
         ]
       </Typography>
     )


### PR DESCRIPTION
## What it solves

In case a transaction method parameter is an empty array we should not break the brackets into multiple lines to improve readability.

## How this PR fixes it

- Only renders the div for the array contents if its not empty

## How to test it

1. Open a transaction that has array method parameters that are empty
2. Observe the array brackets don't break into the next line

## Screenshots

Before:
<img width="1126" alt="Screenshot 2024-11-26 at 15 50 11" src="https://github.com/user-attachments/assets/a4e0dbc6-d00d-4d7e-b899-3f3f91d32410">

After:
<img width="1128" alt="Screenshot 2024-11-26 at 15 50 45" src="https://github.com/user-attachments/assets/edb62424-8452-4dd7-b9ae-8595cb50a7c7">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
