### PR TITLE
fix: do not clear AddressInput when disabled

### DIFF
--- a/src/components/common/AddressInput/index.tsx
+++ b/src/components/common/AddressInput/index.tsx
@@ -114,6 +114,12 @@ const AddressInput = ({
     </InputAdornment>
   )
 
+  const resetName = () => {
+    if (!props.disabled && addressBook[watchedValue]) {
+      setValue(name, '')
+    }
+  }
+
   return (
     <>
       <TextField
@@ -124,7 +130,7 @@ const AddressInput = ({
         label={<>{error?.message || props.label || `Recipient address${isDomainLookupEnabled ? ' or ENS' : ''}`}</>}
         error={!!error}
         fullWidth
-        onClick={addressBook[watchedValue] ? () => setValue(name, '') : undefined}
+        onClick={resetName}
         spellCheck={false}
         InputProps={{
           ...(props.InputProps || {}),


### PR DESCRIPTION
## What it solves

Resolves #4378

## How this PR fixes it
Does not clear `AddressInput` on click when disabled.

## How to test it
- Rename a Safe in the Sidebar that has a Name in the current chain's addresbook.
- Click on the Address field
- Nothing should happen

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
