### PR TITLE
Fix: pass chainId in address book dialog

### DIFF
--- a/src/components/address-book/EntryDialog/index.tsx
+++ b/src/components/address-book/EntryDialog/index.tsx
@@ -57,6 +57,7 @@ function EntryDialog({
       onClose={handleClose}
       dialogTitle={defaultValues.name ? 'Edit entry' : 'Create entry'}
       hideChainIndicator={chainIds && chainIds.length > 1}
+      chainId={chainIds?.[0]}
     >
       <FormProvider {...methods}>
         <form onSubmit={onSubmit}>


### PR DESCRIPTION
## What it solves

Resolves @liliya-soroka's bug report:

> - [ ]  Wrong network in the Edit entry pop up 
> Steps: 
> 1. Open the side menu and try to add name for the safe on Sepolia when connected EOA is on Ethereum
Expected result:  Safe network should be displayed instead of connected EOA network
<img width="1094" alt="image" src="https://github.com/user-attachments/assets/3581fd7c-2746-45a6-bd1c-6277a0d6974f" />


## How this PR fixes it

Chain id wasn't passed to the header so it was always showing the current Safe's chain id.