### PR TITLE
fix: Show raw data if decodedData doesn't contain any parameters [SW-435]

### DIFF
--- a/src/components/transactions/TxDetails/TxData/DecodedData/MethodDetails/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/MethodDetails/index.tsx
@@ -1,3 +1,4 @@
+import { HexEncodedData } from '@/components/transactions/HexEncodedData'
 import type { ReactElement } from 'react'
 import { generateDataRowValue, TxDataRow } from '@/components/transactions/TxDetails/Summary/TxDataRow'
 import { isAddress, isArrayParameter, isByte } from '@/utils/transaction-guards'
@@ -7,21 +8,25 @@ import { Value } from '@/components/transactions/TxDetails/TxData/DecodedData/Va
 
 type MethodDetailsProps = {
   data: DataDecoded
+  hexData?: string
   addressInfoIndex?: {
     [key: string]: AddressEx
   }
 }
 
-export const MethodDetails = ({ data, addressInfoIndex }: MethodDetailsProps): ReactElement => {
+export const MethodDetails = ({ data, hexData, addressInfoIndex }: MethodDetailsProps): ReactElement => {
   if (!data.parameters?.length) {
     return (
-      <Typography
-        sx={{
-          color: 'text.secondary',
-        }}
-      >
-        No parameters
-      </Typography>
+      <>
+        <Typography
+          sx={{
+            color: 'text.secondary',
+          }}
+        >
+          No parameters
+        </Typography>
+        {hexData && <HexEncodedData title="Data (hex-encoded)" hexData={hexData} />}
+      </>
     )
   }
 

--- a/src/components/transactions/TxDetails/TxData/DecodedData/MethodDetails/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/MethodDetails/index.tsx
@@ -25,6 +25,7 @@ export const MethodDetails = ({ data, hexData, addressInfoIndex }: MethodDetails
         >
           No parameters
         </Typography>
+
         {hexData && <HexEncodedData title="Data (hex-encoded)" hexData={hexData} />}
       </>
     )

--- a/src/components/transactions/TxDetails/TxData/DecodedData/index.test.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/index.test.tsx
@@ -1,0 +1,37 @@
+import DecodedData from '@/components/transactions/TxDetails/TxData/DecodedData/index'
+import { render } from '@/tests/test-utils'
+
+describe('DecodedData', () => {
+  it('returns null if txData and toInfo are missing', () => {
+    const { container } = render(<DecodedData txData={undefined} toInfo={undefined} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows an Interact with block if there is no txData but toInfo', () => {
+    const { getByText } = render(<DecodedData txData={undefined} toInfo={{ value: '0x123', name: 'Test' }} />)
+
+    expect(getByText('Interact with')).toBeInTheDocument()
+  })
+
+  it('shows Hex encoded data if no method name exists or there are no parameters', () => {
+    const mockTxData = {
+      to: {
+        value: '0x874E2190e6B10f5173F00E27E6D5D9F90b7664C4',
+      },
+      value: '0',
+      operation: 0,
+      dataDecoded: {
+        method: 'fallback',
+        parameters: [],
+      },
+      hexData:
+        '0x895a74850000000000000000000000000000000000000000000004bb752b4d22ab390000000000000000000000000000000000000000000000000000000000000000000b00000000000000000000000000000001f76adba2311f154678f5e5605db5c9c2',
+      trustedDelegateCallTarget: false,
+    }
+
+    const { getByText } = render(<DecodedData txData={mockTxData} toInfo={{ value: '0x123', name: 'Test' }} />)
+
+    expect(getByText('Data (hex-encoded)')).toBeInTheDocument()
+  })
+})

--- a/src/components/transactions/TxDetails/TxData/DecodedData/index.test.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/index.test.tsx
@@ -9,12 +9,12 @@ describe('DecodedData', () => {
   })
 
   it('shows an Interact with block if there is no txData but toInfo', () => {
-    const { getByText } = render(<DecodedData txData={undefined} toInfo={{ value: '0x123', name: 'Test' }} />)
+    const { getByText } = render(<DecodedData txData={undefined} toInfo={{ value: '0x123' }} />)
 
     expect(getByText('Interact with')).toBeInTheDocument()
   })
 
-  it('shows Hex encoded data if no method name exists or there are no parameters', () => {
+  it('shows Hex encoded data if there are no parameters', () => {
     const mockTxData = {
       to: {
         value: '0x874E2190e6B10f5173F00E27E6D5D9F90b7664C4',
@@ -30,8 +30,48 @@ describe('DecodedData', () => {
       trustedDelegateCallTarget: false,
     }
 
-    const { getByText } = render(<DecodedData txData={mockTxData} toInfo={{ value: '0x123', name: 'Test' }} />)
+    const { getByText } = render(<DecodedData txData={mockTxData} toInfo={{ value: '0x123' }} />)
 
+    expect(getByText('No parameters')).toBeInTheDocument()
+    expect(getByText('Data (hex-encoded)')).toBeInTheDocument()
+  })
+
+  it('does not show Hex encoded data if there is none', () => {
+    const mockTxData = {
+      to: {
+        value: '0x874E2190e6B10f5173F00E27E6D5D9F90b7664C4',
+      },
+      value: '0',
+      operation: 0,
+      dataDecoded: {
+        method: 'mint',
+        parameters: [],
+      },
+      hexData: '',
+      trustedDelegateCallTarget: false,
+    }
+
+    const { getByText, queryByText } = render(<DecodedData txData={mockTxData} toInfo={{ value: '0x123' }} />)
+
+    expect(getByText('No parameters')).toBeInTheDocument()
+    expect(queryByText('Data (hex-encoded)')).not.toBeInTheDocument()
+  })
+
+  it('only shows Hex encoded data if no decodedData exists', () => {
+    const mockTxData = {
+      to: {
+        value: '0x874E2190e6B10f5173F00E27E6D5D9F90b7664C4',
+      },
+      value: '0',
+      operation: 0,
+      hexData:
+        '0x895a74850000000000000000000000000000000000000000000004bb752b4d22ab390000000000000000000000000000000000000000000000000000000000000000000b00000000000000000000000000000001f76adba2311f154678f5e5605db5c9c2',
+      trustedDelegateCallTarget: false,
+    }
+
+    const { getByText, queryByText } = render(<DecodedData txData={mockTxData} toInfo={{ value: '0x123' }} />)
+
+    expect(queryByText('No parameters')).not.toBeInTheDocument()
     expect(getByText('Data (hex-encoded)')).toBeInTheDocument()
   })
 })

--- a/src/components/transactions/TxDetails/TxData/DecodedData/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/index.tsx
@@ -47,11 +47,12 @@ export const DecodedData = ({ txData, toInfo }: Props): ReactElement | null => {
     ? 'this Safe Account'
     : addressInfo?.name || toInfo?.name || txData.to.name
   const avatar = addressInfo?.logoUri || toInfo?.logoUri || txData.to.logoUri
-  const isFallback = !method || txData?.dataDecoded?.parameters?.length === 0
 
   let decodedData = <></>
-  if (txData.dataDecoded && !isFallback) {
-    decodedData = <MethodDetails data={txData.dataDecoded} addressInfoIndex={txData.addressInfoIndex} />
+  if (txData.dataDecoded) {
+    decodedData = (
+      <MethodDetails data={txData.dataDecoded} hexData={txData.hexData} addressInfoIndex={txData.addressInfoIndex} />
+    )
   } else if (txData.hexData) {
     // When no decoded data, display raw hex data
     decodedData = <HexEncodedData title="Data (hex-encoded)" hexData={txData.hexData} />

--- a/src/components/transactions/TxDetails/TxData/DecodedData/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/index.tsx
@@ -24,9 +24,9 @@ export const DecodedData = ({ txData, toInfo }: Props): ReactElement | null => {
   const chainInfo = useCurrentChain()
 
   // nothing to render
-  if (!txData && !toInfo) return null
+  if (!txData) {
+    if (!toInfo) return null
 
-  if (!txData && toInfo) {
     return (
       <SendToBlock
         title="Interact with"
@@ -38,8 +38,6 @@ export const DecodedData = ({ txData, toInfo }: Props): ReactElement | null => {
     )
   }
 
-  if (!txData) return null
-
   const amountInWei = txData.value ?? '0'
   const isDelegateCall = txData.operation === Operation.DELEGATE
   const toAddress = toInfo?.value || txData.to.value
@@ -49,7 +47,7 @@ export const DecodedData = ({ txData, toInfo }: Props): ReactElement | null => {
     ? 'this Safe Account'
     : addressInfo?.name || toInfo?.name || txData.to.name
   const avatar = addressInfo?.logoUri || toInfo?.logoUri || txData.to.logoUri
-  const isFallback = !method && !txData?.dataDecoded?.parameters
+  const isFallback = !method || txData?.dataDecoded?.parameters?.length === 0
 
   let decodedData = <></>
   if (txData.dataDecoded && !isFallback) {


### PR DESCRIPTION
## What it solves

Resolves [SW-435](https://www.notion.so/safe-global/Display-raw-fallback-data-12f8180fe57380fc941cd73042bb0837)

## How this PR fixes it

- Removes the `isFallback` condition and instead shows `HexEncodedData` additionally when there are no parameters
- Case from https://github.com/safe-global/safe-wallet-web/pull/4260 is still covered
<img width="696" alt="Screenshot 2024-12-06 at 15 52 16" src="https://github.com/user-attachments/assets/52b2197e-7872-45ac-9ec8-23984b99ba4a">

## How to test it

1. Open a transaction where the method name is there but no parameters
2. Observe it displays Hex encoded data instead of nothing

## Screenshots
<img width="861" alt="Screenshot 2024-12-06 at 15 52 24" src="https://github.com/user-attachments/assets/61230599-b3bb-4294-aac2-012cc90de8f7">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
