### PR TITLE
Tests: Add timeout for drain account app

### DIFF
--- a/cypress/e2e/safe-apps/drain_account.spec.cy.js
+++ b/cypress/e2e/safe-apps/drain_account.spec.cy.js
@@ -13,7 +13,7 @@ let iframeSelector
 const walletCredentials = JSON.parse(Cypress.env('CYPRESS_WALLET_CREDENTIALS'))
 const signer = walletCredentials.OWNER_4_PRIVATE_KEY
 
-describe('Drain Account tests', () => {
+describe('Drain Account tests', { defaultCommandTimeout: 40000 }, () => {
   before(async () => {
     safeAppSafes = await getSafes(CATEGORIES.safeapps)
   })


### PR DESCRIPTION
## What it solves

## How this PR fixes it

- Sometimes there is a longer wait period for safe with the message "Waiting for Safe". The wait time in tests to be increased a bit to handle this wait. 

## How to test it

- Run Cypress tests and observe outcome.

## Screenshots
![safe](https://github.com/user-attachments/assets/a6b1596e-6bb0-4c4f-b73a-e3fd23eb322e)


