### PR TITLE
fix: Revert add read-only button naming

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/src/components/sidebar/WatchlistAddButton/index.tsx
+++ b/src/components/sidebar/WatchlistAddButton/index.tsx
@@ -58,7 +58,7 @@ const WatchlistAddButton = () => {
             sx={{ py: 1.3 }}
             startIcon={<VisibilityOutlined sx={{ verticalAlign: 'middle', marginRight: 1 }} />}
           >
-            Add as Read-only
+            Add read-only
           </Button>
         </Track>
       )}


### PR DESCRIPTION
## What it solves

Reverts change introduced in https://github.com/safe-global/safe-wallet-web/pull/4657

## How this PR fixes it

- Reverts the naming of the read-only button in the sidebar to "Add read-only" instead of "Add as Read-only"

## How to test it

1. Open a Safe without a wallet connected
2. Observe the button in the sidebar says "Add read-only"

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
