### PR TITLE
Chore: extract terms version into a separate file for a smaller build

### DIFF
--- a/docs/update-terms.md
+++ b/docs/update-terms.md
@@ -4,7 +4,7 @@ To update the terms and conditions, follow these steps:
 
 1. Export the terms and conditions from Google Docs as a Markdown file.
 2. Replace the content of the src/markdown/terms/terms.md file with the exported content.
-3. Update the frontmatter of the file with the new version number and date.
+3. If significant changes were made, update the version and last updated date in `version.ts` in the same folder.
 
 That’s it!
 
@@ -13,7 +13,7 @@ will automatically appear for users who haven’t accepted the new terms.
 
 ## How does this work?
 
-We rely on the version number from the frontmatter. When the Redux store is rehydrated, we check the version stored in
+We rely on the version number from `version.ts`. When the Redux store is rehydrated, we check the version stored in
 the store against the version in the frontmatter. If they differ, we reset the accepted terms, forcing the user to
 accept the new version.
 

--- a/mocks/terms.md.js
+++ b/mocks/terms.md.js
@@ -1,6 +1,0 @@
-export const metadata = {
-  version: 'test-version',
-  last_update_date: 'test-date',
-}
-
-export default metadata

--- a/src/components/common/CookieAndTermBanner/index.tsx
+++ b/src/components/common/CookieAndTermBanner/index.tsx
@@ -4,7 +4,7 @@ import type { CheckboxProps } from '@mui/material'
 import { Grid, Button, Checkbox, FormControlLabel, Typography, Paper, SvgIcon, Box } from '@mui/material'
 import WarningIcon from '@/public/images/notifications/warning.svg'
 import { useForm } from 'react-hook-form'
-import { metadata } from '@/markdown/terms/terms.md'
+import * as metadata from '@/markdown/terms/version'
 
 import { useAppDispatch, useAppSelector } from '@/store'
 import {
@@ -104,7 +104,7 @@ export const CookieAndTermBanner = ({
             >
               By browsing this page, you accept our{' '}
               <ExternalLink href={AppRoutes.terms}>Terms & Conditions</ExternalLink> (last updated{' '}
-              {metadata.last_update_date}) and the use of necessary cookies. By clicking &quot;Accept all&quot; you
+              {metadata.lastUpdated}) and the use of necessary cookies. By clicking &quot;Accept all&quot; you
               additionally agree to the use of Beamer and Analytics cookies as listed below.{' '}
               <ExternalLink href={AppRoutes.cookie}>Cookie policy</ExternalLink>
             </Typography>

--- a/src/markdown/terms/terms.md
+++ b/src/markdown/terms/terms.md
@@ -1,8 +1,3 @@
----
-version: 1.2
-last_update_date: September, 2024
----
-
 # Terms and Conditions
 
 Last updated: September, 2024

--- a/src/markdown/terms/terms.md.d.ts
+++ b/src/markdown/terms/terms.md.d.ts
@@ -1,5 +1,0 @@
-export { default } from '*.md'
-export const metadata = {
-  version: string,
-  last_update_date: string,
-}

--- a/src/markdown/terms/version.ts
+++ b/src/markdown/terms/version.ts
@@ -1,0 +1,2 @@
+export const version = '1.2'
+export const lastUpdated = 'September, 2024'

--- a/src/store/cookiesAndTermsSlice.ts
+++ b/src/store/cookiesAndTermsSlice.ts
@@ -1,7 +1,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
 import type { RootState } from '.'
-import { metadata } from '@/markdown/terms/terms.md'
+import { version } from '@/markdown/terms/version'
 
 export enum CookieAndTermType {
   TERMS = 'terms',
@@ -38,12 +38,12 @@ export const selectCookies = (state: RootState) => state[cookiesAndTermsSlice.na
 
 export const hasAcceptedTerms = (state: RootState): boolean => {
   const cookies = selectCookies(state)
-  return cookies[CookieAndTermType.TERMS] === true && cookies.termsVersion === metadata.version
+  return cookies[CookieAndTermType.TERMS] === true && cookies.termsVersion === version
 }
 
 export const hasConsentFor = (state: RootState, type: CookieAndTermType): boolean => {
   const cookies = selectCookies(state)
-  return cookies[type] === true && cookies.termsVersion === metadata.version
+  return cookies[type] === true && cookies.termsVersion === version
 }
 
 export const { saveCookieAndTermConsent } = cookiesAndTermsSlice.actions

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -26,7 +26,7 @@ import * as slices from './slices'
 import * as hydrate from './useHydrateStore'
 import { ofacApi } from '@/store/api/ofac'
 import { safePassApi } from './api/safePass'
-import { metadata } from '@/markdown/terms/terms.md'
+import { version as termsVersion } from '@/markdown/terms/version'
 
 const rootReducer = combineReducers({
   [slices.chainsSlice.name]: slices.chainsSlice.reducer,
@@ -103,10 +103,7 @@ export const _hydrationReducer: typeof rootReducer = (state, action) => {
     const nextState = merge({}, state, action.payload) as RootState
 
     // Check if termsVersion matches
-    if (
-      nextState[cookiesAndTermsSlice.name] &&
-      nextState[cookiesAndTermsSlice.name].termsVersion !== metadata.version
-    ) {
+    if (nextState[cookiesAndTermsSlice.name] && nextState[cookiesAndTermsSlice.name].termsVersion !== termsVersion) {
       // Reset consent
       nextState[cookiesAndTermsSlice.name] = {
         ...cookiesAndTermsInitialState,


### PR DESCRIPTION
## What it solves

The entire `terms.md` (100kb+) was bundled with the main app chunk just to read the version. So I extracted it into a separate file instead.
