### PR TITLE
Feat: include recently visited safes in import and export data [SW-594]

### DIFF
--- a/src/components/settings/DataManagement/FileListCard.tsx
+++ b/src/components/settings/DataManagement/FileListCard.tsx
@@ -14,6 +14,7 @@ import type { UndeployedSafesState } from '@/features/counterfactual/store/undep
 import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 
 import css from './styles.module.css'
+import type { VisitedSafesState } from '@/store/visitedSafesSlice'
 
 const getItemSecondaryText = (
   chains: ChainInfo[],
@@ -53,6 +54,7 @@ type Data = {
   settings?: SettingsState
   safeApps?: SafeAppsState
   undeployedSafes?: UndeployedSafesState
+  visitedSafes?: VisitedSafesState
   error?: string
 }
 
@@ -68,6 +70,7 @@ const getItems = ({
   settings,
   safeApps,
   undeployedSafes,
+  visitedSafes,
   error,
   chains,
   showPreview = false,
@@ -120,6 +123,18 @@ const getItems = ({
     items.push(settingsPreview)
   }
 
+  if (visitedSafes) {
+    const visitedSafesPreview: ListItemTextProps = {
+      primary: (
+        <>
+          <b>Visited Safe Accounts history</b>
+        </>
+      ),
+    }
+
+    items.push(visitedSafesPreview)
+  }
+
   const hasBookmarkedSafeApps = Object.values(safeApps || {}).some((chainId) => chainId.pinned?.length > 0)
   if (hasBookmarkedSafeApps) {
     const safeAppsPreview: ListItemTextProps = {
@@ -160,6 +175,7 @@ export const FileListCard = ({
   settings,
   safeApps,
   undeployedSafes,
+  visitedSafes,
   error,
   showPreview = false,
   ...cardHeaderProps
@@ -170,6 +186,7 @@ export const FileListCard = ({
     addressBook,
     settings,
     safeApps,
+    visitedSafes,
     undeployedSafes,
     error,
     chains: chains.configs,

--- a/src/components/settings/DataManagement/ImportDialog.tsx
+++ b/src/components/settings/DataManagement/ImportDialog.tsx
@@ -35,7 +35,8 @@ export const ImportDialog = ({
   const { addedSafes, addressBook, addressBookEntriesCount, settings, safeApps, undeployedSafes, visitedSafes, error } =
     useGlobalImportJsonParser(jsonData)
 
-  const isDisabled = (!addedSafes && !addressBook && !settings && !safeApps) || !!error
+  const isDisabled =
+    (!addedSafes && !addressBook && !settings && !safeApps && !undeployedSafes && !visitedSafes) || !!error
 
   const handleClose = () => {
     setFileName(undefined)
@@ -116,6 +117,7 @@ export const ImportDialog = ({
               addressBook={addressBook}
               settings={settings}
               safeApps={safeApps}
+              visitedSafes={visitedSafes}
               undeployedSafes={undeployedSafes}
               error={error}
               showPreview

--- a/src/components/settings/DataManagement/ImportDialog.tsx
+++ b/src/components/settings/DataManagement/ImportDialog.tsx
@@ -14,6 +14,7 @@ import { useGlobalImportJsonParser } from '@/components/settings/DataManagement/
 import FileIcon from '@/public/images/settings/data/file.svg'
 import { ImportFileUpload } from '@/components/settings/DataManagement/ImportFileUpload'
 import { showNotification } from '@/store/notificationsSlice'
+import { visitedSafesSlice } from '@/store/visitedSafesSlice'
 
 import css from './styles.module.css'
 
@@ -31,7 +32,7 @@ export const ImportDialog = ({
   setJsonData: Dispatch<SetStateAction<string | undefined>>
 }): ReactElement => {
   const dispatch = useAppDispatch()
-  const { addedSafes, addressBook, addressBookEntriesCount, settings, safeApps, undeployedSafes, error } =
+  const { addedSafes, addressBook, addressBookEntriesCount, settings, safeApps, undeployedSafes, visitedSafes, error } =
     useGlobalImportJsonParser(jsonData)
 
   const isDisabled = (!addedSafes && !addressBook && !settings && !safeApps) || !!error
@@ -71,6 +72,11 @@ export const ImportDialog = ({
     if (undeployedSafes) {
       dispatch(undeployedSafesSlice.actions.addUndeployedSafes(undeployedSafes))
       trackEvent(SETTINGS_EVENTS.DATA.IMPORT_UNDEPLOYED_SAFES)
+    }
+
+    if (visitedSafes) {
+      dispatch(visitedSafesSlice.actions.setVisitedSafes(visitedSafes))
+      trackEvent(SETTINGS_EVENTS.DATA.IMPORT_VISITED_SAFES)
     }
 
     dispatch(

--- a/src/components/settings/DataManagement/index.tsx
+++ b/src/components/settings/DataManagement/index.tsx
@@ -13,6 +13,7 @@ import { ImportFileUpload } from '@/components/settings/DataManagement/ImportFil
 import { ImportDialog } from '@/components/settings/DataManagement/ImportDialog'
 import { SAFE_EXPORT_VERSION } from '@/components/settings/DataManagement/useGlobalImportFileParser'
 import { FileListCard } from '@/components/settings/DataManagement/FileListCard'
+import { visitedSafesSlice } from '@/store/visitedSafesSlice'
 
 import css from './styles.module.css'
 import Track from '@/components/common/Track'
@@ -31,6 +32,7 @@ export const exportAppData = () => {
     [settingsSlice.name]: setting,
     [safeAppsSlice.name]: safeApps,
     [undeployedSafesSlice.name]: undeployedSafes,
+    [visitedSafesSlice.name]: visitedSafes,
   } = getPersistedState()
 
   // Ensure they are under the same name as the slice
@@ -40,9 +42,10 @@ export const exportAppData = () => {
     [settingsSlice.name]: setting,
     [safeAppsSlice.name]: safeApps,
     [undeployedSafesSlice.name]: undeployedSafes,
+    [visitedSafesSlice.name]: visitedSafes,
   }
 
-  const data = JSON.stringify({ version: SAFE_EXPORT_VERSION.V2, data: exportData })
+  const data = JSON.stringify({ version: SAFE_EXPORT_VERSION.V3, data: exportData })
 
   const blob = new Blob([data], { type: 'text/json' })
   const link = document.createElement('a')

--- a/src/components/settings/DataManagement/index.tsx
+++ b/src/components/settings/DataManagement/index.tsx
@@ -13,7 +13,7 @@ import { ImportFileUpload } from '@/components/settings/DataManagement/ImportFil
 import { ImportDialog } from '@/components/settings/DataManagement/ImportDialog'
 import { SAFE_EXPORT_VERSION } from '@/components/settings/DataManagement/useGlobalImportFileParser'
 import { FileListCard } from '@/components/settings/DataManagement/FileListCard'
-import { visitedSafesSlice } from '@/store/visitedSafesSlice'
+import { selectAllVisitedSafes, visitedSafesSlice } from '@/store/visitedSafesSlice'
 
 import css from './styles.module.css'
 import Track from '@/components/common/Track'
@@ -64,6 +64,7 @@ const DataManagement = () => {
   const addedSafes = useAppSelector(selectAllAddedSafes)
   const addressBook = useAppSelector(selectAllAddressBooks)
   const settings = useAppSelector(selectSettings)
+  const visitedSafes = useAppSelector(selectAllVisitedSafes)
   const safeApps = useAppSelector(selectSafeApps)
   const undeployedSafes = useAppSelector(selectUndeployedSafes)
 
@@ -102,6 +103,7 @@ const DataManagement = () => {
               addedSafes={addedSafes}
               addressBook={addressBook}
               settings={settings}
+              visitedSafes={visitedSafes}
               safeApps={safeApps}
               undeployedSafes={undeployedSafes}
             />

--- a/src/components/settings/DataManagement/useGlobalImportFileParser.ts
+++ b/src/components/settings/DataManagement/useGlobalImportFileParser.ts
@@ -10,10 +10,12 @@ import type { SettingsState } from '@/store/settingsSlice'
 import type { UndeployedSafesState } from '@/features/counterfactual/store/undeployedSafesSlice'
 
 import { useMemo } from 'react'
+import type { VisitedSafesState } from '@/store/visitedSafesSlice'
 
 export const enum SAFE_EXPORT_VERSION {
   V1 = '1.0',
   V2 = '2.0',
+  V3 = '3.0',
 }
 
 export enum ImportErrors {
@@ -59,6 +61,13 @@ export const _filterValidAbEntries = (ab?: AddressBookState): AddressBookState |
  *  - safeApps
  *  - settings
  *
+ * 3.0:
+ *  - address book
+ *  - added Safes
+ *  - safeApps
+ *  - settings
+ *  - visited Safes
+ *
  * @param jsonData
  * @returns data to import and some insights about it
  */
@@ -69,6 +78,7 @@ type Data = {
   settings?: SettingsState
   safeApps?: SafeAppsState
   undeployedSafes?: UndeployedSafesState
+  visitedSafes?: VisitedSafesState
   error?: ImportErrors
   addressBookEntriesCount: number
   addedSafesCount: number
@@ -84,6 +94,7 @@ export const useGlobalImportJsonParser = (jsonData: string | undefined): Data =>
       settings: undefined,
       safeApps: undefined,
       undeployedSafes: undefined,
+      visitedSafes: undefined,
     }
 
     if (!jsonData) {
@@ -120,6 +131,17 @@ export const useGlobalImportJsonParser = (jsonData: string | undefined): Data =>
         data.settings = parsedFile.data.settings
         data.safeApps = parsedFile.data.safeApps
         data.undeployedSafes = parsedFile.data.undeployedSafes
+
+        break
+      }
+
+      case SAFE_EXPORT_VERSION.V3: {
+        data.addressBook = _filterValidAbEntries(parsedFile.data.addressBook)
+        data.addedSafes = parsedFile.data.addedSafes
+        data.settings = parsedFile.data.settings
+        data.safeApps = parsedFile.data.safeApps
+        data.undeployedSafes = parsedFile.data.undeployedSafes
+        data.visitedSafes = parsedFile.data.visitedSafes
 
         break
       }

--- a/src/features/myAccounts/hooks/useAllOwnedSafes.ts
+++ b/src/features/myAccounts/hooks/useAllOwnedSafes.ts
@@ -4,14 +4,14 @@ import useLocalStorage from '@/services/local-storage/useLocalStorage'
 import { useEffect } from 'react'
 import { useGetAllOwnedSafesQuery } from '@/store/api/gateway'
 import { asError } from '@/services/exceptions/utils'
+import { skipToken } from '@reduxjs/toolkit/query'
 
 const CACHE_KEY = 'ownedSafesCache_'
 
 const useAllOwnedSafes = (address: string): AsyncResult<AllOwnedSafes> => {
   const [cache, setCache] = useLocalStorage<AllOwnedSafes>(CACHE_KEY + address)
 
-  const { data, error, isLoading } = useGetAllOwnedSafesQuery({ walletAddress: address })
-  // const { data, error, isLoading } = useGetAllOwnedSafesQuery(address === '' ? skipToken : { walletAddress: address })
+  const { data, error, isLoading } = useGetAllOwnedSafesQuery(address === '' ? skipToken : { walletAddress: address })
 
   useEffect(() => {
     if (data != undefined) {

--- a/src/features/myAccounts/hooks/useAllOwnedSafes.ts
+++ b/src/features/myAccounts/hooks/useAllOwnedSafes.ts
@@ -4,14 +4,14 @@ import useLocalStorage from '@/services/local-storage/useLocalStorage'
 import { useEffect } from 'react'
 import { useGetAllOwnedSafesQuery } from '@/store/api/gateway'
 import { asError } from '@/services/exceptions/utils'
-import { skipToken } from '@reduxjs/toolkit/query'
 
 const CACHE_KEY = 'ownedSafesCache_'
 
 const useAllOwnedSafes = (address: string): AsyncResult<AllOwnedSafes> => {
   const [cache, setCache] = useLocalStorage<AllOwnedSafes>(CACHE_KEY + address)
 
-  const { data, error, isLoading } = useGetAllOwnedSafesQuery(address === '' ? skipToken : { walletAddress: address })
+  const { data, error, isLoading } = useGetAllOwnedSafesQuery({ walletAddress: address })
+  // const { data, error, isLoading } = useGetAllOwnedSafesQuery(address === '' ? skipToken : { walletAddress: address })
 
   useEffect(() => {
     if (data != undefined) {
@@ -19,7 +19,7 @@ const useAllOwnedSafes = (address: string): AsyncResult<AllOwnedSafes> => {
     }
   }, [data, setCache])
 
-  return [cache, asError(error), isLoading]
+  return address ? [cache, asError(error), isLoading] : [undefined, undefined, false]
 }
 
 export default useAllOwnedSafes

--- a/src/features/myAccounts/hooks/useAllOwnedSafes.ts
+++ b/src/features/myAccounts/hooks/useAllOwnedSafes.ts
@@ -19,7 +19,7 @@ const useAllOwnedSafes = (address: string): AsyncResult<AllOwnedSafes> => {
     }
   }, [data, setCache])
 
-  return address ? [cache, asError(error), isLoading] : [undefined, undefined, false]
+  return address ? [cache, asError(error), isLoading] : [{}, undefined, false]
 }
 
 export default useAllOwnedSafes

--- a/src/services/analytics/events/settings.ts
+++ b/src/services/analytics/events/settings.ts
@@ -129,6 +129,10 @@ export const SETTINGS_EVENTS = {
       action: 'Imported counterfactual safes via Import all',
       category: SETTINGS_CATEGORY,
     },
+    IMPORT_VISITED_SAFES: {
+      action: 'Imported visited safes via Import all',
+      category: SETTINGS_CATEGORY,
+    },
   },
   ENV_VARIABLES: {
     SAVE: {

--- a/src/store/api/gateway/index.ts
+++ b/src/store/api/gateway/index.ts
@@ -1,6 +1,5 @@
 import { proposerEndpoints } from '@/store/api/gateway/proposers'
 import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react'
-
 import {
   type AllOwnedSafes,
   getAllOwnedSafes,

--- a/src/store/visitedSafesSlice.ts
+++ b/src/store/visitedSafesSlice.ts
@@ -24,6 +24,10 @@ export const visitedSafesSlice = createSlice({
       state[chainId] ??= {}
       state[chainId][address] = { lastVisited }
     },
+    setVisitedSafes: (_, { payload }: PayloadAction<VisitedSafesState>) => {
+      // We must return as we are overwriting the entire state
+      return payload
+    },
   },
 })
 


### PR DESCRIPTION
## What it solves

Resolves: https://www.notion.so/safe-global/Sidebar-pinned-safes-add-last-visited-to-the-export-data-14a8180fe573801bb256c388061a2305?pvs=4
Resolves: #4612
## How this PR fixes it
- Creates a new `Export Version` (v3) which includes the data the visitedSafes store
- also fixes a bug where the account list is not cleared when disconnecting a wallet.

## How to test it
- make sure the visitedSafes has been populated (by opening several safes).
- Export safe data using the data widget.
- Import the exported file into a private window. 
- See that the visitedSafes store has been populated. Choose to order the safes list by recently opened. See that the order is as expected.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
