### PR TITLE
fix: rank featured Safe Apps first on dashboard

### DIFF
--- a/src/components/dashboard/SafeAppsDashboardSection/__tests__/SafeAppsDashboardSection.test.tsx
+++ b/src/components/dashboard/SafeAppsDashboardSection/__tests__/SafeAppsDashboardSection.test.tsx
@@ -23,6 +23,7 @@ jest.mock('@safe-global/safe-gateway-typescript-sdk', () => ({
         features: [],
         socialProfiles: [],
         developerWebsite: '',
+        featured: true,
       },
       {
         id: 3,
@@ -40,6 +41,7 @@ jest.mock('@safe-global/safe-gateway-typescript-sdk', () => ({
         features: [],
         socialProfiles: [],
         developerWebsite: '',
+        featured: true,
       },
       {
         id: 14,
@@ -56,6 +58,7 @@ jest.mock('@safe-global/safe-gateway-typescript-sdk', () => ({
         features: [],
         socialProfiles: [],
         developerWebsite: '',
+        featured: false,
       },
       {
         id: 24,
@@ -73,6 +76,7 @@ jest.mock('@safe-global/safe-gateway-typescript-sdk', () => ({
         features: [],
         socialProfiles: [],
         developerWebsite: '',
+        featured: true,
       },
     ]),
 }))
@@ -116,8 +120,7 @@ describe('Safe Apps Dashboard Section', () => {
       expect(screen.getByText('Decentralised naming for wallets, websites, & more.')).toBeInTheDocument(),
     )
 
-    await waitFor(() => expect(screen.getByText('Synthetix')).toBeInTheDocument())
-    await waitFor(() => expect(screen.getByText('Trade synthetic assets on Ethereum')).toBeInTheDocument())
+    // Synthetix is not displayed as it is not featured
 
     await waitFor(() => expect(screen.getByText('Transaction Builder')).toBeInTheDocument())
     await waitFor(() => expect(screen.getByText('A Safe app to compose custom transactions')).toBeInTheDocument())

--- a/src/hooks/__tests__/useRankedSafeApps.test.ts
+++ b/src/hooks/__tests__/useRankedSafeApps.test.ts
@@ -31,7 +31,7 @@ describe('useRankedSafeApps', () => {
     expect(result.current.length).toEqual(5)
   })
 
-  it('returns featured apps first', () => {
+  it('returns featured, then pinned apps', () => {
     const mockSafeApp1 = getMockSafeApp({ id: 1 })
     const mockSafeApp2 = getMockSafeApp({ id: 2, featured: true } as Partial<SafeAppData>)
     const mockSafeApp3 = getMockSafeApp({ id: 3, featured: true } as Partial<SafeAppData>)
@@ -52,27 +52,5 @@ describe('useRankedSafeApps', () => {
     expect(result.current[1]).toStrictEqual(mockSafeApp3)
     expect(result.current[2]).toStrictEqual(mockPinnedApp1)
     expect(result.current[3]).toStrictEqual(mockPinnedApp2)
-  })
-
-  it('returns pinned after featured apps', () => {
-    const mockSafeApp1 = getMockSafeApp({ id: 1, featured: true } as Partial<SafeAppData>)
-    const mockSafeApp2 = getMockSafeApp({ id: 2 })
-    const mockSafeApp3 = getMockSafeApp({ id: 3 })
-    const mockSafeApp4 = getMockSafeApp({ id: 4 })
-    const mockSafeApp5 = getMockSafeApp({ id: 5 })
-
-    const mockPinnedApp1 = getMockSafeApp({ id: 6 })
-    const mockPinnedApp2 = getMockSafeApp({ id: 7 })
-
-    const { result } = renderHook(() =>
-      useRankedSafeApps(
-        [mockSafeApp1, mockSafeApp2, mockSafeApp3, mockSafeApp4, mockSafeApp5],
-        [mockPinnedApp1, mockPinnedApp2],
-      ),
-    )
-
-    expect(result.current[0]).toStrictEqual(mockSafeApp1)
-    expect(result.current[1]).toStrictEqual(mockPinnedApp1)
-    expect(result.current[2]).toStrictEqual(mockPinnedApp2)
   })
 })

--- a/src/hooks/__tests__/useRankedSafeApps.test.ts
+++ b/src/hooks/__tests__/useRankedSafeApps.test.ts
@@ -17,7 +17,7 @@ describe('useRankedSafeApps', () => {
   })
 
   it('returns 5 safe apps at most', () => {
-    const mockSafeApp1 = getMockSafeApp({ id: 1 })
+    const mockSafeApp1 = getMockSafeApp({ id: 1, featured: true } as Partial<SafeAppData>)
     const mockSafeApp2 = getMockSafeApp({ id: 2 })
     const mockSafeApp3 = getMockSafeApp({ id: 3 })
     const mockSafeApp4 = getMockSafeApp({ id: 4 })
@@ -25,31 +25,10 @@ describe('useRankedSafeApps', () => {
     const mockSafeApp6 = getMockSafeApp({ id: 6 })
 
     const { result } = renderHook(() =>
-      useRankedSafeApps([mockSafeApp1, mockSafeApp2, mockSafeApp3, mockSafeApp4, mockSafeApp5, mockSafeApp6], []),
+      useRankedSafeApps([mockSafeApp1], [mockSafeApp2, mockSafeApp3, mockSafeApp4, mockSafeApp5, mockSafeApp6]),
     )
 
     expect(result.current.length).toEqual(5)
-  })
-
-  it('returns pinned apps first', () => {
-    const mockSafeApp1 = getMockSafeApp({ id: 1 })
-    const mockSafeApp2 = getMockSafeApp({ id: 2 })
-    const mockSafeApp3 = getMockSafeApp({ id: 3 })
-    const mockSafeApp4 = getMockSafeApp({ id: 4 })
-    const mockSafeApp5 = getMockSafeApp({ id: 5 })
-
-    const mockPinnedApp1 = getMockSafeApp({ id: 6 })
-    const mockPinnedApp2 = getMockSafeApp({ id: 7 })
-
-    const { result } = renderHook(() =>
-      useRankedSafeApps(
-        [mockSafeApp1, mockSafeApp2, mockSafeApp3, mockSafeApp4, mockSafeApp5],
-        [mockPinnedApp1, mockPinnedApp2],
-      ),
-    )
-
-    expect(result.current[0]).toStrictEqual(mockPinnedApp1)
-    expect(result.current[1]).toStrictEqual(mockPinnedApp2)
   })
 
   it('returns featured apps first', () => {
@@ -73,5 +52,27 @@ describe('useRankedSafeApps', () => {
     expect(result.current[1]).toStrictEqual(mockSafeApp3)
     expect(result.current[2]).toStrictEqual(mockPinnedApp1)
     expect(result.current[3]).toStrictEqual(mockPinnedApp2)
+  })
+
+  it('returns pinned after featured apps', () => {
+    const mockSafeApp1 = getMockSafeApp({ id: 1, featured: true } as Partial<SafeAppData>)
+    const mockSafeApp2 = getMockSafeApp({ id: 2 })
+    const mockSafeApp3 = getMockSafeApp({ id: 3 })
+    const mockSafeApp4 = getMockSafeApp({ id: 4 })
+    const mockSafeApp5 = getMockSafeApp({ id: 5 })
+
+    const mockPinnedApp1 = getMockSafeApp({ id: 6 })
+    const mockPinnedApp2 = getMockSafeApp({ id: 7 })
+
+    const { result } = renderHook(() =>
+      useRankedSafeApps(
+        [mockSafeApp1, mockSafeApp2, mockSafeApp3, mockSafeApp4, mockSafeApp5],
+        [mockPinnedApp1, mockPinnedApp2],
+      ),
+    )
+
+    expect(result.current[0]).toStrictEqual(mockSafeApp1)
+    expect(result.current[1]).toStrictEqual(mockPinnedApp1)
+    expect(result.current[2]).toStrictEqual(mockPinnedApp2)
   })
 })

--- a/src/hooks/__tests__/useRankedSafeApps.test.ts
+++ b/src/hooks/__tests__/useRankedSafeApps.test.ts
@@ -51,4 +51,27 @@ describe('useRankedSafeApps', () => {
     expect(result.current[0]).toStrictEqual(mockPinnedApp1)
     expect(result.current[1]).toStrictEqual(mockPinnedApp2)
   })
+
+  it('returns featured apps first', () => {
+    const mockSafeApp1 = getMockSafeApp({ id: 1 })
+    const mockSafeApp2 = getMockSafeApp({ id: 2, featured: true } as Partial<SafeAppData>)
+    const mockSafeApp3 = getMockSafeApp({ id: 3, featured: true } as Partial<SafeAppData>)
+    const mockSafeApp4 = getMockSafeApp({ id: 4 })
+    const mockSafeApp5 = getMockSafeApp({ id: 5 })
+
+    const mockPinnedApp1 = getMockSafeApp({ id: 6 })
+    const mockPinnedApp2 = getMockSafeApp({ id: 7 })
+
+    const { result } = renderHook(() =>
+      useRankedSafeApps(
+        [mockSafeApp1, mockSafeApp2, mockSafeApp3, mockSafeApp4, mockSafeApp5],
+        [mockPinnedApp1, mockPinnedApp2],
+      ),
+    )
+
+    expect(result.current[0]).toStrictEqual(mockSafeApp2)
+    expect(result.current[1]).toStrictEqual(mockSafeApp3)
+    expect(result.current[2]).toStrictEqual(mockPinnedApp1)
+    expect(result.current[3]).toStrictEqual(mockPinnedApp2)
+  })
 })

--- a/src/hooks/safe-apps/useRankedSafeApps.ts
+++ b/src/hooks/safe-apps/useRankedSafeApps.ts
@@ -9,11 +9,13 @@ const useRankedSafeApps = (safeApps: SafeAppData[], pinnedSafeApps: SafeAppData[
   return useMemo(() => {
     if (!safeApps.length) return []
 
+    // TODO: Remove assertion after migrating to new SDK
+    const featuredApps = safeApps.filter((app) => (app as SafeAppData & { featured: boolean }).featured)
     const mostUsedApps = rankSafeApps(safeApps)
     const rankedPinnedApps = rankSafeApps(pinnedSafeApps)
     const randomApps = safeApps.slice().sort(() => Math.random() - 0.5)
 
-    const allRankedApps = rankedPinnedApps.concat(pinnedSafeApps, mostUsedApps, randomApps)
+    const allRankedApps = featuredApps.concat(rankedPinnedApps, pinnedSafeApps, mostUsedApps, randomApps)
 
     // Use a Set to remove duplicates
     return [...new Set(allRankedApps)].slice(0, NUMBER_OF_SAFE_APPS)

--- a/src/hooks/safe-apps/useRankedSafeApps.ts
+++ b/src/hooks/safe-apps/useRankedSafeApps.ts
@@ -11,11 +11,9 @@ const useRankedSafeApps = (safeApps: SafeAppData[], pinnedSafeApps: SafeAppData[
 
     // TODO: Remove assertion after migrating to new SDK
     const featuredApps = safeApps.filter((app) => (app as SafeAppData & { featured: boolean }).featured)
-    const mostUsedApps = rankSafeApps(safeApps)
     const rankedPinnedApps = rankSafeApps(pinnedSafeApps)
-    const randomApps = safeApps.slice().sort(() => Math.random() - 0.5)
 
-    const allRankedApps = featuredApps.concat(rankedPinnedApps, pinnedSafeApps, mostUsedApps, randomApps)
+    const allRankedApps = featuredApps.concat(rankedPinnedApps, pinnedSafeApps)
 
     // Use a Set to remove duplicates
     return [...new Set(allRankedApps)].slice(0, NUMBER_OF_SAFE_APPS)


### PR DESCRIPTION
## What it solves

Resolves [inconsistent display of featured Safe Apps on dashboard](https://5afe.slack.com/archives/C03CQ5ABLQM/p1733926283956939)

## How this PR fixes it

We display Safe Apps on the dashboard by ranking (the amount of times an App is opened) and whether they are pinned. This does not take into account whether they are featured.

This updates the ranking of Safe Apps to put any which are featured in the initial position(s). Thereafter are only (ranked|) pinned Apps, and the "Explore" card.

## How to test it

Open the dashboard on a network which has featured Safe Apps and observe featured Apps at the beginning of the list on the dashboard.

## Screenshots

![image](https://github.com/user-attachments/assets/c0fd356b-43c4-4774-9c50-409727f5579e)

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
