### PR TITLE
fix: remove unnecessary deps. from `useAllOwnedSafes` cache

### DIFF
--- a/src/features/myAccounts/hooks/useAllOwnedSafes.ts
+++ b/src/features/myAccounts/hooks/useAllOwnedSafes.ts
@@ -17,7 +17,7 @@ const useAllOwnedSafes = (address: string): AsyncResult<AllOwnedSafes> => {
     if (data != undefined) {
       setCache(data)
     }
-  }, [address, cache, data, setCache])
+  }, [data, setCache])
 
   return [cache, asError(error), isLoading]
 }


### PR DESCRIPTION
## What it solves

Resolves unnecessary cache updates

## How this PR fixes it

We cache the owned Safes for a given address. This is used as an initial value for the sidebar, before the list of owned Safes is returned.

Currently, we are updating the cache if the aforementioned list is returned, as well as when the request address changes and **when the cache updates**. This results in an endless update to the cache, broadcasting across browser tabs.

This removes the unnecessary deps.: `address` and `cache`.

## How to test it

1. Open the same Safe in two different browser tabs, ensuring wallet connection with the same owner.
2. Create a new Safe, owned by the same owner.
3. Refresh both tabs and observe no `storage` event warning in the console.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
