### PR TITLE
Tests: fix safe-wallet-provider unit tests

### DIFF
--- a/src/services/safe-wallet-provider/index.test.ts
+++ b/src/services/safe-wallet-provider/index.test.ts
@@ -658,10 +658,10 @@ describe('SafeWalletProvider', () => {
           result: {
             receipts: [
               {
-                blockHash: receipt.blockHash,
-                blockNumber: receipt.blockNumber,
+                blockHash: numberToHex(Number(receipt.blockHash)),
+                blockNumber: numberToHex(Number(receipt.blockNumber)),
                 chainId: '0x1',
-                gasUsed: receipt.gasUsed,
+                gasUsed: numberToHex(Number(receipt.gasUsed)),
                 logs: receipt.logs,
                 status: '0x1',
                 transactionHash: '0x123',


### PR DESCRIPTION
## What it solves

This test was passing locally but not on CI, likely because of the fuzzy output from faker. If a hex string doesn't contain alphabetical characters, it passes.
