### PR TITLE
Fix: pass sx prop to Box and Typography

### DIFF
--- a/src/components/common/Mui/index.test.tsx
+++ b/src/components/common/Mui/index.test.tsx
@@ -29,4 +29,11 @@ describe('Box Component', () => {
     const box = getByTestId('box')
     expect(box).toHaveStyle('text-align: center')
   })
+
+  it('should pass the sx prop to the MuiBox component', () => {
+    const { getByTestId } = render(<Box p={1} sx={{ p: 3, fontSize: '14px' }} data-testid="box" />)
+    const box = getByTestId('box')
+    expect(box).toHaveStyle('padding: 24px')
+    expect(box).toHaveStyle('font-size: 14px')
+  })
 })

--- a/src/components/common/Mui/index.tsx
+++ b/src/components/common/Mui/index.tsx
@@ -95,6 +95,7 @@ export const Box = ({
         bgcolor,
         gridArea,
         lineHeight,
+        ...props.sx,
       }}
       {...props}
     />
@@ -175,6 +176,7 @@ export const Typography = ({
         letterSpacing,
         whiteSpace,
         width,
+        ...props.sx,
       }}
       {...props}
     />

--- a/src/components/new-safe/create/steps/StatusStep/StatusStep.tsx
+++ b/src/components/new-safe/create/steps/StatusStep/StatusStep.tsx
@@ -22,13 +22,7 @@ const StatusStep = ({
       className={css.label}
       icon={<SvgIcon component={Icon} className={css.icon} color={color} fontSize="small" />}
     >
-      <Box
-        display="flex"
-        alignItems="center"
-        gap={2}
-        color={color}
-        sx={{ color: ({ palette }) => (isLoading ? palette.border.main : palette.text.primary) }}
-      >
+      <Box display="flex" alignItems="center" gap={2} color={color}>
         <Box flexShrink={0}>
           {safeAddress && !isLoading ? (
             <Identicon address={safeAddress} size={32} />


### PR DESCRIPTION
## What it solves

The `sx` prop wasn't passed down to MUI Box and Typography because it was overwritten by individual props.