### PR TITLE
fix: add event labels to opening and (un-)pinning of Safe Apps

### DIFF
--- a/src/components/dashboard/SafeAppsDashboardSection/SafeAppsDashboardSection.tsx
+++ b/src/components/dashboard/SafeAppsDashboardSection/SafeAppsDashboardSection.tsx
@@ -10,6 +10,7 @@ import SafeAppPreviewDrawer from '@/components/safe-apps/SafeAppPreviewDrawer'
 import SafeAppCard, { SafeAppCardContainer } from '@/components/safe-apps/SafeAppCard'
 import { AppRoutes } from '@/config/routes'
 import ExploreSafeAppsIcon from '@/public/images/apps/explore.svg'
+import { SAFE_APPS_LABELS } from '@/services/analytics'
 
 import css from './styles.module.css'
 
@@ -34,7 +35,7 @@ const SafeAppsDashboardSection = () => {
           <Grid key={rankedSafeApp.id} item xs={12} sm={6} md={4} xl={4}>
             <SafeAppCard
               safeApp={rankedSafeApp}
-              onBookmarkSafeApp={togglePin}
+              onBookmarkSafeApp={(appId) => togglePin(appId, SAFE_APPS_LABELS.dashboard)}
               isBookmarked={pinnedSafeAppIds.has(rankedSafeApp.id)}
               onClickSafeApp={() => openPreviewDrawer(rankedSafeApp)}
               openPreviewDrawer={openPreviewDrawer}
@@ -51,7 +52,7 @@ const SafeAppsDashboardSection = () => {
         safeApp={previewDrawerApp}
         isBookmarked={previewDrawerApp && pinnedSafeAppIds.has(previewDrawerApp.id)}
         onClose={closePreviewDrawer}
-        onBookmark={togglePin}
+        onBookmark={(appId) => togglePin(appId, SAFE_APPS_LABELS.apps_sidebar)}
       />
     </WidgetContainer>
   )

--- a/src/components/dashboard/SafeAppsDashboardSection/SafeAppsDashboardSection.tsx
+++ b/src/components/dashboard/SafeAppsDashboardSection/SafeAppsDashboardSection.tsx
@@ -37,7 +37,11 @@ const SafeAppsDashboardSection = () => {
               safeApp={rankedSafeApp}
               onBookmarkSafeApp={(appId) => togglePin(appId, SAFE_APPS_LABELS.dashboard)}
               isBookmarked={pinnedSafeAppIds.has(rankedSafeApp.id)}
-              onClickSafeApp={() => openPreviewDrawer(rankedSafeApp)}
+              onClickSafeApp={(e) => {
+                // Don't open link
+                e.preventDefault()
+                openPreviewDrawer(rankedSafeApp)
+              }}
               openPreviewDrawer={openPreviewDrawer}
             />
           </Grid>

--- a/src/components/safe-apps/AppFrame/index.tsx
+++ b/src/components/safe-apps/AppFrame/index.tsx
@@ -2,14 +2,12 @@ import useAddressBook from '@/hooks/useAddressBook'
 import useChainId from '@/hooks/useChainId'
 import { type AddressBookItem, Methods } from '@safe-global/safe-apps-sdk'
 import type { ReactElement } from 'react'
-import { useMemo } from 'react'
 import { useCallback, useEffect } from 'react'
 import { Box, CircularProgress, Typography } from '@mui/material'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
 import type { RequestId } from '@safe-global/safe-apps-sdk'
 import { trackSafeAppOpenCount } from '@/services/safe-apps/track-app-usage-count'
-import { SAFE_APPS_EVENTS, trackSafeAppEvent } from '@/services/analytics'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { useSafeAppFromBackend } from '@/hooks/safe-apps/useSafeAppFromBackend'
 import { useSafePermissions } from '@/hooks/safe-apps/permissions'
@@ -57,13 +55,12 @@ const AppFrame = ({ appUrl, allowedFeaturesList, safeAppFromManifest, isNativeEm
     transactions,
   } = useTransactionQueueBarState()
   const queueBarVisible = transactions.results.length > 0 && !queueBarDismissed
-  const [remoteApp, , isBackendAppsLoading] = useSafeAppFromBackend(appUrl, safe.chainId)
+  const [remoteApp] = useSafeAppFromBackend(appUrl, safe.chainId)
   const { thirdPartyCookiesDisabled, setThirdPartyCookiesDisabled } = useThirdPartyCookies()
   const { iframeRef, appIsLoading, isLoadingSlow, setAppIsLoading } = useAppIsLoading()
   useAnalyticsFromSafeApp(iframeRef)
   const { permissionsRequest, setPermissionsRequest, confirmPermissionRequest, getPermissions, hasPermission } =
     useSafePermissions()
-  const appName = useMemo(() => (remoteApp ? remoteApp.name : appUrl), [appUrl, remoteApp])
 
   const communicator = useCustomAppCommunicator(iframeRef, remoteApp || safeAppFromManifest, chain, {
     onGetPermissions: getPermissions,
@@ -109,17 +106,6 @@ const AppFrame = ({ appUrl, allowedFeaturesList, safeAppFromManifest, isNativeEm
       gtmTrackPageview(`${router.pathname}?appUrl=${router.query.appUrl}`, router.asPath)
     }
   }, [appUrl, iframeRef, setAppIsLoading, router, isNativeEmbed])
-
-  useEffect(() => {
-    if (!isNativeEmbed && !appIsLoading && !isBackendAppsLoading) {
-      trackSafeAppEvent(
-        {
-          ...SAFE_APPS_EVENTS.OPEN_APP,
-        },
-        appName,
-      )
-    }
-  }, [appIsLoading, isBackendAppsLoading, appName, isNativeEmbed])
 
   if (!safeLoaded) {
     return <div />

--- a/src/components/safe-apps/SafeAppCard/index.tsx
+++ b/src/components/safe-apps/SafeAppCard/index.tsx
@@ -21,7 +21,7 @@ import css from './styles.module.css'
 
 type SafeAppCardProps = {
   safeApp: SafeAppData
-  onClickSafeApp?: () => void
+  onClickSafeApp?: (e: SyntheticEvent) => void
   isBookmarked?: boolean
   onBookmarkSafeApp?: (safeAppId: number) => void
   removeCustomApp?: (safeApp: SafeAppData) => void
@@ -66,7 +66,7 @@ export const getSafeAppUrl = (router: NextRouter, safeAppUrl: string) => {
 
 type SafeAppCardViewProps = {
   safeApp: SafeAppData
-  onClickSafeApp?: () => void
+  onClickSafeApp?: (e: SyntheticEvent) => void
   safeAppUrl: string
   isBookmarked?: boolean
   onBookmarkSafeApp?: (safeAppId: number) => void
@@ -137,7 +137,7 @@ const SafeAppCardGridView = ({
 }
 
 type SafeAppCardContainerProps = {
-  onClickSafeApp?: () => void
+  onClickSafeApp?: (e: SyntheticEvent) => void
   safeAppUrl: string
   children: ReactNode
   height?: string
@@ -153,8 +153,7 @@ export const SafeAppCardContainer = ({
 }: SafeAppCardContainerProps) => {
   const handleClickSafeApp = (event: SyntheticEvent) => {
     if (onClickSafeApp) {
-      event.preventDefault()
-      onClickSafeApp()
+      onClickSafeApp(event)
     }
   }
 

--- a/src/components/safe-apps/SafeAppList/index.tsx
+++ b/src/components/safe-apps/SafeAppList/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { type SyntheticEvent, useCallback } from 'react'
 import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
 
 import SafeAppCard from '@/components/safe-apps/SafeAppCard'
@@ -46,18 +46,16 @@ const SafeAppList = ({
   const showZeroResultsPlaceholder = query && safeAppsList.length === 0
 
   const handleSafeAppClick = useCallback(
-    (safeApp: SafeAppData) => {
-      if (openedSafeAppIds.includes(safeApp.id)) {
+    (e: SyntheticEvent, safeApp: SafeAppData) => {
+      const isCustomApp = safeApp.id < 1
+      if (!openedSafeAppIds.includes(safeApp.id) && !isCustomApp) {
+        // Don't open link
+        e.preventDefault()
+        openPreviewDrawer(safeApp)
+      } else {
         // We only track if not previously opened as it is then tracked in preview drawer
         trackSafeAppEvent({ ...SAFE_APPS_EVENTS.OPEN_APP, label: eventLabel }, safeApp.name)
-        return
       }
-
-      const isCustomApp = safeApp.id < 1
-
-      if (isCustomApp) return
-
-      openPreviewDrawer(safeApp)
     },
     [eventLabel, openPreviewDrawer, openedSafeAppIds],
   )
@@ -93,7 +91,7 @@ const SafeAppList = ({
               isBookmarked={bookmarkedSafeAppsId?.has(safeApp.id)}
               onBookmarkSafeApp={() => togglePin(safeApp.id, eventLabel)}
               removeCustomApp={removeCustomApp}
-              onClickSafeApp={() => handleSafeAppClick(safeApp)}
+              onClickSafeApp={(e) => handleSafeAppClick(e, safeApp)}
               openPreviewDrawer={openPreviewDrawer}
             />
           </li>

--- a/src/components/safe-apps/SafeAppPreviewDrawer/index.tsx
+++ b/src/components/safe-apps/SafeAppPreviewDrawer/index.tsx
@@ -18,6 +18,7 @@ import SafeAppSocialLinksCard from '@/components/safe-apps/SafeAppSocialLinksCar
 import CloseIcon from '@/public/images/common/close.svg'
 import { useOpenedSafeApps } from '@/hooks/safe-apps/useOpenedSafeApps'
 import css from './styles.module.css'
+import { SAFE_APPS_EVENTS, SAFE_APPS_LABELS, trackSafeAppEvent } from '@/services/analytics'
 
 type SafeAppPreviewDrawerProps = {
   safeApp?: SafeAppData
@@ -35,6 +36,7 @@ const SafeAppPreviewDrawer = ({ isOpen, safeApp, isBookmarked, onClose, onBookma
   const onOpenSafe = () => {
     if (safeApp) {
       markSafeAppOpened(safeApp.id)
+      trackSafeAppEvent({ ...SAFE_APPS_EVENTS.OPEN_APP, label: SAFE_APPS_LABELS.apps_sidebar }, safeApp.name)
     }
   }
 

--- a/src/hooks/safe-apps/useSafeApps.ts
+++ b/src/hooks/safe-apps/useSafeApps.ts
@@ -5,7 +5,7 @@ import { useCustomSafeApps } from '@/hooks/safe-apps/useCustomSafeApps'
 import { usePinnedSafeApps } from '@/hooks/safe-apps/usePinnedSafeApps'
 import { useBrowserPermissions, useSafePermissions } from './permissions'
 import { useRankedSafeApps } from '@/hooks/safe-apps/useRankedSafeApps'
-import { SAFE_APPS_EVENTS, trackSafeAppEvent } from '@/services/analytics'
+import { SAFE_APPS_EVENTS, type SAFE_APPS_LABELS, trackSafeAppEvent } from '@/services/analytics'
 
 type ReturnType = {
   allSafeApps: SafeAppData[]
@@ -18,7 +18,7 @@ type ReturnType = {
   customSafeAppsLoading: boolean
   remoteSafeAppsError?: Error
   addCustomApp: (app: SafeAppData) => void
-  togglePin: (appId: number) => void
+  togglePin: (appId: number, eventLabel: SAFE_APPS_LABELS) => void
   removeCustomApp: (appId: number) => void
 }
 
@@ -61,17 +61,17 @@ const useSafeApps = (): ReturnType => {
     [updateCustomSafeApps, customSafeApps, removeSafePermissions, removeBrowserPermissions],
   )
 
-  const togglePin = (appId: number) => {
+  const togglePin = (appId: number, eventLabel: SAFE_APPS_LABELS) => {
     const alreadyPinned = pinnedSafeAppIds.has(appId)
     const newSet = new Set(pinnedSafeAppIds)
     const appName = allSafeApps.find((app) => app.id === appId)?.name
 
     if (alreadyPinned) {
       newSet.delete(appId)
-      trackSafeAppEvent(SAFE_APPS_EVENTS.UNPIN, appName)
+      trackSafeAppEvent({ ...SAFE_APPS_EVENTS.UNPIN, label: eventLabel }, appName)
     } else {
       newSet.add(appId)
-      trackSafeAppEvent(SAFE_APPS_EVENTS.PIN, appName)
+      trackSafeAppEvent({ ...SAFE_APPS_EVENTS.PIN, label: eventLabel }, appName)
     }
     updatePinnedSafeApps(newSet)
   }

--- a/src/pages/apps/custom.tsx
+++ b/src/pages/apps/custom.tsx
@@ -8,6 +8,7 @@ import SafeAppList from '@/components/safe-apps/SafeAppList'
 import SafeAppsSDKLink from '@/components/safe-apps/SafeAppsSDKLink'
 import { RemoveCustomAppModal } from '@/components/safe-apps/RemoveCustomAppModal'
 import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
+import { SAFE_APPS_LABELS } from '@/services/analytics'
 
 const CustomSafeApps: NextPage = () => {
   // TODO: create a custom hook instead of use useSafeApps
@@ -42,6 +43,7 @@ const CustomSafeApps: NextPage = () => {
           safeAppsList={customSafeApps}
           addCustomApp={addCustomApp}
           removeCustomApp={openRemoveCustomAppModal}
+          eventLabel={SAFE_APPS_LABELS.apps_custom}
         />
       </main>
 

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -14,10 +14,11 @@ import useSafeAppsFilters from '@/hooks/safe-apps/useSafeAppsFilters'
 import SafeAppsFilters from '@/components/safe-apps/SafeAppsFilters'
 import { useHasFeature } from '@/hooks/useChains'
 import { FEATURES } from '@/utils/chains'
+import { SAFE_APPS_LABELS } from '@/services/analytics'
 
 const SafeApps: NextPage = () => {
   const router = useRouter()
-  const { remoteSafeApps, remoteSafeAppsLoading, pinnedSafeApps, pinnedSafeAppIds, togglePin } = useSafeApps()
+  const { remoteSafeApps, remoteSafeAppsLoading, pinnedSafeApps, pinnedSafeAppIds } = useSafeApps()
   const { filteredApps, query, setQuery, setSelectedCategories, setOptimizedWithBatchFilter, selectedCategories } =
     useSafeAppsFilters(remoteSafeApps)
   const isFiltered = filteredApps.length !== remoteSafeApps.length
@@ -72,7 +73,7 @@ const SafeApps: NextPage = () => {
             title="My pinned apps"
             safeAppsList={pinnedSafeApps}
             bookmarkedSafeAppsId={pinnedSafeAppIds}
-            onBookmarkSafeApp={togglePin}
+            eventLabel={SAFE_APPS_LABELS.apps_pinned}
           />
         )}
 
@@ -82,7 +83,7 @@ const SafeApps: NextPage = () => {
             title="Featured apps"
             safeAppsList={featuredSafeApps}
             bookmarkedSafeAppsId={pinnedSafeAppIds}
-            onBookmarkSafeApp={togglePin}
+            eventLabel={SAFE_APPS_LABELS.apps_featured}
           />
         )}
 
@@ -93,7 +94,7 @@ const SafeApps: NextPage = () => {
           safeAppsList={isFiltered ? filteredApps : nonPinnedApps}
           safeAppsListLoading={remoteSafeAppsLoading}
           bookmarkedSafeAppsId={pinnedSafeAppIds}
-          onBookmarkSafeApp={togglePin}
+          eventLabel={SAFE_APPS_LABELS.apps_all}
           query={query}
           showNativeSwapsCard
         />

--- a/src/services/analytics/events/safeApps.ts
+++ b/src/services/analytics/events/safeApps.ts
@@ -70,3 +70,12 @@ export const SAFE_APPS_EVENTS = {
     action: 'SDK method call',
   },
 }
+
+export enum SAFE_APPS_LABELS {
+  dashboard = 'dashboard',
+  apps_pinned = 'apps_pinned',
+  apps_featured = 'apps_featured',
+  apps_all = 'apps_all',
+  apps_custom = 'apps_custom',
+  apps_sidebar = 'apps_sidebar',
+}

--- a/src/services/analytics/gtm.ts
+++ b/src/services/analytics/gtm.ts
@@ -159,7 +159,7 @@ export const normalizeAppName = (appName?: string): string => {
 }
 
 export const gtmTrackSafeApp = (eventData: AnalyticsEvent, appName?: string, sdkEventData?: SafeAppSDKEvent): void => {
-  if (!location.pathname.startsWith(AppRoutes.apps.index)) {
+  if (!location.pathname.startsWith(AppRoutes.apps.index) && !eventData.label) {
     return
   }
 


### PR DESCRIPTION
## What it solves

Resolves [tracking of featured Safe Apps](https://www.notion.so/safe-global/Add-tracking-events-for-featured-Safe-Apps-1468180fe57380dc9c12e898861574bb)

## How this PR fixes it

Featured Safe App interactions are currently not tracked.

This adds tracking to featured Safe Apps, as well as propagating the improvements to existing events: opening and (un-)pinning of Safe Apps (from their respective sections) now includes a `label`:

- `dashboard`
- `apps_pinned`
- `apps_featured`
- `apps_all`
- `apps_custom`
- `apps_sidebar`

## How to test it

Open and/or (un-pin) a Safe App from one of the label-specific locations, observing the new `label` in the tracked event:

- Dashboard
- Apps sections
  - Pinned
  - Featured
  - All
  - Custom
- Apps preview drawer

Important: when opening a Safe App for the first time, the "opened" event should _only_ occur from the preview sidebar. Thereafter, only from the Safe App card.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
