### PR TITLE
fix: Add sorting back to useAllSafes hook

### DIFF
--- a/src/features/myAccounts/hooks/__tests__/useAllSafes.test.ts
+++ b/src/features/myAccounts/hooks/__tests__/useAllSafes.test.ts
@@ -132,7 +132,7 @@ describe('useAllSafes hook', () => {
     ])
   })
 
-  it('returns SafeItems for added safes and undeployed safes', () => {
+  it('returns SafeItems for added safes and undeployed safes sorted', () => {
     const { result } = renderHook(() => useAllSafes(), {
       initialReduxState: {
         addedSafes: {
@@ -164,7 +164,7 @@ describe('useAllSafes hook', () => {
     ])
   })
 
-  it('returns SafeItems for owned safes and undeployed safes', () => {
+  it('returns SafeItems for owned safes and undeployed safes sorted', () => {
     const mockOwnedSafes = {
       '1': ['0x456', '0x789'],
     }
@@ -188,13 +188,13 @@ describe('useAllSafes hook', () => {
     })
 
     expect(result.current).toEqual([
+      { address: '0x123', chainId: '1', isPinned: false, isReadOnly: true, lastVisited: 0, name: undefined },
       { address: '0x456', chainId: '1', isPinned: false, isReadOnly: false, lastVisited: 0, name: undefined },
       { address: '0x789', chainId: '1', isPinned: false, isReadOnly: false, lastVisited: 0, name: undefined },
-      { address: '0x123', chainId: '1', isPinned: false, isReadOnly: true, lastVisited: 0, name: undefined },
     ])
   })
 
-  it('returns SafeItems for added, owned and undeployed safes', () => {
+  it('returns SafeItems for added, owned and undeployed safes sorted', () => {
     const mockOwnedSafes = {
       '1': ['0x456', '0x789'],
     }
@@ -227,9 +227,9 @@ describe('useAllSafes hook', () => {
 
     expect(result.current).toEqual([
       { address: '0x123', chainId: '1', isPinned: true, isReadOnly: true, lastVisited: 0, name: undefined },
+      { address: '0x321', chainId: '1', isPinned: false, isReadOnly: true, lastVisited: 0, name: undefined },
       { address: '0x456', chainId: '1', isPinned: false, isReadOnly: false, lastVisited: 0, name: undefined },
       { address: '0x789', chainId: '1', isPinned: false, isReadOnly: false, lastVisited: 0, name: undefined },
-      { address: '0x321', chainId: '1', isPinned: false, isReadOnly: true, lastVisited: 0, name: undefined },
     ])
   })
 

--- a/src/features/myAccounts/hooks/useAllSafes.ts
+++ b/src/features/myAccounts/hooks/useAllSafes.ts
@@ -33,7 +33,7 @@ export const _prepareAddresses = (
 
   const combined = [...addedOnChain, ...ownedOnChain, ...undeployedOnChain]
 
-  return [...new Set(combined)]
+  return [...new Set(combined)].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
 }
 
 export const _buildSafeItem = (

--- a/src/features/myAccounts/hooks/useAllSafes.ts
+++ b/src/features/myAccounts/hooks/useAllSafes.ts
@@ -33,6 +33,7 @@ export const _prepareAddresses = (
 
   const combined = [...addedOnChain, ...ownedOnChain, ...undeployedOnChain]
 
+  // We need to sort to prevent potential jumps when pinning safes
   return [...new Set(combined)].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
 }
 


### PR DESCRIPTION
## What it solves

We should return safes sorted from `useAllSafes` after all otherwise there is a jump when pinning a safe while there are other safes in the same network

## How this PR fixes it

- Adds back the sorting of safes that was removed in #4641

## How to test it

1. Open the safe list
2. Pin a safe thats not the first one from its chain
3. Observe no jump

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
