### PR TITLE
fix: don't use `chainId` when calculating domain hash of <=1.2.0

### DIFF
--- a/src/components/transactions/TxDetails/Summary/SafeTxHashDataRow/index.test.ts
+++ b/src/components/transactions/TxDetails/Summary/SafeTxHashDataRow/index.test.ts
@@ -1,0 +1,48 @@
+import { faker } from '@faker-js/faker'
+import { getDomainHash } from '.'
+import { AbiCoder, keccak256 } from 'ethers'
+
+// <= 1.2.0
+// keccak256("EIP712Domain(address verifyingContract)");
+const OLD_DOMAIN_TYPEHASH = '0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749'
+
+// >= 1.3.0
+// keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");
+const NEW_DOMAIN_TYPEHASH = '0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218'
+
+describe('SafeTxHashDataRow', () => {
+  describe('getDomainHash', () => {
+    it.each(['1.0.0' as const, '1.1.1' as const, '1.2.0' as const])(
+      'should return the domain hash without chain ID for version %s',
+      (version) => {
+        const chainId = faker.string.numeric()
+        const safeAddress = faker.finance.ethereumAddress()
+
+        const result = getDomainHash({ chainId, safeAddress, safeVersion: version })
+
+        expect(result).toEqual(
+          keccak256(AbiCoder.defaultAbiCoder().encode(['bytes32', 'address'], [OLD_DOMAIN_TYPEHASH, safeAddress])),
+        )
+      },
+    )
+
+    it.each(['1.3.0' as const, '1.4.1' as const])(
+      'should return the domain hash with chain ID for version %s',
+      (version) => {
+        const chainId = faker.string.numeric()
+        const safeAddress = faker.finance.ethereumAddress()
+
+        const result = getDomainHash({ chainId, safeAddress, safeVersion: version })
+
+        expect(result).toEqual(
+          keccak256(
+            AbiCoder.defaultAbiCoder().encode(
+              ['bytes32', 'uint256', 'address'],
+              [NEW_DOMAIN_TYPEHASH, chainId, safeAddress],
+            ),
+          ),
+        )
+      },
+    )
+  })
+})

--- a/src/components/transactions/TxDetails/Summary/SafeTxHashDataRow/index.tsx
+++ b/src/components/transactions/TxDetails/Summary/SafeTxHashDataRow/index.tsx
@@ -17,8 +17,9 @@ export function getDomainHash({
   safeAddress: string
   safeVersion: SafeVersion
 }): string {
+  const includeChainId = semverSatisfies(safeVersion, NEW_DOMAIN_TYPE_HASH_VERSION)
   return TypedDataEncoder.hashDomain({
-    ...(semverSatisfies(safeVersion, NEW_DOMAIN_TYPE_HASH_VERSION) && { chainId }),
+    ...(includeChainId && { chainId }),
     verifyingContract: safeAddress,
   })
 }

--- a/src/components/transactions/TxDetails/Summary/SafeTxHashDataRow/index.tsx
+++ b/src/components/transactions/TxDetails/Summary/SafeTxHashDataRow/index.tsx
@@ -4,6 +4,24 @@ import { type SafeTransactionData, type SafeVersion } from '@safe-global/safe-co
 import { getEip712TxTypes } from '@safe-global/protocol-kit/dist/src/utils'
 import useSafeAddress from '@/hooks/useSafeAddress'
 import useChainId from '@/hooks/useChainId'
+import semverSatisfies from 'semver/functions/satisfies'
+
+const NEW_DOMAIN_TYPE_HASH_VERSION = '>=1.3.0'
+
+export function getDomainHash({
+  chainId,
+  safeAddress,
+  safeVersion,
+}: {
+  chainId: string
+  safeAddress: string
+  safeVersion: SafeVersion
+}): string {
+  return TypedDataEncoder.hashDomain({
+    ...(semverSatisfies(safeVersion, NEW_DOMAIN_TYPE_HASH_VERSION) && { chainId }),
+    verifyingContract: safeAddress,
+  })
+}
 
 export const SafeTxHashDataRow = ({
   safeTxHash,
@@ -17,10 +35,7 @@ export const SafeTxHashDataRow = ({
   const chainId = useChainId()
   const safeAddress = useSafeAddress()
 
-  const domainHash = TypedDataEncoder.hashDomain({
-    chainId,
-    verifyingContract: safeAddress,
-  })
+  const domainHash = getDomainHash({ chainId, safeAddress, safeVersion })
   const messageHash = safeTxData
     ? TypedDataEncoder.hashStruct('SafeTx', { SafeTx: getEip712TxTypes(safeVersion).SafeTx }, safeTxData)
     : undefined


### PR DESCRIPTION
## What it solves

Resolves #4613

## How this PR fixes it

For Safe versions <= 1.2.0, the domain separator typehash of the Safe contracts [does not include a `chainId`](https://github.com/safe-global/safe-smart-account/blob/v1.2.0/contracts/GnosisSafe.sol#L26):

```sol
bytes32 private constant DOMAIN_SEPARATOR_TYPEHASH = 0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749;
```

For versions >= 1.3.0, [a `chainId` is included](https://github.com/safe-global/safe-smart-account/blob/v1.3.0/contracts/GnosisSafe.sol#L38):

```sol
bytes32 private constant DOMAIN_SEPARATOR_TYPEHASH = 0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218;
```

When calculating the domain hash, we do not take the contract version into account, calculating based on the newer domain separator typehash.

This conditionally includes the `chainId` when calculating the domain hash for the current Safe, therefore correcting it for <= 1.2.0 versions.

## How to test it

Using a Ledger device, observe the domain hash matching that in the interface for all versions from >= 1.0.0.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
