### PR TITLE
Chore: generating docker image was failing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,12 @@ RUN apk add --no-cache libc6-compat git python3 py3-pip make g++ libusb-dev eude
 WORKDIR /app
 COPY . .
 
+RUN corepack enable
 # Fix arm64 timeouts
-RUN yarn config set network-timeout 300000 && yarn global add node-gyp
+RUN yarn config set httpTimeout 300000
 
 # install deps
-RUN yarn install --frozen-lockfile
+RUN yarn install --immutable
 RUN yarn after-install
 
 ENV NODE_ENV production


### PR DESCRIPTION

## What it solves
With the change to yarn v4 we need to slightly adjust the Dockerfile as the deploying an image to docker.hub was failng.

Resolves #

## How this PR fixes it
- network-timeout is now httpTimeout
- there is no need for global node-gyp as yarn uses whatever is specified in the package

sidenote: `yarn global` no longer works. It's not something yarn wants to do. https://yarnpkg.com/migration/guide#use-yarn-dlx-instead-of-yarn-global

## How to test it

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
