### PR TITLE
fix: always estimate relay `gasLimit`

### DIFF
--- a/src/components/new-safe/create/logic/index.ts
+++ b/src/components/new-safe/create/logic/index.ts
@@ -2,7 +2,8 @@ import type { SafeVersion } from '@safe-global/safe-core-sdk-types'
 import { type Eip1193Provider, type Provider } from 'ethers'
 import semverSatisfies from 'semver/functions/satisfies'
 
-import { getSafeInfo, type SafeInfo, type ChainInfo, relayTransaction } from '@safe-global/safe-gateway-typescript-sdk'
+import { getSafeInfo, type SafeInfo, type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { relayTransaction } from '@/services/tx/relaying'
 import { getReadOnlyProxyFactoryContract } from '@/services/contracts/safeContracts'
 import type { UrlObject } from 'url'
 import { AppRoutes } from '@/config/routes'
@@ -178,7 +179,11 @@ export const getRedirect = (
   return redirectUrl + `${appendChar}safe=${address}`
 }
 
-export const relaySafeCreation = async (chain: ChainInfo, undeployedSafeProps: UndeployedSafeProps) => {
+export const relaySafeCreation = async (
+  chain: ChainInfo,
+  undeployedSafeProps: UndeployedSafeProps,
+  gasLimit: string | undefined,
+) => {
   const replayedSafeProps = assertNewUndeployedSafeProps(undeployedSafeProps, chain)
   const encodedSafeCreationTx = encodeSafeCreationTx(replayedSafeProps, chain)
 
@@ -186,6 +191,7 @@ export const relaySafeCreation = async (chain: ChainInfo, undeployedSafeProps: U
     to: replayedSafeProps.factoryAddress,
     data: encodedSafeCreationTx,
     version: replayedSafeProps.safeVersion,
+    gasLimit,
   })
 
   return relayResponse.taskId

--- a/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -336,7 +336,7 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
       }
 
       if (willRelay) {
-        const taskId = await relaySafeCreation(chain, props)
+        const taskId = await relaySafeCreation(chain, props, gasLimit?.toString())
         onSubmitCallback(taskId)
       } else {
         await createNewSafe(

--- a/src/features/counterfactual/ActivateAccountFlow.tsx
+++ b/src/features/counterfactual/ActivateAccountFlow.tsx
@@ -121,7 +121,7 @@ const ActivateAccountFlow = () => {
 
     try {
       if (willRelay) {
-        const taskId = await relaySafeCreation(chain, undeployedSafe.props)
+        const taskId = await relaySafeCreation(chain, undeployedSafe.props, options?.gasLimit?.toString())
         safeCreationDispatch(SafeCreationEvent.RELAYING, { groupKey: CF_TX_GROUP_KEY, taskId, safeAddress })
 
         onSubmit()

--- a/src/services/tx/__tests__/relaying.test.ts
+++ b/src/services/tx/__tests__/relaying.test.ts
@@ -1,0 +1,66 @@
+import { faker } from '@faker-js/faker'
+import { relayTransaction as _relayTransaction } from '@safe-global/safe-gateway-typescript-sdk'
+
+import { relayTransaction } from '@/services/tx/relaying'
+import { getWeb3ReadOnly } from '@/hooks/wallets/web3'
+
+jest.mock('@/hooks/wallets/web3')
+jest.mock('@safe-global/safe-gateway-typescript-sdk')
+
+describe('relayTransaction', () => {
+  let chainId: string
+  let body: {
+    version: string
+    to: string
+    data: string
+    gasLimit: string | undefined
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    chainId = faker.string.numeric()
+    body = {
+      version: faker.system.semver(),
+      to: faker.finance.ethereumAddress(),
+      data: faker.string.hexadecimal(),
+      gasLimit: undefined,
+    }
+  })
+
+  it('should relay with the correct parameters when gasLimit is provided', async () => {
+    const bodyWithGasLimit = {
+      ...body,
+      gasLimit: faker.string.numeric(),
+    }
+
+    await relayTransaction(chainId, bodyWithGasLimit)
+
+    expect(_relayTransaction).toHaveBeenCalledWith(chainId, bodyWithGasLimit)
+  })
+
+  it('should estimate gasLimit if not provided and relay with the estimated gasLimit', async () => {
+    const gasLimit = faker.number.bigInt()
+    const mockProvider = {
+      estimateGas: jest.fn().mockResolvedValue(gasLimit),
+    }
+    ;(getWeb3ReadOnly as jest.Mock).mockReturnValue(mockProvider)
+
+    await relayTransaction(chainId, body)
+
+    expect(mockProvider.estimateGas).toHaveBeenCalledWith(body)
+    expect(_relayTransaction).toHaveBeenCalledWith(chainId, { ...body, gasLimit: gasLimit.toString() })
+  })
+
+  it('should relay with undefined gasLimit if estimation fails', async () => {
+    const mockProvider = {
+      estimateGas: jest.fn().mockRejectedValue(new Error('Estimation failed')),
+    }
+    ;(getWeb3ReadOnly as jest.Mock).mockReturnValue(mockProvider)
+
+    await relayTransaction(chainId, body)
+
+    expect(mockProvider.estimateGas).toHaveBeenCalledWith(body)
+    expect(_relayTransaction).toHaveBeenCalledWith(chainId, { ...body, gasLimit: undefined })
+  })
+})

--- a/src/services/tx/relaying.ts
+++ b/src/services/tx/relaying.ts
@@ -1,0 +1,29 @@
+import { relayTransaction as _relayTransaction } from '@safe-global/safe-gateway-typescript-sdk'
+
+import { getWeb3ReadOnly } from '@/hooks/wallets/web3'
+
+export async function relayTransaction(
+  chainId: string,
+  body: { version: string; to: string; data: string; gasLimit: string | undefined },
+) {
+  /**
+   * Ensures `gasLimit` is estimate so 150k execution overhead buffer can be added by CGW.
+   *
+   * @see https://github.com/safe-global/safe-client-gateway/blob/b7640ed4bd7416ecb7696d21ba105fcb5af52a10/src/datasources/relay-api/gelato-api.service.ts#L62-L75
+   *
+   * - If provided, CGW adds a 150k buffer before submission to Gelato.
+   * - If not provided, no buffer is added, and Gelato estimates the it.
+   *
+   * Note: particularly important on networks like Arbitrum, where estimation is unreliable.
+   */
+  if (!body.gasLimit) {
+    const provider = getWeb3ReadOnly()
+
+    body.gasLimit = await provider
+      ?.estimateGas(body)
+      .then(String)
+      .catch(() => undefined)
+  }
+
+  return _relayTransaction(chainId, body)
+}

--- a/src/services/tx/tx-sender/__tests__/ts-sender.test.ts
+++ b/src/services/tx/tx-sender/__tests__/ts-sender.test.ts
@@ -22,6 +22,7 @@ import {
   type JsonRpcProvider,
   type JsonRpcSigner,
 } from 'ethers'
+import { faker } from '@faker-js/faker'
 import * as safeContracts from '@/services/contracts/safeContracts'
 
 import * as web3 from '@/hooks/wallets/web3'
@@ -515,6 +516,13 @@ describe('txSender', () => {
 
   describe('dispatchBatchExecutionRelay', () => {
     it('should relay a batch execution', async () => {
+      const gasLimit = faker.number.bigInt()
+      jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(() => {
+        return {
+          estimateGas: jest.fn(() => Promise.resolve(gasLimit)),
+        } as unknown as JsonRpcProvider
+      })
+
       const mockMultisendAddress = zeroPadValue('0x1234', 20)
       const safeAddress = toBeHex('0x567', 20)
 

--- a/src/services/tx/tx-sender/dispatch.ts
+++ b/src/services/tx/tx-sender/dispatch.ts
@@ -2,12 +2,8 @@ import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import { isMultisigExecutionInfo } from '@/utils/transaction-guards'
 import { isHardwareWallet, isSmartContractWallet } from '@/utils/wallets'
 import type { MultiSendCallOnlyContractImplementationType } from '@safe-global/protocol-kit'
-import {
-  type ChainInfo,
-  relayTransaction,
-  type SafeInfo,
-  type TransactionDetails,
-} from '@safe-global/safe-gateway-typescript-sdk'
+import { type ChainInfo, type SafeInfo, type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
+import { relayTransaction } from '@/services/tx/relaying'
 import type {
   SafeSignature,
   SafeTransaction,
@@ -559,6 +555,8 @@ export const dispatchBatchExecutionRelay = async (
       to,
       data,
       version: safeVersion,
+      // We have no estimation in place
+      gasLimit: undefined,
     })
   } catch (error) {
     txs.forEach(({ txId }) => {


### PR DESCRIPTION
## What it solves

Resolves inconsistent relays on Arbitrum

## How this PR fixes it

When relaying, a `gasLimit` can be optionally provided in the request. If provided, [a 150k buffer is added to it](https://github.com/safe-global/safe-client-gateway/blob/b7640ed4bd7416ecb7696d21ba105fcb5af52a10/src/datasources/relay-api/gelato-api.service.ts#L62-L75) for the Gelato execution overhead. If none is provided, Gelato estimates this on our behalf and no buffer is added.

This explicitly provides the `gasLimit` to relay requests (if present), otherwise manually estimates it if none is provided.

## How to test it

Ensure relay attempts do not fail (particularly on Arbitrum) for the following cases, and that the `gasLimit` is present in each `POST` request to the `/v1/chains/:chainId/relay`:

1. Safe creation/activation - uses estimation from UI
2. Bulk execution - estimation occurs in the background

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
