### PR TITLE
Tests: Add safe pin tests

### DIFF
--- a/cypress/e2e/pages/create_wallet.pages.js
+++ b/cypress/e2e/pages/create_wallet.pages.js
@@ -191,9 +191,12 @@ export function clickOnContinueWithWalletBtn() {
   cy.get('button').contains(continueWithWalletBtn).click().wait(1000)
 }
 
+export function verifyConnectWalletBtnDisplayed() {
+  return cy.get(connectWalletBtn).should('be.visible')
+}
 export function clickOnConnectWalletBtn() {
   cy.get(welcomeLoginScreen).within(() => {
-    cy.get(connectWalletBtn).should('be.visible').should('be.enabled').click().wait(1000)
+    verifyConnectWalletBtnDisplayed().should('be.enabled').click().wait(1000)
   })
 }
 

--- a/cypress/e2e/pages/sidebar.pages.js
+++ b/cypress/e2e/pages/sidebar.pages.js
@@ -6,6 +6,7 @@ import { safeHeaderInfo } from './import_export.pages.js'
 import * as file from './import_export.pages.js'
 import safes from '../../fixtures/safes/static.json'
 import * as address_book from './address_book.page.js'
+import * as create_wallet from '../pages/create_wallet.pages.js'
 
 export const chainLogo = '[data-testid="chain-logo"]'
 const safeIcon = '[data-testid="safe-icon"]'
@@ -31,7 +32,7 @@ const readOnlyVisibility = '[data-testid="read-only-visibility"]'
 const currencySection = '[data-testid="currency-section"]'
 const missingSignatureInfo = '[data-testid="missing-signature-info"]'
 const queuedTxInfo = '[data-testid="queued-tx-info"]'
-const expandSafesList = '[data-testid="expand-safes-list" ]'
+const expandSafesList = '[data-testid="expand-safes-list"]'
 export const importBtn = '[data-testid="import-btn"]'
 export const pendingActivationIcon = '[data-testid="pending-activation-icon"]'
 const safeItemMenuIcon = '[data-testid="MoreVertIcon"]'
@@ -54,6 +55,10 @@ const modalAddNetworkName = '[data-testid="added-network"]'
 const networkSeperator = 'div[role="separator"]'
 export const addNetworkTooltip = '[data-testid="add-network-tooltip"]'
 const pinnedAccountsContainer = '[data-testid="pinned-accounts"]'
+const emptyPinnedList = '[data-testid="empty-pinned-list"]'
+const boomarkIcon = '[data-testid="bookmark-icon"]'
+const emptyAccountList = '[data-testid="empty-account-list"]'
+const searchInput = '[id="search-by-name"]'
 export const importBtnStr = 'Import'
 export const exportBtnStr = 'Export'
 export const undeployedSafe = 'Undeployed Sepolia'
@@ -67,6 +72,7 @@ const signersNotConsistentMsg3 =
 const signersNotConsistentConfirmTxViewMsg = (network) =>
   `Signers are not consistent across networks on this account. Changing signers will only affect the account on ${network}`
 const activateStr = 'You need to activate your Safe first'
+const emptyPinnedMessage = 'Personalize your account list by clicking theicon on the accounts most important to you.'
 
 export const addedSafesEth = ['0x8675...a19b']
 export const addedSafesSepolia = ['0x6d0b...6dC1', '0x5912...fFdb', '0x0637...708e', '0xD157...DE9a']
@@ -75,18 +81,22 @@ export const sideBarSafes = {
   safe1: '0xBb26E3717172d5000F87DeFd391994f789D80aEB',
   safe2: '0x905934aA8758c06B2422F0C90D97d2fbb6677811',
   safe1short: '0xBb26...0aEB',
+  safe1short_: '0xBb26',
   safe2short: '0x9059...7811',
   safe3short: '0x86Cb...2C27',
+  safe4short: '0x9261...7E00',
 }
+
+// 0x926186108f74dB20BFeb2b6c888E523C78cb7E00
 export const sideBarSafesPendingActions = {
   safe1: '0x5912f6616c84024cD1aff0D5b55bb36F5180fFdb',
   safe1short: '0x5912...fFdb',
 }
 export const testSafeHeaderDetails = ['2/2', safes.SEP_STATIC_SAFE_9_SHORT]
 const receiveAssetsStr = 'Receive assets'
-const emptyWatchListStr = 'Watch any Safe Account to keep an eye on its activity'
-const emptySafeListStr = "You don't have any Safe Accounts yet"
-const myAccountsStr = 'My accounts'
+const emptyPinnedListStr = 'Watch any Safe Account to keep an eye on its activity'
+const emptySafeListStr = "You don't have any safes yet"
+const accountsStr = 'Accounts'
 const confirmTxStr = (number) => `${number} to confirm`
 const pedningTxStr = (n) => `${n} pending`
 export const confirmGenStr = 'to confirm'
@@ -96,9 +106,28 @@ export const multichainSafes = {
   sepolia: 'Multichain Sepolia',
 }
 
+export function searchSafe(safe) {
+  cy.get(searchInput).clear().type(safe)
+}
+
+export function verifySearchInputPosition() {
+  cy.get(searchInput).then(($searchInput) => {
+    cy.get(pinnedAccountsContainer).then(($pinnedList) => {
+      const searchInputPosition = $searchInput[0].compareDocumentPosition($pinnedList[0])
+      expect(searchInputPosition & Node.DOCUMENT_POSITION_FOLLOWING).to.equal(Node.DOCUMENT_POSITION_FOLLOWING)
+    })
+  })
+}
+
 export function verifyNumberOfPendingTxTag(tx) {
   cy.get(pinnedAccountsContainer).within(() => {
     cy.get('span').contains(pedningTxStr(tx))
+  })
+}
+
+export function verifyPinnedSafe(safe) {
+  cy.get(pinnedAccountsContainer).within(() => {
+    cy.get(sideSafeListItem).contains(safe)
   })
 }
 
@@ -117,6 +146,16 @@ export function showAllSafes() {
       cy.get(expandSafesList).click()
       cy.wait(500)
     }
+  })
+}
+
+export function verifyAccountsCollapsed() {
+  cy.get(expandSafesList).should('have.attr', 'aria-expanded', 'false')
+}
+
+export function verifyConnectBtnDisplayed() {
+  cy.get(emptyAccountList).within(() => {
+    create_wallet.verifyConnectWalletBtnDisplayed()
   })
 }
 
@@ -193,8 +232,13 @@ export function verifySafeCount(count) {
   main.verifyMinimumElementsCount(sideSafeListItem, count)
 }
 
-export function openSidebar() {
+export function clickOnOpenSidebarBtn() {
   cy.get(openSafesIcon).click()
+}
+
+// Expands all safes in the sidebar
+export function openSidebar() {
+  clickOnOpenSidebarBtn()
   cy.wait(500)
   showAllSafes()
   main.verifyElementsExist([sidebarSafeContainer])
@@ -221,32 +265,30 @@ export function verifySafesByNetwork(netwrok, safes) {
   })
 }
 
-function getSafeItemByName(name) {
-  return cy
-    .get(sidebarSafeContainer)
-    .find(sideSafeListItem)
-    .contains(name)
-    .parents('span')
-    .parent()
-    .within(() => {
-      cy.get(safeItemOptionsBtn)
-    })
+function getSafeByName(safe) {
+  return cy.get(sidebarSafeContainer).find(sideSafeListItem).contains(safe).parents('span').parent()
+}
+
+function getSafeItemOptions(name) {
+  return getSafeByName(name).within(() => {
+    cy.get(safeItemOptionsBtn)
+  })
 }
 
 export function verifySafeReadOnlyState(safe) {
-  getSafeItemByName(safe).find(readOnlyVisibility).should('exist')
+  getSafeItemOptions(safe).find(readOnlyVisibility).should('exist')
 }
 
 export function verifyMissingSignature(safe) {
-  getSafeItemByName(safe).find(missingSignatureInfo).should('exist')
+  getSafeItemOptions(safe).find(missingSignatureInfo).should('exist')
 }
 
 export function verifyQueuedTx(safe) {
-  return getSafeItemByName(safe).find(queuedTxInfo).should('exist')
+  return getSafeItemOptions(safe).find(queuedTxInfo).should('exist')
 }
 
 export function clickOnSafeItemOptionsBtn(name) {
-  getSafeItemByName(name).find(safeItemOptionsBtn).click()
+  getSafeItemOptions(name).find(safeItemOptionsBtn).click()
 }
 
 export function clickOnSafeItemOptionsBtnByIndex(index) {
@@ -395,12 +437,25 @@ export function checkSafeAddressInHeader(address) {
   main.verifyValuesExist(sidebarSafeHeader, address)
 }
 
-export function verifyWatchlistIsEmpty() {
-  main.verifyValuesExist(sidebarSafeContainer, [emptyWatchListStr])
+export function verifyPinnedListIsEmpty() {
+  cy.get(emptyPinnedList).should('contain.text', emptyPinnedMessage).find('svg').should('exist')
 }
 
 export function verifySafeListIsEmpty() {
   main.verifyValuesExist(sidebarSafeContainer, [emptySafeListStr])
+}
+
+export function verifySafeBookmarkBtnExists(safe) {
+  getSafeByName(safe).within(() => {
+    cy.get(boomarkIcon).should('exist')
+  })
+}
+
+export function clickOnBookmarkBtn(safe) {
+  getSafeByName(safe).within(() => {
+    cy.get(boomarkIcon).click()
+    cy.wait(500)
+  })
 }
 
 export function verifySafeGiveNameOptionExists(index) {
@@ -408,8 +463,8 @@ export function verifySafeGiveNameOptionExists(index) {
   clickOnRenameBtn()
 }
 
-export function checkMyAccountCounter(value) {
-  cy.contains(myAccountsStr).should('contain', value)
+export function checkAccountsCounter(value) {
+  cy.contains(accountsStr).should('contain', value)
 }
 
 export function checkTxToConfirm(numberOfTx) {

--- a/cypress/e2e/prodhealthcheck/sidebar_3.cy.js
+++ b/cypress/e2e/prodhealthcheck/sidebar_3.cy.js
@@ -15,14 +15,14 @@ describe('[PROD] Sidebar tests 3', () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  it('Verify the "My accounts" counter at the top is counting all safes the user owns', () => {
+  it('Verify the "Accounts" counter at the top is counting all safes the user owns', () => {
     cy.visit(constants.prodbaseUrl + constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
     cy.intercept('GET', constants.safeListEndpoint, {
       11155111: [sideBar.sideBarSafes.safe1, sideBar.sideBarSafes.safe2],
     })
     wallet.connectSigner(signer)
     sideBar.openSidebar()
-    sideBar.checkMyAccountCounter(2)
+    sideBar.checkAccountsCounter(2)
   })
 
   it('Verify pending signature is displayed in sidebar for unsigned tx', () => {
@@ -33,14 +33,12 @@ describe('[PROD] Sidebar tests 3', () => {
     })
     sideBar.openSidebar()
     sideBar.verifyTxToConfirmDoesNotExist()
-    cy.get('body').click()
     owner.clickOnWalletExpandMoreIcon()
     navigation.clickOnDisconnectBtn()
     cy.intercept('GET', constants.safeListEndpoint, {
       11155111: [sideBar.sideBarSafesPendingActions.safe1],
     })
     wallet.connectSigner(signer2)
-    sideBar.openSidebar()
     sideBar.verifyAddedSafesExist([sideBar.sideBarSafesPendingActions.safe1short])
     sideBar.checkTxToConfirm(1)
   })

--- a/cypress/e2e/regression/sidebar_3.cy.js
+++ b/cypress/e2e/regression/sidebar_3.cy.js
@@ -19,7 +19,7 @@ describe('Sidebar tests 3', () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  it('Verify that users with no accounts see the empty state in "My accounts" block', () => {
+  it('Verify the empty state of the "All accounts" list', () => {
     cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
     cy.intercept('GET', constants.safeListEndpoint, { 1: [], 100: [], 137: [], 11155111: [] })
     wallet.connectSigner(signer)
@@ -27,12 +27,12 @@ describe('Sidebar tests 3', () => {
     sideBar.verifySafeListIsEmpty()
   })
 
-  it('Verify empty state of the Watchlist', () => {
+  it('Verify the empty state of the pinned safes list', () => {
     cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
     cy.intercept('GET', constants.safeListEndpoint, {})
     wallet.connectSigner(signer)
     sideBar.openSidebar()
-    sideBar.verifyWatchlistIsEmpty()
+    sideBar.verifyPinnedListIsEmpty()
   })
 
   it('Verify connected user is redirected from welcome page to accounts page', () => {
@@ -50,11 +50,9 @@ describe('Sidebar tests 3', () => {
     cy.intercept('GET', constants.safeListEndpoint, {
       11155111: [sideBar.sideBarSafes.safe1, sideBar.sideBarSafes.safe2],
     })
-
     wallet.connectSigner(signer)
     sideBar.openSidebar()
-    sideBar.verifyAddedSafesExistByIndex(0, sideBar.sideBarSafes.safe1short)
-    sideBar.verifyAddedSafesExistByIndex(1, sideBar.sideBarSafes.safe2short)
+    sideBar.verifyAddedSafesExist([sideBar.sideBarSafes.safe1short, sideBar.sideBarSafes.safe2short])
   })
 
   it('Verify there is an option to name an unnamed safe', () => {
@@ -80,14 +78,14 @@ describe('Sidebar tests 3', () => {
   })
 
   // Added to prod
-  it('Verify the "My accounts" counter at the top is counting all safes the user owns', () => {
+  it('Verify the "Accounts" counter at the top is counting all safes the user owns', () => {
     cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
     cy.intercept('GET', constants.safeListEndpoint, {
       11155111: [sideBar.sideBarSafes.safe1, sideBar.sideBarSafes.safe2],
     })
     wallet.connectSigner(signer)
     sideBar.openSidebar()
-    sideBar.checkMyAccountCounter(2)
+    sideBar.checkAccountsCounter(2)
   })
 
   it('Verify that safes the user do not owns show in the watchlist after adding them', () => {
@@ -115,16 +113,12 @@ describe('Sidebar tests 3', () => {
     })
     sideBar.openSidebar()
     sideBar.verifyTxToConfirmDoesNotExist()
-
-    cy.get('body').click()
-
     owner.clickOnWalletExpandMoreIcon()
     navigation.clickOnDisconnectBtn()
     cy.intercept('GET', constants.safeListEndpoint, {
       11155111: [sideBar.sideBarSafesPendingActions.safe1],
     })
     wallet.connectSigner(signer2)
-    sideBar.openSidebar()
     sideBar.verifyAddedSafesExist([sideBar.sideBarSafesPendingActions.safe1short])
     sideBar.checkTxToConfirm(1)
   })

--- a/cypress/e2e/regression/sidebar_4.cy.js
+++ b/cypress/e2e/regression/sidebar_4.cy.js
@@ -1,0 +1,67 @@
+import * as constants from '../../support/constants.js'
+import * as main from '../pages/main.page.js'
+import * as sideBar from '../pages/sidebar.pages.js'
+import * as ls from '../../support/localstorage_data.js'
+import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
+import * as wallet from '../../support/utils/wallet.js'
+
+let staticSafes = []
+const walletCredentials = JSON.parse(Cypress.env('CYPRESS_WALLET_CREDENTIALS'))
+const signer = walletCredentials.OWNER_4_PRIVATE_KEY
+
+describe('Sidebar tests 4', () => {
+  before(async () => {
+    staticSafes = await getSafes(CATEGORIES.static)
+  })
+
+  it('Verify that safes in the sidebar show the "bookmark" icon', () => {
+    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
+    cy.intercept('GET', constants.safeListEndpoint, {
+      11155111: [sideBar.sideBarSafes.safe1],
+    })
+    wallet.connectSigner(signer)
+    sideBar.openSidebar()
+    sideBar.verifySafeBookmarkBtnExists(sideBar.sideBarSafes.safe1short)
+  })
+
+  it('Verify a safe can be added and removed from the pinned list', () => {
+    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
+    cy.intercept('GET', constants.safeListEndpoint, {
+      11155111: [sideBar.sideBarSafes.safe1],
+    })
+    wallet.connectSigner(signer)
+    sideBar.openSidebar()
+    sideBar.clickOnBookmarkBtn(sideBar.sideBarSafes.safe1short)
+    sideBar.verifyPinnedSafe(sideBar.sideBarSafes.safe1short)
+    sideBar.clickOnBookmarkBtn(sideBar.sideBarSafes.safe1short)
+    sideBar.verifyPinnedListIsEmpty()
+  })
+
+  it('Verify CF safe can be added and removed from the pinned list', () => {
+    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
+    cy.intercept('GET', constants.safeListEndpoint, { 1: [], 100: [], 137: [], 11155111: [] })
+    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__undeployedSafes, ls.undeployedSafe.safe1)
+    wallet.connectSigner(signer)
+    sideBar.openSidebar()
+    sideBar.clickOnBookmarkBtn(sideBar.sideBarSafes.safe4short)
+    sideBar.verifyPinnedSafe(sideBar.sideBarSafes.safe4short)
+    sideBar.clickOnBookmarkBtn(sideBar.sideBarSafes.safe4short)
+    sideBar.verifyPinnedListIsEmpty()
+  })
+
+  it('Verify the "All account" list is always closed by whenever you open the sidebar', () => {
+    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
+    cy.intercept('GET', constants.safeListEndpoint, {
+      11155111: [sideBar.sideBarSafes.safe1],
+    })
+    wallet.connectSigner(signer)
+    sideBar.clickOnOpenSidebarBtn()
+    sideBar.verifyAccountsCollapsed()
+  })
+
+  it('Verify the empty state of Accounts shows "Connect" for a disconnected user', () => {
+    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
+    sideBar.openSidebar()
+    sideBar.verifyConnectBtnDisplayed()
+  })
+})

--- a/cypress/e2e/regression/sidebar_5.cy.js
+++ b/cypress/e2e/regression/sidebar_5.cy.js
@@ -1,0 +1,39 @@
+import * as constants from '../../support/constants.js'
+import * as main from '../pages/main.page.js'
+import * as sideBar from '../pages/sidebar.pages.js'
+import * as ls from '../../support/localstorage_data.js'
+import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
+import * as wallet from '../../support/utils/wallet.js'
+import * as create_wallet from '../pages/create_wallet.pages.js'
+import * as navigation from '../pages/navigation.page.js'
+import * as owner from '../pages/owners.pages.js'
+
+let staticSafes = []
+const walletCredentials = JSON.parse(Cypress.env('CYPRESS_WALLET_CREDENTIALS'))
+const signer = walletCredentials.OWNER_4_PRIVATE_KEY
+
+describe('Sidebar search tests', () => {
+  before(async () => {
+    staticSafes = await getSafes(CATEGORIES.static)
+  })
+
+  it('Verify the search input shows at the top above the pinned safes list', () => {
+    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
+    cy.intercept('GET', constants.safeListEndpoint, { 1: [], 100: [], 137: [], 11155111: [] })
+    sideBar.openSidebar()
+    sideBar.verifySearchInputPosition()
+  })
+
+  it('Verify the search find safes in both pinned and unpinned safes', () => {
+    cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_9)
+    cy.intercept('GET', constants.safeListEndpoint, {
+      11155111: [sideBar.sideBarSafes.safe1, sideBar.sideBarSafes.safe2],
+    })
+    wallet.connectSigner(signer)
+    sideBar.openSidebar()
+    sideBar.clickOnBookmarkBtn(sideBar.sideBarSafes.safe1short)
+    sideBar.searchSafe(sideBar.sideBarSafes.safe1short_)
+    sideBar.verifyAddedSafesExist([sideBar.sideBarSafes.safe1short])
+    sideBar.verifySafeCount(1)
+  })
+})

--- a/src/features/myAccounts/index.tsx
+++ b/src/features/myAccounts/index.tsx
@@ -183,7 +183,7 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
                   {pinnedSafes.length > 0 ? (
                     <SafesList safes={pinnedSafes} onLinkClick={onLinkClick} />
                   ) : (
-                    <Box className={css.noPinnedSafesMessage}>
+                    <Box data-testid="empty-pinned-list" className={css.noPinnedSafesMessage}>
                       <Typography color="text.secondary" variant="body2" maxWidth="350px" textAlign="center">
                         Personalize your account list by clicking the
                         <SvgIcon
@@ -233,6 +233,7 @@ const AccountsList = ({ safes, onLinkClick, isSidebar = false }: AccountsListPro
                       </Box>
                     ) : (
                       <Typography
+                        data-testid="empty-account-list"
                         component="div"
                         variant="body2"
                         color="text.secondary"


### PR DESCRIPTION
## What it solves

## How this PR fixes it

- To provide automation coverage, some sidebar safe pin/unpin tests were added.
- This task also includes fixes for existing sidebar tests changed due to introduction of pin/unpin functionality.

## How to test it

- Run Cypress tests and observe outcome.