### PR TITLE
Refactor: use recommendedMasterCopyVersion

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@safe-global/protocol-kit": "^4.1.2",
     "@safe-global/safe-apps-sdk": "^9.1.0",
     "@safe-global/safe-client-gateway-sdk": "v1.60.1",
-    "@safe-global/safe-gateway-typescript-sdk": "3.22.4",
+    "@safe-global/safe-gateway-typescript-sdk": "3.22.5-beta.0",
     "@safe-global/safe-modules-deployments": "^2.2.1",
     "@sentry/react": "^7.91.0",
     "@spindl-xyz/attribution-lite": "^1.4.0",

--- a/src/components/common/NetworkSelector/__tests__/NetworkMultiSelector.test.tsx
+++ b/src/components/common/NetworkSelector/__tests__/NetworkMultiSelector.test.tsx
@@ -33,30 +33,35 @@ describe('NetworkMultiSelector', () => {
       .with({ chainName: 'Ethereum' })
       .with({ shortName: 'eth' })
       .with({ features: [FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
+      .with({ recommendedMasterCopyVersion: '1.4.1' })
       .build(),
     chainBuilder()
       .with({ chainId: '10' })
       .with({ chainName: 'Optimism' })
       .with({ shortName: 'oeth' })
       .with({ features: [FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
+      .with({ recommendedMasterCopyVersion: '1.4.1' })
       .build(),
     chainBuilder()
       .with({ chainId: '100' })
       .with({ chainName: 'Gnosis Chain' })
       .with({ shortName: 'gno' })
       .with({ features: [FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
+      .with({ recommendedMasterCopyVersion: '1.4.1' })
       .build(),
     chainBuilder()
       .with({ chainId: '324' })
       .with({ chainName: 'ZkSync Era' })
       .with({ shortName: 'zksync' })
       .with({ features: [FEATURES.COUNTERFACTUAL] as any })
+      .with({ recommendedMasterCopyVersion: '1.4.1' })
       .build(),
     chainBuilder()
       .with({ chainId: '480' })
       .with({ chainName: 'Worldchain' })
       .with({ shortName: 'wc' })
       .with({ features: [FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
+      .with({ recommendedMasterCopyVersion: '1.4.1' })
       .build(),
   ]
 

--- a/src/components/common/NetworkSelector/__tests__/NetworkMultiSelector.test.tsx
+++ b/src/components/common/NetworkSelector/__tests__/NetworkMultiSelector.test.tsx
@@ -32,31 +32,31 @@ describe('NetworkMultiSelector', () => {
       .with({ chainId: '1' })
       .with({ chainName: 'Ethereum' })
       .with({ shortName: 'eth' })
-      .with({ features: [FEATURES.SAFE_141, FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
+      .with({ features: [FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
       .build(),
     chainBuilder()
       .with({ chainId: '10' })
       .with({ chainName: 'Optimism' })
       .with({ shortName: 'oeth' })
-      .with({ features: [FEATURES.SAFE_141, FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
+      .with({ features: [FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
       .build(),
     chainBuilder()
       .with({ chainId: '100' })
       .with({ chainName: 'Gnosis Chain' })
       .with({ shortName: 'gno' })
-      .with({ features: [FEATURES.SAFE_141, FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
+      .with({ features: [FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
       .build(),
     chainBuilder()
       .with({ chainId: '324' })
       .with({ chainName: 'ZkSync Era' })
       .with({ shortName: 'zksync' })
-      .with({ features: [FEATURES.SAFE_141, FEATURES.COUNTERFACTUAL] as any })
+      .with({ features: [FEATURES.COUNTERFACTUAL] as any })
       .build(),
     chainBuilder()
       .with({ chainId: '480' })
       .with({ chainName: 'Worldchain' })
       .with({ shortName: 'wc' })
-      .with({ features: [FEATURES.SAFE_141, FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
+      .with({ features: [FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
       .build(),
   ]
 

--- a/src/components/new-safe/create/logic/index.test.ts
+++ b/src/components/new-safe/create/logic/index.test.ts
@@ -23,7 +23,6 @@ import {
 } from '@/services/contracts/safeContracts'
 import * as gateway from '@safe-global/safe-gateway-typescript-sdk'
 import { FEATURES, getLatestSafeVersion } from '@/utils/chains'
-import { type FEATURES as GatewayFeatures } from '@safe-global/safe-gateway-typescript-sdk'
 import { chainBuilder } from '@/tests/builders/chains'
 import { type ReplayedSafeProps } from '@/store/slices'
 import { faker } from '@faker-js/faker'
@@ -40,9 +39,7 @@ import { Safe_to_l2_setup__factory } from '@/types/contracts'
 const provider = new JsonRpcProvider(undefined, { name: 'ethereum', chainId: 1 })
 
 const latestSafeVersion = getLatestSafeVersion(
-  chainBuilder()
-    .with({ chainId: '1', features: [FEATURES.SAFE_141 as unknown as GatewayFeatures] })
-    .build(),
+  chainBuilder().with({ chainId: '1', recommendedMasterCopyVersion: '1.4.1' }).build(),
 )
 
 const safeToL2SetupDeployment = getSafeToL2SetupDeployment()
@@ -58,7 +55,7 @@ describe('create/logic', () => {
       .with({
         chainId: '1',
         l2: false,
-        features: [FEATURES.SAFE_141 as unknown as GatewayFeatures],
+        recommendedMasterCopyVersion: '1.4.1',
       })
       .build()
 
@@ -207,7 +204,7 @@ describe('create/logic', () => {
           chainBuilder()
             .with({ chainId: '1' })
             // Multichain creation is toggled off
-            .with({ features: [FEATURES.SAFE_141, FEATURES.COUNTERFACTUAL] as any })
+            .with({ features: [FEATURES.COUNTERFACTUAL] as any })
             .with({ l2: false })
             .build(),
         ),
@@ -237,7 +234,7 @@ describe('create/logic', () => {
           chainBuilder()
             .with({ chainId: '137' })
             // Multichain creation is toggled off
-            .with({ features: [FEATURES.SAFE_141, FEATURES.COUNTERFACTUAL] as any })
+            .with({ features: [FEATURES.COUNTERFACTUAL] as any })
             .with({ l2: true })
             .build(),
         ),
@@ -267,7 +264,7 @@ describe('create/logic', () => {
           chainBuilder()
             .with({ chainId: '137' })
             // Multichain creation is toggled on
-            .with({ features: [FEATURES.SAFE_141, FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
+            .with({ features: [FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
             .with({ l2: true })
             .build(),
         ),
@@ -301,7 +298,7 @@ describe('create/logic', () => {
           chainBuilder()
             .with({ chainId: '137' })
             // Multichain creation is toggled on
-            .with({ features: [FEATURES.SAFE_141, FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
+            .with({ features: [FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
             .with({ l2: true })
             .build(),
         ),

--- a/src/components/new-safe/create/logic/index.test.ts
+++ b/src/components/new-safe/create/logic/index.test.ts
@@ -235,6 +235,7 @@ describe('create/logic', () => {
             .with({ chainId: '137' })
             // Multichain creation is toggled off
             .with({ features: [FEATURES.COUNTERFACTUAL] as any })
+            .with({ recommendedMasterCopyVersion: '1.4.1' })
             .with({ l2: true })
             .build(),
         ),
@@ -265,6 +266,7 @@ describe('create/logic', () => {
             .with({ chainId: '137' })
             // Multichain creation is toggled on
             .with({ features: [FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
+            .with({ recommendedMasterCopyVersion: '1.3.0' })
             .with({ l2: true })
             .build(),
         ),
@@ -299,6 +301,7 @@ describe('create/logic', () => {
             .with({ chainId: '137' })
             // Multichain creation is toggled on
             .with({ features: [FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
+            .with({ recommendedMasterCopyVersion: '1.4.1' })
             .with({ l2: true })
             .build(),
         ),
@@ -331,6 +334,7 @@ describe('create/logic', () => {
             .with({ chainId: '324' })
             // Multichain and 1.4.1 creation is toggled off
             .with({ features: [FEATURES.COUNTERFACTUAL] as any })
+            .with({ recommendedMasterCopyVersion: '1.3.0' })
             .with({ l2: true })
             .build(),
         ),

--- a/src/features/multichain/utils/utils.ts
+++ b/src/features/multichain/utils/utils.ts
@@ -121,11 +121,7 @@ export const predictAddressBasedOnReplayData = async (safeCreationData: Replayed
 }
 
 export const hasMultiChainCreationFeatures = (chain: ChainInfo): boolean => {
-  return (
-    hasFeature(chain, FEATURES.MULTI_CHAIN_SAFE_CREATION) &&
-    hasFeature(chain, FEATURES.COUNTERFACTUAL) &&
-    hasFeature(chain, FEATURES.SAFE_141)
-  )
+  return hasFeature(chain, FEATURES.MULTI_CHAIN_SAFE_CREATION) && hasFeature(chain, FEATURES.COUNTERFACTUAL)
 }
 
 export const hasMultiChainAddNetworkFeature = (chain: ChainInfo | undefined): boolean => {

--- a/src/features/multichain/utils/utils.ts
+++ b/src/features/multichain/utils/utils.ts
@@ -1,16 +1,17 @@
-import type { DecodedDataResponse } from '@safe-global/safe-gateway-typescript-sdk'
+import type { DecodedDataResponse, ChainInfo, SafeOverview } from '@safe-global/safe-gateway-typescript-sdk'
+import semverSatisfies from 'semver/functions/satisfies'
+import memoize from 'lodash/memoize'
+import { keccak256, ethers, solidityPacked, getCreate2Address, type Provider } from 'ethers'
 
-import { type ChainInfo, type SafeOverview } from '@safe-global/safe-gateway-typescript-sdk'
 import { type UndeployedSafesState, type ReplayedSafeProps } from '@/store/slices'
 import { sameAddress } from '@/utils/addresses'
 import { Safe_proxy_factory__factory } from '@/types/contracts'
-import { keccak256, ethers, solidityPacked, getCreate2Address, type Provider } from 'ethers'
 import { extractCounterfactualSafeSetup } from '@/features/counterfactual/utils'
 import { encodeSafeSetupCall } from '@/components/new-safe/create/logic'
-import memoize from 'lodash/memoize'
 import { FEATURES, hasFeature } from '@/utils/chains'
 import { type SafeItem } from '@/features/myAccounts/hooks/useAllSafes'
 import { type MultiChainSafeItem } from '@/features/myAccounts/hooks/useAllSafesGrouped'
+import { LATEST_SAFE_VERSION } from '@/config/constants'
 
 type SafeSetup = {
   owners: string[]
@@ -126,5 +127,9 @@ export const hasMultiChainCreationFeatures = (chain: ChainInfo): boolean => {
 
 export const hasMultiChainAddNetworkFeature = (chain: ChainInfo | undefined): boolean => {
   if (!chain) return false
-  return hasFeature(chain, FEATURES.MULTI_CHAIN_SAFE_ADD_NETWORK) && hasFeature(chain, FEATURES.COUNTERFACTUAL)
+  return (
+    hasFeature(chain, FEATURES.MULTI_CHAIN_SAFE_ADD_NETWORK) &&
+    hasFeature(chain, FEATURES.COUNTERFACTUAL) &&
+    semverSatisfies(chain.recommendedMasterCopyVersion || LATEST_SAFE_VERSION, '>=1.4.1')
+  )
 }

--- a/src/features/recovery/services/__tests__/recovery-state.test.ts
+++ b/src/features/recovery/services/__tests__/recovery-state.test.ts
@@ -15,8 +15,7 @@ import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { encodeMultiSendData } from '@safe-global/protocol-kit/dist/src/utils/transactions/utils'
 import { getMultiSendCallOnlyDeployment, getSafeSingletonDeployment } from '@safe-global/safe-deployments'
 import { Interface } from 'ethers'
-import { FEATURES, getLatestSafeVersion } from '@/utils/chains'
-import { type FEATURES as GatewayFeatures } from '@safe-global/safe-gateway-typescript-sdk'
+import { getLatestSafeVersion } from '@/utils/chains'
 import { chainBuilder } from '@/tests/builders/chains'
 
 jest.mock('@/hooks/wallets/web3')
@@ -24,9 +23,7 @@ jest.mock('@/hooks/wallets/web3')
 const mockUseWeb3ReadOnly = useWeb3ReadOnly as jest.MockedFunction<typeof useWeb3ReadOnly>
 
 const latestSafeVersion = getLatestSafeVersion(
-  chainBuilder()
-    .with({ chainId: '1', features: [FEATURES.SAFE_141 as unknown as GatewayFeatures] })
-    .build(),
+  chainBuilder().with({ chainId: '1', recommendedMasterCopyVersion: '1.4.1' }).build(),
 )
 const PRE_MULTI_SEND_CALL_ONLY_VERSIONS = ['1.0.0', '1.1.1']
 const SUPPORTED_MULTI_SEND_CALL_ONLY_VERSIONS = [

--- a/src/services/contracts/__tests__/deployments.test.ts
+++ b/src/services/contracts/__tests__/deployments.test.ts
@@ -2,21 +2,17 @@ import * as safeDeployments from '@safe-global/safe-deployments'
 import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 
 import * as deployments from '../deployments'
-import { FEATURES, getLatestSafeVersion } from '@/utils/chains'
+import { getLatestSafeVersion } from '@/utils/chains'
 import { chainBuilder } from '@/tests/builders/chains'
 
-const mainnetInfo = chainBuilder()
-  .with({ chainId: '1', features: [FEATURES.SAFE_141 as any], l2: false })
-  .build()
-const l2ChainInfo = chainBuilder()
-  .with({ chainId: '137', features: [FEATURES.SAFE_141 as any], l2: true })
-  .build()
+const mainnetInfo = chainBuilder().with({ chainId: '1', l2: false, recommendedMasterCopyVersion: '1.4.1' }).build()
+const l2ChainInfo = chainBuilder().with({ chainId: '137', l2: true, recommendedMasterCopyVersion: '1.4.1' }).build()
 const unsupportedChainInfo = chainBuilder()
-  .with({ chainId: '69420', features: [FEATURES.SAFE_141 as any], l2: false })
+  .with({ chainId: '69420', l2: false, recommendedMasterCopyVersion: '1.3.0' })
   .build()
 
 const unsupportedL2ChainInfo = chainBuilder()
-  .with({ chainId: '69420', features: [FEATURES.SAFE_141 as any], l2: true })
+  .with({ chainId: '69420', l2: true, recommendedMasterCopyVersion: '1.3.0' })
   .build()
 const latestSafeVersion = getLatestSafeVersion(mainnetInfo)
 

--- a/src/services/safe-wallet-provider/useSafeWalletProvider.test.tsx
+++ b/src/services/safe-wallet-provider/useSafeWalletProvider.test.tsx
@@ -17,7 +17,6 @@ import { Interface } from 'ethers'
 import { getCreateCallDeployment } from '@safe-global/safe-deployments'
 import { useCurrentChain } from '@/hooks/useChains'
 import { chainBuilder } from '@/tests/builders/chains'
-import { FEATURES } from '@/utils/chains'
 
 const appInfo = {
   id: 1,
@@ -47,9 +46,7 @@ describe('useSafeWalletProvider', () => {
     jest.clearAllMocks()
 
     mockUseCurrentChain.mockReturnValue(
-      chainBuilder()
-        .with({ chainId: '1', features: [FEATURES.SAFE_141 as any] })
-        .build(),
+      chainBuilder().with({ chainId: '1', recommendedMasterCopyVersion: '1.4.1' }).build(),
     )
   })
 

--- a/src/services/tx/__tests__/safeUpdateParams.test.ts
+++ b/src/services/tx/__tests__/safeUpdateParams.test.ts
@@ -10,7 +10,7 @@ import { type SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { Interface, JsonRpcProvider } from 'ethers'
 import { createUpdateSafeTxs } from '../safeUpdateParams'
 import * as web3 from '@/hooks/wallets/web3'
-import { FEATURES, getLatestSafeVersion } from '@/utils/chains'
+import { getLatestSafeVersion } from '@/utils/chains'
 import { chainBuilder } from '@/tests/builders/chains'
 
 const MOCK_SAFE_ADDRESS = '0x0000000000000000000000000000000000005AFE'
@@ -39,7 +39,7 @@ describe('safeUpgradeParams', () => {
     } as SafeInfo
 
     const mockChainInfo = chainBuilder()
-      .with({ chainId: '1', l2: false, features: [FEATURES.SAFE_141 as any] })
+      .with({ chainId: '1', l2: false, recommendedMasterCopyVersion: '1.4.1' })
       .build()
     const txs = await createUpdateSafeTxs(mockSafe, mockChainInfo)
     const [masterCopyTx, fallbackHandlerTx] = txs
@@ -74,7 +74,7 @@ describe('safeUpgradeParams', () => {
       version: '1.1.1',
     } as SafeInfo
     const mockChainInfo = chainBuilder()
-      .with({ chainId: '1', l2: false, features: [FEATURES.SAFE_141 as any] })
+      .with({ chainId: '1', l2: false, recommendedMasterCopyVersion: '1.4.1' })
       .build()
     const txs = await createUpdateSafeTxs(mockSafe, mockChainInfo)
     const [masterCopyTx, fallbackHandlerTx] = txs
@@ -111,7 +111,7 @@ describe('safeUpgradeParams', () => {
       version: '1.1.1',
     } as SafeInfo
     const mockChainInfo = chainBuilder()
-      .with({ chainId: '100', l2: true, features: [FEATURES.SAFE_141 as any] })
+      .with({ chainId: '100', l2: true, recommendedMasterCopyVersion: '1.4.1' })
       .build()
 
     const txs = await createUpdateSafeTxs(mockSafe, mockChainInfo)

--- a/src/tests/builders/chains.ts
+++ b/src/tests/builders/chains.ts
@@ -110,6 +110,7 @@ export const chainBuilder = (): IBuilder<ChainInfo> => {
     disabledWallets: generateRandomArray(() => faker.word.sample(), { min: 1, max: 10 }),
     // @ts-expect-error - we are using a local FEATURES enum
     features: generateRandomArray(() => faker.helpers.enumValue(FEATURES), { min: 1, max: 10 }),
+    recommendedMasterCopyVersion: faker.system.semver(),
   })
 }
 

--- a/src/tests/mocks/chains.ts
+++ b/src/tests/mocks/chains.ts
@@ -68,6 +68,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       chainName: null,
       enabled: false,
     },
+    recommendedMasterCopyVersion: '1.4.1',
   },
   {
     transactionService: 'https://safe-transaction.xdai.gnosis.io',
@@ -122,6 +123,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       chainName: null,
       enabled: false,
     },
+    recommendedMasterCopyVersion: '1.4.1',
   },
   {
     transactionService: 'https://safe-transaction.polygon.gnosis.io',
@@ -182,6 +184,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       chainName: null,
       enabled: false,
     },
+    recommendedMasterCopyVersion: '1.4.1',
   },
   {
     transactionService: 'https://safe-transaction.bsc.gnosis.io',
@@ -238,6 +241,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       chainName: null,
       enabled: false,
     },
+    recommendedMasterCopyVersion: '1.4.1',
   },
   {
     transactionService: 'https://safe-transaction.ewc.gnosis.io',
@@ -292,6 +296,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       chainName: null,
       enabled: false,
     },
+    recommendedMasterCopyVersion: '1.4.1',
   },
   {
     transactionService: 'https://safe-transaction.arbitrum.gnosis.io',
@@ -339,6 +344,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       chainName: null,
       enabled: false,
     },
+    recommendedMasterCopyVersion: '1.4.1',
   },
   {
     transactionService: 'https://safe-transaction.aurora.gnosis.io',
@@ -387,6 +393,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       chainName: null,
       enabled: false,
     },
+    recommendedMasterCopyVersion: '1.4.1',
   },
   {
     transactionService: 'https://safe-transaction.avalanche.gnosis.io',
@@ -446,6 +453,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       chainName: null,
       enabled: false,
     },
+    recommendedMasterCopyVersion: '1.4.1',
   },
   {
     transactionService: 'https://safe-transaction.optimism.gnosis.io',
@@ -493,6 +501,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       chainName: null,
       enabled: false,
     },
+    recommendedMasterCopyVersion: '1.4.1',
   },
   {
     transactionService: 'https://safe-transaction.goerli.gnosis.io/',
@@ -548,6 +557,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       chainName: null,
       enabled: false,
     },
+    recommendedMasterCopyVersion: '1.4.1',
   },
   {
     transactionService: 'https://safe-transaction.rinkeby.gnosis.io',
@@ -593,6 +603,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       chainName: null,
       enabled: false,
     },
+    recommendedMasterCopyVersion: '1.4.1',
   },
   {
     transactionService: 'https://safe-transaction.volta.gnosis.io',
@@ -647,6 +658,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
       chainName: null,
       enabled: false,
     },
+    recommendedMasterCopyVersion: '1.4.1',
   },
 ]
 

--- a/src/utils/__tests__/chains.test.ts
+++ b/src/utils/__tests__/chains.test.ts
@@ -41,46 +41,20 @@ describe('chains', () => {
 
   describe('chains', () => {
     describe('getLatestSafeVersion', () => {
-      it('should return 1.4.1 on supported networks', () => {
+      it('should return the version from recommendedMasterCopyVersion', () => {
         expect(
-          getLatestSafeVersion(
-            chainBuilder()
-              .with({ chainId: '1', features: [FEATURES.SAFE_141 as any] })
-              .build(),
-          ),
+          getLatestSafeVersion(chainBuilder().with({ chainId: '1', recommendedMasterCopyVersion: '1.4.1' }).build()),
         ).toEqual('1.4.1')
         expect(
-          getLatestSafeVersion(
-            chainBuilder()
-              .with({ chainId: '137', features: [FEATURES.SAFE_141 as any] })
-              .build(),
-          ),
-        ).toEqual('1.4.1')
-        expect(
-          getLatestSafeVersion(
-            chainBuilder()
-              .with({ chainId: '11155111', features: [FEATURES.SAFE_141 as any] })
-              .build(),
-          ),
-        ).toEqual('1.4.1')
-      })
-
-      it('should return 1.3.0 on networks where 1.4.1 is not released', () => {
-        expect(
-          getLatestSafeVersion(
-            chainBuilder()
-              .with({ chainId: '324', features: [FEATURES.SAFE_141 as any] })
-              .build(),
-          ),
+          getLatestSafeVersion(chainBuilder().with({ chainId: '137', recommendedMasterCopyVersion: '1.3.0' }).build()),
         ).toEqual('1.3.0')
       })
-
-      it('should return 1.3.0 if the feature is off', () => {
-        expect(getLatestSafeVersion(chainBuilder().with({ chainId: '1', features: [] }).build())).toEqual('1.3.0')
-        expect(getLatestSafeVersion(chainBuilder().with({ chainId: '137', features: [] }).build())).toEqual('1.3.0')
-        expect(getLatestSafeVersion(chainBuilder().with({ chainId: '11155111', features: [] }).build())).toEqual(
-          '1.3.0',
-        )
+      it('should fall back to LATEST_VERSION', () => {
+        expect(
+          getLatestSafeVersion(
+            chainBuilder().with({ chainId: '11155111', recommendedMasterCopyVersion: null }).build(),
+          ),
+        ).toEqual('1.4.1')
       })
     })
   })

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -32,7 +32,6 @@ export enum FEATURES {
   NATIVE_SWAPS_USE_COW_STAGING_SERVER = 'NATIVE_SWAPS_USE_COW_STAGING_SERVER',
   NATIVE_SWAPS_FEE_ENABLED = 'NATIVE_SWAPS_FEE_ENABLED',
   ZODIAC_ROLES = 'ZODIAC_ROLES',
-  SAFE_141 = 'SAFE_141',
   STAKING = 'STAKING',
   STAKING_BANNER = 'STAKING_BANNER',
   MULTI_CHAIN_SAFE_CREATION = 'MULTI_CHAIN_SAFE_CREATION',
@@ -71,7 +70,7 @@ export const isRouteEnabled = (route: string, chain?: ChainInfo) => {
 }
 
 export const getLatestSafeVersion = (chain: ChainInfo | undefined): SafeVersion => {
-  const latestSafeVersion = chain && hasFeature(chain, FEATURES.SAFE_141) ? LATEST_SAFE_VERSION : FALLBACK_SAFE_VERSION
+  const latestSafeVersion = chain?.recommendedMasterCopyVersion || LATEST_SAFE_VERSION
   // Without version filter it will always return the LATEST_SAFE_VERSION constant to avoid automatically updating to the newest version if the deployments change
   const latestDeploymentVersion = (getSafeSingletonDeployment({ network: chain?.chainId, released: true })?.version ??
     FALLBACK_SAFE_VERSION) as SafeVersion

--- a/yarn.lock
+++ b/yarn.lock
@@ -4433,10 +4433,10 @@
   dependencies:
     semver "^7.6.2"
 
-"@safe-global/safe-gateway-typescript-sdk@3.22.4":
-  version "3.22.4"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.22.4.tgz#9109a538df40f778666a3e6776e7a08c757e893d"
-  integrity sha512-Z7Z8w3GEJdJ/paF+NK23VN4AwqWPadq0AeRYjYLjIBiPWpRB2UO/FKq7ONABEq0YFgNPklazIV4IExQU1gavXA==
+"@safe-global/safe-gateway-typescript-sdk@3.22.5-beta.0":
+  version "3.22.5-beta.0"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.22.5-beta.0.tgz#0cc37a86af200c342dbcb56a641e9f3e3611d16e"
+  integrity sha512-nNfWRpnNFk8y14XJ7aORx+ZZyEqGi3gkME7oPrP/O5Pt+SBJY/6aQ4Z23fbNnPHi7bQDZPQUdjK+mWHZ2b8dCA==
 
 "@safe-global/safe-gateway-typescript-sdk@^3.5.3":
   version "3.21.2"


### PR DESCRIPTION
## What it solves

Instead of the SAFE_141 feature toggle, use the recommendedMasterCopyVersion field from the ChainInfo.

This field from the config service is also used by CGW to determine whether a Safe is UP_TO_DATE or OUTDATED.

<img width="569" alt="Screenshot 2024-12-11 at 17 09 23" src="https://github.com/user-attachments/assets/a8bc01f8-2291-4917-ba08-fbc22ee2020a" />

## NB

After we merge this, we'll need to make sure to update the config service to switch all chains where SAFE_141 was enabled to 1.4.1. This will have the side effect of enabling the upgrade to 1.4.1 for old Safes – must be tested.