### PR TITLE
Tests: Increase timeout

### DIFF
--- a/.github/workflows/e2e-full-ondemand.yml
+++ b/.github/workflows/e2e-full-ondemand.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   e2e:
     runs-on: ubuntu-20.04
-    timeout-minutes: 40
+    timeout-minutes: 90
     name: Cypress Full Regression on demand tests
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e-ondemand.yml
+++ b/.github/workflows/e2e-ondemand.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   e2e:
     runs-on: ubuntu-20.04
-    timeout-minutes: 40
+    timeout-minutes: 90
     name: Cypress Regression on demand tests
     strategy:
       fail-fast: false


### PR DESCRIPTION
## What it solves

## How this PR fixes it

- With continuous development of new automation tests, we need to increase job timeouts. 

## How to test it

- Run Cypress tests and observe outcome.