### PR TITLE
fix: Exclude SAP allocation from voting power

### DIFF
--- a/src/hooks/useSafeTokenAllocation.ts
+++ b/src/hooks/useSafeTokenAllocation.ts
@@ -186,10 +186,7 @@ export const useSafeVotingPower = (allocationData?: Vesting[]): AsyncResult<bigi
     }
 
     const tokensInVesting = allocationData.reduce(
-      (acc, data) =>
-        data.isExpired || data.startDate > Math.floor(Date.now() / 1000)
-          ? acc
-          : acc + BigInt(data.amount) - BigInt(data.amountClaimed),
+      (acc, data) => (data.isExpired ? acc : acc + BigInt(data.amount) - BigInt(data.amountClaimed)),
       BigInt(0),
     )
 

--- a/src/hooks/useSafeTokenAllocation.ts
+++ b/src/hooks/useSafeTokenAllocation.ts
@@ -186,7 +186,10 @@ export const useSafeVotingPower = (allocationData?: Vesting[]): AsyncResult<bigi
     }
 
     const tokensInVesting = allocationData.reduce(
-      (acc, data) => (data.isExpired ? acc : acc + BigInt(data.amount) - BigInt(data.amountClaimed)),
+      (acc, data) =>
+        data.isExpired || data.tag === 'sap_boosted' || data.tag === 'sap_unboosted' // Exclude the SAP Airdrops from voting power
+          ? acc
+          : acc + BigInt(data.amount) - BigInt(data.amountClaimed),
       BigInt(0),
     )
 


### PR DESCRIPTION
## What it solves

Follow-up on #4565

## How this PR fixes it

This changes the logic that calculates the total voting power for the safe header widget.

Our snapshot strategy includes all vesting contracts into the total voting power. This also includes contracts that haven't started yet so users would be able to vote with the SAP airdrop allocation. However since some users will not be able to claim their full allocation through the app it is safe to exclude this allocation.

## How to test it

1. Open the app with a Safe that has an SAP allocation that hasn't been claimed yet (but redeemed)
2. Observe not seeing that number in the header widget

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
