### PR TITLE
Fix: allow removing counterfactual safes from safe list

### DIFF
--- a/src/components/sidebar/SafeListRemoveDialog/index.tsx
+++ b/src/components/sidebar/SafeListRemoveDialog/index.tsx
@@ -12,8 +12,9 @@ import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
 import { AppRoutes } from '@/config/routes'
 import router from 'next/router'
 import { removeAddressBookEntry } from '@/store/addressBookSlice'
-import { removeUndeployedSafe } from '@/store/slices'
+import { removeSafe, removeUndeployedSafe } from '@/store/slices'
 import useSafeAddress from '@/hooks/useSafeAddress'
+import useChainId from '@/hooks/useChainId'
 
 const SafeListRemoveDialog = ({
   handleClose,
@@ -26,6 +27,7 @@ const SafeListRemoveDialog = ({
 }): ReactElement => {
   const dispatch = useAppDispatch()
   const safeAddress = useSafeAddress()
+  const safeChainId = useChainId()
   const addressBook = useAddressBook()
   const trackingLabel =
     router.pathname === AppRoutes.welcome.accounts ? OVERVIEW_LABELS.login_page : OVERVIEW_LABELS.sidebar
@@ -34,10 +36,11 @@ const SafeListRemoveDialog = ({
 
   const handleConfirm = async () => {
     // When removing the current counterfactual safe, redirect to the accounts page
-    if (safeAddress === address) {
+    if (safeAddress === address && safeChainId === chainId) {
       await router.push(AppRoutes.welcome.accounts)
     }
     dispatch(removeUndeployedSafe({ chainId, address }))
+    dispatch(removeSafe({ chainId, address }))
     dispatch(removeAddressBookEntry({ chainId, address }))
     handleClose()
   }

--- a/src/components/sidebar/SafeListRemoveDialog/index.tsx
+++ b/src/components/sidebar/SafeListRemoveDialog/index.tsx
@@ -7,12 +7,13 @@ import type { ReactElement } from 'react'
 import ModalDialog from '@/components/common/ModalDialog'
 import { useAppDispatch } from '@/store'
 import useAddressBook from '@/hooks/useAddressBook'
-import { removeSafe } from '@/store/addedSafesSlice'
 import Track from '@/components/common/Track'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
 import { AppRoutes } from '@/config/routes'
 import router from 'next/router'
 import { removeAddressBookEntry } from '@/store/addressBookSlice'
+import { removeUndeployedSafe } from '@/store/slices'
+import useSafeAddress from '@/hooks/useSafeAddress'
 
 const SafeListRemoveDialog = ({
   handleClose,
@@ -24,14 +25,19 @@ const SafeListRemoveDialog = ({
   chainId: string
 }): ReactElement => {
   const dispatch = useAppDispatch()
+  const safeAddress = useSafeAddress()
   const addressBook = useAddressBook()
   const trackingLabel =
     router.pathname === AppRoutes.welcome.accounts ? OVERVIEW_LABELS.login_page : OVERVIEW_LABELS.sidebar
 
   const safe = addressBook?.[address] || address
 
-  const handleConfirm = () => {
-    dispatch(removeSafe({ chainId, address }))
+  const handleConfirm = async () => {
+    // When removing the current counterfactual safe, redirect to the accounts page
+    if (safeAddress === address) {
+      await router.push(AppRoutes.welcome.accounts)
+    }
+    dispatch(removeUndeployedSafe({ chainId, address }))
     dispatch(removeAddressBookEntry({ chainId, address }))
     handleClose()
   }


### PR DESCRIPTION
## What it solves

Resolves #4611

## How this PR fixes it
- Removes the counterfactual safe from the `undeployedSafes` store as well as from the `addedSafes` store.
- If the safe being removed is the currently opened safe, redirect to the accounts page.

## How to test it
- Create a counterfactual safe
- it should be possible to remove the safe from the context menu of the CF safe in the sidebar.
- If the CF safe being removed is currently opened, redirect to the accounts page.

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
