### PR TITLE
Tests: Add regex to handle my accounts

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -67,7 +67,7 @@ export default defineConfig({
     hideXHR: true,
     defaultCommandTimeout: 10000,
     pageLoadTimeout: 60000,
-    numTestsKeptInMemory: 0,
+    numTestsKeptInMemory: 20,
   },
 
   chromeWebSecurity: false,

--- a/cypress/e2e/pages/sidebar.pages.js
+++ b/cypress/e2e/pages/sidebar.pages.js
@@ -96,7 +96,7 @@ export const testSafeHeaderDetails = ['2/2', safes.SEP_STATIC_SAFE_9_SHORT]
 const receiveAssetsStr = 'Receive assets'
 const emptyPinnedListStr = 'Watch any Safe Account to keep an eye on its activity'
 const emptySafeListStr = "You don't have any safes yet"
-const accountsStr = 'Accounts'
+const accountsRegex = /(My accounts|Accounts) \((\d+)\)/
 const confirmTxStr = (number) => `${number} to confirm`
 const pedningTxStr = (n) => `${n} pending`
 export const confirmGenStr = 'to confirm'
@@ -464,7 +464,14 @@ export function verifySafeGiveNameOptionExists(index) {
 }
 
 export function checkAccountsCounter(value) {
-  cy.contains(accountsStr).should('contain', value)
+  cy.get(sidebarSafeContainer)
+    .should('exist')
+    .then(($el) => {
+      const text = $el.text()
+      const match = text.match(accountsRegex)
+      expect(match).not.to.be.null
+      expect(match[0]).to.exist
+    })
 }
 
 export function checkTxToConfirm(numberOfTx) {

--- a/cypress/e2e/prodhealthcheck/sidebar_3.cy.js
+++ b/cypress/e2e/prodhealthcheck/sidebar_3.cy.js
@@ -22,7 +22,7 @@ describe('[PROD] Sidebar tests 3', () => {
     })
     wallet.connectSigner(signer)
     sideBar.openSidebar()
-    sideBar.checkAccountsCounter(2)
+    sideBar.checkAccountsCounter('2')
   })
 
   it('Verify pending signature is displayed in sidebar for unsigned tx', () => {


### PR DESCRIPTION
## What it solves

## How this PR fixes it

- To handle string variations in Accounts/My accounts section, the regex was added.

## How to test it

- Run Cypress tests and observe outcome.