### PR TITLE
fix: Disable Add to Batch button for safe apps [SW-363]

### DIFF
--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -101,6 +101,8 @@ export const SignForm = ({
   const submitDisabled =
     !safeTx || !isSubmittable || disableSubmit || cannotPropose || (needsRiskConfirmation && !isRiskConfirmed)
 
+  const isSafeAppTransaction = !!origin
+
   return (
     <form onSubmit={handleSubmit}>
       {hasSigned && <ErrorMessage level="warning">You have already signed this transaction.</ErrorMessage>}
@@ -130,7 +132,7 @@ export const SignForm = ({
           spacing={{ xs: 2, md: 2 }}
         >
           {/* Batch button */}
-          {isCreation && !isBatch && (
+          {isCreation && !isBatch && !isSafeAppTransaction && (
             <BatchButton
               onClick={onBatchClick}
               disabled={submitDisabled || !isBatchable}

--- a/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -132,10 +132,10 @@ export const SignForm = ({
           spacing={{ xs: 2, md: 2 }}
         >
           {/* Batch button */}
-          {isCreation && !isBatch && !isSafeAppTransaction && (
+          {isCreation && !isBatch && (
             <BatchButton
               onClick={onBatchClick}
-              disabled={submitDisabled || !isBatchable}
+              disabled={submitDisabled || !isBatchable || isSafeAppTransaction}
               tooltip={!isBatchable ? `Cannot batch this type of transaction` : undefined}
             />
           )}

--- a/src/components/tx/SignOrExecuteForm/__tests__/SignForm.test.tsx
+++ b/src/components/tx/SignOrExecuteForm/__tests__/SignForm.test.tsx
@@ -227,4 +227,29 @@ describe('SignForm', () => {
     expect(button).toBeInTheDocument()
     expect(button).not.toBeDisabled()
   })
+
+  it('Hides the Add to batch button if there is an origin', () => {
+    const { queryByText } = render(
+      <SignForm
+        {...defaultProps}
+        safeTx={safeTransaction}
+        txSecurity={{ ...defaultSecurityContextValues, needsRiskConfirmation: true, isRiskConfirmed: true }}
+        origin="MockOrigin"
+      />,
+    )
+
+    const button = queryByText('Add to batch')
+
+    expect(button).not.toBeInTheDocument()
+  })
+
+  it('Shows the Add to batch button if there is no origin and it is a creation', () => {
+    const { getByText } = render(
+      <SignForm {...defaultProps} safeTx={safeTransaction} origin={undefined} isCreation={true} />,
+    )
+
+    const button = getByText('Add to batch')
+
+    expect(button).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## What it solves

Resolves [SW-363](https://www.notion.so/safe-global/Disable-add-to-batch-button-for-Dapps-1238180fe57380ac935aec33de026aef)

## How this PR fixes it

- Disables the `BatchButton` if there is an `origin` passed (it is a safe app or walletconnect)

## How to test it

1. Create a transaction through a safe app
2. Choose Sign
3. Observe Add to batch button is disabled
4. Create a transaction through the native UI
5. Observe there is an Add to batch button when signing and it is enabled

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
