### PR TITLE
Fix: display Safe App icon and name in history

### DIFF
--- a/src/hooks/useTransactionType.tsx
+++ b/src/hooks/useTransactionType.tsx
@@ -111,7 +111,14 @@ export const getTransactionType = (tx: TransactionSummary, addressBook: AddressB
       }
     }
     case TransactionInfoType.CUSTOM: {
-      if (isMultiSendTxInfo(tx.txInfo) && !tx.safeAppInfo) {
+      if (tx.safeAppInfo) {
+        return {
+          icon: tx.safeAppInfo.logoUri,
+          text: tx.safeAppInfo.name,
+        }
+      }
+
+      if (isMultiSendTxInfo(tx.txInfo)) {
         return {
           icon: <SvgIcon component={BatchIcon} inheritViewBox fontSize="small" alt="Batch" />,
           text: 'Batch',
@@ -145,13 +152,6 @@ export const getTransactionType = (tx: TransactionSummary, addressBook: AddressB
       }
     }
     default: {
-      if (tx.safeAppInfo) {
-        return {
-          icon: tx.safeAppInfo.logoUri,
-          text: tx.safeAppInfo.name,
-        }
-      }
-
       return {
         icon: '/images/transactions/custom.svg',
         text: addressBookName || 'Contract interaction',


### PR DESCRIPTION
## What it solves

We weren't displaying Safe App info in the queue/history due to a regression. Safe App txs had default icons and names.

Before this PR:
<img width="691" alt="Screenshot 2024-12-19 at 14 08 06" src="https://github.com/user-attachments/assets/6ff308ff-0171-43a3-a715-d50e1d526f91" />

After:
<img width="675" alt="Screenshot 2024-12-19 at 14 07 52" src="https://github.com/user-attachments/assets/626d1598-f832-4431-9c17-8adad6c600e0" />
