### PR TITLE
fix: CheckWallet sdk only if safe is also loaded

### DIFF
--- a/src/components/common/CheckWallet/index.test.tsx
+++ b/src/components/common/CheckWallet/index.test.tsx
@@ -231,8 +231,17 @@ describe('CheckWallet', () => {
     expect(getByText('Continue')).toBeDisabled()
   })
 
-  it('should disable the button if SDK is not initialized', () => {
+  it('should disable the button if SDK is not initialized and safe is loaded', () => {
     mockUseSafeSdk.mockReturnValue(undefined)
+
+    const mockSafeInfo = {
+      safeLoaded: true,
+      safe: extendedSafeInfoBuilder(),
+    }
+
+    ;(useSafeInfo as jest.MockedFunction<typeof useSafeInfo>).mockReturnValueOnce(
+      mockSafeInfo as unknown as ReturnType<typeof useSafeInfo>,
+    )
 
     const { getByText, getByLabelText } = render(
       <CheckWallet>{(isOk) => <button disabled={!isOk}>Continue</button>}</CheckWallet>,
@@ -241,6 +250,29 @@ describe('CheckWallet', () => {
     expect(getByText('Continue')).toBeDisabled()
     expect(getByLabelText('SDK is not initialized yet'))
   })
+
+  it('should not disable the button if SDK is not initialized and safe is not loaded', () => {
+    mockUseSafeSdk.mockReturnValue(undefined)
+
+    const safeAddress = faker.finance.ethereumAddress()
+    const mockSafeInfo = {
+      safeAddress,
+      safe: extendedSafeInfoBuilder()
+        .with({ address: { value: safeAddress } })
+        .with({ deployed: true })
+        .build(),
+      safeLoaded: false,
+    }
+
+    ;(useSafeInfo as jest.MockedFunction<typeof useSafeInfo>).mockReturnValueOnce(
+      mockSafeInfo as unknown as ReturnType<typeof useSafeInfo>,
+    )
+
+    const { queryByText } = render(<CheckWallet>{(isOk) => <button disabled={!isOk}>Continue</button>}</CheckWallet>)
+
+    expect(queryByText('Continue')).not.toBeDisabled()
+  })
+
   it('should allow nested Safe owners', () => {
     ;(useIsSafeOwner as jest.MockedFunction<typeof useIsSafeOwner>).mockReturnValueOnce(false)
     mockUseNestedSafeOwners.mockReturnValue([faker.finance.ethereumAddress()])

--- a/src/components/common/CheckWallet/index.tsx
+++ b/src/components/common/CheckWallet/index.tsx
@@ -87,6 +87,7 @@ const CheckWallet = ({
     isUndeployedSafe,
     sdk,
     wallet,
+    safeLoaded,
   ])
 
   if (checkNetwork && isWrongChain) return children(false)

--- a/src/components/common/CheckWallet/index.tsx
+++ b/src/components/common/CheckWallet/index.tsx
@@ -44,7 +44,7 @@ const CheckWallet = ({
   const sdk = useSafeSDK()
   const isProposer = useIsWalletProposer()
 
-  const { safe } = useSafeInfo()
+  const { safe, safeLoaded } = useSafeInfo()
 
   const isNestedSafeOwner = useIsNestedSafeOwner()
 
@@ -54,7 +54,7 @@ const CheckWallet = ({
     if (!wallet) {
       return Message.WalletNotConnected
     }
-    if (!sdk) {
+    if (!sdk && safeLoaded) {
       return Message.SDKNotInitialized
     }
 


### PR DESCRIPTION
## What it solves

Resolves #4636 

## How this PR fixes it

- Also checks for `safeLoaded` when evaluating if the sdk exists or not in `CheckWallet` since the sdk won't exist if there is no safe opened

## How to test it

This should not break existing behaviour for transaction related buttons

1. Go to the global preferences page
2. Activate notifications
3. Observe the Save button is enabled

## Screenshots
<img width="1004" alt="Screenshot 2024-12-10 at 16 43 12" src="https://github.com/user-attachments/assets/ccbc92e1-aae6-4d95-aca8-9c4e6f72c111">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
