### PR TITLE
fix: do not duplicate hex prefixes in `wallet_getCallsStatus` receipts

### DIFF
--- a/src/services/safe-wallet-provider/index.ts
+++ b/src/services/safe-wallet-provider/index.ts
@@ -403,13 +403,18 @@ export class SafeWalletProvider {
     }
 
     const calls = tx.txData?.dataDecoded?.parameters?.[0].valueDecoded?.length ?? 1
+
+    // Typed as number; is hex
+    const blockNumber = Number(receipt.blockNumber)
+    const gasUsed = Number(receipt.gasUsed)
+
     const receipts = Array.from({ length: calls }, () => ({
       logs: receipt.logs,
       status: numberToHex(tx.txStatus === TransactionStatus.SUCCESS ? 1 : 0),
       chainId: numberToHex(this.safe.chainId),
       blockHash: receipt.blockHash as `0x${string}`,
-      blockNumber: numberToHex(receipt.blockNumber),
-      gasUsed: numberToHex(receipt.gasUsed),
+      blockNumber: numberToHex(blockNumber),
+      gasUsed: numberToHex(gasUsed),
       transactionHash: tx.txHash as `0x${string}`,
     }))
 


### PR DESCRIPTION
## What it solves

Resolves duplicate hex prefixes in `wallet_getCallsStatus` receipts

## How this PR fixes it

In https://github.com/safe-global/safe-wallet-web/pull/4569, the types of `blockNumber`/`gasUsed` were explicitly referenced for the receipts of `wallet_getCallsStatus`.

After further testing, the types of aforementioned values are incorrect. They are hex, not `number`/`bigint`. This adds a check to ensure that they are of type `number` (as we do [in the SDK](https://github.com/safe-global/safe-apps-sdk/blob/main/packages/safe-apps-provider/src/provider.ts#L262-L264)).

Test coverage for both the correct (in case the types are fixed) and incorrect types have also been added.

## How to test it

Request the receipts of an EIP-5792 batch via `wallet_getCallsStatus`, and observe the `blockNumber`/`gasUsed` are hex, without a repeated `0x` prefix.

## Screenshots

The following is the bug that this solves:

![image](https://github.com/user-attachments/assets/cfc96360-b320-457a-85c5-9b63394920c8)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
